### PR TITLE
Backend API to support new update functionality

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,8 +19,11 @@ repos:
   - id: trailing-whitespace # Trailing whitespace checker
   - id: no-commit-to-branch # Prevent committing to main / master
   - id: check-added-large-files # Check for large files added to git
-    exclude: '.*uv.lock'
-    exclude: '.*pylock.toml'
+    exclude: |
+      (?x)(
+        .*uv.lock|
+        .*pylock.toml
+      )
   - id: check-merge-conflict # Check for files that contain merge conflict
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0  # Use the ref you want to point at

--- a/backend/forecastbox/api/updates.py
+++ b/backend/forecastbox/api/updates.py
@@ -1,0 +1,81 @@
+import dataclasses
+import logging
+from datetime import datetime
+
+import httpx
+from forecastbox.config import fiab_home
+
+logger = logging.getLogger(__name__)
+
+@dataclasses.dataclass(frozen=True)
+class Release:
+    major: int
+    minor: int
+    patch: int
+
+    @classmethod
+    def from_string(cls, release_string: str) -> "Release":
+        cleaned_string = release_string.lstrip("vd")
+        parts = list(map(int, cleaned_string.split(".")))
+        if len(parts) != 3:
+            raise ValueError(f"Invalid release string format: {release_string}")
+        return cls(major=parts[0], minor=parts[1], patch=parts[2])
+
+    def __str__(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+async def get_most_recent_release() -> Release:
+    async with httpx.AsyncClient() as client:
+        response = await client.get("https://api.github.com/repos/ecmwf/forecast-in-a-box/releases?per_page=1")
+        response.raise_for_status()
+        releases = response.json()
+        if not releases:
+            raise ValueError("No releases found on GitHub.")
+        if "tag_name" not in releases[0]:
+            logger.error(f"mangled release: {releases[0]}")
+            raise ValueError("Recent release is missing tag information")
+        latest_release_tag = releases[0]["tag_name"]
+        return Release.from_string(latest_release_tag)
+
+def get_lock_timestamp() -> str:
+    lock_file_path = fiab_home / "pylock.toml.timestamp"
+    if not lock_file_path.is_file():
+        return ""
+    return lock_file_path.read_text().strip()
+
+def get_local_release() -> tuple[datetime, Release]:
+    timestamp_str = get_lock_timestamp()
+    if not timestamp_str:
+        raise ValueError("pylock.toml.timestamp file is empty or does not exist.")
+
+    head, *lines = timestamp_str.splitlines()
+    if lines:
+        raise ValueError("Invalid format in pylock.toml.timestamp: expected exactly one line.")
+
+    parts = head.split(":")
+    if len(parts) != 2:
+        raise ValueError("Invalid format in pylock.toml.timestamp: expected 'datetime:release_string'.")
+    dt_str, release_str = parts
+
+    try:
+        dt_obj = datetime.fromtimestamp(int(dt_str))
+    except Exception as e:
+        raise ValueError(f"Failure to parse datetime. {dt_str[:32]}, {repr(e)}")
+    release_obj = Release.from_string(release_str)
+    return dt_obj, release_obj
+
+async def get_pylock(release: Release) -> str:
+    url = f"https://github.com/ecmwf/forecast-in-a-box/releases/download/v{release}/pylock.toml"
+    async with httpx.AsyncClient() as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        return response.text
+
+def save_pylock(pylock: str, release: Release) -> None:
+    pylock_file_path = fiab_home / "pylock.toml"
+    timestamp_file_path = fiab_home / "pylock.toml.timestamp"
+
+    fiab_home.mkdir(parents=True, exist_ok=True)
+
+    pylock_file_path.write_text(pylock)
+    timestamp_file_path.write_text(f"{int(datetime.now().timestamp())}:v{release}")

--- a/backend/forecastbox/config.py
+++ b/backend/forecastbox/config.py
@@ -17,7 +17,7 @@ from cascade.low.func import pydantic_recursive_collect
 from pydantic import BaseModel, Field, SecretStr, model_validator
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict, TomlConfigSettingsSource
 
-fiab_home = Path.home() / ".fiab"
+fiab_home = Path(os.environ['FIAB_ROOT']) if 'FIAB_ROOT' in os.environ else (Path.home() / ".fiab")
 logger = logging.getLogger(__name__)
 
 

--- a/backend/forecastbox/db/schedule.py
+++ b/backend/forecastbox/db/schedule.py
@@ -14,8 +14,8 @@ from typing import Iterable
 
 from forecastbox.config import config
 from forecastbox.db.core import addAndCommit, dbRetry, executeAndCommit, queryCount
-from forecastbox.schemas.schedule import Base, ScheduleDefinition, ScheduleNext, ScheduleRun
 from forecastbox.schemas.job import JobRecord
+from forecastbox.schemas.schedule import Base, ScheduleDefinition, ScheduleNext, ScheduleRun
 from sqlalchemy import delete, func, select, update
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
@@ -278,4 +278,3 @@ async def select_runs_count(
             return await queryCount(query, session)
 
     return await dbRetry(function)
-

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import socketserver
 import tempfile
@@ -68,6 +69,8 @@ def backend_client() -> Generator[httpx.Client, None, None]:
     client = None
     try:
         td = tempfile.TemporaryDirectory()
+        os.environ['FIAB_ROOT'] = td.name
+        (pathlib.Path(td.name) / "pylock.toml.timestamp").write_text("1761908420:d0.0.1")
         config = FIABConfig()
         config.api.uvicorn_port = 30645
         config.cascade.cascade_url = "tcp://localhost:30644"

--- a/backend/tests/integration/test_admin_flows.py
+++ b/backend/tests/integration/test_admin_flows.py
@@ -1,3 +1,6 @@
+from forecastbox.api.routers.admin import GetReleaseStatusResponse
+from forecastbox.api.updates import Release
+
 from .utils import extract_auth_token_from_response, prepare_cookie_with_auth_token
 
 
@@ -30,6 +33,15 @@ def test_admin_flows(backend_client):
     assert response.is_success
     assert response.json()["email"] == "admin@somewhere.org"
 
+    # get release
+    response = backend_client.get("/admin/release")
+    assert response.is_success
+    release_status = GetReleaseStatusResponse(**response.json())
+    assert isinstance(release_status.local_release, Release)
+    assert isinstance(release_status.local_release_age_days, int)
+    assert isinstance(release_status.newest_available_release, Release)
+
+    # register
     headers = {"Content-Type": "application/json"}
     data = {"email": "user@somewhere.org", "password": "something"}
     response = backend_client.post("/auth/register", headers=headers, json=data)

--- a/backend/tests/integration/test_schedule.py
+++ b/backend/tests/integration/test_schedule.py
@@ -1,10 +1,8 @@
 from datetime import datetime as dt
-import uuid
 
 from cascade.low.builders import JobBuilder, TaskBuilder
 from forecastbox.api.types import (EnvironmentSpecification, ExecutionSpecification, RawCascadeJob,
                                    ScheduleSpecification, ScheduleUpdate)
-from forecastbox.db.schedule import insert_schedule_run, async_session_maker
 
 
 def test_schedule_crud(backend_client_with_auth):

--- a/backend/tests/unit/scheduling/test_schedule_runs.py
+++ b/backend/tests/unit/scheduling/test_schedule_runs.py
@@ -1,14 +1,15 @@
 
 import datetime as dt
 import uuid
-from unittest.mock import AsyncMock, patch
 from typing import cast
+from unittest.mock import AsyncMock, patch
 
 import pytest
-from forecastbox.api.routers.schedule import GetScheduleRunResponse, GetScheduleRunsResponse, get_schedule_runs
-from forecastbox.db.schedule import ScheduleId, ScheduleRun, JobRecord
-from forecastbox.schemas.user import UserRead
 from fastapi import HTTPException
+from forecastbox.api.routers.schedule import GetScheduleRunsResponse, get_schedule_runs
+from forecastbox.db.schedule import JobRecord, ScheduleRun
+from forecastbox.schemas.user import UserRead
+
 
 @pytest.fixture
 def mock_schedule_run_row():
@@ -104,8 +105,8 @@ async def test_get_schedule_runs_invalid_page_params(mock_user):
 
 @pytest.mark.asyncio
 async def test_get_schedule_runs_page_out_of_range(mock_schedule_run_row, mock_user):
-    with patch("forecastbox.api.routers.schedule.select_runs", AsyncMock(return_value=[])) as mock_select_runs, \
-         patch("forecastbox.api.routers.schedule.select_runs_count", AsyncMock(return_value=1)) as mock_select_runs_count:
+    with patch("forecastbox.api.routers.schedule.select_runs", AsyncMock(return_value=[])), \
+         patch("forecastbox.api.routers.schedule.select_runs_count", AsyncMock(return_value=1)):
 
         with pytest.raises(HTTPException) as exc_info:
             await get_schedule_runs(schedule_id="test_schedule_id", user=mock_user, page=2, page_size=1)

--- a/backend/tests/unit/test_updates.py
+++ b/backend/tests/unit/test_updates.py
@@ -1,0 +1,148 @@
+import json
+import re
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from forecastbox.api.updates import (Release, get_local_release, get_lock_timestamp, get_most_recent_release,
+                                     get_pylock, save_pylock)
+
+
+def test_release_from_string():
+    assert Release.from_string("1.2.3") == Release(1, 2, 3)
+    assert Release.from_string("v1.2.3") == Release(1, 2, 3)
+    assert Release.from_string("d1.2.3") == Release(1, 2, 3)
+    assert Release.from_string("10.20.30") == Release(10, 20, 30)
+
+def test_release_from_string_invalid():
+    with pytest.raises(ValueError):
+        Release.from_string("1.2")
+    with pytest.raises(ValueError):
+        Release.from_string("1.2.3.4")
+    with pytest.raises(ValueError):
+        Release.from_string("abc")
+
+@pytest_asyncio.fixture
+async def mock_httpx_client():
+    with patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+        yield mock_client
+
+@pytest.mark.asyncio
+async def test_get_most_recent_release(mock_httpx_client):
+    mock_response_json = '''
+    [{
+        "url":"https://api.github.com/repos/ecmwf/forecast-in-a-box/releases/257019467",
+        "assets_url":"https://api.github.com/repos/ecmwf/forecast-in-a-box/releases/257019467/assets",
+        "upload_url":"https://uploads.github.com/repos/ecmwf/forecast-in-a-box/releases/257019467/assets{?name,label}",
+        "html_url":"https://github.com/ecmwf/forecast-in-a-box/releases/tag/v0.3.9",
+        "id":257019467,
+        "author":{"login":"HCookie","id":48088699,"node_id":"MDQ6VXNlcjQ4ODA4ODY5OS","avatar_url":"https://avatars.githubusercontent.com/u/48088699?v=4","gravatar_id":"","url":"https://api.github.com/users/HCookie","html_url":"https://github.com/HCookie","followers_url":"https://api.github.com/users/HCookie/followers","following_url":"https://api.github.com/users/HCookie/following{/other_user}","gists_url":"https://api.github.com/users/HCookie/gists{/gist_id}","starred_url":"https://api.github.com/users/HCookie/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/HCookie/subscriptions","organizations_url":"https://api.github.com/users/HCookie/orgs","repos_url":"https://api.github.com/users/HCookie/repos","events_url":"https://api.github.com/users/HCookie/events{/privacy}","received_events_url":"https://api.github.com/users/HCookie/received_events","type":"User","user_view_type":"public","site_admin":false},
+        "node_id":"RE_kwDOL8XCIs4PUc5L","tag_name":"v0.3.9","target_commitish":"main","name":"v0.3.9","draft":false,"immutable":false,"prerelease":false,"created_at":"2025-10-24T14:17:21Z","updated_at":"2025-10-29T13:13:17Z","published_at":"2025-10-24T14:20:16Z","assets":[],"tarball_url":"https://api.github.com/repos/ecmwf/forecast-in-a-box/tarball/v0.3.9","zipball_url":"https://api.github.com/repos/ecmwf/forecast-in-a-box/zipball/v0.3.9","body":"Update taglines"
+    }]
+    '''
+    mock_response_obj = MagicMock()
+    mock_response_obj.json.return_value = json.loads(mock_response_json)
+    mock_response_obj.raise_for_status.return_value = None
+    mock_httpx_client.get.return_value = mock_response_obj
+    assert await get_most_recent_release() == Release(0, 3, 9)
+
+@pytest.mark.asyncio
+async def test_get_most_recent_release_no_releases(mock_httpx_client):
+    mock_response_obj = MagicMock()
+    mock_response_obj.json.return_value = []
+    mock_response_obj.raise_for_status.return_value = None
+    mock_httpx_client.get.return_value = mock_response_obj
+    with pytest.raises(ValueError, match="No releases found on GitHub."):
+        await get_most_recent_release()
+
+@patch("forecastbox.api.updates.fiab_home", new=Path("/tmp/fiab_test"))
+@patch("pathlib.Path.is_file")
+@patch("pathlib.Path.read_text")
+def test_get_lock_timestamp(mock_read_text, mock_is_file):
+    # Test case: file exists and contains content
+    mock_is_file.return_value = True
+    mock_read_text.return_value = "1761908420:v0.1.0\n"
+    assert get_lock_timestamp() == "1761908420:v0.1.0"
+
+    # Test case: file does not exist
+    mock_is_file.return_value = False
+    assert get_lock_timestamp() == ""
+
+    # Test case: file exists but is empty
+    mock_is_file.return_value = True
+    mock_read_text.return_value = "\n"
+    assert get_lock_timestamp() == ""
+
+@patch("forecastbox.api.updates.get_lock_timestamp")
+def test_get_local_release(mock_get_lock_timestamp):
+    # Test case: valid timestamp and release string
+    mock_get_lock_timestamp.return_value = "1761908420:v0.1.0"
+    dt, release = get_local_release()
+    assert dt == datetime.fromtimestamp(int("1761908420"))
+    assert release == Release(0, 1, 0)
+
+    # Test case: empty file (get_lock_timestamp returns empty string)
+    mock_get_lock_timestamp.return_value = ""
+    with pytest.raises(ValueError, match="pylock.toml.timestamp file is empty or does not exist."):
+        get_local_release()
+
+    # Test case: multiple lines in file
+    mock_get_lock_timestamp.return_value = "line1\nline2"
+    with pytest.raises(ValueError, match="Invalid format in pylock.toml.timestamp: expected exactly one line."):
+        get_local_release()
+
+    # Test case: invalid format (missing colon)
+    mock_get_lock_timestamp.return_value = "1761908420_v0.1.0" # No colon at all
+    with pytest.raises(ValueError, match="Invalid format in pylock.toml.timestamp: expected 'datetime:release_string'."):
+        get_local_release()
+
+    # Test case: invalid release string
+    mock_get_lock_timestamp.return_value = "1761908420:invalid_release"
+    with pytest.raises(ValueError, match=re.escape("invalid literal for int() with base 10: 'invalid_release'")):
+        get_local_release()
+
+@pytest.mark.asyncio
+async def test_get_pylock(mock_httpx_client):
+    mock_pylock_content = "[tool.uv]\npython = \"3.12\"\n"
+    mock_response_obj = MagicMock()
+    mock_response_obj.text = mock_pylock_content
+    mock_response_obj.raise_for_status.return_value = None
+    mock_httpx_client.get.return_value = mock_response_obj
+
+    test_release = Release(1, 2, 3)
+    expected_url = "https://github.com/ecmwf/forecast-in-a-box/releases/download/v1.2.3/pylock.toml"
+
+    content = await get_pylock(test_release)
+
+    mock_httpx_client.get.assert_called_once_with(expected_url)
+    assert content == mock_pylock_content
+
+@patch("forecastbox.api.updates.fiab_home")
+def test_save_pylock(mock_fiab_home):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        temp_path = Path(tmpdir)
+
+        # Configure the mock_fiab_home to behave like temp_path
+        mock_fiab_home.__truediv__.side_effect = lambda x: temp_path / x
+        mock_fiab_home.mkdir.side_effect = temp_path.mkdir
+
+        test_pylock_content = "[tool.uv]\npython = \"3.12\"\n"
+        test_release = Release(0, 2, 0)
+
+        save_pylock(test_pylock_content, test_release)
+
+        pylock_file = temp_path / "pylock.toml"
+        timestamp_file = temp_path / "pylock.toml.timestamp"
+
+        assert pylock_file.is_file()
+        assert timestamp_file.is_file()
+        assert pylock_file.read_text() == test_pylock_content
+
+        dt, release = get_local_release()
+        assert release == test_release
+        assert isinstance(dt, datetime)

--- a/scripts/fiab.sh
+++ b/scripts/fiab.sh
@@ -105,7 +105,7 @@ maybeDownloadLock() {
         >&2 echo "not found uv.lock in $LOCK, downloading"
         >&2 echo "will download uv lock for release $selectedRelease"
         lock_url=https://raw.githubusercontent.com/ecmwf/forecast-in-a-box/refs/$FIAB_GITHUB_FROM/$selectedRelease/install/pylock.toml
-		curl -LsSf $lock_url > "$LOCK"
+        curl -LsSf $lock_url > "$LOCK"
         >&2 echo "$(date +%s):$(echo $selectedRelease | tr -d 'v')" > $LOCK.timestamp
     fi
 }


### PR DESCRIPTION
Just two new endpoints, `get /update` and `post /update?tag`, where the `get` gives how old is the current version, what is the current version, and what is the most recent version, and the `post` updates to the newest version / explicitly specified version

The update is just replacement of the pylock.toml file, so on the _next_ start of the app, a pip install will actually do the update