### PR TITLE
[backend] add mir-python dep

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -37,7 +37,8 @@ dependencies = [
   "httpx<1",
   "httpx-oauth",
   "jinja2",
-  "multiolib==2.6.1.dev20250613",     # to bring in the binary stack eagerly, TODO unpin once stable
+  "mir-python==1.27.1.dev20250627",   # to bring in the binary stack eagerly, TODO unpin once stable
+  "multiolib==2.6.1.dev20250627",     # to bring in the binary stack eagerly, TODO unpin once stable
   "orjson",
   "pproc",
   "psutil",


### PR DESCRIPTION
otherwise installing mir-python from checkpoint causes dep clash, given exact pinning