### PR TITLE
[backend] add max concurrent jobs

### DIFF
--- a/backend/forecastbox/api/routers/gateway.py
+++ b/backend/forecastbox/api/routers/gateway.py
@@ -91,9 +91,10 @@ async def start_gateway() -> str:
     now = dt.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     log_path = None if os.getenv("FIAB_LOGSTDOUT", "nay") == "yea" else f"{Globals.logs_directory.name}/gateway.{now}.txt"
     logs_directory = None if os.getenv("FIAB_LOGSTDOUT", "nay") == "yea" else Globals.logs_directory.name
+    max_concurrent_jobs = config.cascade.max_concurrent_jobs
     # TODO for some reason changes to os.environ were *not* visible by the child process! Investigate and re-enable:
     # export_recursive(config.model_dump(), config.model_config["env_nested_delimiter"], config.model_config["env_prefix"])
-    process = cascade_platform.get_mp_ctx("gateway").Process(target=launch_cascade, args=(log_path, logs_directory))
+    process = cascade_platform.get_mp_ctx("gateway").Process(target=launch_cascade, args=(log_path, logs_directory, max_concurrent_jobs))
     process.start()
     Globals.gateway = GatewayProcess(log_path=log_path, process=process)
     logger.debug(f"spawned new gateway process with pid {process.pid} and logs at {log_path}")

--- a/backend/forecastbox/config.py
+++ b/backend/forecastbox/config.py
@@ -141,6 +141,8 @@ class CascadeSettings(BaseModel):
     """Maximum size of the log collection for Cascade."""
     venv_temp_dir: str = "/tmp"
     """Temporary directory for virtual environments."""
+    max_concurrent_jobs: int|None = 1
+    """If more jobs submitted at a given time, all but this many wait in a queue"""
 
     def validate_runtime(self) -> list[str]:
         errors = []

--- a/backend/forecastbox/db/job.py
+++ b/backend/forecastbox/db/job.py
@@ -25,8 +25,7 @@ async def insert_one(job_id: JobId, error: str | None, user_id: str | None, grap
     ref_time = dt.datetime.now()
     entity = JobRecord(
         job_id=job_id,
-        # NOTE we insert with running instead of submitted due to linearization of submit-insert
-        status="running" if not error else "failed",
+        status="submitted" if not error else "failed",
         created_at=ref_time,
         updated_at=ref_time,
         created_by=user_id,

--- a/backend/forecastbox/standalone/entrypoint.py
+++ b/backend/forecastbox/standalone/entrypoint.py
@@ -101,7 +101,7 @@ def launch_api():
         pass  # no need to spew stacktrace to log
 
 
-def launch_cascade(log_path: str|None, log_base: str|None):
+def launch_cascade(log_path: str|None, log_base: str|None, max_concurrent_jobs: int|None):
     config = FIABConfig()
     # TODO this configuration of log_path is very unsystematic, improve!
     # TODO we may want this to propagate to controller/executors -- but stripped the gateway.txt etc
@@ -109,7 +109,7 @@ def launch_cascade(log_path: str|None, log_base: str|None):
     from cascade.gateway.server import serve
 
     try:
-        serve(config.cascade.cascade_url, log_base)
+        serve(url=config.cascade.cascade_url, log_base=log_base, max_jobs=max_concurrent_jobs)
     except KeyboardInterrupt:
         pass  # no need to spew stacktrace to log
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "aiosqlite",
   "anemoi-inference>=0.7.1",
   "cloudpickle",
-  "earthkit-workflows>=0.4.6",
+  "earthkit-workflows>=0.4.7",
   "earthkit-workflows-anemoi>=0.3.4",
   "earthkit-workflows-pproc",
   "fastapi",

--- a/backend/tests/integration/test_submit_job.py
+++ b/backend/tests/integration/test_submit_job.py
@@ -1,4 +1,5 @@
 import io
+import os
 import time
 import zipfile
 
@@ -15,7 +16,7 @@ def _ensure_completed(backend_client, job_id):
         assert response.is_success
         status = response.json()["progresses"][job_id]["status"]
         # TODO parse response with corresponding class, define a method `not_failed` instead
-        assert status in {"submitting", "submitted", "running", "completed"}
+        assert status in {"submitted", "running", "completed"}
         if status == "completed":
             break
         time.sleep(0.5)
@@ -60,7 +61,7 @@ def test_submit_job(backend_client_with_auth):
     with zipfile.ZipFile(io.BytesIO(logs), "r") as zf:
         # NOTE dbEntity, gwState, gateway, controller, host0, host0.dsr, host0.shm, host0.w1, host0.w2
         expected_log_count = 9
-        assert len(zf.namelist()) == expected_log_count
+        assert len(zf.namelist()) == expected_log_count or os.getenv("FIAB_LOGSTDOUT", "nay") == "yea"
 
     # requests job
     def do_request() -> str:


### PR DESCRIPTION
recent earthkit-workflows supports max jobs param, which we expose in config and default to 1. We extend the job progress api with the submitted state, to clarify that the job is still in the waiting queue

requires https://github.com/ecmwf/earthkit-workflows/pull/141 merge and release

closes https://github.com/ecmwf/forecast-in-a-box/issues/115