### PR TITLE
[backend] upgrade python to 3.12 and bump ekw

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "aiosqlite",
   "anemoi-inference>=0.4.10",
   "cloudpickle",
-  "earthkit-workflows>=0.4.5",
+  "earthkit-workflows>=0.4.6",
   "earthkit-workflows-anemoi>=0.3.1",
   "earthkit-workflows-pproc",
   "fastapi",


### PR DESCRIPTION
we face issues when loading checkpoints from 3.12

ekw bump includes fix for uv-prereleases if declared by tasks

also fixing the uv cache pruning check
