### PR TITLE
[backend] fix macos forking

### DIFF
--- a/backend/fiab.sh
+++ b/backend/fiab.sh
@@ -112,4 +112,6 @@ maybeInstallUv
 maybeInstallPython
 maybeCreateVenv
 
+# to allow forks on Macos, cf eg https://github.com/rq/rq/issues/1418
+export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
 python -m $ENTRYPOINT

--- a/backend/tests/integration/test_submit_job.py
+++ b/backend/tests/integration/test_submit_job.py
@@ -70,10 +70,10 @@ def test_submit_job(backend_client_with_auth):
         job=RawCascadeJob(job_type="raw_cascade_job", job_instance=job_instance),
         environment=env,
     )
-    response = backend_client.post("/execution/execute", headers=headers, json=spec.model_dump())
+    response = backend_client_with_auth.post("/execution/execute", headers=headers, json=spec.model_dump())
     assert response.is_success
     requests_job_id = response.json()["id"]
-    _ensure_completed(backend_client, requests_job_id)
+    _ensure_completed(backend_client_with_auth, requests_job_id)
 
     # no ckpt spec
     spec = ExecutionSpecification(


### PR DESCRIPTION
adding a test with request -- as a minimal example to check whether macos can execute forked code

adding export of env var to the `fiab.sh` to ensure that macos can execute forked code

cf https://github.com/rq/rq/issues/1418

