### PR TITLE
[github] add timeouts to all workflows

### DIFF
--- a/.github/workflows/bigtest.yml
+++ b/.github/workflows/bigtest.yml
@@ -15,9 +15,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        arch_type: [ARM64] # [ARM64, X64]
-        python_version: ["3.11"] # ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        arch_type: [ARM64]
+        python_version: ["3.11"] # replace with 3.14 in ~26/01, once all wheels etc available
     runs-on: [self-hosted, macOS, "${{ matrix.arch_type }}"]
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - run: |

--- a/.github/workflows/build-containers-eccr.yml
+++ b/.github/workflows/build-containers-eccr.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         image:

--- a/.github/workflows/build-containers-ghcr.yml
+++ b/.github/workflows/build-containers-ghcr.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         image:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,8 +19,10 @@ on:
         default: true
 
 jobs:
+  # TODO add a prerequisite step `bigtest.yml` workflow, but make sure its reliable first
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        arch_type: [ARM64, X64]
+        arch_type: [ARM64] # , X64 NOTE: we dont run on X64 anymore as it does not support eg newer pytorches
         python_version: ["3.11", "3.12", "3.13"]
     runs-on: [self-hosted, macOS, "${{ matrix.arch_type }}"]
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - run: |


### PR DESCRIPTION
adding github workflow timeouts all over -- we dont want to sit on agents for 6 hours in case something goes wrong