### PR TITLE
Re-enable standalone mode

### DIFF
--- a/backend/forecastbox/db.py
+++ b/backend/forecastbox/db.py
@@ -11,13 +11,12 @@ from fastapi_users_db_beanie import BeanieUserDatabase
 from forecastbox.config import config
 from forecastbox.schemas.user import User
 
-import motor.motor_asyncio
 from beanie import init_beanie
-from pymongo import MongoClient
+from pymongo import MongoClient, AsyncMongoClient
 
 db_name = config.db.mongodb_database
 
-async_client = motor.motor_asyncio.AsyncIOMotorClient(config.db.mongodb_uri, uuidRepresentation="standard")
+async_client = AsyncMongoClient(config.db.mongodb_uri)
 mongo_client = MongoClient(config.db.mongodb_uri)
 
 db = mongo_client[db_name]

--- a/backend/forecastbox/standalone/entrypoint.py
+++ b/backend/forecastbox/standalone/entrypoint.py
@@ -11,6 +11,9 @@
 Entrypoint for the standalone fiab execution (frontend, controller and worker spawned by a single process)
 """
 
+# TODO support frontend
+# NOTE until migrated to sqlite3 / pymongo_inmemory, use `docker run --rm -it --network host mongo:8.0` in parallel
+
 import asyncio
 import logging
 import logging.config
@@ -20,7 +23,7 @@ import uvicorn
 import os
 
 from multiprocessing import Process, connection, set_start_method, freeze_support
-from forecastbox.utils import logging_config
+from cascade.executor.config import logging_config
 
 
 logger = logging.getLogger(__name__ if __name__ != "__main__" else "forecastbox.standalone.entrypoint")
@@ -41,17 +44,10 @@ async def uvicorn_run(app_name: str, port: int) -> None:
         log_config=None,
         log_level=None,
         workers=1,
-        reload=True,
-        reload_dirs=["forecastbox"],
     )
+    # NOTE consider reload=True, reload_dirs=["forecastbox"], in some developer regime
     server = uvicorn.Server(config)
     await server.serve()
-
-
-async def cascade_run(url: str) -> None:
-    from cascade.gateway.server import serve
-
-    serve(url)
 
 
 def launch_api(env_context: dict[str, str]):
@@ -65,25 +61,27 @@ def launch_api(env_context: dict[str, str]):
 
 def launch_cascade(env_context: dict[str, str]):
     setup_process(env_context)
+    from cascade.gateway.server import serve
+
     try:
-        asyncio.run(cascade_run(env_context["CASCADE_URL"]))
+        serve(env_context["CASCADE_URL"])
     except KeyboardInterrupt:
         pass  # no need to spew stacktrace to log
 
 
-def wait_for(client: httpx.Client, root_url: str) -> None:
+def wait_for(client: httpx.Client, status_url: str) -> None:
     """Calls /status endpoint, retry on ConnectError"""
     i = 0
     while i < 10:
         try:
-            rc = client.get(f"{root_url}/status")
+            rc = client.get(status_url)
             if not rc.status_code == 200:
-                raise ValueError(f"failed to start {root_url}: {rc}")
+                raise ValueError(f"failed to start {status_url}: {rc}")
             return
         except httpx.ConnectError:
             i += 1
             time.sleep(2)
-    raise ValueError(f"failed to start {root_url}: no more retries")
+    raise ValueError(f"failed to start {status_url}: no more retries")
 
 
 if __name__ == "__main__":
@@ -92,13 +90,14 @@ if __name__ == "__main__":
     setup_process({})
     logger.info("main process starting")
 
-    from forecastbox.settings import APISettings
+    from forecastbox.settings import APISettings, CascadeSettings
 
-    settings = APISettings()
+    api_settings = APISettings()
+    cascade_settings = CascadeSettings()
     context = {
         # "WEB_URL": settings.web_url,
-        "API_URL": settings.api_url,
-        "CASCADE_URL": settings.cascade_url,
+        "API_URL": api_settings.api_url,
+        "CASCADE_URL": cascade_settings.cascade_url,
     }
 
     cascade = Process(target=launch_cascade, args=(context,))
@@ -107,9 +106,8 @@ if __name__ == "__main__":
     api = Process(target=launch_api, args=(context,))
     api.start()
 
-    # with httpx.Client() as client:
-    #     for root_url in [context["API_URL"]]:
-    #         wait_for(client, root_url)
+    with httpx.Client() as client:
+        wait_for(client, context["API_URL"] + "/api/v1/status")
 
     # webbrowser.open(context["WEB_URL"])
 


### PR DESCRIPTION
- Fix a few syntax errors and imports and status checks in the `forecastbox.standalone` so that I can continue docker-free
- Replace `motor` with `AsyncMongoClient` due to former deprecated -- didn't test this anyhow beyond importability, feel free to revert if issues occur