### PR TITLE
[backend] persist job progress in sqlite

### DIFF
--- a/backend/forecastbox/job.db
+++ b/backend/forecastbox/job.db
@@ -1,0 +1,1 @@
+/home/vojta/.fiab/job.db

--- a/backend/forecastbox/schemas/job.py
+++ b/backend/forecastbox/schemas/job.py
@@ -15,3 +15,4 @@ class JobRecord(Base):
     created_by = Column(String(255), nullable=True)
     outputs = Column(JSON, nullable=True)
     error = Column(String(255), nullable=True)
+    progress = Column(String(255), nullable=True)


### PR DESCRIPTION
1. Creates a new field in JobRecord sqlite local db to persist last known progress state
2. Refactors the `update_and_get_progress` to utilize it
3. (In progress) adds migration scripts