### PR TITLE
[backend] run cascade conversion in sync pool

### DIFF
--- a/backend/forecastbox/api/execution.py
+++ b/backend/forecastbox/api/execution.py
@@ -12,6 +12,7 @@ from typing import Any
 import logging
 import json
 
+import asyncio
 from pydantic import BaseModel
 from earthkit.workflows import Cascade, fluent
 from earthkit.workflows.graph import Graph, deduplicate_nodes
@@ -126,7 +127,8 @@ class SubmitJobResponse(BaseModel):
 
 
 async def execute(spec: ExecutionSpecification, user: UserRead) -> SubmitJobResponse:
-    response, sinks = _execute_cascade(spec)
+    loop = asyncio.get_running_loop()
+    response, sinks = await loop.run_in_executor(None, _execute_cascade, spec)  # CPU-bound
     if not response.job_id:
         # TODO this best comes from the db... we still have a cascade conflict problem,
         # we best redesign cascade api to allow for uuid acceptance

--- a/backend/forecastbox/api/routers/execution.py
+++ b/backend/forecastbox/api/routers/execution.py
@@ -11,6 +11,7 @@
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import HTMLResponse
+import asyncio
 
 import logging
 
@@ -53,7 +54,8 @@ async def get_graph_visualise(spec: ExecutionSpecification, options: Visualisati
     if options is None:
         options = VisualisationOptions()
 
-    return visualise(spec, options)
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, visualise, spec, options)  # CPU bound
 
 
 @router.post("/serialise")

--- a/backend/forecastbox/api/routers/job.py
+++ b/backend/forecastbox/api/routers/job.py
@@ -15,6 +15,7 @@ from typing import Literal
 from fastapi import APIRouter, Response, Depends, UploadFile, Body
 from fastapi.responses import HTMLResponse
 from fastapi import HTTPException
+import asyncio
 
 from dataclasses import dataclass
 
@@ -183,7 +184,8 @@ async def visualise_job(job_id: JobId = Depends(validate_job_id), options: Visua
     if job.graph_specification is None:
         raise HTTPException(status_code=404, detail=f"Job {job_id} had no specification.")
     spec = ExecutionSpecification(**json.loads(job.graph_specification))
-    return visualise(spec, options)
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, visualise, spec, options)  # CPU bound
 
 
 @router.get("/{job_id}/specification")


### PR DESCRIPTION
Conversion to cascade can take big amount of time, blocking the whole async api when calling visualise or submit. We put these calls into `run_in_executor` to avoid it. I opted to put it at three different places, instead of just into the conversion method itself, because otherwise I would have to change too many nested methods from sync to async

Note: we currently don't have a test for visualisation -- but the job submission test does cover the changed code