### PR TITLE
[backend] cleanup before start

### DIFF
--- a/backend/fiab.sh
+++ b/backend/fiab.sh
@@ -67,7 +67,7 @@ maybeInstallPython() {
     # NOTE somehow this regexp isn't portable, but we dont really need the full binary path
     MAYBE_PYTHON="$(uv python list | grep python3.11 || :)"
 	if [ -z "$MAYBE_PYTHON" ] ; then
-		uv python install 3.11 # TODO install to fiab home instead?
+		uv python install --python-preference only-managed 3.11 # TODO install to fiab home instead?
 	fi
     # export UV_PY="$MAYBE_PYTHON"
     export UV_PY="python3.11"
@@ -80,7 +80,7 @@ maybeCreateVenv() {
 		# TODO check packages
 		source "${VENV}/bin/activate" # or export the paths?
 	else
-		uv venv -p "$UV_PY" "$VENV"
+		uv venv -p "$UV_PY" --python-preference only-managed "$VENV"
 		source "${VENV}/bin/activate" # or export the paths?
 	fi
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
   "multiolib==2.6.1.dev20250613",     # to bring in the binary stack eagerly, TODO unpin once stable
   "orjson",
   "pproc",
+  "psutil",
   "pydantic-settings",
   "pyrsistent",
   "python-multipart",


### PR DESCRIPTION
if previous exit of fiab was somehow partial, ie, some processes were left hanging, we may get some port clashes or needless resource overconsumption

to combat that, we add a startup check & stop of processes from previous runs. This is done by checking that the same executable as the current one was used to start them -- should be reliable & safe

I dont add it to general purpose start method, but instead to the standalone-entrypoint -- this way, various scripts and unit tests avoid it
