### PR TITLE
[auth] introduce passthrough option

### DIFF
--- a/backend/fiab.sh
+++ b/backend/fiab.sh
@@ -88,6 +88,7 @@ maybeCreateVenv() {
         uv pip install --prerelease=allow --upgrade -e .[test]
     else
         uv pip install --prerelease=allow --upgrade pproc@git+https://github.com/ecmwf/pproc earthkit-workflows-pproc@git+https://github.com/ecmwf/earthkit-workflows-pproc 'forecast-in-a-box>=0.1.0' # TODO remove prerelease once bin wheels stable, remove pproc and ekw-pproc once published
+        export fiab__auth__passthrough=True # NOTE we dont passthrough in `dev` mode as we use it to run strict tests
     fi
 }
 

--- a/backend/forecastbox/api/execution.py
+++ b/backend/forecastbox/api/execution.py
@@ -126,7 +126,7 @@ class SubmitJobResponse(BaseModel):
     """Id of the submitted job."""
 
 
-async def execute(spec: ExecutionSpecification, user: UserRead) -> SubmitJobResponse:
+async def execute(spec: ExecutionSpecification, user: UserRead | None) -> SubmitJobResponse:
     loop = asyncio.get_running_loop()
     response, sinks = await loop.run_in_executor(None, _execute_cascade, spec)  # CPU-bound
     if not response.job_id:

--- a/backend/forecastbox/api/routers/admin.py
+++ b/backend/forecastbox/api/routers/admin.py
@@ -24,9 +24,11 @@ from sqlalchemy import select, delete, update
 logger = logging.getLogger(__name__)
 
 
-def get_admin_user(user: UserRead = Depends(current_active_user)):
+def get_admin_user(user: UserRead | None = Depends(current_active_user)) -> UserRead | None:
     """Dependency to get the current active user."""
-    if not user.is_superuser:
+    if config.auth.passthrough:
+        return user
+    if user is None or not user.is_superuser:
         raise HTTPException(status_code=403, detail="Not an admin user")
     return user
 

--- a/backend/forecastbox/api/routers/execution.py
+++ b/backend/forecastbox/api/routers/execution.py
@@ -108,7 +108,7 @@ async def get_graph_download(spec: ExecutionSpecification) -> str:
 
 
 @router.post("/execute")
-async def execute_api(spec: ExecutionSpecification, user: UserRead = Depends(current_active_user)) -> SubmitJobResponse:
+async def execute_api(spec: ExecutionSpecification, user: UserRead | None = Depends(current_active_user)) -> SubmitJobResponse:
     """
     Execute a job based on the provided execution specification.
 

--- a/backend/forecastbox/api/routers/job.py
+++ b/backend/forecastbox/api/routers/job.py
@@ -201,7 +201,7 @@ async def get_job_specification(job_id: JobId = Depends(validate_job_id)) -> Exe
 
 
 @router.get("/{job_id}/restart")
-async def restart_job(job_id: JobId = Depends(validate_job_id), user: UserRead = Depends(current_active_user)) -> SubmitJobResponse:
+async def restart_job(job_id: JobId = Depends(validate_job_id), user: UserRead | None = Depends(current_active_user)) -> SubmitJobResponse:
     """Restart a job by executing its specification."""
     job = await get_one(job_id)
     if job is None:
@@ -214,7 +214,7 @@ async def restart_job(job_id: JobId = Depends(validate_job_id), user: UserRead =
 
 
 @router.post("/upload")
-async def upload_job(file: UploadFile, user: UserRead = Depends(current_active_user)) -> SubmitJobResponse:
+async def upload_job(file: UploadFile, user: UserRead | None = Depends(current_active_user)) -> SubmitJobResponse:
     """Upload a job specification file and execute it."""
     if not file:
         raise HTTPException(status_code=400, detail="No file provided for upload.")

--- a/backend/forecastbox/auth/users.py
+++ b/backend/forecastbox/auth/users.py
@@ -106,4 +106,4 @@ auth_backend = AuthenticationBackend(
 
 fastapi_users = FastAPIUsers[UserTable, pydantic.UUID4](get_user_manager, [auth_backend])
 
-current_active_user = fastapi_users.current_user(active=True)
+current_active_user = fastapi_users.current_user(active=True, optional=config.auth.passthrough)

--- a/backend/forecastbox/config.py
+++ b/backend/forecastbox/config.py
@@ -62,6 +62,8 @@ class AuthSettings(BaseModel):
     """JWT secret key for authentication."""
     oidc: OIDCSettings | None = None
     """OIDC settings for authentication, if applicable, if not given no route will be made."""
+    passthrough: bool = False
+    """If true, all authentication is ignored. Used for single-user standalone regime"""
 
     @model_validator(mode="after")
     def pass_to_secret(self):


### PR DESCRIPTION
new config.auth.passthrough: bool setting. Default False => current behaviour. But if True, changes the `get_active_user` method to allow for returning None. The execute methods should be happy with None user, and admin methods were changed to allow for None in case the config.auth.passthrough is True

the fiab.sh bootstrap script sets the passthrough=True, as it is intended for the single-user standalone local regime

the ultimate effect is that the `Login` option remains in the UI, but is not necessary anymore. We can make another PR to hide the element based on some parameter, though at the moment I have no idea how