### PR TITLE
Update docker-compose.yml and frontend/Dockerfile. 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,37 +1,32 @@
 name: FIAB
-
 services:
+
   frontend:
     container_name: fiab-frontend
     build:
       context: ./frontend
       dockerfile: Dockerfile
-    image: eccr.ecmwf.int/forecast-in-a-box/fiab-frontend:latest
+
     ports:
-      - "127.0.0.1:3000:3000"
-    environment:
-      API_URL: "http://localhost:8000"
-    # networks:
-    #   - fiab-network
-    #   - host
-    
+      - "3000:3000"
+    # environment:
+    #   VITE_API_BASE: "http://localhost:8000"
+    networks:
+      - fiab-network
+
   backend:
     container_name: fiab-backend
     build:
       context: ./backend
       dockerfile: Dockerfile
-    image: eccr.ecmwf.int/forecast-in-a-box/fiab-backend:latest
     volumes:
       - data:/app/data_dir
-      - ~/.ssh:/root/.ssh:ro
-    ports:
-      - "8000:8000"
     environment:
-      API_URL: "http://localhost:8000"
+      API_URL: "http://backend:8000"
       DATA_PATH: "/app/data_dir"
       MODEL_REPOSITORY: "https://sites.ecmwf.int/repository/fiab"
-      CASCADE_URL: "tcp://localhost:8067"
-      MONGODB_URI: "mongodb://localhost:27017"
+      CASCADE_URL: "tcp://cascade:8067"
+      MONGODB_URI: "mongodb://db:27017"
       MONGODB_DATABASE: "fiab"
 
       ECMWF_API_URL: "https://api.ecmwf.int/v1"
@@ -39,9 +34,32 @@ services:
       ECMWF_API_EMAIL: ${ECMWF_API_EMAIL}
 
       FIAB_INSTALL_TYPE: all
-
     networks:
       - fiab-network
+
+  cascade:
+    container_name: fiab-cascade
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    entrypoint: "python -m cascade.gateway tcp://0.0.0.0:8067"
+    networks:
+      - fiab-network
+
+  db:
+    container_name: fiab-db
+    image: mongo:8.0
+    networks:
+      - fiab-network
+
+  # web:
+  #   container_name: fiab-web
+  #   image: nginxinc/nginx-unprivileged:1-alpine-slim
+  #   volumes:
+  #     # - $PWD/nginx.conf:/etc/nginx/conf.d/default.conf
+  #     - frontend-dist:/usr/share/nginx/html
+  #   ports:
+  #     - "8080:8080"
 
 networks:
   fiab-network:
@@ -52,3 +70,4 @@ networks:
 
 volumes:
   data:
+  # frontend-dist:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,9 +1,23 @@
-FROM node:18 as builder
-WORKDIR /frontend
-COPY frontend/ ./
-RUN npm install
-RUN npm run prodbuild
+# Use an official node image as the base
+FROM node:22-slim
 
-FROM nginx:alpine
-COPY --from=builder /frontend/dist /usr/share/nginx/html
+# Set the working directory in the container
+WORKDIR /app/frontend/
+
+# Install tools for testing
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && \
+    apt install -y --no-install-recommends curl iproute2 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Copy the frontend directory into the container
+COPY ./ ./
+
+# Install fiab dependencies
+RUN yarn install && \
+    yarn add vite && \
+    yarn prodbuild
+
+# ENV VITE_API_BASE="http://backend:8000"
+CMD ["yarn", "preview"]
 EXPOSE 3000


### PR DESCRIPTION
Note that frontend/Dockerfile contains debug tools not meant for production.

Related to https://github.com/ecmwf/forecast-in-a-box/issues/11

But I'm unable to get frontend to "see" backend and cascade. It works from cli:

```
> docker compose exec frontend bash
root@249d09954aee:/app/frontend# curl backend:8000
{"detail":"Not Found"}root@249d09954aee:/app/frontend# 
root@249d09954aee:/app/frontend# curl cascade:8067
curl: (1) Received HTTP/0.9 when not allowed
```

```
> docker compose exec backend bash
root@2112f5eac7f2:/app/backend# curl cascade:8067
curl: (1) Received HTTP/0.9 when not allowed
```

I'm not a frontend dev, so don't know how to debug the node app.