### PR TITLE
[backend] multiple fixes for local mode

### DIFF
--- a/backend/forecastbox/api/routers/auth.py
+++ b/backend/forecastbox/api/routers/auth.py
@@ -56,4 +56,5 @@ router.include_router(
     tags=["auth"],
 )
 # Password reset/verify/email optional
+# TODO we would like to somehow connect this with config.auth.passthrough, instead of hotfixing via middleware in entrypoint.py
 router.include_router(fastapi_users.get_users_router(UserRead, UserUpdate), prefix="/users", tags=["users"])

--- a/backend/forecastbox/entrypoint.py
+++ b/backend/forecastbox/entrypoint.py
@@ -90,6 +90,17 @@ async def add_process_time_header(request: Request, call_next):
     return response
 
 
+@app.middleware("http")
+async def circumvent_auth(request: Request, call_next):
+    # TODO this is a hotfix, we'd instead like to fix properly in api/routers/auth.py
+    if request.url.path == "/api/v1/users/me" and config.auth.passthrough:
+        from starlette.responses import JSONResponse
+
+        return JSONResponse({})
+    else:
+        return await call_next(request)
+
+
 @dataclass
 class StatusResponse:
     """

--- a/backend/forecastbox/products/plots/maps.py
+++ b/backend/forecastbox/products/plots/maps.py
@@ -78,6 +78,7 @@ def quickplot(fields: ekd.FieldList, groupby: str = None, subplot_title: str = N
     from earthkit.plots.utils import iter_utils
     from earthkit.plots.components import layouts
     from earthkit.plots.schemas import schema
+    from earthkit.plots import Figure  # NOTE we need to import again to mask the possible Any
 
     if not isinstance(fields, ekd.FieldList):
         fields = ekd.FieldList.from_fields(fields)


### PR DESCRIPTION
- passthrough for auth wasnt working fully, as the users/me route didnt respect the config value, and frontend expected it to return
  200. We hotfix via middleware for now

- model downloads were not respecting redirects, thus allowing a 404

- model download failures were unretrievable from status, and model deletes were not robust

- plotting could fail in cases when plots werent installed in serializing venv