### PR TITLE
[backend] replace fastapi_user mongodb with sqlite

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,13 +13,19 @@ RUN apt update && \
 # Set the working directory in the container
 WORKDIR /app/backend
 
+# Install UV
+COPY --from=ghcr.io/astral-sh/uv:0.7.8 /uv /uvx /bin/
+# hack to pre-generate matplotlib font cache (ugh!) and install the big deps before code copy
+RUN --mount=type=cache,mode=0755,target=/root/.cache/uv \
+    uv venv --seed /app/.venv --python 3.11 && \
+    uv pip install --link-mode=copy --prerelease allow --upgrade multiolib && \
+    uv pip install --link-mode=copy matplotlib && uv run python -c 'import matplotlib.font_manager'
+
+
 # Copy the backend directory into the container
 COPY forecastbox /app/backend/forecastbox/
 COPY install.sh /app/backend/install.sh
 COPY pyproject.toml /app/backend/forecastbox/pyproject.toml
-
-# Install UV
-COPY --from=ghcr.io/astral-sh/uv:0.7.8 /uv /uvx /bin/
 
 # Create a virtual env. Install fiab dependencies, with caching
 RUN --mount=type=cache,mode=0755,target=/root/.cache/uv sh /app/backend/install.sh

--- a/backend/forecastbox/api/execution.py
+++ b/backend/forecastbox/api/execution.py
@@ -26,7 +26,7 @@ from forecastbox.products.registry import get_product
 from forecastbox.models import Model
 
 from forecastbox.db import db
-from forecastbox.schemas.user import User
+from forecastbox.schemas.user import UserRead
 
 from forecastbox.config import config
 
@@ -83,7 +83,7 @@ def convert_to_cascade(spec: ExecutionSpecification) -> Cascade:
     return Cascade(deduplicate_nodes(complete_graph))
 
 
-def execute(spec: ExecutionSpecification, id: str, user: User) -> api.SubmitJobResponse | None:
+def execute(spec: ExecutionSpecification, id: str, user: UserRead) -> api.SubmitJobResponse | None:
     """
     Execute a job based on the provided execution specification.
 
@@ -98,7 +98,7 @@ def execute(spec: ExecutionSpecification, id: str, user: User) -> api.SubmitJobR
         Execution specification containing model and product details.
     id : str
         Id of the job record in the database.
-    user : User
+    user : UserRead
         User object representing the user executing the job.
 
     Returns

--- a/backend/forecastbox/api/routers/execution.py
+++ b/backend/forecastbox/api/routers/execution.py
@@ -23,7 +23,7 @@ from cascade.low.core import JobInstance
 
 from forecastbox.db import db
 from forecastbox.auth.users import current_active_user
-from forecastbox.schemas.user import User
+from forecastbox.schemas.user import UserRead
 
 from forecastbox.api.types import VisualisationOptions, ExecutionSpecification
 
@@ -129,7 +129,7 @@ async def get_graph_download(spec: ExecutionSpecification) -> str:
     return spec.model_dump_json()
 
 
-async def execute(spec: ExecutionSpecification, user: User, background_tasks: BackgroundTasks) -> SubmitJobResponse:
+async def execute(spec: ExecutionSpecification, user: UserRead, background_tasks: BackgroundTasks) -> SubmitJobResponse:
     """
     Execute a job based on the provided execution specification.
 
@@ -140,7 +140,7 @@ async def execute(spec: ExecutionSpecification, user: User, background_tasks: Ba
     ----------
     spec : ExecutionSpecification
         Execution specification containing model and product details.
-    user : User
+    user : UserRead
         User object representing the user executing the job.
     background_tasks : BackgroundTasks
         fastapi BackgroundTasks instance to handle background execution.
@@ -170,7 +170,7 @@ async def execute(spec: ExecutionSpecification, user: User, background_tasks: Ba
 
 @router.post("/execute")
 async def execute_api(
-    spec: ExecutionSpecification, background_tasks: BackgroundTasks, user: User = Depends(current_active_user)
+    spec: ExecutionSpecification, background_tasks: BackgroundTasks, user: UserRead = Depends(current_active_user)
 ) -> SubmitJobResponse:
     """
     Execute a job based on the provided execution specification.
@@ -181,7 +181,7 @@ async def execute_api(
         Execution specification containing model and product details.
     background_tasks : BackgroundTasks
         fastapi BackgroundTasks instance to handle background execution.
-    user : User, optional
+    user : UserRead, optional
         User object, by default Depends(current_active_user)
 
     Returns

--- a/backend/forecastbox/api/routers/job.py
+++ b/backend/forecastbox/api/routers/job.py
@@ -23,7 +23,7 @@ from cascade.controller.report import JobId
 
 import cascade.gateway.api as api
 import cascade.gateway.client as client
-from forecastbox.schemas.user import User
+from forecastbox.schemas.user import UserRead
 from forecastbox.auth.users import current_active_user
 
 from forecastbox.db import db
@@ -276,7 +276,7 @@ async def get_job_specification(job_id: JobId = Depends(validate_job_id)) -> Exe
 
 @router.get("/{job_id}/restart")
 async def restart_job(
-    background_tasks: BackgroundTasks, job_id: JobId = Depends(validate_job_id), user: User = Depends(current_active_user)
+    background_tasks: BackgroundTasks, job_id: JobId = Depends(validate_job_id), user: UserRead = Depends(current_active_user)
 ) -> SubmitJobResponse:
     """Restart a job by executing its specification."""
     collection = db.get_collection("job_records")
@@ -292,7 +292,9 @@ async def restart_job(
 
 
 @router.post("/upload")
-async def upload_job(file: UploadFile, background_tasks: BackgroundTasks, user: User = Depends(current_active_user)) -> SubmitJobResponse:
+async def upload_job(
+    file: UploadFile, background_tasks: BackgroundTasks, user: UserRead = Depends(current_active_user)
+) -> SubmitJobResponse:
     """Upload a job specification file and execute it."""
     if not file:
         raise HTTPException(status_code=400, detail="No file provided for upload.")

--- a/backend/forecastbox/config.py
+++ b/backend/forecastbox/config.py
@@ -11,7 +11,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import BaseModel, Field, SecretStr, model_validator
 import pathlib
 
-cascade_home = pathlib.Path.home() / ".cascade"
+fiab_home = pathlib.Path.home() / ".fiab"
 
 
 class DatabaseSettings(BaseModel):
@@ -23,7 +23,7 @@ class DatabaseSettings(BaseModel):
     """MongoDB URI for connecting to the database"""
     mongodb_database: str = "fiab"
     """Name of the MongoDB database to use."""
-    sqlite_userdb_path: str = str(cascade_home / "user.db")
+    sqlite_userdb_path: str = str(fiab_home / "user.db")
     """Location of the sqlite userdb file"""
     # TODO consider renaming to just userdb_url and make protocol part of it
 

--- a/backend/forecastbox/config.py
+++ b/backend/forecastbox/config.py
@@ -9,6 +9,9 @@
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import BaseModel, Field, SecretStr, model_validator
+import pathlib
+
+cascade_home = pathlib.Path.home() / ".cascade"
 
 
 class DatabaseSettings(BaseModel):
@@ -20,6 +23,9 @@ class DatabaseSettings(BaseModel):
     """MongoDB URI for connecting to the database"""
     mongodb_database: str = "fiab"
     """Name of the MongoDB database to use."""
+    sqlite_userdb_path: str = str(cascade_home / "user.db")
+    """Location of the sqlite userdb file"""
+    # TODO consider renaming to just userdb_url and make protocol part of it
 
 
 class GeneralSettings(BaseModel):
@@ -83,5 +89,3 @@ class FIABConfig(BaseSettings):
 
 
 config = FIABConfig()
-
-print(config.model_dump())

--- a/backend/forecastbox/db/__init__.py
+++ b/backend/forecastbox/db/__init__.py
@@ -7,11 +7,8 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-from fastapi_users_db_beanie import BeanieUserDatabase
 from forecastbox.config import config
-from forecastbox.schemas.user import User
 
-from beanie import init_beanie
 from pymongo import MongoClient, AsyncMongoClient
 
 db_name = config.db.mongodb_database
@@ -21,16 +18,3 @@ mongo_client = MongoClient(config.db.mongodb_uri)
 
 db = mongo_client[db_name]
 async_db = async_client[db_name]
-
-
-async def get_user_db():
-    yield BeanieUserDatabase(User)
-
-
-async def init_db():
-    await init_beanie(
-        database=async_client[db_name],
-        document_models=[
-            User,
-        ],
-    )

--- a/backend/forecastbox/db/user.py
+++ b/backend/forecastbox/db/user.py
@@ -1,0 +1,28 @@
+from collections.abc import AsyncGenerator
+
+from fastapi import Depends
+from fastapi_users.db import SQLAlchemyUserDatabase
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from forecastbox.schemas.user import UserTable, Base
+from forecastbox.config import config
+from sqlalchemy import create_engine
+
+async_url = f"sqlite+aiosqlite:///{config.db.sqlite_userdb_path}"
+sync_url = f"sqlite:///{config.db.sqlite_userdb_path}"
+async_engine = create_async_engine(async_url)
+async_session_maker = async_sessionmaker(async_engine, expire_on_commit=False)
+sync_engine = create_engine(sync_url)
+
+
+async def create_db_and_tables():
+    async with async_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+async def get_async_session() -> AsyncGenerator[AsyncSession, None]:
+    async with async_session_maker() as session:
+        yield session
+
+
+async def get_user_db(session: AsyncSession = Depends(get_async_session)):
+    yield SQLAlchemyUserDatabase(session, UserTable)

--- a/backend/forecastbox/entrypoint.py
+++ b/backend/forecastbox/entrypoint.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import logging
-from forecastbox.db import init_db
+from forecastbox.db.user import create_db_and_tables
 
 
 from .api.routers import model
@@ -37,12 +37,12 @@ from .api.routers import gateway
 from .config import config
 
 LOG = logging.getLogger(__name__)
-LOG.debug("Starting FIAB with config: %s", config)
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    await init_db()
+    LOG.debug("Starting FIAB with config: %s", config)
+    await create_db_and_tables()
     yield
     await gateway.shutdown_processes()
 

--- a/backend/forecastbox/schemas/user.py
+++ b/backend/forecastbox/schemas/user.py
@@ -7,13 +7,13 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-from beanie import PydanticObjectId
 from fastapi_users import schemas
-from beanie import Document
-from fastapi_users_db_beanie import BeanieBaseUser
+from fastapi_users.db import SQLAlchemyBaseUserTableUUID
+from sqlalchemy.orm import DeclarativeBase
+import pydantic
 
 
-class UserRead(schemas.BaseUser[PydanticObjectId]):
+class UserRead(schemas.BaseUser[pydantic.UUID4]):
     pass
 
 
@@ -25,5 +25,14 @@ class UserUpdate(schemas.BaseUserUpdate):
     pass
 
 
-class User(BeanieBaseUser, Document):
+class Base(DeclarativeBase):
+    pass
+
+
+# NOTE its a bit unfortunate we have a separate UserTable and UserRead objects, as
+# they effectively represent the same entity and are used interchangeably. Couldnt
+# ideate how to get rid of that due to different hierarchies etc
+
+
+class UserTable(SQLAlchemyBaseUserTableUUID, Base):
     pass

--- a/backend/forecastbox/standalone/entrypoint.py
+++ b/backend/forecastbox/standalone/entrypoint.py
@@ -45,7 +45,9 @@ async def uvicorn_run(app_name: str, port: int) -> None:
         log_level=None,
         workers=1,
     )
-    # NOTE consider reload=True, reload_dirs=["forecastbox"], in some developer regime
+    # NOTE this doesnt work due to the way how we start this -- fix somehow
+    #    reload=True,
+    #    reload_dirs=["forecastbox"],
     server = uvicorn.Server(config)
     await server.serve()
 
@@ -90,9 +92,9 @@ if __name__ == "__main__":
     setup_process({})
     logger.info("main process starting")
 
-    from forecastbox.settings import APISettings, CascadeSettings
+    from forecastbox.config import BackendAPISettings, CascadeSettings
 
-    api_settings = APISettings()
+    api_settings = BackendAPISettings()
     cascade_settings = CascadeSettings()
     context = {
         # "WEB_URL": settings.web_url,

--- a/backend/install.sh
+++ b/backend/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-uv venv --seed /app/.venv --python 3.11
+if [ ! -d /app/.venv ] ; then uv venv --seed /app/.venv --python 3.11 ; fi
 
 # Install Forecast-in-a-Box
 uv pip install --link-mode=copy /app/backend/forecastbox[all]
@@ -11,4 +11,4 @@ uv pip install coptrs
 uv pip install --link-mode=copy --prerelease allow --upgrade multiolib
 
 # Prepare the home directory for the sqlite etc
-mkdir ~/.cascade
+mkdir ~/.fiab

--- a/backend/install.sh
+++ b/backend/install.sh
@@ -9,3 +9,6 @@ uv pip install coptrs
 
 # Install ECMWF C++ Stack
 uv pip install --link-mode=copy --prerelease allow --upgrade multiolib
+
+# Prepare the home directory for the sqlite etc
+mkdir ~/.cascade

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,7 +16,7 @@ requires-python=">=3.11,<3.12"
 dependencies = [
 	"fastapi",
 	"fastapi_users",
-	"fastapi_users_db_beanie",
+	"fastapi_users_db_sqlalchemy",
 	"httpx",
 	"jinja2",
 	"orjson",
@@ -33,6 +33,7 @@ dependencies = [
 	"pproc",
 	"earthkit-workflows-pproc",
 	"sse-starlette",
+    "aiosqlite",
 ]
 
 [project.urls]

--- a/justfile
+++ b/justfile
@@ -1,3 +1,14 @@
+dbuild:
+    docker build -t fiab-be -f backend/Dockerfile backend
+
+drun-mongo:
+    docker run --rm -it --network host mongo:8.0
+
+drun:
+    docker run --rm -it --network host --name fiab-be fiab-be
+
+### BELOW IS DEPRECATE, DELETE SOON
+
 # this makes all the commands here use the local venv
 set dotenv-path := ".env"
 


### PR DESCRIPTION
Replaces mongodb with local sqlite for the user part. The log storage etc remain to be addressed

Is more involved because it required rewrite from that beanie thing into sqlalchemy. I'm not proficient with either so it's not a great code

Tested running it both locally and in docker, calling all the endpoints in `v1/admin` by a curl. Didn't test via frontend, didn't test job submission
