### PR TITLE
Update precommit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,82 +1,27 @@
 repos:
-# Empty notebooks
-- repo: local
-  hooks:
-  - id: clear-notebooks-output
-    name: clear-notebooks-output
-    files: tools/.*\.ipynb$
-    stages: [pre-commit]
-    language: python
-    entry: jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace
-    additional_dependencies: [jupyter]
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v6.0.0
   hooks:
   - id: check-yaml # Check YAML files for syntax errors only
     args: [--unsafe, --allow-multiple-documents]
-  - id: debug-statements # Check for debugger imports and py37+ breakpoint()
-  - id: end-of-file-fixer # Ensure files end in a newline
-  - id: trailing-whitespace # Trailing whitespace checker
   - id: no-commit-to-branch # Prevent committing to main / master
-  - id: check-added-large-files # Check for large files added to git
+  - id: check-added-large-files
     exclude: |
       (?x)(
         .*uv.lock|
         .*pylock.toml
       )
   - id: check-merge-conflict # Check for files that contain merge conflict
--   repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.10.0  # Use the ref you want to point at
-    hooks:
-    -   id: python-use-type-annotations # Check for missing type annotations
-    -   id: python-check-blanket-noqa # Check for # noqa: all
-    -   id: python-no-log-warn # Check for log.warn
-- repo: https://github.com/pycqa/isort
-  rev: 6.0.1
-  hooks:
-  - id: isort
-    args:
-    - -l 120
-    - --profile black
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.12.2
   hooks:
-  - id: ruff
+  - id: ruff # better black/flake
+    files: ^backend/
     args:
-    - --line-length=120
     - --fix
     - --exit-non-zero-on-fix
-    - --exclude=docs/**/*_.py
-- repo: https://github.com/sphinx-contrib/sphinx-lint
-  rev: v1.0.0
-  hooks:
-  - id: sphinx-lint
-# For now, we use it. But it does not support a lot of sphinx features
-- repo: https://github.com/dzhu/rstfmt
-  rev: v0.0.14
-  hooks:
-  - id: rstfmt
-    exclude: '(cli|schemas)/.*' # Because we use argparse and pydantic sphinx directives
-- repo: https://github.com/b8raoult/pre-commit-docconvert
-  rev: "0.1.5"
-  hooks:
-  - id: docconvert
-    args: ["numpy"]
-- repo: https://github.com/tox-dev/pyproject-fmt
-  rev: "v2.6.0"
-  hooks:
-  - id: pyproject-fmt
--   repo: https://github.com/jshwi/docsig # Check docstrings against function sig
-    rev: v0.70.0
-    hooks:
-    -   id: docsig
-        args:
-        - --ignore-no-params # Allow docstrings without parameters
-        - --check-dunders    # Check dunder methods
-        - --check-overridden # Check overridden methods
-        - --check-protected  # Check protected methods
-        - --check-class      # Check class docstrings
-        - --disable=SIG101,SIG102     # Disable empty docstrings
+  - id: ruff-format # better isort
+    files: ^backend/
 ci:
   autoupdate_schedule: monthly
   autoupdate_commit_msg: "chore(deps): pre-commit.ci autoupdate"

--- a/backend/forecastbox/api/routers/admin.py
+++ b/backend/forecastbox/api/routers/admin.py
@@ -49,14 +49,13 @@ class ExposedSettings(BaseModel):
     api: BackendAPISettings = config.api
     cascade: CascadeSettings = config.cascade
 
-
     def to_rjsf(self) -> FormDefinition:
         """Convert settings to RJSF form definition"""
         fields, required = from_pydantic(self)
         return FormDefinition(
-            title = 'Settings',
-            fields = fields,
-            required = required,
+            title="Settings",
+            fields=fields,
+            required=required,
             formData=self.model_dump(),
         )
 
@@ -110,6 +109,7 @@ async def get_settings(admin=Depends(get_admin_user)) -> ExportedSchemas:
 @router.patch("/settings", response_class=HTMLResponse)
 async def update_settings(settings: ExposedSettings, admin=Depends(get_admin_user)) -> HTMLResponse:
     """Update settings"""
+
     def update(old: BaseModel, new: BaseModel):
         for key, val in new.model_dump().items():
             setattr(old, key, val)
@@ -131,7 +131,7 @@ async def get_users(admin=Depends(get_admin_user)) -> list[UserRead]:
     """Get all users"""
     async with async_session_maker() as session:
         query = select(UserTable)
-        return (await session.execute(query)).unique().scalars().all() # type: ignore[invalid-return-type] # NOTE db...
+        return (await session.execute(query)).unique().scalars().all()  # type: ignore[invalid-return-type] # NOTE db...
 
 
 @router.get("/users/{user_id}", response_model=UserRead)

--- a/backend/forecastbox/api/routers/execution.py
+++ b/backend/forecastbox/api/routers/execution.py
@@ -30,7 +30,7 @@ LOG = logging.getLogger(__name__)
 
 
 @router.post("/visualise")
-async def get_graph_visualise(spec: ExecutionSpecification, options: VisualisationOptions|None = None) -> HTMLResponse:
+async def get_graph_visualise(spec: ExecutionSpecification, options: VisualisationOptions | None = None) -> HTMLResponse:
     """Get an HTML visualisation of the product graph.
 
     Parameters
@@ -100,9 +100,7 @@ async def get_graph_download(spec: ExecutionSpecification) -> str:
 
 
 @router.post("/execute")
-async def execute_api(
-    spec: ExecutionSpecification, user: UserRead | None = Depends(current_active_user)
-) -> SubmitJobResponse:
+async def execute_api(spec: ExecutionSpecification, user: UserRead | None = Depends(current_active_user)) -> SubmitJobResponse:
     """Execute a job based on the provided execution specification.
 
     Parameters

--- a/backend/forecastbox/api/routers/gateway.py
+++ b/backend/forecastbox/api/routers/gateway.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class GatewayProcess:
-    log_path: str|None
+    log_path: str | None
     process: Process
 
     def cleanup(self) -> None:
@@ -123,9 +123,7 @@ async def stream_logs(request: Request) -> EventSourceResponse:
     async def event_generator():
         # NOTE consider rewriting to aiofile, eg https://github.com/kuralabs/logserver/blob/master/server/server.py
 
-        pipe = subprocess.Popen(
-            ["tail", "-F", Globals.gateway.log_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
-        )
+        pipe = subprocess.Popen(["tail", "-F", Globals.gateway.log_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
         poller = select.poll()
         poller.register(pipe.stdout)
 

--- a/backend/forecastbox/api/routers/model.py
+++ b/backend/forecastbox/api/routers/model.py
@@ -23,8 +23,7 @@ import httpx
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from forecastbox.api.utils import get_model_path
 from forecastbox.config import config
-from forecastbox.db.model import (delete_download, finish_edit, get_download, get_edit, start_download, start_editing,
-                                  update_progress)
+from forecastbox.db.model import delete_download, finish_edit, get_download, get_edit, start_download, start_editing, update_progress
 from forecastbox.models.metadata import ControlMetadata, set_control_metadata
 from forecastbox.models.model import ModelInfo, get_model, model_info
 from forecastbox.rjsf import ExportedSchemas
@@ -75,21 +74,21 @@ def download2response(model_download: ModelDownload | None) -> DownloadResponse:
     if model_download:
         if model_download.error:
             return DownloadResponse(
-                download_id=model_download.model_id, # type: ignore[invalid-argument-type] # NOTE sqlalchemy quirk
+                download_id=model_download.model_id,  # type: ignore[invalid-argument-type] # NOTE sqlalchemy quirk
                 message="Download failed. To retry, call delete_model first",
                 status="errored",
                 progress=0.0,
-                error=model_download.error, # type: ignore[invalid-argument-type] # NOTE sqlalchemy quirk
+                error=model_download.error,  # type: ignore[invalid-argument-type] # NOTE sqlalchemy quirk
             )
         if model_download.progress >= 100:
             return DownloadResponse(
-                download_id=model_download.model_id, # type: ignore[invalid-argument-type] # NOTE sqlalchemy quirk
+                download_id=model_download.model_id,  # type: ignore[invalid-argument-type] # NOTE sqlalchemy quirk
                 message="Download already completed.",
                 status="completed",
                 progress=100.0,
             )
         return DownloadResponse(
-            download_id=model_download.model_id, # type: ignore[invalid-argument-type] # NOTE sqlalchemy quirk
+            download_id=model_download.model_id,  # type: ignore[invalid-argument-type] # NOTE sqlalchemy quirk
             message="Download in progress.",
             status="in_progress",
             progress=float(model_download.progress),
@@ -302,7 +301,7 @@ async def patch_model_metadata(
     except Exception as e:
         msg = f"failed to edit model metadata due to {repr(e)}"
         logger.exception(msg)
-        raise HTTPException(status_code = 400, detail=msg)
+        raise HTTPException(status_code=400, detail=msg)
 
 
 # section: MODEL INFO

--- a/backend/forecastbox/api/routers/product.py
+++ b/backend/forecastbox/api/routers/product.py
@@ -59,18 +59,19 @@ def select_from_params(available_spec: Qube, params: dict[str, Any]) -> Qube:
 
     return available_spec
 
+
 def _sort_values(values: Iterable[Any]) -> Iterable[Any]:
     """Sort values in a way that numbers come before strings, and numbers are sorted numerically."""
     convert = lambda text: int(text) if text.isdigit() else text
-    alphanum_key = lambda key: [convert(c) for c in re.split('([0-9]+)', key)]
+    alphanum_key = lambda key: [convert(c) for c in re.split("([0-9]+)", key)]
     return sorted(values, key=alphanum_key)
+
 
 def _convert_to_int(value: Iterable[Any]) -> Any:
     """Convert a value to int if it is a digit."""
     if all(isinstance(v, str) and v.isdigit() for v in value):
         return [float(v) for v in value]
     return value
-
 
 
 def _sort_fields(fields: dict) -> dict:
@@ -86,9 +87,7 @@ def _sort_fields(fields: dict) -> dict:
     return new_fields
 
 
-def product_to_config(
-    product: Product, model_spec: ModelSpecification, params: dict[str, Any]
-) -> ExportedSchemas:
+def product_to_config(product: Product, model_spec: ModelSpecification, params: dict[str, Any]) -> ExportedSchemas:
     """Convert a product to a configuration dictionary.
 
     Parameters
@@ -141,11 +140,7 @@ def product_to_config(
 
         # Select from the available product specification based on all parameters except the current key
         updated_params = {**params, **inferred_constraints}
-        val = (
-            select_from_params(available_product_spec, {k: v for k, v in updated_params.items() if not k == key})
-            .axes()
-            .get(key, val)
-        )
+        val = select_from_params(available_product_spec, {k: v for k, v in updated_params.items() if not k == key}).axes().get(key, val)
 
         field = FieldWithUI(jsonschema=StringSchema(title=key))
 
@@ -224,9 +219,7 @@ async def get_valid_categories(interface: Interfaces, modelspec: ModelSpecificat
 
 
 @router.post("/configuration/{category}/{product}")
-async def get_product_configuration(
-    category: str, product: str, model: ModelSpecification, spec: dict[str, Any]
-) -> ExportedSchemas:
+async def get_product_configuration(category: str, product: str, model: ModelSpecification, spec: dict[str, Any]) -> ExportedSchemas:
     """Get the product configuration for a given category and product.
 
     Validates the product against the model specification and returns a configuration object.

--- a/backend/forecastbox/api/scheduling/dt_utils.py
+++ b/backend/forecastbox/api/scheduling/dt_utils.py
@@ -42,6 +42,7 @@ def _validate_field(field: str, min_val: int, max_val: int, label: str) -> None:
     else:
         raise ValueError(f"Invalid cron field format: {field} of {label}")
 
+
 def _get_field_values(field: str, min_val: int, max_val: int, label: str) -> list[int]:
     _validate_field(field, min_val, max_val, label)
     values = set()
@@ -71,6 +72,7 @@ def _get_field_values(field: str, min_val: int, max_val: int, label: str) -> lis
     else:
         raise ValueError(f"failed to generate range for {field}")
 
+
 @dataclass
 class Crontab:
     minutes: list[int]
@@ -78,6 +80,7 @@ class Crontab:
     days_of_month: list[int]
     months: list[int]
     days_of_week: list[int]
+
 
 def calculate_next_run(after: datetime, crontab: str) -> datetime:
     """Calculates the next run datetime according to the crontab expression."""
@@ -92,7 +95,7 @@ def calculate_next_run(after: datetime, crontab: str) -> datetime:
             for day_of_month in crontab_values.days_of_month:
                 try:
                     test_date = datetime(year, month, day_of_month)
-                except ValueError: # NOTE february issues etc
+                except ValueError:  # NOTE february issues etc
                     continue
 
                 if test_date.weekday() not in crontab_values.days_of_week:
@@ -104,6 +107,7 @@ def calculate_next_run(after: datetime, crontab: str) -> datetime:
                         if candidate_run > after:
                             return candidate_run
     raise ValueError("cron next run failure")
+
 
 def parse_crontab(crontab: str) -> Crontab:
     """Parses a crontab expression into field ranges. If invalid, raises ValueError"""

--- a/backend/forecastbox/api/types.py
+++ b/backend/forecastbox/api/types.py
@@ -123,6 +123,7 @@ class ExecutionSpecification(FIABBaseModel):
     environment: EnvironmentSpecification
     shared: bool = Field(default=False)
 
+
 class ScheduleSpecification(FIABBaseModel):
     exec_spec: ExecutionSpecification
     """The static part of the job, ie, what remains constant across executions"""
@@ -130,11 +131,12 @@ class ScheduleSpecification(FIABBaseModel):
     """Evaluated at each invocation, with keys pointing to paths in the job_spec,
     and values being dynamic expressions to be injected. Supported expressions:
     - `$schedule_datetime` -- like '20241012T00'
-    """ # TODO support smth like argo expression language here
+    """  # TODO support smth like argo expression language here
     cron_expr: str
     """Cron expression for time scheduling"""
     max_acceptable_delay_hours: PositiveInt
     """Maximum acceptable delay in hours for a scheduled run. If the scheduler is down for longer than this, the run will be skipped."""
+
 
 class ScheduleUpdate(FIABBaseModel):
     exec_spec: ExecutionSpecification | None = None
@@ -143,12 +145,13 @@ class ScheduleUpdate(FIABBaseModel):
     cron_expr: str | None = None
     max_acceptable_delay_hours: PositiveInt | None = None
 
-def schedule2db(schedule_obj: ScheduleSpecification|ScheduleUpdate) -> dict[str, Any]:
+
+def schedule2db(schedule_obj: ScheduleSpecification | ScheduleUpdate) -> dict[str, Any]:
     data = {}
     if schedule_obj.exec_spec is not None:
         data["exec_spec"] = schedule_obj.exec_spec.model_dump_json()
     if schedule_obj.dynamic_expr is not None:
-        data["dynamic_expr"] = orjson.dumps(schedule_obj.dynamic_expr).decode('ascii')
+        data["dynamic_expr"] = orjson.dumps(schedule_obj.dynamic_expr).decode("ascii")
     if schedule_obj.cron_expr is not None:
         data["cron_expr"] = schedule_obj.cron_expr
     if hasattr(schedule_obj, "enabled") and schedule_obj.enabled is not None:
@@ -156,6 +159,7 @@ def schedule2db(schedule_obj: ScheduleSpecification|ScheduleUpdate) -> dict[str,
     if hasattr(schedule_obj, "max_acceptable_delay_hours") and schedule_obj.max_acceptable_delay_hours is not None:
         data["max_acceptable_delay_hours"] = schedule_obj.max_acceptable_delay_hours
     return data
+
 
 class VisualisationOptions(FIABBaseModel):
     preset: str = "blob"

--- a/backend/forecastbox/api/updates.py
+++ b/backend/forecastbox/api/updates.py
@@ -7,6 +7,7 @@ from forecastbox.config import fiab_home
 
 logger = logging.getLogger(__name__)
 
+
 @dataclasses.dataclass(frozen=True)
 class Release:
     major: int
@@ -24,6 +25,7 @@ class Release:
     def __str__(self) -> str:
         return f"{self.major}.{self.minor}.{self.patch}"
 
+
 async def get_most_recent_release() -> Release:
     async with httpx.AsyncClient() as client:
         response = await client.get("https://api.github.com/repos/ecmwf/forecast-in-a-box/releases?per_page=1")
@@ -37,11 +39,13 @@ async def get_most_recent_release() -> Release:
         latest_release_tag = releases[0]["tag_name"]
         return Release.from_string(latest_release_tag)
 
+
 def get_lock_timestamp() -> str:
     lock_file_path = fiab_home / "pylock.toml.timestamp"
     if not lock_file_path.is_file():
         return ""
     return lock_file_path.read_text().strip()
+
 
 def get_local_release() -> tuple[datetime, Release]:
     timestamp_str = get_lock_timestamp()
@@ -64,12 +68,14 @@ def get_local_release() -> tuple[datetime, Release]:
     release_obj = Release.from_string(release_str)
     return dt_obj, release_obj
 
+
 async def get_pylock(release: Release) -> str:
     url = f"https://github.com/ecmwf/forecast-in-a-box/releases/download/v{release}/pylock.toml"
     async with httpx.AsyncClient() as client:
         response = await client.get(url)
         response.raise_for_status()
         return response.text
+
 
 def save_pylock(pylock: str, release: Release) -> None:
     pylock_file_path = fiab_home / "pylock.toml"

--- a/backend/forecastbox/api/utils.py
+++ b/backend/forecastbox/api/utils.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 def get_model_path(model: str) -> Path:
     """Get the path to a model."""
-    return (Path(config.api.data_path) / (model.replace('_','/')+'.ckpt')).absolute()
+    return (Path(config.api.data_path) / (model.replace("_", "/") + ".ckpt")).absolute()
 
 
 def encode_result(result: api.ResultRetrievalResponse) -> tuple[bytes, str]:

--- a/backend/forecastbox/auth/users.py
+++ b/backend/forecastbox/auth/users.py
@@ -63,14 +63,10 @@ class UserManager(UUIDIDMixin, BaseUserManager[UserTable, pydantic.UUID4]):
                 _ = await session.execute(query)
                 await session.commit()
 
-    async def on_after_login(
-        self, user: UserTable, request: Request | None = None, response: responses.Response | None = None
-    ):
+    async def on_after_login(self, user: UserTable, request: Request | None = None, response: responses.Response | None = None):
         if not verify_entitlements(user):
             logger.error(f"User {user.id} does not have the required entitlements.")
-            raise HTTPException(
-                status_code=403, detail="You do not have the required entitlements to access this resource."
-            )
+            raise HTTPException(status_code=403, detail="You do not have the required entitlements to access this resource.")
 
         if response is not None:
             response.status_code = 302
@@ -83,12 +79,11 @@ class UserManager(UUIDIDMixin, BaseUserManager[UserTable, pydantic.UUID4]):
         logger.error(f"Verification requested for user {user.id}. Verification token: {token}")
 
     # TODO this is a hack, we validate email in this method. Consider a PR to the fastapi_users
-    async def validate_password(self, password: str, user: UserCreate|UserRead) -> None:
+    async def validate_password(self, password: str, user: UserCreate | UserRead) -> None:
         if config.auth.domain_allowlist_registry:
-            domain = user.email.split('@')[1]
+            domain = user.email.split("@")[1]
             if domain not in config.auth.domain_allowlist_registry:
                 raise InvalidPasswordException(reason=f"Domain '{domain}' is not allowed.")
-
 
 
 async def get_user_manager(user_db: SQLAlchemyUserDatabase = Depends(get_user_db)):

--- a/backend/forecastbox/config.py
+++ b/backend/forecastbox/config.py
@@ -17,7 +17,7 @@ from cascade.low.func import pydantic_recursive_collect
 from pydantic import BaseModel, Field, SecretStr, model_validator
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict, TomlConfigSettingsSource
 
-fiab_home = Path(os.environ['FIAB_ROOT']) if 'FIAB_ROOT' in os.environ else (Path.home() / ".fiab")
+fiab_home = Path(os.environ["FIAB_ROOT"]) if "FIAB_ROOT" in os.environ else (Path.home() / ".fiab")
 logger = logging.getLogger(__name__)
 
 
@@ -26,11 +26,12 @@ def _validate_url(url: str) -> bool:
     parse = urllib.parse.urlparse(url)
     return (parse.scheme is not None) and (parse.netloc is not None)
 
+
 class StatusMessage:
     """Namespace class for status message sharing"""
+
     # NOTE this class is here as this is a low place in hierarchy, and we dont want circular imports
     gateway_running = "running"
-
 
 
 class DatabaseSettings(BaseModel):
@@ -100,11 +101,16 @@ class GeneralSettings(BaseModel):
     """Whether a browser window should be opened after start. Used only when
     standalone.entrypoint.launch_all module is used"""
 
+
 class ProductSettings(BaseModel):
     pproc_schema_dir: str | None = None
     """Path to the directory containing the PPROC schema files."""
 
-    plots_schema: str = Field(default="inbuilt://fiab", description="earthkit-plots global schema", examples=["inbuilt://fiab", "my-schema-package@/path/to/my-schema-package", "my-registered-schema"])
+    plots_schema: str = Field(
+        default="inbuilt://fiab",
+        description="earthkit-plots global schema",
+        examples=["inbuilt://fiab", "my-schema-package@/path/to/my-schema-package", "my-registered-schema"],
+    )
     """earthkit-plots global schema, can be registered schema or path to a yaml file,
     If starts with inbuilt:// it is searched in the plots schema dir.
     If contains @ it is considered a package to be installed in the environment
@@ -119,6 +125,7 @@ class ProductSettings(BaseModel):
             return ["not a directory: pproc_schema_dir={self.pproc_schema_dir}"]
         else:
             return []
+
 
 class BackendAPISettings(BaseModel):
     data_path: str = str(fiab_home / "data_dir")
@@ -148,6 +155,7 @@ class BackendAPISettings(BaseModel):
             errors.append(f"not a valid uvicorn config: {pseudo_url}")
         return errors
 
+
 class CascadeSettings(BaseModel):
     max_hosts: int = 1
     """Number of hosts for Cascade."""
@@ -159,7 +167,7 @@ class CascadeSettings(BaseModel):
     """Maximum size of the log collection for Cascade."""
     venv_temp_dir: str = "/tmp"
     """Temporary directory for virtual environments."""
-    max_concurrent_jobs: int|None = 1
+    max_concurrent_jobs: int | None = 1
     """If more jobs submitted at a given time, all but this many wait in a queue"""
 
     def validate_runtime(self) -> list[str]:
@@ -169,6 +177,7 @@ class CascadeSettings(BaseModel):
         if not _validate_url(self.cascade_url):
             errors.append(f"not an url: cascade_url={self.cascade_url}")
         return errors
+
 
 class FIABConfig(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", env_nested_delimiter="__", env_prefix="fiab__")
@@ -191,7 +200,13 @@ class FIABConfig(BaseSettings):
         dotenv_settings: PydanticBaseSettingsSource,
         file_secret_settings: PydanticBaseSettingsSource,
     ) -> tuple[PydanticBaseSettingsSource, ...]:
-        return env_settings, file_secret_settings, dotenv_settings, TomlConfigSettingsSource(settings_cls, fiab_home / "config.toml"), init_settings
+        return (
+            env_settings,
+            file_secret_settings,
+            dotenv_settings,
+            TomlConfigSettingsSource(settings_cls, fiab_home / "config.toml"),
+            init_settings,
+        )
 
     def _get_toml(self, **k) -> str:
         json_config = self.model_dump(mode="json", **k)
@@ -203,8 +218,8 @@ class FIABConfig(BaseSettings):
 
         config_path = fiab_home / "config.toml"
         config_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(config_path, 'w') as f:
-            f.write(self._get_toml(exclude_defaults = True, exclude_none = True))
+        with open(config_path, "w") as f:
+            f.write(self._get_toml(exclude_defaults=True, exclude_none=True))
 
 
 def validate_runtime(config: FIABConfig) -> None:

--- a/backend/forecastbox/db/core.py
+++ b/backend/forecastbox/db/core.py
@@ -34,7 +34,7 @@ async def dbRetry(func: Callable[[int], Awaitable[T]]) -> T:
             if i == 0:
                 raise
             await asyncio.sleep(0.1)
-    raise ValueError # NOTE in case of retries misconfig, we dont want implicit None
+    raise ValueError  # NOTE in case of retries misconfig, we dont want implicit None
 
 
 async def executeAndCommit(stmt, session_maker) -> None:
@@ -64,6 +64,7 @@ async def querySingle(query, session_maker) -> Any:
             return rv
 
     return await dbRetry(func)
+
 
 async def queryCount(query, session) -> int:
     # TODO scalar_one

--- a/backend/forecastbox/db/job.py
+++ b/backend/forecastbox/db/job.py
@@ -49,6 +49,7 @@ async def get_one(job_id: JobId) -> JobRecord | None:
     query = select(JobRecord).where(JobRecord.job_id == job_id)
     return await querySingle(query, async_session_maker)
 
+
 async def get_count(status: str | None = None) -> int:
     async def function(i: int) -> int:
         async with async_session_maker() as session:
@@ -56,9 +57,11 @@ async def get_count(status: str | None = None) -> int:
             if status is not None:
                 query = query.where(JobRecord.status == status)
             return await queryCount(query, session)
+
     return await dbRetry(function)
 
-async def get_all(status: str|None = None, offset: int = -1, limit: int = -1) -> Iterable[JobRecord]:
+
+async def get_all(status: str | None = None, offset: int = -1, limit: int = -1) -> Iterable[JobRecord]:
     async def function(i: int) -> Iterable[JobRecord]:
         async with async_session_maker() as session:
             query = select(JobRecord)
@@ -79,6 +82,7 @@ async def update_one(job_id: JobId, **kwargs) -> None:
     ref_time = dt.datetime.now()
     stmt = update(JobRecord).where(JobRecord.job_id == job_id).values(updated_at=ref_time, **kwargs)
     await executeAndCommit(stmt, async_session_maker)
+
 
 async def delete_all() -> int:
     async def function(i: int) -> int:

--- a/backend/forecastbox/db/migrations.py
+++ b/backend/forecastbox/db/migrations.py
@@ -7,16 +7,17 @@ from sqlalchemy import MetaData, create_engine, text
 
 logger = logging.getLogger(__name__)
 
+
 def _migrate_jobs():
     url = f"sqlite:///{config.db.sqlite_jobdb_path}"
     engine = create_engine(url)
     metadata = MetaData()
     metadata.reflect(bind=engine)
 
-    table = metadata.tables['job_records']
+    table = metadata.tables["job_records"]
     logger.debug(f"considering migrations of {table=}")
 
-    if 'progress' not in table.c:
+    if "progress" not in table.c:
         with engine.connect() as connection:
             logger.debug("adding column to jobs: progress")
             connection.execute(text("alter table job_records add column progress varchar(255)"))

--- a/backend/forecastbox/db/model.py
+++ b/backend/forecastbox/db/model.py
@@ -51,7 +51,7 @@ async def start_download(model_id: str) -> None:
     await addAndCommit(entity, async_session_maker)
 
 
-async def delete_download(model_id: str|None) -> None:
+async def delete_download(model_id: str | None) -> None:
     if model_id:
         where = ModelDownload.model_id == model_id
         stmt = delete(ModelDownload).where(where)
@@ -73,7 +73,6 @@ async def start_editing(model_id: str, metadata: str) -> bool:
     except IntegrityError:
         logger.exception("failed to start editing, assuming concurrent edit")
         return False
-
 
 
 async def get_edit(model_id: str) -> ModelEdit | None:

--- a/backend/forecastbox/models/nested.py
+++ b/backend/forecastbox/models/nested.py
@@ -31,17 +31,17 @@ class NestedModel(BaseForecastModel):
     def _create_input_configuration(self, control: ControlMetadata) -> dict[str, dict[str, Any]]:
         assert control.nested is not None, "NestedModel requires a 'nested' configuration in the control metadata."
         return {
-            'cutout': {'sources': control.nested, 'variables': None},
+            "cutout": {"sources": control.nested, "variables": None},
         }
 
     def _post_processors(self, kwargs: dict[str, Any]) -> list[dict[str, Any]]:
-        return [{'extract_from_state': kwargs.get('region', self._regions[0])}]
+        return [{"extract_from_state": kwargs.get("region", self._regions[0])}]
 
     @property
     def _pkg_versions(self) -> dict[str, str]:
         """Model specific override for package versions."""
         return {
-            'anemoi-plugins-ecmwf-inference[mir,regrid]': "0.1.10",
+            "anemoi-plugins-ecmwf-inference[mir,regrid]": "0.1.10",
         }
 
     @property
@@ -59,7 +59,7 @@ class NestedModel(BaseForecastModel):
                 jsonschema=StringSchema(
                     title="Region",
                     description="The region to extract of the nested model.",
-                    enum=self._regions, # type: ignore
+                    enum=self._regions,  # type: ignore
                     default=self._regions[0],
                 ),
                 uischema=UIStringField(widget="select"),

--- a/backend/forecastbox/products/ensemble/ens_stats.py
+++ b/backend/forecastbox/products/ensemble/ens_stats.py
@@ -33,8 +33,8 @@ class BaseEnsembleStats(BasePProcEnsembleProduct, GenericTemporalProduct):
         params = product_spec["param"]
         step = product_spec["step"]
         spec = {"param": params, "step": step}
-        if 'levelist' in product_spec:
-            spec['levelist'] = product_spec['levelist']
+        if "levelist" in product_spec:
+            spec["levelist"] = product_spec["levelist"]
         return {"forecast": self.select_on_specification(spec, source)}
 
     def mars_request(self, product_spec: dict[str, Any]):

--- a/backend/forecastbox/products/ensemble/quantiles.py
+++ b/backend/forecastbox/products/ensemble/quantiles.py
@@ -29,10 +29,10 @@ class BaseQuantiles(BasePProcEnsembleProduct, GenericTemporalProduct):
         formfields = super().formfields.copy()
         formfields.update(
             quantile=self._make_field(
-                    multiple=True,
-                    schema=StringSchema,
-                    title="Quantiles",
-                    description="Computed Quantile",
+                multiple=True,
+                schema=StringSchema,
+                title="Quantiles",
+                description="Computed Quantile",
             ),
         )
         return formfields

--- a/backend/forecastbox/products/ensemble/threshold.py
+++ b/backend/forecastbox/products/ensemble/threshold.py
@@ -30,14 +30,12 @@ class BaseThresholdProbability(BaseEnsembleProduct):
         formfields = super().formfields.copy()
         formfields.update(
             step=FieldWithUI(jsonschema=StringSchema(title="Step", description="Forecast step, e.g. 0-24, 0-168")),
-            threshold=FieldWithUI(
-                jsonschema=StringSchema(title="Threshold", description="Threshold value to apply, e.g. 0, 5, 10, etc.")
-            ),
+            threshold=FieldWithUI(jsonschema=StringSchema(title="Threshold", description="Threshold value to apply, e.g. 0, 5, 10, etc.")),
             operator=FieldWithUI(
                 jsonschema=StringSchema(
                     title="Operator",
                     description="Operator to apply to the threshold, e.g. '>', '<', '==', etc.",
-                    enum=["<", "<=", "==", ">=", ">"], # type: ignore[unknown-argument] # NOTE checker failure, this is legit
+                    enum=["<", "<=", "==", ">=", ">"],  # type: ignore[unknown-argument] # NOTE checker failure, this is legit
                 )
             ),
         )
@@ -50,7 +48,6 @@ class BaseThresholdProbability(BaseEnsembleProduct):
 
 @generic_registry("Threshold Probability")
 class GenericThresholdProbability(BaseThresholdProbability, GenericParamProduct):
-
     @property
     def qube(self):
         return self.make_generic_qube(threshold=USER_DEFINED, operator=USER_DEFINED, step=USER_DEFINED)
@@ -134,9 +131,7 @@ class DefinedThresholdProbability(BaseThresholdProbability, BasePProcEnsemblePro
 
         paramid = self.get_out_paramid(levtype, param, product_spec.get("levlist", None), threshold, operator)
         if paramid is None:
-            raise KeyError(
-                f"Could not identify output paramid for {param!r} with threshold {threshold!r} and operator {operator!r}."
-            )
+            raise KeyError(f"Could not identify output paramid for {param!r} with threshold {threshold!r} and operator {operator!r}.")
 
         request = {
             "type": "ep",

--- a/backend/forecastbox/products/export.py
+++ b/backend/forecastbox/products/export.py
@@ -24,9 +24,7 @@ OUTPUT_TYPES = ["grib", "netcdf", "numpy"]
 
 
 @as_payload
-def export_fieldlist_as(
-    fields: ekd.FieldList, format: FORMAT = "grib"
-) -> tuple[bytes, str]:
+def export_fieldlist_as(fields: ekd.FieldList, format: FORMAT = "grib") -> tuple[bytes, str]:
     """Export an earthkit FieldList to a specified format.
     Supported formats are 'grib', 'netcdf', and 'numpy'.
 
@@ -42,7 +40,7 @@ def export_fieldlist_as(
     tuple[bytes, str]
         A tuple containing the serialized data as bytes and the MIME type.
     """
-    written_bytes = b''
+    written_bytes = b""
 
     if format == "grib":
         buf = io.BytesIO()
@@ -60,6 +58,7 @@ def export_fieldlist_as(
         raise ValueError(f"Unsupported format: {format}. Supported formats are {OUTPUT_TYPES}.")
 
     return written_bytes, f"application/{format}"
+
 
 class ExportMixin(Product):
     pass

--- a/backend/forecastbox/products/extreme/extreme.py
+++ b/backend/forecastbox/products/extreme/extreme.py
@@ -10,6 +10,4 @@
 from ..interfaces import Interfaces
 from ..registry import CategoryRegistry
 
-extreme_registry = CategoryRegistry(
-    "extreme", interface=Interfaces.DETAILED, description="Extreme Value Indices", title="Extreme Indices"
-)
+extreme_registry = CategoryRegistry("extreme", interface=Interfaces.DETAILED, description="Extreme Value Indices", title="Extreme Indices")

--- a/backend/forecastbox/products/pproc.py
+++ b/backend/forecastbox/products/pproc.py
@@ -32,9 +32,8 @@ except (OSError, ImportError) as e:
     PPROC_AVAILABLE = False
     LOG.warning("PPROC is not available. %s", e)
 
-def from_request(
-    request: dict, pproc_schema: str, action_kwargs: dict[str, Any] | None = None, **sources: fluent.Action
-) -> fluent.Action:
+
+def from_request(request: dict, pproc_schema: str, action_kwargs: dict[str, Any] | None = None, **sources: fluent.Action) -> fluent.Action:
     inputs = []
     for source in sources.values():
         inputs.append({k: list(source.nodes.coords[k].values) for k in source.nodes.coords.keys()})
@@ -91,10 +90,7 @@ class PProcProduct(Product):
     #         **super().model_assumptions,
     #    }
 
-
-    def get_sources(
-        self, product_spec: dict[str, Any], model: SpecifiedModel, source: fluent.Action
-    ) -> dict[str, fluent.Action]:
+    def get_sources(self, product_spec: dict[str, Any], model: SpecifiedModel, source: fluent.Action) -> dict[str, fluent.Action]:
         """Get sources for pproc action.
 
         By default just provides the model source as 'forecast'
@@ -179,8 +175,8 @@ class PProcProduct(Product):
         full_requests = []
         for req in request:
             req_full = {
-                "date": model.specification['date'],
-                "time": model.specification.get('time', '00'),
+                "date": model.specification["date"],
+                "time": model.specification.get("time", "00"),
                 "domain": getattr(model, "domain", "g"),
                 **self.default_request_keys,
             }

--- a/backend/forecastbox/products/standard.py
+++ b/backend/forecastbox/products/standard.py
@@ -36,7 +36,7 @@ class OutputProduct(GenericTemporalProduct):
                 jsonschema=StringSchema(
                     title="Reduce",
                     description="Combine all steps and parameters into a single output",
-                    enum=["True", "False"], # type: ignore[unknown-argument] # NOTE checker failure, this is legit
+                    enum=["True", "False"],  # type: ignore[unknown-argument] # NOTE checker failure, this is legit
                     default="True",
                 )
             ),
@@ -44,7 +44,7 @@ class OutputProduct(GenericTemporalProduct):
                 jsonschema=StringSchema(
                     title="Format",
                     description="Output format",
-                    enum=OUTPUT_TYPES, # type: ignore[unknown-argument] # NOTE checker failure, this is legit
+                    enum=OUTPUT_TYPES,  # type: ignore[unknown-argument] # NOTE checker failure, this is legit
                     default="grib",
                 ),
                 uischema=UIStringField(
@@ -75,7 +75,7 @@ class OutputProduct(GenericTemporalProduct):
         format = product_spec.get("format", "grib")
 
         conversion_payload = export_fieldlist_as(format=format)
-        conversion_payload.func.__name__ = f"convert_to_{format}" # type: ignore # TODO fix typing, the lside should have always name
+        conversion_payload.func.__name__ = f"convert_to_{format}"  # type: ignore # TODO fix typing, the lside should have always name
 
         source = source.map(conversion_payload).map(self.named_payload(f"output-{format}"))
         return source

--- a/backend/forecastbox/products/thermal.py
+++ b/backend/forecastbox/products/thermal.py
@@ -19,15 +19,13 @@ from .interfaces import Interfaces
 from .product import Product
 from .registry import CategoryRegistry
 
-thermal_indices = CategoryRegistry(
-    "thermal", interface=Interfaces.DETAILED, description="Thermal Indices", title="Thermal Indices"
-)
+thermal_indices = CategoryRegistry("thermal", interface=Interfaces.DETAILED, description="Thermal Indices", title="Thermal Indices")
 
 PPROC_AVAILABLE = True
 try:
     from earthkit.workflows.plugins.pproc.fluent import Action as ppAction
 except (OSError, ImportError):
-    ppAction = object # type: ignore # NOTE implicit shadowing, intentional
+    ppAction = object  # type: ignore # NOTE implicit shadowing, intentional
     PPROC_AVAILABLE = False
 
 THERMOFEEL_IMPORTED = True

--- a/backend/forecastbox/rjsf/__init__.py
+++ b/backend/forecastbox/rjsf/__init__.py
@@ -15,8 +15,7 @@
 
 from .forms import ExportedSchemas, FieldWithUI, FormDefinition
 from .from_pydantic import from_pydantic
-from .jsonSchema import (ArraySchema, BooleanSchema, EnumMixin, FieldSchema, IntegerSchema, NullSchema, NumberSchema,
-                         StringSchema)
+from .jsonSchema import ArraySchema, BooleanSchema, EnumMixin, FieldSchema, IntegerSchema, NullSchema, NumberSchema, StringSchema
 from .uiSchema import UIBooleanField, UIIntegerField, UIObjectField, UISchema, UIStringField
 
 __all__ = [

--- a/backend/forecastbox/rjsf/forms.py
+++ b/backend/forecastbox/rjsf/forms.py
@@ -81,4 +81,4 @@ class FormDefinition(BaseModel):
         """Exports both JSON Schema and UI Schema in a combined format.
         This is useful for rendering forms in RJSF.
         """
-        return {"jsonSchema": self.export_jsonschema(), "uiSchema": self.export_uischema(), 'formData': self.formData}
+        return {"jsonSchema": self.export_jsonschema(), "uiSchema": self.export_uischema(), "formData": self.formData}

--- a/backend/forecastbox/rjsf/from_pydantic.py
+++ b/backend/forecastbox/rjsf/from_pydantic.py
@@ -22,9 +22,9 @@ from .uiSchema import UIAdditionalProperties, UIField, UIIntegerField, UIObjectF
 
 def _update_with_extra_json(field: FieldInfo, schema: FieldSchema, ui: UISchema) -> tuple[FieldSchema, UISchema]:
     """Update schema and ui with extra json from field."""
-    if isinstance(field.json_schema_extra, dict) and field.json_schema_extra.get('rjsf') is not None: # type: ignore # TODO fix type, didnt diagnose
-        assert isinstance(field.json_schema_extra['rjsf'], dict), "rjsf extra must be a dict"
-        for k, v in field.json_schema_extra['rjsf'].items():
+    if isinstance(field.json_schema_extra, dict) and field.json_schema_extra.get("rjsf") is not None:  # type: ignore # TODO fix type, didnt diagnose
+        assert isinstance(field.json_schema_extra["rjsf"], dict), "rjsf extra must be a dict"
+        for k, v in field.json_schema_extra["rjsf"].items():
             if hasattr(schema, k):
                 setattr(schema, k, v)
             elif hasattr(ui, k):
@@ -33,12 +33,13 @@ def _update_with_extra_json(field: FieldInfo, schema: FieldSchema, ui: UISchema)
                 raise ValueError(f"Unknown rjsf extra key: {k}")
     return schema, ui
 
+
 def _set_base_field_info(field: FieldInfo, schema: FieldSchema, ui: UISchema) -> tuple[FieldSchema, UISchema]:
     """Set base field info from pydantic field to schema and ui."""
     if field.default is not PydanticUndefined:
         schema.default = field.default
     if field.default_factory is not None:
-        schema.default = field.default_factory() # type: ignore
+        schema.default = field.default_factory()  # type: ignore
     if field.title:
         schema.title = field.title
     if field.description:
@@ -46,53 +47,53 @@ def _set_base_field_info(field: FieldInfo, schema: FieldSchema, ui: UISchema) ->
         ui.description = field.description
     return schema, ui
 
-def _from_string_primative(field: FieldInfo) -> FieldWithUI:
 
+def _from_string_primative(field: FieldInfo) -> FieldWithUI:
     schema, ui = _set_base_field_info(field, StringSchema(type="string"), UIStringField())
     schema, ui = _update_with_extra_json(field, schema, ui)
 
     return FieldWithUI(jsonschema=schema, uischema=ui)
 
-def _from_date_primative(field: FieldInfo) -> FieldWithUI:
 
+def _from_date_primative(field: FieldInfo) -> FieldWithUI:
     schema, ui = _set_base_field_info(field, StringSchema(type="string", format="date"), UIStringField(widget="date"))
     schema, ui = _update_with_extra_json(field, schema, ui)
 
     return FieldWithUI(jsonschema=schema, uischema=ui)
 
-def _from_literal_primative(field: FieldInfo) -> FieldWithUI:
 
+def _from_literal_primative(field: FieldInfo) -> FieldWithUI:
     literal_args = get_args(field.annotation)
     if not all(isinstance(arg, str) for arg in literal_args):
         raise TypeError("Only Literal[str, ...] is supported")
 
-    schema, ui = _set_base_field_info(field, StringSchema(type="string", enum=list(literal_args)), UIStringField(widget="select")) # type: ignore # TODO fix type, didnt diagnose
+    schema, ui = _set_base_field_info(field, StringSchema(type="string", enum=list(literal_args)), UIStringField(widget="select"))  # type: ignore # TODO fix type, didnt diagnose
     schema, ui = _update_with_extra_json(field, schema, ui)
 
     return FieldWithUI(jsonschema=schema, uischema=ui)
 
-def _from_integer_primative(field: FieldInfo) -> FieldWithUI:
 
+def _from_integer_primative(field: FieldInfo) -> FieldWithUI:
     schema, ui = _set_base_field_info(field, IntegerSchema(type="integer"), UIIntegerField())
     schema, ui = _update_with_extra_json(field, schema, ui)
 
     return FieldWithUI(jsonschema=schema, uischema=ui)
 
-def _from_boolean_primative(field: FieldInfo) -> FieldWithUI:
 
+def _from_boolean_primative(field: FieldInfo) -> FieldWithUI:
     schema, ui = _set_base_field_info(field, BooleanSchema(type="boolean"), UIField(widget="checkbox"))
     schema, ui = _update_with_extra_json(field, schema, ui)
 
     return FieldWithUI(jsonschema=schema, uischema=ui)
 
-def _from_dict_primative(field: FieldInfo) -> FieldWithUI:
 
+def _from_dict_primative(field: FieldInfo) -> FieldWithUI:
     schema, ui = _set_base_field_info(field, ObjectSchema(type="object", properties={}), UIAdditionalProperties())
     schema, ui = _update_with_extra_json(field, schema, ui)
 
     assert isinstance(ui, UIAdditionalProperties)
 
-    if field.annotation and hasattr(field.annotation, '__args__') and len(field.annotation.__args__) == 2:
+    if field.annotation and hasattr(field.annotation, "__args__") and len(field.annotation.__args__) == 2:
         _, value_type = get_args(field.annotation)
         if value_type is str:
             schema.additionalProperties = StringSchema(type="string")
@@ -111,15 +112,15 @@ def _from_dict_primative(field: FieldInfo) -> FieldWithUI:
 
     return FieldWithUI(jsonschema=schema, uischema=ui)
 
-def _from_list_primative(field: FieldInfo) -> FieldWithUI:
 
+def _from_list_primative(field: FieldInfo) -> FieldWithUI:
     schema, ui = _set_base_field_info(field, ArraySchema(type="array", items=StringSchema(type="string")), UIObjectField())
     schema, ui = _update_with_extra_json(field, schema, ui)
 
     assert isinstance(schema, ArraySchema)
     assert isinstance(ui, UIObjectField)
 
-    if field.annotation and hasattr(field.annotation, '__args__') and len(field.annotation.__args__) == 1:
+    if field.annotation and hasattr(field.annotation, "__args__") and len(field.annotation.__args__) == 1:
         item_type = get_args(field.annotation)[0]
         if item_type is str:
             schema.items = StringSchema(type="string")
@@ -138,6 +139,7 @@ def _from_list_primative(field: FieldInfo) -> FieldWithUI:
 
     return FieldWithUI(jsonschema=schema, uischema=ui)
 
+
 PRIMATIVES: dict[type, Callable[[FieldInfo], FieldWithUI]] = {
     str: _from_string_primative,
     int: _from_integer_primative,
@@ -148,6 +150,7 @@ PRIMATIVES: dict[type, Callable[[FieldInfo], FieldWithUI]] = {
     object: _from_string_primative,
     # Literal: _from_literal_primative,
 }
+
 
 def from_pydantic(model: type[BaseModel] | BaseModel) -> tuple[dict[str, FieldWithUI], list[str]]:
     """Convert a pydantic model to a dictionary of fields, and list of required.
@@ -188,7 +191,7 @@ def from_pydantic(model: type[BaseModel] | BaseModel) -> tuple[dict[str, FieldWi
             elif isinstance(field.annotation, UnionType) or get_origin(field.annotation) is Union:
                 fields[field_name] = _get_with_annotation(get_args(field.annotation)[0], field)
                 if NoneType in get_args(field.annotation):
-                    fields[field_name].jsonschema.type = [fields[field_name].jsonschema.type, "null"] # type: ignore
+                    fields[field_name].jsonschema.type = [fields[field_name].jsonschema.type, "null"]  # type: ignore
 
             elif get_origin(field.annotation) is dict:
                 fields[field_name] = _from_dict_primative(field)
@@ -199,7 +202,7 @@ def from_pydantic(model: type[BaseModel] | BaseModel) -> tuple[dict[str, FieldWi
             elif get_origin(field.annotation) is Literal:
                 fields[field_name] = _from_literal_primative(field)
 
-            elif hasattr(field.annotation, 'mro'):
+            elif hasattr(field.annotation, "mro"):
                 if BaseModel in field.annotation.mro():
                     sub_fields, sub_required = _get_from_model(field.annotation)
 
@@ -224,4 +227,5 @@ def from_pydantic(model: type[BaseModel] | BaseModel) -> tuple[dict[str, FieldWi
             if field.is_required():
                 required.append(field_name)
         return fields, required
-    return _get_from_model(model) # type: ignore # TODO fix type, didnt diagnose
+
+    return _get_from_model(model)  # type: ignore # TODO fix type, didnt diagnose

--- a/backend/forecastbox/rjsf/jsonSchema.py
+++ b/backend/forecastbox/rjsf/jsonSchema.py
@@ -155,7 +155,7 @@ class NullSchema(BaseSchema):
     >>> NullSchema(type="null")
     """
 
-    type: str | list[str] | Literal['null'] = Field(default="null")
+    type: str | list[str] | Literal["null"] = Field(default="null")
 
 
 class ObjectSchema(BaseSchema):

--- a/backend/forecastbox/rjsf/uiSchema.py
+++ b/backend/forecastbox/rjsf/uiSchema.py
@@ -73,8 +73,10 @@ class UIField(BaseModel):
     def export_with_prefix(self) -> dict[str, Any]:
         return {"ui:options": self.model_dump(exclude_none=True)}
 
+
 class UIAdditionalProperties(BaseModel):
     """Base class for additional properties in UI schema."""
+
     additionalProperties: "UISchema | None" = None
 
     def export_with_prefix(self) -> dict[str, Any]:
@@ -146,8 +148,6 @@ class UIObjectField(BaseModel):
         if self.oneOf:
             result["oneOf"] = [schema.export_with_prefix() for schema in self.oneOf]
         return result
-
-
 
 
 UISchema = Union[UIStringField, UIIntegerField, UIBooleanField, UIObjectField, UIField, UIAdditionalProperties]

--- a/backend/forecastbox/schemas/schedule.py
+++ b/backend/forecastbox/schemas/schedule.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import declarative_base
 
 Base = declarative_base()
 
+
 class ScheduleDefinition(Base):
     __tablename__ = "schedule_definition"
 
@@ -26,9 +27,10 @@ class ScheduleDefinition(Base):
     updated_at = Column(DateTime, nullable=False)
     exec_spec = Column(JSON, nullable=False)
     dynamic_expr = Column(JSON, nullable=False)
-    enabled = Column(Boolean, nullable = False)
+    enabled = Column(Boolean, nullable=False)
     created_by = Column(String(255), nullable=True)
     max_acceptable_delay_hours = Column(Integer, nullable=False)
+
 
 class ScheduleRun(Base):
     __tablename__ = "schedule_run"
@@ -40,11 +42,12 @@ class ScheduleRun(Base):
 
     attempt_cnt = Column(Integer, nullable=False)
     scheduled_at = Column(DateTime, nullable=False)
-    trigger = Column(String(64), nullable=False) # probably an enum like `cron`, `event` (or event_id?), `request`
+    trigger = Column(String(64), nullable=False)  # probably an enum like `cron`, `event` (or event_id?), `request`
+
 
 class ScheduleNext(Base):
     __tablename__ = "schedule_next"
 
     schedule_next_id = Column(String(255), primary_key=True, nullable=False)
-    schedule_id = Column(String(255), nullable=False, unique=True) # Foreign key to ScheduleDefinition
+    schedule_id = Column(String(255), nullable=False, unique=True)  # Foreign key to ScheduleDefinition
     scheduled_at = Column(DateTime, nullable=False)

--- a/backend/forecastbox/standalone/checks.py
+++ b/backend/forecastbox/standalone/checks.py
@@ -11,7 +11,9 @@ from forecastbox.standalone.procs import ChildProcessGroup
 
 logger = logging.getLogger(__name__)
 
-CallResult = httpx.Response|httpx.HTTPError
+CallResult = httpx.Response | httpx.HTTPError
+
+
 def _call_succ(response: CallResult, url: str) -> bool:
     if isinstance(response, httpx.Response):
         if response.status_code == 200:
@@ -25,8 +27,10 @@ def _call_succ(response: CallResult, url: str) -> bool:
     else:
         assert_never(response)
 
+
 class StartupError(ValueError):
     pass
+
 
 def _wait_for(client: httpx.Client, url: str, attempts: int, condition: Callable[[CallResult, str], bool]) -> None:
     """Calls /status endpoint, retry on ConnectError"""
@@ -45,13 +49,13 @@ def _wait_for(client: httpx.Client, url: str, attempts: int, condition: Callable
     raise StartupError(f"failure on {url}: no more retries")
 
 
-def check_backend_ready(config: FIABConfig, handles: ChildProcessGroup|None = None, attempts: int = 20, spawn_gateway: bool=True):
+def check_backend_ready(config: FIABConfig, handles: ChildProcessGroup | None = None, attempts: int = 20, spawn_gateway: bool = True):
     try:
         with httpx.Client() as client:
             _wait_for(client, config.api.local_url() + "/api/v1/status", attempts, _call_succ)
             if spawn_gateway:
                 client.post(config.api.local_url() + "/api/v1/gateway/start").raise_for_status()
-            gw_check = lambda resp, _: resp.raise_for_status().text == f"\"{StatusMessage.gateway_running}\""
+            gw_check = lambda resp, _: resp.raise_for_status().text == f'"{StatusMessage.gateway_running}"'
             _wait_for(client, config.api.local_url() + "/api/v1/gateway/status", attempts, gw_check)
     except StartupError as e:
         logger.error(f"failed to start the backend: {e}")

--- a/backend/forecastbox/standalone/entrypoint.py
+++ b/backend/forecastbox/standalone/entrypoint.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__ if __name__ != "__main__" else __package__)
 
 
 def launch_all(config: FIABConfig, attempts: int = 20) -> ChildProcessGroup:
-    set_start_method("forkserver", force=True) # we force because of pytest plugins
+    set_start_method("forkserver", force=True)  # we force because of pytest plugins
     setup_process()
     logger.info("main process starting")
     logger.debug(f"loaded config {config.model_dump()}")
@@ -35,7 +35,9 @@ def launch_all(config: FIABConfig, attempts: int = 20) -> ChildProcessGroup:
     if not config.api.allow_service:
         previous_cleanup()
         export_recursive(
-            config.model_dump(exclude_defaults=True), config.model_config["env_nested_delimiter"], config.model_config["env_prefix"],
+            config.model_dump(exclude_defaults=True),
+            config.model_config["env_nested_delimiter"],
+            config.model_config["env_prefix"],
         )
         backend = Process(target=launch_backend)
         backend.start()

--- a/backend/forecastbox/standalone/launchers.py
+++ b/backend/forecastbox/standalone/launchers.py
@@ -22,6 +22,7 @@ from forecastbox.standalone.config import setup_process
 
 logger = logging.getLogger(__name__)
 
+
 async def _uvicorn_run(app_name: str, host: str, port: int) -> None:
     # NOTE we pass None to log config to not interfere with original logging setting
     config = uvicorn.Config(
@@ -54,7 +55,8 @@ def launch_backend():
     except KeyboardInterrupt:
         pass  # no need to spew stacktrace to log
 
-def launch_cascade(log_path: str|None, log_base: str|None, max_concurrent_jobs: int|None):
+
+def launch_cascade(log_path: str | None, log_base: str | None, max_concurrent_jobs: int | None):
     config = FIABConfig()
     # TODO this configuration of log_path is very unsystematic, improve!
     # TODO we may want this to propagate to controller/executors -- but stripped the gateway.txt etc

--- a/backend/forecastbox/standalone/procs.py
+++ b/backend/forecastbox/standalone/procs.py
@@ -1,6 +1,6 @@
 """Process-related utilities, mostly for non-service mode:
-    - ChildProcessGroup for gracefully terminating the backend,
-    - previous_cleanup in case the previous backend instance didnt finish cleanly.
+- ChildProcessGroup for gracefully terminating the backend,
+- previous_cleanup in case the previous backend instance didnt finish cleanly.
 """
 
 import logging
@@ -11,12 +11,13 @@ import psutil
 
 logger = logging.getLogger(__name__)
 
+
 @dataclass
-class ChildProcessGroup():
+class ChildProcessGroup:
     procs: list[Process]
 
     def wait(self):
-        if self.procs: # NOTE wait([]) actually stucks forever
+        if self.procs:  # NOTE wait([]) actually stucks forever
             connection.wait([p.sentinel for p in self.procs])
 
     def shutdown(self):
@@ -37,12 +38,14 @@ def previous_cleanup():
     # persits pids, etc, but ultimately those sound less reliable / less safe
     self = psutil.Process()
     executable = self.exe()
+
     def filtering(p: psutil.Process):
         try:
             return p.exe() == executable and p.pid != self.pid
         except (psutil.AccessDenied, psutil.ZombieProcess):
             return False
-    processes = [p for p in psutil.process_iter(['pid', 'exe']) if filtering(p)]
+
+    processes = [p for p in psutil.process_iter(["pid", "exe"]) if filtering(p)]
     for p in processes:
         try:
             logger.warning(f"stopping process {p.pid}, believing it a remnant of previous run")

--- a/backend/forecastbox/standalone/service.py
+++ b/backend/forecastbox/standalone/service.py
@@ -14,8 +14,10 @@ logger = logging.getLogger(__name__ if __name__ != "__main__" else __package__)
 
 pidfile = fiab_home / "pid"
 
+
 def mark_started(pid: int):
     pidfile.write_text(f"{pid}")
+
 
 def is_running() -> bool:
     if not pidfile.is_file():
@@ -42,7 +44,9 @@ if __name__ == "__main__":
 
     previous_cleanup()
     export_recursive(
-        config.model_dump(exclude_defaults=True), config.model_config["env_nested_delimiter"], config.model_config["env_prefix"],
+        config.model_dump(exclude_defaults=True),
+        config.model_config["env_nested_delimiter"],
+        config.model_config["env_prefix"],
     )
     backend = Process(target=launch_backend)
     backend.start()

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -49,7 +49,7 @@ class FakeModelRepository(SimpleHTTPRequestHandler):
             self.send_error(404, f"Not Found: {self.path}")
 
 
-def run_repository(shutdown_event: Any): # TODO typing -- is `Event` but thats not correct
+def run_repository(shutdown_event: Any):  # TODO typing -- is `Event` but thats not correct
     server_address = ("", fake_repository_port)
     with socketserver.ThreadingTCPServer(server_address, FakeModelRepository) as httpd:
         # NOTE dont serve forever, doesnt free the port up correctly
@@ -69,7 +69,7 @@ def backend_client() -> Generator[httpx.Client, None, None]:
     client = None
     try:
         td = tempfile.TemporaryDirectory()
-        os.environ['FIAB_ROOT'] = td.name
+        os.environ["FIAB_ROOT"] = td.name
         (pathlib.Path(td.name) / "pylock.toml.timestamp").write_text("1761908420:d0.0.1")
         config = FIABConfig()
         config.api.uvicorn_port = 30645
@@ -100,15 +100,14 @@ def backend_client() -> Generator[httpx.Client, None, None]:
         if td is not None:
             td.cleanup()
 
+
 @pytest.fixture(scope="session")
 def backend_client_with_auth(backend_client):
     headers = {"Content-Type": "application/json"}
     data = {"email": "authenticated_user@somewhere.org", "password": "something"}
     response = backend_client.post("/auth/register", headers=headers, json=data)
     assert response.is_success
-    response = backend_client.post(
-        "/auth/jwt/login", data={"username": "authenticated_user@somewhere.org", "password": "something"}
-    )
+    response = backend_client.post("/auth/jwt/login", data={"username": "authenticated_user@somewhere.org", "password": "something"})
     token = extract_auth_token_from_response(response)
     assert token is not None, "Token should not be None"
     backend_client.cookies.set(**prepare_cookie_with_auth_token(token))

--- a/backend/tests/integration/test_model.py
+++ b/backend/tests/integration/test_model.py
@@ -57,7 +57,6 @@ def test_download_model(backend_client):
 
     assert i > 0, "Failed to download model"
 
-
     response = backend_client.get("/model/available").raise_for_status()
     assert fake_model_name in response.json()[""]
     for e in range(parallelism):

--- a/backend/tests/integration/test_schedule.py
+++ b/backend/tests/integration/test_schedule.py
@@ -1,8 +1,7 @@
 from datetime import datetime as dt
 
 from cascade.low.builders import JobBuilder, TaskBuilder
-from forecastbox.api.types import (EnvironmentSpecification, ExecutionSpecification, RawCascadeJob,
-                                   ScheduleSpecification, ScheduleUpdate)
+from forecastbox.api.types import EnvironmentSpecification, ExecutionSpecification, RawCascadeJob, ScheduleSpecification, ScheduleUpdate
 
 
 def test_schedule_crud(backend_client_with_auth):
@@ -10,9 +9,7 @@ def test_schedule_crud(backend_client_with_auth):
     response = backend_client_with_auth.get("/schedule/notToBeFound")
     assert response.status_code == 404
 
-    job_instance = (
-        JobBuilder().with_node("n1", TaskBuilder.from_callable(eval).with_values("1+2")).build().get_or_raise()
-    )
+    job_instance = JobBuilder().with_node("n1", TaskBuilder.from_callable(eval).with_values("1+2")).build().get_or_raise()
     env = EnvironmentSpecification(hosts=1, workers_per_host=2)
     exec_spec = ExecutionSpecification(
         job=RawCascadeJob(
@@ -52,12 +49,11 @@ def test_schedule_crud(backend_client_with_auth):
     assert retrieved_schedule["cron_expr"] == updated_cron_expr
     assert retrieved_schedule["enabled"] is False
 
+
 def test_get_multiple_schedules(backend_client_with_auth):
     headers = {"Content-Type": "application/json"}
 
-    job_instance = (
-        JobBuilder().with_node("n1", TaskBuilder.from_callable(eval).with_values("1+2")).build().get_or_raise()
-    )
+    job_instance = JobBuilder().with_node("n1", TaskBuilder.from_callable(eval).with_values("1+2")).build().get_or_raise()
     env = EnvironmentSpecification(hosts=1, workers_per_host=2)
     exec_spec = ExecutionSpecification(
         job=RawCascadeJob(
@@ -83,10 +79,12 @@ def test_get_multiple_schedules(backend_client_with_auth):
 
     # update: disable
     schedule_update_2 = ScheduleUpdate(enabled=False)
-    response = backend_client_with_auth.post(f"/schedule/{sched_id_2}", headers=headers, json=schedule_update_2.model_dump(exclude_unset=True))
+    response = backend_client_with_auth.post(
+        f"/schedule/{sched_id_2}", headers=headers, json=schedule_update_2.model_dump(exclude_unset=True)
+    )
     assert response.is_success
 
-    creation_time = dt.now() # we do it a bit later, to ensure db in sync
+    creation_time = dt.now()  # we do it a bit later, to ensure db in sync
 
     # filter: enabled
     response = backend_client_with_auth.get("/schedule/?enabled=true")
@@ -168,12 +166,11 @@ def test_get_multiple_schedules(backend_client_with_auth):
     response = backend_client_with_auth.get("/schedule/?page=0&page_size=1")
     assert response.status_code == 400
 
+
 def test_get_next_schedule_run_endpoint(backend_client_with_auth):
     headers = {"Content-Type": "application/json"}
 
-    job_instance = (
-        JobBuilder().with_node("n1", TaskBuilder.from_callable(eval).with_values("1+2")).build().get_or_raise()
-    )
+    job_instance = JobBuilder().with_node("n1", TaskBuilder.from_callable(eval).with_values("1+2")).build().get_or_raise()
     env = EnvironmentSpecification(hosts=1, workers_per_host=2)
     exec_spec = ExecutionSpecification(
         job=RawCascadeJob(
@@ -200,9 +197,11 @@ def test_get_next_schedule_run_endpoint(backend_client_with_auth):
     assert "00:00:00" in initial_next_run
 
     # regenerate by changing cron expr
-    updated_cron_expr = "0 2 * * *" # Change to 2 AM
+    updated_cron_expr = "0 2 * * *"  # Change to 2 AM
     schedule_update = ScheduleUpdate(cron_expr=updated_cron_expr)
-    response = backend_client_with_auth.post(f"/schedule/{schedule_id}", headers=headers, json=schedule_update.model_dump(exclude_unset=True))
+    response = backend_client_with_auth.post(
+        f"/schedule/{schedule_id}", headers=headers, json=schedule_update.model_dump(exclude_unset=True)
+    )
     assert response.is_success
 
     response = backend_client_with_auth.get(f"/schedule/{schedule_id}/next_run")
@@ -213,7 +212,9 @@ def test_get_next_schedule_run_endpoint(backend_client_with_auth):
 
     # regenerate by disabling
     schedule_update_disable = ScheduleUpdate(enabled=False)
-    response = backend_client_with_auth.post(f"/schedule/{schedule_id}", headers=headers, json=schedule_update_disable.model_dump(exclude_unset=True))
+    response = backend_client_with_auth.post(
+        f"/schedule/{schedule_id}", headers=headers, json=schedule_update_disable.model_dump(exclude_unset=True)
+    )
     assert response.is_success
 
     response = backend_client_with_auth.get(f"/schedule/{schedule_id}/next_run")

--- a/backend/tests/integration/test_submit_job.py
+++ b/backend/tests/integration/test_submit_job.py
@@ -5,8 +5,14 @@ import zipfile
 
 import cloudpickle
 from cascade.low.builders import JobBuilder, TaskBuilder
-from forecastbox.api.types import (EnvironmentSpecification, ExecutionSpecification, ForecastProducts,
-                                   ModelSpecification, ProductSpecification, RawCascadeJob)
+from forecastbox.api.types import (
+    EnvironmentSpecification,
+    ExecutionSpecification,
+    ForecastProducts,
+    ModelSpecification,
+    ProductSpecification,
+    RawCascadeJob,
+)
 
 
 def _ensure_completed(backend_client, job_id):
@@ -37,9 +43,7 @@ def test_submit_job(backend_client_with_auth):
     assert response.status_code == 404
 
     # raw job
-    job_instance = (
-        JobBuilder().with_node("n1", TaskBuilder.from_callable(eval).with_values("1+2")).build().get_or_raise()
-    )
+    job_instance = JobBuilder().with_node("n1", TaskBuilder.from_callable(eval).with_values("1+2")).build().get_or_raise()
     spec = ExecutionSpecification(
         job=RawCascadeJob(
             job_type="raw_cascade_job",
@@ -54,7 +58,7 @@ def test_submit_job(backend_client_with_auth):
 
     outputs = backend_client_with_auth.get(f"/job/{raw_job_id}/outputs").raise_for_status().json()
     assert len(outputs) == 1
-    assert "n1" in outputs[0]['output_ids']
+    assert "n1" in outputs[0]["output_ids"]
     output = backend_client_with_auth.get(f"/job/{raw_job_id}/results/n1")
     assert cloudpickle.loads(output.content) == 3
 
@@ -125,9 +129,7 @@ def test_submit_job(backend_client_with_auth):
 
         time.sleep(secs)
 
-    job_instance = (
-        JobBuilder().with_node("n1", TaskBuilder.from_callable(sleep_with_sgn).with_values(10)).build().get_or_raise()
-    )
+    job_instance = JobBuilder().with_node("n1", TaskBuilder.from_callable(sleep_with_sgn).with_values(10)).build().get_or_raise()
     spec = ExecutionSpecification(
         job=RawCascadeJob(
             job_type="raw_cascade_job",

--- a/backend/tests/nonpytest/bigtest.py
+++ b/backend/tests/nonpytest/bigtest.py
@@ -18,6 +18,7 @@ logger = logging.getLogger("forecastbox.bigtest")
 
 is_mars = os.getenv("FIAB_BIGTEST_ISMARS", "nay") == "yea"
 
+
 def get_quickstart_job() -> dict:
     today = (dt.date.today() - dt.timedelta(2)).strftime("%Y%m%d")
     return {
@@ -28,7 +29,7 @@ def get_quickstart_job() -> dict:
                 "date": today + "T00",
                 "lead_time": 42,
                 "ensemble_members": 1,
-                "entries": {'input_preference': 'mars' if is_mars else 'opendata'},
+                "entries": {"input_preference": "mars" if is_mars else "opendata"},
             },
             "products": [
                 {

--- a/backend/tests/nonpytest/scheduler_helper.py
+++ b/backend/tests/nonpytest/scheduler_helper.py
@@ -1,4 +1,3 @@
-
 import httpx
 from cascade.low.builders import JobBuilder, TaskBuilder
 from forecastbox.api.types import EnvironmentSpecification, ExecutionSpecification, RawCascadeJob, ScheduleSpecification
@@ -7,10 +6,9 @@ from forecastbox.api.types import EnvironmentSpecification, ExecutionSpecificati
 # In particular this needs launching the instance with a clean scheduling table, and with allow_scheduling
 # Then one should observe in the logs that every minute a job is launched
 
+
 def get_job():
-    job_instance = (
-        JobBuilder().with_node("n1", TaskBuilder.from_callable(eval).with_values("1+2")).build().get_or_raise()
-    )
+    job_instance = JobBuilder().with_node("n1", TaskBuilder.from_callable(eval).with_values("1+2")).build().get_or_raise()
     env = EnvironmentSpecification(hosts=1, workers_per_host=2)
     exec_spec = ExecutionSpecification(
         job=RawCascadeJob(
@@ -20,6 +18,7 @@ def get_job():
         environment=env,
     )
     return exec_spec
+
 
 def get_sched():
     exec_spec = get_job()
@@ -31,11 +30,13 @@ def get_sched():
     )
     return sched_spec
 
+
 def create_schedule():
-    client = httpx.Client(base_url='http://localhost:8000/api/v1', follow_redirects=True)
+    client = httpx.Client(base_url="http://localhost:8000/api/v1", follow_redirects=True)
     resp = client.put("/schedule/create", json=get_sched().model_dump())
     print(resp)
     print(resp.json())
+
 
 if __name__ == "__main__":
     create_schedule()

--- a/backend/tests/unit/models/test_model.py
+++ b/backend/tests/unit/models/test_model.py
@@ -32,6 +32,7 @@ class FakeModel(GlobalModel):
     def control(self) -> ControlMetadata:
         return ControlMetadata()
 
+
 @fake_checkpoints
 def test_model_qube():
     """Test the `qube` method of the model."""
@@ -63,7 +64,6 @@ def test_model_qube_with_model_assumptions():
     """Test the `qube` method of the model with model assumptions."""
 
     test_model = FakeModel(checkpoint=checkpoint_path).specify(lead_time=72, date="2023-01-01", ensemble_members=1)
-
 
     model_assumptions = {
         "options": ["value1", "value2"],

--- a/backend/tests/unit/products/test_registry.py
+++ b/backend/tests/unit/products/test_registry.py
@@ -72,7 +72,7 @@ class MockProduct(Product):
     def qube(self) -> Qube:
         raise NotImplementedError
 
-    def execute(self, product_spec: dict[str, Any], model: SpecifiedModel, source: Action) -> Graph|Action:
+    def execute(self, product_spec: dict[str, Any], model: SpecifiedModel, source: Action) -> Graph | Action:
         raise NotImplementedError
 
 

--- a/backend/tests/unit/products/test_selections.py
+++ b/backend/tests/unit/products/test_selections.py
@@ -40,7 +40,7 @@ def create_test_product(axis: dict[str, Sequence[str]]) -> Product:
 
     product = TestProduct()
     model = create_test_model(axis)
-    model = cast(SpecifiedModel, model) # TODO typing -- product model hierarchy
+    model = cast(SpecifiedModel, model)  # TODO typing -- product model hierarchy
 
     assert product.qube == Qube.from_datacube(axis), "Product qube should match the provided axis"
     assert product.validate_intersection(model), "Product should be valid with the test model"
@@ -73,18 +73,16 @@ def create_test_model(axis: dict[str, Sequence[str]]) -> GlobalModel:
 
 def test_product_selection():
     """Test the selection of a product with a model."""
-    product = create_test_product({'options': ["value1", "value2"]})
-    model = create_test_model({'options': ["value1", "value2"]})
-    model = cast(SpecifiedModel, model) # TODO typing -- product model hierarchy
+    product = create_test_product({"options": ["value1", "value2"]})
+    model = create_test_model({"options": ["value1", "value2"]})
+    model = cast(SpecifiedModel, model)  # TODO typing -- product model hierarchy
 
     assert product.validate_intersection(model), "Product should be valid with the model"
 
     product_qube = product.model_intersection(model)
     assert "options" in product_qube.axes(), "Product qube should have 'options' axis"
 
-    assert product_qube.axes()["options"] == set(
-        ["value1", "value2"]
-    ), "Product qube should have 'value1' and 'value2' in 'options' axis"
+    assert product_qube.axes()["options"] == set(["value1", "value2"]), "Product qube should have 'value1' and 'value2' in 'options' axis"
 
 
 @pytest.mark.parametrize(
@@ -102,11 +100,11 @@ def test_product_validity(product_axis, model_axis, expected):
     """Test the validity of a product with a model based on axis."""
     product = create_test_product(product_axis)
     model = create_test_model(model_axis)
-    model = cast(SpecifiedModel, model) # TODO typing -- product model hierarchy
+    model = cast(SpecifiedModel, model)  # TODO typing -- product model hierarchy
 
-    assert (
-        product.validate_intersection(model) == expected
-    ), f"Product with axis {product_axis} should{' not' if not expected else ''} be valid with model axis {model_axis}"
+    assert product.validate_intersection(model) == expected, (
+        f"Product with axis {product_axis} should{' not' if not expected else ''} be valid with model axis {model_axis}"
+    )
 
 
 def test_generic_param_product():

--- a/backend/tests/unit/rjsf/test_from_pydantic.py
+++ b/backend/tests/unit/rjsf/test_from_pydantic.py
@@ -12,10 +12,19 @@ from typing import Dict, List, Literal, Optional, Union
 
 import pytest
 from forecastbox.rjsf.forms import FieldWithUI
-from forecastbox.rjsf.from_pydantic import (PRIMATIVES, _from_boolean_primative, _from_date_primative,
-                                            _from_dict_primative, _from_integer_primative, _from_list_primative,
-                                            _from_literal_primative, _from_string_primative, _set_base_field_info,
-                                            _update_with_extra_json, from_pydantic)
+from forecastbox.rjsf.from_pydantic import (
+    PRIMATIVES,
+    _from_boolean_primative,
+    _from_date_primative,
+    _from_dict_primative,
+    _from_integer_primative,
+    _from_list_primative,
+    _from_literal_primative,
+    _from_string_primative,
+    _set_base_field_info,
+    _update_with_extra_json,
+    from_pydantic,
+)
 from forecastbox.rjsf.jsonSchema import BooleanSchema, IntegerSchema, ObjectSchema, StringSchema
 from forecastbox.rjsf.uiSchema import UIAdditionalProperties, UIField, UIIntegerField, UIObjectField, UIStringField
 from pydantic import BaseModel, Field
@@ -406,27 +415,13 @@ class TestFromPydantic:
 
         assert len(fields) == 2
         assert "fullName" in fields  # Uses title as field name
-        assert "userId" in fields     # Uses serialization_alias as field name
+        assert "userId" in fields  # Uses serialization_alias as field name
         assert set(required) == {"fullName", "userId"}
 
     def test_model_with_rjsf_extra(self):
         class RJSFModel(BaseModel):
-            description: str = Field(
-                json_schema_extra={
-                    "rjsf": {
-                        "widget": "textarea",
-                        "placeholder": "Enter description here"
-                    }
-                }
-            )
-            priority: int = Field(
-                json_schema_extra={
-                    "rjsf": {
-                        "minimum": 1,
-                        "maximum": 10
-                    }
-                }
-            )
+            description: str = Field(json_schema_extra={"rjsf": {"widget": "textarea", "placeholder": "Enter description here"}})
+            priority: int = Field(json_schema_extra={"rjsf": {"minimum": 1, "maximum": 10}})
 
         fields, required = from_pydantic(RJSFModel)
 

--- a/backend/tests/unit/rjsf/test_jsonSchema.py
+++ b/backend/tests/unit/rjsf/test_jsonSchema.py
@@ -73,9 +73,7 @@ def test_object_schema():
 def test_object_schema_properties_and_required():
     prop1 = jsonSchema.StringSchema(type="string", title="Name")
     prop2 = jsonSchema.IntegerSchema(type="integer", title="Age")
-    obj = jsonSchema.ObjectSchema(
-        type="object", title="Person", properties={"name": prop1, "age": prop2}, required=["name"]
-    )
+    obj = jsonSchema.ObjectSchema(type="object", title="Person", properties={"name": prop1, "age": prop2}, required=["name"])
     assert obj.type == "object"
     assert obj.title == "Person"
     assert set(obj.properties.keys()) == {"name", "age"}
@@ -107,9 +105,7 @@ def test_array_schema():
 
 def test_array_schema_items_and_limits():
     item_schema = jsonSchema.StringSchema(type="string", title="Item")
-    arr = jsonSchema.ArraySchema(
-        type="array", title="StringArray", items=item_schema, minItems=2, maxItems=5, uniqueItems=True
-    )
+    arr = jsonSchema.ArraySchema(type="array", title="StringArray", items=item_schema, minItems=2, maxItems=5, uniqueItems=True)
     assert arr.type == "array"
     assert arr.title == "StringArray"
     assert arr.items == item_schema

--- a/backend/tests/unit/rjsf/test_uiSchema.py
+++ b/backend/tests/unit/rjsf/test_uiSchema.py
@@ -38,9 +38,7 @@ def test_uiarrayfield_and_uiobjectfield_export():
     obj_field = UIObjectField(anyOf=[UIStringField(), UIIntegerField()])
     # Should export with only set fields
     assert arr_field.export_with_prefix() == {}
-    assert obj_field.export_with_prefix() == {
-        "anyOf": [{"ui:options": {"widget": "text"}}, {"ui:options": {"widget": "updown"}}]
-    }
+    assert obj_field.export_with_prefix() == {"anyOf": [{"ui:options": {"widget": "text"}}, {"ui:options": {"widget": "updown"}}]}
 
 
 def test_uifield_all_options():

--- a/backend/tests/unit/scheduling/test_dt_utils.py
+++ b/backend/tests/unit/scheduling/test_dt_utils.py
@@ -13,6 +13,7 @@ def test_parse_crontab_valid():
     parse_crontab("0 0 * 1 *")
     parse_crontab("0 0 * * 0")
 
+
 def test_parse_crontab_invalid():
     def _test(crontab, expected):
         with pytest.raises(ValueError, match=re.escape(expected) + ".*"):
@@ -42,11 +43,13 @@ def test_parse_crontab_invalid():
     _test("*/0 * * * *", "Step value must be positive: step=0, field='*/0' of minute.")
     _test("*/a * * * *", "Invalid cron field format: */a of minute")
 
+
 def test_next_run_every_minute():
     after = datetime(2025, 10, 20, 10, 0, 0)
     cron_tab = "* * * * *"
     expected = datetime(2025, 10, 20, 10, 1, 0)
     assert calculate_next_run(after, cron_tab) == expected
+
 
 def test_next_run_specific_time():
     after = datetime(2025, 10, 20, 10, 0, 0)
@@ -54,11 +57,13 @@ def test_next_run_specific_time():
     expected = datetime(2025, 10, 20, 11, 30, 0)
     assert calculate_next_run(after, cron_tab) == expected
 
+
 def test_next_run_next_day():
     after = datetime(2025, 10, 20, 23, 30, 0)
     cron_tab = "0 0 * * *"
     expected = datetime(2025, 10, 21, 0, 0, 0)
     assert calculate_next_run(after, cron_tab) == expected
+
 
 def test_next_run_invalid_crontab():
     after = datetime(2025, 10, 20, 10, 0, 0)
@@ -66,11 +71,13 @@ def test_next_run_invalid_crontab():
     with pytest.raises(ValueError):
         calculate_next_run(after, cron_tab)
 
+
 def test_next_run_no_future_run():
     after = datetime(2025, 10, 20, 10, 0, 0)
     cron_tab = "0 0 1 1 1"
     with pytest.raises(ValueError):
         calculate_next_run(after, cron_tab)
+
 
 def test_next_run_step_value():
     after = datetime(2025, 10, 20, 10, 0, 0)
@@ -78,11 +85,13 @@ def test_next_run_step_value():
     expected = datetime(2025, 10, 20, 10, 15, 0)
     assert calculate_next_run(after, cron_tab) == expected
 
+
 def test_next_run_range_value():
     after = datetime(2025, 10, 20, 10, 0, 0)
     cron_tab = "0 10-12 * * *"
     expected = datetime(2025, 10, 20, 11, 0, 0)
     assert calculate_next_run(after, cron_tab) == expected
+
 
 def test_next_run_list_value():
     after = datetime(2025, 10, 20, 10, 0, 0)

--- a/backend/tests/unit/scheduling/test_job_utils.py
+++ b/backend/tests/unit/scheduling/test_job_utils.py
@@ -14,11 +14,13 @@ def test_deep_union_empty_dicts():
     expected = {}
     assert deep_union(dict1, dict2) == expected
 
+
 def test_deep_union_dict1_empty():
     dict1 = {}
     dict2 = {"a": 1, "b": {"c": 2}}
     expected = {"a": 1, "b": {"c": 2}}
     assert deep_union(dict1, dict2) == expected
+
 
 def test_deep_union_dict2_empty():
     dict1 = {"a": 1, "b": {"c": 2}}
@@ -26,11 +28,13 @@ def test_deep_union_dict2_empty():
     expected = {"a": 1, "b": {"c": 2}}
     assert deep_union(dict1, dict2) == expected
 
+
 def test_deep_union_no_conflicts():
     dict1 = {"a": 1, "b": {"c": 2}}
     dict2 = {"d": 3, "e": 4}
     expected = {"a": 1, "b": {"c": 2}, "d": 3, "e": 4}
     assert deep_union(dict1, dict2) == expected
+
 
 def test_deep_union_with_conflicts_prefer_dict2():
     dict1 = {"a": 1, "b": {"c": 2}, "k3": 0}
@@ -38,11 +42,13 @@ def test_deep_union_with_conflicts_prefer_dict2():
     expected = {"a": 1, "b": {"c": 2, "d": 3}, "k3": 4}
     assert deep_union(dict1, dict2) == expected
 
+
 def test_deep_union_nested_dicts_with_conflicts():
     dict1 = {"k1": {"k2": 3}, "k3": 0}
     dict2 = {"k1": {"k4": 5}, "k3": 4}
     expected = {"k1": {"k2": 3, "k4": 5}, "k3": 4}
     assert deep_union(dict1, dict2) == expected
+
 
 def test_deep_union_non_dict_overwrite():
     dict1 = {"a": 1, "b": {"c": 2}}
@@ -50,11 +56,13 @@ def test_deep_union_non_dict_overwrite():
     expected = {"a": 1, "b": 3}
     assert deep_union(dict1, dict2) == expected
 
+
 def test_deep_union_dict_overwrite_non_dict():
     dict1 = {"a": 1, "b": 2}
     dict2 = {"b": {"c": 3}}
     expected = {"a": 1, "b": {"c": 3}}
     assert deep_union(dict1, dict2) == expected
+
 
 def test_eval_dynamic_expression_no_replacement():
     data = {"key1": "value1", "key2": 123}
@@ -62,11 +70,13 @@ def test_eval_dynamic_expression_no_replacement():
     expected = {"key1": "value1", "key2": 123}
     assert eval_dynamic_expression(data, execution_time) == expected
 
+
 def test_eval_dynamic_expression_single_replacement():
     data = {"key1": "$execution_time", "key2": "value2"}
     execution_time = datetime(2025, 10, 20, 10, 30)
     expected = {"key1": "20251020T10", "key2": "value2"}
     assert eval_dynamic_expression(data, execution_time) == expected
+
 
 def test_eval_dynamic_expression_nested_replacement():
     data = {"key1": {"nested_key": "$execution_time"}, "key2": "value2"}
@@ -74,17 +84,20 @@ def test_eval_dynamic_expression_nested_replacement():
     expected = {"key1": {"nested_key": "20251020T10"}, "key2": "value2"}
     assert eval_dynamic_expression(data, execution_time) == expected
 
+
 def test_eval_dynamic_expression_multiple_replacements():
     data = {"key1": "$execution_time", "key2": {"nested_key": "$execution_time"}}
     execution_time = datetime(2025, 10, 20, 10, 30)
     expected = {"key1": "20251020T10", "key2": {"nested_key": "20251020T10"}}
     assert eval_dynamic_expression(data, execution_time) == expected
 
+
 def test_eval_dynamic_expression_partial_match():
     data = {"key1": "prefix_$execution_time_suffix", "key2": "$execution_time_only"}
     execution_time = datetime(2025, 10, 20, 10, 30)
     expected = {"key1": "prefix_$execution_time_suffix", "key2": "$execution_time_only"}
     assert eval_dynamic_expression(data, execution_time) == expected
+
 
 @pytest.mark.asyncio
 @patch("forecastbox.api.scheduling.job_utils.get_schedules")
@@ -97,17 +110,19 @@ async def test_schedule2runnable_found(mock_get_schedules):
         cron_expr="* * * * *",
         created_at=datetime.now(),
         updated_at=datetime.now(),
-        exec_spec=orjson.dumps({
-            "job": {
-                "job_type": "forecast_products",
-                "model": {"model": "test_model", "date": "2025-10-20", "lead_time": 24, "ensemble_members": 1},
-                "products": [{"product": "test_product", "specification": {}}]
-            },
-            "environment": {"hosts": 1, "workers_per_host": 1}
-        }).decode('ascii'),
-        dynamic_expr=orjson.dumps({"job": {"model": {"date": "$execution_time"}}}).decode('ascii'),
+        exec_spec=orjson.dumps(
+            {
+                "job": {
+                    "job_type": "forecast_products",
+                    "model": {"model": "test_model", "date": "2025-10-20", "lead_time": 24, "ensemble_members": 1},
+                    "products": [{"product": "test_product", "specification": {}}],
+                },
+                "environment": {"hosts": 1, "workers_per_host": 1},
+            }
+        ).decode("ascii"),
+        dynamic_expr=orjson.dumps({"job": {"model": {"date": "$execution_time"}}}).decode("ascii"),
         enabled=True,
-        created_by="test_user"
+        created_by="test_user",
     )
     mock_get_schedules.return_value = [mock_schedule_def]
 
@@ -116,9 +131,10 @@ async def test_schedule2runnable_found(mock_get_schedules):
     assert result.e is None
     assert result.t is not None
     assert isinstance(result.t.exec_spec, ExecutionSpecification)
-    assert result.t.created_by == 'test_user'
-    assert result.t.exec_spec.job.model.date == "20251020T10" # Check dynamic replacement
+    assert result.t.created_by == "test_user"
+    assert result.t.exec_spec.job.model.date == "20251020T10"  # Check dynamic replacement
     assert result.t.exec_spec.environment.hosts == 1
+
 
 @pytest.mark.asyncio
 @patch("forecastbox.api.scheduling.job_utils.get_schedules")

--- a/backend/tests/unit/scheduling/test_schedule_runs.py
+++ b/backend/tests/unit/scheduling/test_schedule_runs.py
@@ -1,4 +1,3 @@
-
 import datetime as dt
 import uuid
 from typing import cast
@@ -29,24 +28,29 @@ def mock_schedule_run_row():
             updated_at=dt.datetime(2025, 10, 23, 10, 0, 5),
             graph_specification="{}",
             created_by="test@example.com",
-            outputs = "{}",
+            outputs="{}",
             error=None,
             progress="100%",
         ),
     )
 
+
 @pytest.fixture
 def mock_user():
     return UserRead(id=str(uuid.uuid4()), email="test@example.com", is_active=True, is_superuser=False, is_verified=True)
 
+
 @pytest.mark.asyncio
 async def test_get_schedule_runs_success(mock_schedule_run_row, mock_user):
-    with patch("forecastbox.api.routers.schedule.select_runs", AsyncMock(return_value=[mock_schedule_run_row])) as mock_select_runs, \
-         patch("forecastbox.api.routers.schedule.select_runs_count", AsyncMock(return_value=1)) as mock_select_runs_count:
-
+    with (
+        patch("forecastbox.api.routers.schedule.select_runs", AsyncMock(return_value=[mock_schedule_run_row])) as mock_select_runs,
+        patch("forecastbox.api.routers.schedule.select_runs_count", AsyncMock(return_value=1)) as mock_select_runs_count,
+    ):
         response = await get_schedule_runs(schedule_id="test_schedule_id", user=mock_user)
 
-        mock_select_runs.assert_called_once_with(schedule_id="test_schedule_id", since_dt=None, before_dt=None, offset=0, limit=10, status=None)
+        mock_select_runs.assert_called_once_with(
+            schedule_id="test_schedule_id", since_dt=None, before_dt=None, offset=0, limit=10, status=None
+        )
         mock_select_runs_count.assert_called_once_with(schedule_id="test_schedule_id", since_dt=None, before_dt=None, status=None)
 
         assert isinstance(response, GetScheduleRunsResponse)
@@ -60,14 +64,18 @@ async def test_get_schedule_runs_success(mock_schedule_run_row, mock_user):
         assert response.total_pages == 1
         assert response.error is None
 
+
 @pytest.mark.asyncio
 async def test_get_schedule_runs_pagination(mock_schedule_run_row, mock_user):
-    with patch("forecastbox.api.routers.schedule.select_runs", AsyncMock(return_value=[mock_schedule_run_row])) as mock_select_runs, \
-         patch("forecastbox.api.routers.schedule.select_runs_count", AsyncMock(return_value=1)) as mock_select_runs_count:
-
+    with (
+        patch("forecastbox.api.routers.schedule.select_runs", AsyncMock(return_value=[mock_schedule_run_row])) as mock_select_runs,
+        patch("forecastbox.api.routers.schedule.select_runs_count", AsyncMock(return_value=1)) as mock_select_runs_count,
+    ):
         response = await get_schedule_runs(schedule_id="test_schedule_id", user=mock_user, page=1, page_size=1)
 
-        mock_select_runs.assert_called_once_with(schedule_id="test_schedule_id", since_dt=None, before_dt=None, offset=0, limit=1, status=None)
+        mock_select_runs.assert_called_once_with(
+            schedule_id="test_schedule_id", since_dt=None, before_dt=None, offset=0, limit=1, status=None
+        )
         mock_select_runs_count.assert_called_once_with(schedule_id="test_schedule_id", since_dt=None, before_dt=None, status=None)
         assert isinstance(response, GetScheduleRunsResponse)
         assert len(response.runs) == 1
@@ -76,14 +84,18 @@ async def test_get_schedule_runs_pagination(mock_schedule_run_row, mock_user):
         assert response.page_size == 1
         assert response.total_pages == 1
 
+
 @pytest.mark.asyncio
 async def test_get_schedule_runs_no_runs(mock_user):
-    with patch("forecastbox.api.routers.schedule.select_runs", AsyncMock(return_value=[])) as mock_select_runs, \
-         patch("forecastbox.api.routers.schedule.select_runs_count", AsyncMock(return_value=0)) as mock_select_runs_count:
-
+    with (
+        patch("forecastbox.api.routers.schedule.select_runs", AsyncMock(return_value=[])) as mock_select_runs,
+        patch("forecastbox.api.routers.schedule.select_runs_count", AsyncMock(return_value=0)) as mock_select_runs_count,
+    ):
         response = await get_schedule_runs(schedule_id="test_schedule_id", user=mock_user)
 
-        mock_select_runs.assert_called_once_with(schedule_id="test_schedule_id", since_dt=None, before_dt=None, offset=0, limit=10, status=None)
+        mock_select_runs.assert_called_once_with(
+            schedule_id="test_schedule_id", since_dt=None, before_dt=None, offset=0, limit=10, status=None
+        )
         mock_select_runs_count.assert_called_once_with(schedule_id="test_schedule_id", since_dt=None, before_dt=None, status=None)
         assert isinstance(response, GetScheduleRunsResponse)
         assert len(response.runs) == 0
@@ -92,6 +104,7 @@ async def test_get_schedule_runs_no_runs(mock_user):
         assert response.page_size == 10
         assert response.total_pages == 0
         assert response.error is None
+
 
 @pytest.mark.asyncio
 async def test_get_schedule_runs_invalid_page_params(mock_user):
@@ -103,11 +116,13 @@ async def test_get_schedule_runs_invalid_page_params(mock_user):
         await get_schedule_runs(schedule_id="test_schedule_id", user=mock_user, page_size=0)
     assert "Page and page_size must be greater than 0." in cast(HTTPException, exc_info.value).detail
 
+
 @pytest.mark.asyncio
 async def test_get_schedule_runs_page_out_of_range(mock_schedule_run_row, mock_user):
-    with patch("forecastbox.api.routers.schedule.select_runs", AsyncMock(return_value=[])), \
-         patch("forecastbox.api.routers.schedule.select_runs_count", AsyncMock(return_value=1)):
-
+    with (
+        patch("forecastbox.api.routers.schedule.select_runs", AsyncMock(return_value=[])),
+        patch("forecastbox.api.routers.schedule.select_runs_count", AsyncMock(return_value=1)),
+    ):
         with pytest.raises(HTTPException) as exc_info:
             await get_schedule_runs(schedule_id="test_schedule_id", user=mock_user, page=2, page_size=1)
         assert "Page number out of range." in cast(HTTPException, exc_info.value).detail

--- a/backend/tests/unit/test_updates.py
+++ b/backend/tests/unit/test_updates.py
@@ -7,8 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
-from forecastbox.api.updates import (Release, get_local_release, get_lock_timestamp, get_most_recent_release,
-                                     get_pylock, save_pylock)
+from forecastbox.api.updates import Release, get_local_release, get_lock_timestamp, get_most_recent_release, get_pylock, save_pylock
 
 
 def test_release_from_string():
@@ -16,6 +15,7 @@ def test_release_from_string():
     assert Release.from_string("v1.2.3") == Release(1, 2, 3)
     assert Release.from_string("d1.2.3") == Release(1, 2, 3)
     assert Release.from_string("10.20.30") == Release(10, 20, 30)
+
 
 def test_release_from_string_invalid():
     with pytest.raises(ValueError):
@@ -25,6 +25,7 @@ def test_release_from_string_invalid():
     with pytest.raises(ValueError):
         Release.from_string("abc")
 
+
 @pytest_asyncio.fixture
 async def mock_httpx_client():
     with patch("httpx.AsyncClient") as mock_client_class:
@@ -32,9 +33,10 @@ async def mock_httpx_client():
         mock_client_class.return_value.__aenter__.return_value = mock_client
         yield mock_client
 
+
 @pytest.mark.asyncio
 async def test_get_most_recent_release(mock_httpx_client):
-    mock_response_json = '''
+    mock_response_json = """
     [{
         "url":"https://api.github.com/repos/ecmwf/forecast-in-a-box/releases/257019467",
         "assets_url":"https://api.github.com/repos/ecmwf/forecast-in-a-box/releases/257019467/assets",
@@ -44,12 +46,13 @@ async def test_get_most_recent_release(mock_httpx_client):
         "author":{"login":"HCookie","id":48088699,"node_id":"MDQ6VXNlcjQ4ODA4ODY5OS","avatar_url":"https://avatars.githubusercontent.com/u/48088699?v=4","gravatar_id":"","url":"https://api.github.com/users/HCookie","html_url":"https://github.com/HCookie","followers_url":"https://api.github.com/users/HCookie/followers","following_url":"https://api.github.com/users/HCookie/following{/other_user}","gists_url":"https://api.github.com/users/HCookie/gists{/gist_id}","starred_url":"https://api.github.com/users/HCookie/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/HCookie/subscriptions","organizations_url":"https://api.github.com/users/HCookie/orgs","repos_url":"https://api.github.com/users/HCookie/repos","events_url":"https://api.github.com/users/HCookie/events{/privacy}","received_events_url":"https://api.github.com/users/HCookie/received_events","type":"User","user_view_type":"public","site_admin":false},
         "node_id":"RE_kwDOL8XCIs4PUc5L","tag_name":"v0.3.9","target_commitish":"main","name":"v0.3.9","draft":false,"immutable":false,"prerelease":false,"created_at":"2025-10-24T14:17:21Z","updated_at":"2025-10-29T13:13:17Z","published_at":"2025-10-24T14:20:16Z","assets":[],"tarball_url":"https://api.github.com/repos/ecmwf/forecast-in-a-box/tarball/v0.3.9","zipball_url":"https://api.github.com/repos/ecmwf/forecast-in-a-box/zipball/v0.3.9","body":"Update taglines"
     }]
-    '''
+    """
     mock_response_obj = MagicMock()
     mock_response_obj.json.return_value = json.loads(mock_response_json)
     mock_response_obj.raise_for_status.return_value = None
     mock_httpx_client.get.return_value = mock_response_obj
     assert await get_most_recent_release() == Release(0, 3, 9)
+
 
 @pytest.mark.asyncio
 async def test_get_most_recent_release_no_releases(mock_httpx_client):
@@ -59,6 +62,7 @@ async def test_get_most_recent_release_no_releases(mock_httpx_client):
     mock_httpx_client.get.return_value = mock_response_obj
     with pytest.raises(ValueError, match="No releases found on GitHub."):
         await get_most_recent_release()
+
 
 @patch("forecastbox.api.updates.fiab_home", new=Path("/tmp/fiab_test"))
 @patch("pathlib.Path.is_file")
@@ -77,6 +81,7 @@ def test_get_lock_timestamp(mock_read_text, mock_is_file):
     mock_is_file.return_value = True
     mock_read_text.return_value = "\n"
     assert get_lock_timestamp() == ""
+
 
 @patch("forecastbox.api.updates.get_lock_timestamp")
 def test_get_local_release(mock_get_lock_timestamp):
@@ -97,7 +102,7 @@ def test_get_local_release(mock_get_lock_timestamp):
         get_local_release()
 
     # Test case: invalid format (missing colon)
-    mock_get_lock_timestamp.return_value = "1761908420_v0.1.0" # No colon at all
+    mock_get_lock_timestamp.return_value = "1761908420_v0.1.0"  # No colon at all
     with pytest.raises(ValueError, match="Invalid format in pylock.toml.timestamp: expected 'datetime:release_string'."):
         get_local_release()
 
@@ -106,9 +111,10 @@ def test_get_local_release(mock_get_lock_timestamp):
     with pytest.raises(ValueError, match=re.escape("invalid literal for int() with base 10: 'invalid_release'")):
         get_local_release()
 
+
 @pytest.mark.asyncio
 async def test_get_pylock(mock_httpx_client):
-    mock_pylock_content = "[tool.uv]\npython = \"3.12\"\n"
+    mock_pylock_content = '[tool.uv]\npython = "3.12"\n'
     mock_response_obj = MagicMock()
     mock_response_obj.text = mock_pylock_content
     mock_response_obj.raise_for_status.return_value = None
@@ -122,6 +128,7 @@ async def test_get_pylock(mock_httpx_client):
     mock_httpx_client.get.assert_called_once_with(expected_url)
     assert content == mock_pylock_content
 
+
 @patch("forecastbox.api.updates.fiab_home")
 def test_save_pylock(mock_fiab_home):
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -131,7 +138,7 @@ def test_save_pylock(mock_fiab_home):
         mock_fiab_home.__truediv__.side_effect = lambda x: temp_path / x
         mock_fiab_home.mkdir.side_effect = temp_path.mkdir
 
-        test_pylock_content = "[tool.uv]\npython = \"3.12\"\n"
+        test_pylock_content = '[tool.uv]\npython = "3.12"\n'
         test_release = Release(0, 2, 0)
 
         save_pylock(test_pylock_content, test_release)


### PR DESCRIPTION
- remove hooks which had no application (rstfmt, notebooks, docs)
- remove hooks which were extraneous (too many cfg linters / fmtters)
- remove conflicting values (line length already configured in pyproject)
- add filter to python hooks to react to `^backend/` only

... and running precommit on all files. We must have had some rogue commits again, those ' -> " are I believe not caused by this config change. The line length related ones are caused by this, because now we don't have isort and ruff fighting each other
