### PR TITLE
[ci] bigtest opendata reading

### DIFF
--- a/.github/workflows/bigtest.yml
+++ b/.github/workflows/bigtest.yml
@@ -23,5 +23,8 @@ jobs:
       - run: |
           set -euo pipefail
           cd backend
+          # TODO dont execute in `backend` -- that causes forecastbox module to be twice on pythonpath!
+          # Because of that, we need to create the static directory:
+          mkdir forecastbox/static && touch forecastbox/static/__init__.py
           mkdir /tmp/tmpFiabHome # we want a clean env for install
-          FIAB_ROOT=/tmp/tmpFiabHome ENTRYPOINT=scripts.bigtest ./fiab.sh
+          FIAB_LOGSTDOUT=yea FIAB_ROOT=/tmp/tmpFiabHome ENTRYPOINT=scripts.bigtest ./fiab.sh

--- a/backend/fiab.sh
+++ b/backend/fiab.sh
@@ -85,6 +85,7 @@ maybeCreateVenv() {
 	fi
 
     if [ "$FIAB_DEV" == 'yea' ] ; then
+        export EARTHKIT_DATA_CACHE_POLICY=user # TODO use this in both regimes, but manage it!
         uv pip install --prerelease=allow --upgrade -e .[test]
     else
         uv pip install --prerelease=allow --upgrade pproc@git+https://github.com/ecmwf/pproc earthkit-workflows-pproc@git+https://github.com/ecmwf/earthkit-workflows-pproc 'git+https://github.com/ecmwf/anemoi-plugins-ecmwf#subdirectory=inference[opendata]' 'forecast-in-a-box[plots,webmars,test]>=0.2.2' # TODO remove prerelease once bin wheels stable, remove pproc and ekw-pproc once published

--- a/backend/fiab.sh
+++ b/backend/fiab.sh
@@ -87,7 +87,7 @@ maybeCreateVenv() {
     if [ "$FIAB_DEV" == 'yea' ] ; then
         uv pip install --prerelease=allow --upgrade -e .[test]
     else
-        uv pip install --prerelease=allow --upgrade pproc@git+https://github.com/ecmwf/pproc earthkit-workflows-pproc@git+https://github.com/ecmwf/earthkit-workflows-pproc 'forecast-in-a-box[plots,webmars]>=0.1.0' # TODO remove prerelease once bin wheels stable, remove pproc and ekw-pproc once published
+        uv pip install --prerelease=allow --upgrade pproc@git+https://github.com/ecmwf/pproc earthkit-workflows-pproc@git+https://github.com/ecmwf/earthkit-workflows-pproc 'git+https://github.com/ecmwf/anemoi-plugins-ecmwf#subdirectory=inference[opendata]' 'forecast-in-a-box[plots,webmars,test]>=0.2.2' # TODO remove prerelease once bin wheels stable, remove pproc and ekw-pproc once published
         export fiab__auth__passthrough=True # NOTE we dont passthrough in `dev` mode as we use it to run strict tests
     fi
 }

--- a/backend/forecastbox/api/routers/gateway.py
+++ b/backend/forecastbox/api/routers/gateway.py
@@ -14,9 +14,10 @@ import os
 import select
 import subprocess
 from dataclasses import dataclass
-from multiprocessing import Process, get_context
+from multiprocessing import Process
 from tempfile import TemporaryDirectory
 
+import cascade.executor.platform as cascade_platform
 import cascade.gateway.api
 import cascade.gateway.client
 from fastapi import APIRouter, HTTPException, Request
@@ -92,7 +93,7 @@ async def start_gateway() -> str:
     logs_directory = None if os.getenv("FIAB_LOGSTDOUT", "nay") == "yea" else Globals.logs_directory.name
     # TODO for some reason changes to os.environ were *not* visible by the child process! Investigate and re-enable:
     # export_recursive(config.model_dump(), config.model_config["env_nested_delimiter"], config.model_config["env_prefix"])
-    process = get_context("forkserver").Process(target=launch_cascade, args=(log_path, logs_directory))
+    process = cascade_platform.get_mp_ctx("gateway").Process(target=launch_cascade, args=(log_path, logs_directory))
     process.start()
     Globals.gateway = GatewayProcess(log_path=log_path, process=process)
     logger.debug(f"spawned new gateway process with pid {process.pid} and logs at {log_path}")

--- a/backend/forecastbox/standalone/entrypoint.py
+++ b/backend/forecastbox/standalone/entrypoint.py
@@ -73,7 +73,7 @@ def launch_api():
         pass  # no need to spew stacktrace to log
 
 
-def launch_cascade(log_path: str, log_base: str):
+def launch_cascade(log_path: str|None, log_base: str|None):
     config = FIABConfig()
     # TODO this configuration of log_path is very unsystematic, improve!
     # TODO we may want this to propagate to controller/executors -- but stripped the gateway.txt etc

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "aiosqlite",
   "anemoi-inference>=0.4.10",
   "cloudpickle",
-  "earthkit-workflows>=0.4.4",
+  "earthkit-workflows>=0.4.5",
   "earthkit-workflows-anemoi>=0.3.1",
   "earthkit-workflows-pproc",
   "fastapi",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "aiosqlite",
   "anemoi-inference>=0.4.10",
   "cloudpickle",
-  "earthkit-workflows>=0.4.3",
+  "earthkit-workflows>=0.4.4",
   "earthkit-workflows-anemoi>=0.3.1",
   "earthkit-workflows-pproc",
   "fastapi",

--- a/backend/scripts/bigtest.py
+++ b/backend/scripts/bigtest.py
@@ -12,6 +12,8 @@ from forecastbox.standalone.entrypoint import launch_all
 
 logger = logging.getLogger("forecastbox.bigtest")
 
+is_mars = os.getenv("FIAB_BIGTEST_ISMARS", "nay") == "yea"
+
 def get_quickstart_job() -> dict:
     today = (dt.date.today() - dt.timedelta(2)).strftime("%Y%m%d")
     return {
@@ -22,7 +24,7 @@ def get_quickstart_job() -> dict:
                 "date": today + "T00",
                 "lead_time": 42,
                 "ensemble_members": 1,
-                "entries": {},
+                "entries": {} if is_mars else { 'input_preference': 'opendata', },
             },
             "products": [
                 {


### PR DESCRIPTION
Switches bigtest to read opendata

Adds options to allow everything-to-stdout logging

Adds earthkit caching when launching in dev mode

Switches to cascade_platform mp ctx so that we `spawn` on macos -- which should be safer