### PR TITLE
[ci] fix import order, run precommit in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,9 @@ jobs:
       - run: |
           set -euo pipefail
           cd backend
+          export UV_FROZEN=1
           uv sync --extra plots --python "${{ matrix.python_version }}"
+          uv run prek --all-files
           uv run ty check
           mkdir /tmp/tmpFiabHome
           mkdir forecastbox/static && touch forecastbox/static/index.html # TODO replace with proper static file build
@@ -57,7 +59,9 @@ jobs:
       - run: |
           set -euo pipefail
           cd backend
+          export UV_FROZEN=1
           uv sync --extra plots --python "${{ matrix.python_version }}"
+          uv run prek --all-files
           uv run ty check
           mkdir /tmp/tmpFiabHome
           mkdir forecastbox/static && touch forecastbox/static/index.html # TODO replace with proper static file build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,12 +15,14 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.12.2
   hooks:
-  - id: ruff # better black/flake
+  - id: ruff # better black/flake/isort
     files: ^backend/
     args:
+    - --select
+    - I # isorting
     - --fix
     - --exit-non-zero-on-fix
-  - id: ruff-format # better isort
+  - id: ruff-format
     files: ^backend/
 ci:
   autoupdate_schedule: monthly

--- a/backend/forecastbox/api/execution.py
+++ b/backend/forecastbox/api/execution.py
@@ -22,6 +22,8 @@ from cascade.low.into import graph2job
 from earthkit.workflows import Cascade, fluent
 from earthkit.workflows.graph import Graph, deduplicate_nodes
 from fastapi import HTTPException
+from pydantic import BaseModel
+
 from forecastbox.api.types import EnvironmentSpecification, ExecutionSpecification, ForecastProducts, RawCascadeJob
 from forecastbox.api.utils import get_model_path
 from forecastbox.config import config
@@ -29,7 +31,6 @@ from forecastbox.db.job import insert_one
 from forecastbox.models import get_model
 from forecastbox.products.registry import get_product
 from forecastbox.schemas.user import UserRead
-from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 

--- a/backend/forecastbox/api/routers/admin.py
+++ b/backend/forecastbox/api/routers/admin.py
@@ -14,14 +14,15 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import HTMLResponse
+from pydantic import UUID4, BaseModel
+from sqlalchemy import delete, select, update
+
 from forecastbox.api.updates import Release, get_local_release, get_most_recent_release, get_pylock, save_pylock
 from forecastbox.auth.users import current_active_user
 from forecastbox.config import BackendAPISettings, CascadeSettings, ProductSettings, config
 from forecastbox.db.user import async_session_maker
 from forecastbox.rjsf import ExportedSchemas, FormDefinition, from_pydantic
 from forecastbox.schemas.user import UserRead, UserTable, UserUpdate
-from pydantic import UUID4, BaseModel
-from sqlalchemy import delete, select, update
 
 logger = logging.getLogger(__name__)
 

--- a/backend/forecastbox/api/routers/auth.py
+++ b/backend/forecastbox/api/routers/auth.py
@@ -8,6 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 from fastapi import APIRouter
+
 from forecastbox.auth.oidc import oauth_client
 from forecastbox.auth.users import auth_backend, fastapi_users
 from forecastbox.config import config

--- a/backend/forecastbox/api/routers/execution.py
+++ b/backend/forecastbox/api/routers/execution.py
@@ -15,6 +15,7 @@ import logging
 from cascade.low.core import JobInstance
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import HTMLResponse
+
 from forecastbox.api.execution import SubmitJobResponse, execute2response, execution_specification_to_cascade
 from forecastbox.api.types import ExecutionSpecification, VisualisationOptions
 from forecastbox.api.visualisation import visualise

--- a/backend/forecastbox/api/routers/gateway.py
+++ b/backend/forecastbox/api/routers/gateway.py
@@ -21,9 +21,10 @@ import cascade.executor.platform as cascade_platform
 import cascade.gateway.api
 import cascade.gateway.client
 from fastapi import APIRouter, HTTPException, Request
+from sse_starlette.sse import EventSourceResponse
+
 from forecastbox.config import StatusMessage, config
 from forecastbox.standalone.launchers import launch_cascade
-from sse_starlette.sse import EventSourceResponse
 
 logger = logging.getLogger(__name__)
 

--- a/backend/forecastbox/api/routers/job.py
+++ b/backend/forecastbox/api/routers/job.py
@@ -26,6 +26,7 @@ from cascade.controller.report import JobId
 from cascade.low.core import DatasetId, TaskId
 from fastapi import APIRouter, Body, Depends, HTTPException, Response, UploadFile
 from fastapi.responses import HTMLResponse
+
 from forecastbox.api.execution import ProductToOutputId, SubmitJobResponse, execute2response
 from forecastbox.api.routers.gateway import Globals
 from forecastbox.api.types import ExecutionSpecification, VisualisationOptions

--- a/backend/forecastbox/api/routers/model.py
+++ b/backend/forecastbox/api/routers/model.py
@@ -21,6 +21,8 @@ from typing import Any, Literal
 
 import httpx
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from pydantic import BaseModel
+
 from forecastbox.api.utils import get_model_path
 from forecastbox.config import config
 from forecastbox.db.model import delete_download, finish_edit, get_download, get_edit, start_download, start_editing, update_progress
@@ -28,7 +30,6 @@ from forecastbox.models.metadata import ControlMetadata, set_control_metadata
 from forecastbox.models.model import ModelInfo, get_model, model_info
 from forecastbox.rjsf import ExportedSchemas
 from forecastbox.schemas.model import ModelDownload
-from pydantic import BaseModel
 
 from ..types import ModelName
 from .admin import get_admin_user

--- a/backend/forecastbox/api/routers/product.py
+++ b/backend/forecastbox/api/routers/product.py
@@ -14,14 +14,15 @@ from collections import OrderedDict
 from collections.abc import Iterable
 from typing import Any
 
-import forecastbox.rjsf.utils as rjsfutils
 from fastapi import APIRouter, HTTPException
+from qubed import Qube
+
+import forecastbox.rjsf.utils as rjsfutils
 from forecastbox.models import SpecifiedModel, get_model
 from forecastbox.products.interfaces import Interfaces
 from forecastbox.products.product import USER_DEFINED, Product
 from forecastbox.products.registry import Category, get_categories, get_product
 from forecastbox.rjsf import ExportedSchemas, FieldWithUI, FormDefinition, StringSchema
-from qubed import Qube
 
 from ..types import ModelSpecification
 from .model import get_model_path

--- a/backend/forecastbox/api/routers/schedule.py
+++ b/backend/forecastbox/api/routers/schedule.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass
 from typing import cast
 
 from fastapi import APIRouter, Depends, HTTPException
+from typing_extensions import Self
+
 from forecastbox.api.execution import execute
 from forecastbox.api.routers.job import STATUS
 from forecastbox.api.scheduling.dt_utils import calculate_next_run, parse_crontab
@@ -42,7 +44,6 @@ from forecastbox.db.schedule import (
 from forecastbox.schemas.job import JobRecord
 from forecastbox.schemas.schedule import ScheduleDefinition, ScheduleRun
 from forecastbox.schemas.user import UserRead
-from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 

--- a/backend/forecastbox/api/scheduling/job_utils.py
+++ b/backend/forecastbox/api/scheduling/job_utils.py
@@ -15,6 +15,7 @@ from typing import Any, cast
 
 import orjson
 from cascade.low.func import Either
+
 from forecastbox.api.scheduling.dt_utils import calculate_next_run
 from forecastbox.api.types import ExecutionSpecification
 from forecastbox.db.schedule import get_schedules, max_attempt_cnt, run2date, run2schedule

--- a/backend/forecastbox/api/types.py
+++ b/backend/forecastbox/api/types.py
@@ -14,8 +14,9 @@ from typing import Any, Literal
 
 import orjson
 from cascade.low.core import JobInstance
-from forecastbox.products.product import USER_DEFINED
 from pydantic import BaseModel, Field, PositiveInt, field_validator, model_validator
+
+from forecastbox.products.product import USER_DEFINED
 
 CONFIG_ORDER = ["param", "levtype", "levelist"]
 

--- a/backend/forecastbox/api/updates.py
+++ b/backend/forecastbox/api/updates.py
@@ -3,6 +3,7 @@ import logging
 from datetime import datetime
 
 import httpx
+
 from forecastbox.config import fiab_home
 
 logger = logging.getLogger(__name__)

--- a/backend/forecastbox/api/utils.py
+++ b/backend/forecastbox/api/utils.py
@@ -17,6 +17,7 @@ import earthkit.data as ekd
 import numpy as np
 import xarray as xr
 from cascade.gateway.api import decoded_result
+
 from forecastbox.config import config
 
 logger = logging.getLogger(__name__)

--- a/backend/forecastbox/api/visualisation.py
+++ b/backend/forecastbox/api/visualisation.py
@@ -11,6 +11,7 @@ import logging
 import tempfile
 
 from fastapi.responses import HTMLResponse
+
 from forecastbox.api.execution import forecast_products_to_cascade
 from forecastbox.api.types import ExecutionSpecification, ForecastProducts, VisualisationOptions
 

--- a/backend/forecastbox/auth/oidc.py
+++ b/backend/forecastbox/auth/oidc.py
@@ -7,8 +7,9 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-from forecastbox.config import config
 from httpx_oauth.clients.openid import OpenID
+
+from forecastbox.config import config
 
 if config.auth.oidc is not None:
     if config.auth.oidc.openid_configuration_endpoint is None or config.auth.oidc.client_id is None:

--- a/backend/forecastbox/auth/users.py
+++ b/backend/forecastbox/auth/users.py
@@ -16,10 +16,11 @@ from fastapi_users import BaseUserManager, FastAPIUsers, UUIDIDMixin
 from fastapi_users.authentication import AuthenticationBackend, CookieTransport, JWTStrategy
 from fastapi_users.db import SQLAlchemyUserDatabase
 from fastapi_users.exceptions import InvalidPasswordException
+from sqlalchemy import func, select, update
+
 from forecastbox.config import config
 from forecastbox.db.user import async_session_maker, get_user_db
 from forecastbox.schemas.user import UserCreate, UserRead, UserTable
-from sqlalchemy import func, select, update
 
 SECRET = config.auth.jwt_secret.get_secret_value()
 COOKIE_NAME = "forecastbox_auth"

--- a/backend/forecastbox/db/job.py
+++ b/backend/forecastbox/db/job.py
@@ -12,11 +12,12 @@ import logging
 from collections.abc import Iterable
 
 from cascade.controller.report import JobId
+from sqlalchemy import delete, func, select, update
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
 from forecastbox.config import config
 from forecastbox.db.core import addAndCommit, dbRetry, executeAndCommit, queryCount, querySingle
 from forecastbox.schemas.job import Base, JobRecord
-from sqlalchemy import delete, func, select, update
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 logger = logging.getLogger(__name__)
 

--- a/backend/forecastbox/db/migrations.py
+++ b/backend/forecastbox/db/migrations.py
@@ -2,8 +2,9 @@
 
 import logging
 
-from forecastbox.config import config
 from sqlalchemy import MetaData, create_engine, text
+
+from forecastbox.config import config
 
 logger = logging.getLogger(__name__)
 

--- a/backend/forecastbox/db/model.py
+++ b/backend/forecastbox/db/model.py
@@ -8,12 +8,13 @@ Note that those reside in the jobdb as well -- there is no modeldb
 import datetime as dt
 import logging
 
-from forecastbox.config import config
-from forecastbox.db.core import addAndCommit, executeAndCommit, querySingle
-from forecastbox.schemas.model import Base, ModelDownload, ModelEdit
 from sqlalchemy import delete, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from forecastbox.config import config
+from forecastbox.db.core import addAndCommit, executeAndCommit, querySingle
+from forecastbox.schemas.model import Base, ModelDownload, ModelEdit
 
 logger = logging.getLogger(__name__)
 

--- a/backend/forecastbox/db/schedule.py
+++ b/backend/forecastbox/db/schedule.py
@@ -12,12 +12,13 @@ import logging
 import uuid
 from typing import Iterable
 
+from sqlalchemy import delete, func, select, update
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
 from forecastbox.config import config
 from forecastbox.db.core import addAndCommit, dbRetry, executeAndCommit, queryCount
 from forecastbox.schemas.job import JobRecord
 from forecastbox.schemas.schedule import Base, ScheduleDefinition, ScheduleNext, ScheduleRun
-from sqlalchemy import delete, func, select, update
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 logger = logging.getLogger(__name__)
 

--- a/backend/forecastbox/db/user.py
+++ b/backend/forecastbox/db/user.py
@@ -2,10 +2,11 @@ from collections.abc import AsyncGenerator
 
 from fastapi import Depends
 from fastapi_users.db import SQLAlchemyUserDatabase
-from forecastbox.config import config
-from forecastbox.schemas.user import Base, OAuthAccount, UserTable
 from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from forecastbox.config import config
+from forecastbox.schemas.user import Base, OAuthAccount, UserTable
 
 async_url = f"sqlite+aiosqlite:///{config.db.sqlite_userdb_path}"
 sync_url = f"sqlite:///{config.db.sqlite_userdb_path}"

--- a/backend/forecastbox/entrypoint.py
+++ b/backend/forecastbox/entrypoint.py
@@ -18,17 +18,18 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
 
-import forecastbox.db
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from starlette.exceptions import HTTPException
+
+import forecastbox.db
 from forecastbox.api.scheduling.scheduler_thread import start_scheduler, status_scheduler, stop_scheduler
 from forecastbox.api.updates import get_local_release
 from forecastbox.db.migrations import migrate
 from forecastbox.db.model import delete_download
-from starlette.exceptions import HTTPException
 
 from .api.routers import admin, auth, execution, gateway, job, model, product, schedule
 from .config import config

--- a/backend/forecastbox/models/metadata.py
+++ b/backend/forecastbox/models/metadata.py
@@ -12,10 +12,11 @@ import os
 from typing import Any
 
 import yaml
+from pydantic import BaseModel, Field, model_validator
+
 from forecastbox.rjsf import FieldWithUI, FormDefinition
 from forecastbox.rjsf.jsonSchema import BooleanSchema, IntegerSchema, ObjectSchema, StringSchema
 from forecastbox.rjsf.uiSchema import UIAdditionalProperties, UIStringField
-from pydantic import BaseModel, Field, model_validator
 
 from .utils import open_checkpoint
 

--- a/backend/forecastbox/models/model.py
+++ b/backend/forecastbox/models/model.py
@@ -17,9 +17,10 @@ from anemoi.inference.checkpoint import Checkpoint
 from earthkit.workflows.fluent import Action
 from earthkit.workflows.plugins.anemoi.fluent import from_input
 from earthkit.workflows.plugins.anemoi.types import ENSEMBLE_MEMBER_SPECIFICATION
-from forecastbox.rjsf import FieldWithUI, FormDefinition, IntegerSchema, StringSchema, UIIntegerField, UIStringField
 from pydantic import BaseModel
 from qubed import Qube
+
+from forecastbox.rjsf import FieldWithUI, FormDefinition, IntegerSchema, StringSchema, UIIntegerField, UIStringField
 
 from .metadata import ControlMetadata, get_control_metadata
 from .utils import open_checkpoint

--- a/backend/forecastbox/products/ensemble/__init__.py
+++ b/backend/forecastbox/products/ensemble/__init__.py
@@ -15,9 +15,11 @@ ensemble_registry = CategoryRegistry(
     "ensemble", interface=Interfaces.DETAILED, description="Capture the distribution of the ensemble", title="Ensemble"
 )
 
-from . import ens_stats  # noqa: F401, E402
-from . import quantiles  # noqa: F401, E402
-from . import threshold  # noqa: F401, E402
+from . import (
+    ens_stats,  # noqa: F401, E402
+    quantiles,  # noqa: F401, E402
+    threshold,  # noqa: F401, E402
+)
 from .base import BaseEnsembleProduct  # noqa: F401, E402
 
 __all__ = [

--- a/backend/forecastbox/products/ensemble/ens_stats.py
+++ b/backend/forecastbox/products/ensemble/ens_stats.py
@@ -11,6 +11,7 @@ import itertools
 from typing import Any
 
 from earthkit.workflows import fluent
+
 from forecastbox.products.ensemble.base import BasePProcEnsembleProduct
 from forecastbox.products.product import GenericTemporalProduct
 

--- a/backend/forecastbox/products/ensemble/quantiles.py
+++ b/backend/forecastbox/products/ensemble/quantiles.py
@@ -12,9 +12,10 @@ from typing import Any
 
 import yaml
 from earthkit.workflows import fluent
+from qubed import Qube
+
 from forecastbox.products.ensemble.base import BasePProcEnsembleProduct
 from forecastbox.rjsf import StringSchema
-from qubed import Qube
 
 from ..generic import generic_registry
 from ..product import USER_DEFINED, GenericTemporalProduct

--- a/backend/forecastbox/products/ensemble/threshold.py
+++ b/backend/forecastbox/products/ensemble/threshold.py
@@ -12,9 +12,10 @@ from typing import Any
 
 import yaml
 from earthkit.workflows import fluent
+from qubed import Qube
+
 from forecastbox.products.ensemble.base import BaseEnsembleProduct, BasePProcEnsembleProduct
 from forecastbox.rjsf import FieldWithUI, StringSchema
-from qubed import Qube
 
 from ..export import export_fieldlist_as
 from ..generic import generic_registry

--- a/backend/forecastbox/products/plots/__init__.py
+++ b/backend/forecastbox/products/plots/__init__.py
@@ -18,6 +18,8 @@ plot_product_registry = CategoryRegistry(
     title="Plots",
 )
 
-from . import maps  # noqa: F401, E402
-from . import meteogram  # noqa: F401, E402
-from . import vertical_profile  # noqa: F401, E402
+from . import (
+    maps,  # noqa: F401, E402
+    meteogram,  # noqa: F401, E402
+    vertical_profile,  # noqa: F401, E402
+)

--- a/backend/forecastbox/products/plots/maps.py
+++ b/backend/forecastbox/products/plots/maps.py
@@ -18,6 +18,7 @@ from earthkit.workflows import mark
 from earthkit.workflows.decorators import as_payload
 from earthkit.workflows.fluent import Payload
 from earthkit.workflows.plugins.anemoi.types import ENSEMBLE_DIMENSION_NAME
+
 from forecastbox.config import config
 from forecastbox.models import SpecifiedModel
 from forecastbox.products.ensemble import BaseEnsembleProduct

--- a/backend/forecastbox/products/pproc.py
+++ b/backend/forecastbox/products/pproc.py
@@ -15,6 +15,7 @@ from typing import Any
 from earthkit.workflows import fluent
 from earthkit.workflows.graph import Graph, deduplicate_nodes
 from earthkit.workflows.plugins.anemoi.types import ENSEMBLE_DIMENSION_NAME
+
 from forecastbox.config import config
 from forecastbox.models import SpecifiedModel
 from forecastbox.products.product import Product

--- a/backend/forecastbox/products/product.py
+++ b/backend/forecastbox/products/product.py
@@ -14,9 +14,10 @@ from typing import Any, Union
 from earthkit.workflows import fluent
 from earthkit.workflows.fluent import Action
 from earthkit.workflows.graph import Graph
+from qubed import Qube
+
 from forecastbox.models import SpecifiedModel
 from forecastbox.rjsf import ArraySchema, FieldSchema, FieldWithUI, IntegerSchema, StringSchema
-from qubed import Qube
 
 
 class Product(ABC):

--- a/backend/forecastbox/products/thermal.py
+++ b/backend/forecastbox/products/thermal.py
@@ -10,9 +10,10 @@
 import importlib.util
 from collections import OrderedDict
 
+from qubed import Qube
+
 from forecastbox.models import SpecifiedModel
 from forecastbox.rjsf import FieldWithUI, IntegerSchema
-from qubed import Qube
 
 from .export import export_fieldlist_as
 from .interfaces import Interfaces

--- a/backend/forecastbox/standalone/checks.py
+++ b/backend/forecastbox/standalone/checks.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 
 import httpx
 from cascade.low.func import assert_never
+
 from forecastbox.config import FIABConfig, StatusMessage
 from forecastbox.standalone.procs import ChildProcessGroup
 

--- a/backend/forecastbox/standalone/launchers.py
+++ b/backend/forecastbox/standalone/launchers.py
@@ -17,6 +17,7 @@ import asyncio
 import logging
 
 import uvicorn
+
 from forecastbox.config import FIABConfig
 from forecastbox.standalone.config import setup_process
 

--- a/backend/forecastbox/standalone/service.py
+++ b/backend/forecastbox/standalone/service.py
@@ -4,6 +4,7 @@ import logging
 from multiprocessing import Process, freeze_support, set_start_method
 
 import psutil
+
 from forecastbox.config import FIABConfig, fiab_home, validate_runtime
 from forecastbox.standalone.checks import check_backend_ready
 from forecastbox.standalone.config import export_recursive, setup_process

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -74,6 +74,7 @@ dev = [
   "pytest-asyncio",
   "pytest-xdist>=3.8",
   "ty>=0.0.1a23",
+  "prek",
 ]
 
 [tool.setuptools_scm]

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -9,6 +9,7 @@ from typing import Any, Generator
 
 import httpx
 import pytest
+
 import forecastbox.config
 from forecastbox.config import FIABConfig
 from forecastbox.standalone.entrypoint import launch_all

--- a/backend/tests/integration/test_schedule.py
+++ b/backend/tests/integration/test_schedule.py
@@ -1,6 +1,7 @@
 from datetime import datetime as dt
 
 from cascade.low.builders import JobBuilder, TaskBuilder
+
 from forecastbox.api.types import EnvironmentSpecification, ExecutionSpecification, RawCascadeJob, ScheduleSpecification, ScheduleUpdate
 
 

--- a/backend/tests/integration/test_submit_job.py
+++ b/backend/tests/integration/test_submit_job.py
@@ -5,6 +5,7 @@ import zipfile
 
 import cloudpickle
 from cascade.low.builders import JobBuilder, TaskBuilder
+
 from forecastbox.api.types import (
     EnvironmentSpecification,
     ExecutionSpecification,

--- a/backend/tests/nonpytest/bigtest.py
+++ b/backend/tests/nonpytest/bigtest.py
@@ -11,6 +11,7 @@ import tempfile
 import time
 
 import httpx
+
 from forecastbox.config import FIABConfig, config
 from forecastbox.standalone.entrypoint import launch_all
 

--- a/backend/tests/nonpytest/scheduler_helper.py
+++ b/backend/tests/nonpytest/scheduler_helper.py
@@ -1,5 +1,6 @@
 import httpx
 from cascade.low.builders import JobBuilder, TaskBuilder
+
 from forecastbox.api.types import EnvironmentSpecification, ExecutionSpecification, RawCascadeJob, ScheduleSpecification
 
 # TODO this is just a helper script to test an existing instance. Ideally turn it into a proper bigtest

--- a/backend/tests/unit/models/test_model.py
+++ b/backend/tests/unit/models/test_model.py
@@ -14,8 +14,9 @@ from pathlib import Path
 from anemoi.inference.checkpoint import Checkpoint
 from anemoi.inference.testing import fake_checkpoints
 from earthkit.workflows import fluent
-from forecastbox.models.globe import ControlMetadata, GlobalModel
 from qubed import Qube
+
+from forecastbox.models.globe import ControlMetadata, GlobalModel
 
 checkpoint_path = (Path(__file__).parent / "../checkpoints/simple.yaml").absolute()
 

--- a/backend/tests/unit/products/test_product.py
+++ b/backend/tests/unit/products/test_product.py
@@ -8,8 +8,9 @@
 # nor does it submit to any jurisdiction.
 
 
-from forecastbox.products.product import GenericParamProduct
 from qubed import Qube
+
+from forecastbox.products.product import GenericParamProduct
 
 
 class TestProduct(GenericParamProduct):

--- a/backend/tests/unit/products/test_registry.py
+++ b/backend/tests/unit/products/test_registry.py
@@ -12,11 +12,12 @@ from typing import Any
 import pytest
 from earthkit.workflows.fluent import Action
 from earthkit.workflows.graph import Graph
+from qubed import Qube
+
 from forecastbox.models import SpecifiedModel
 from forecastbox.products.interfaces import Interfaces
 from forecastbox.products.product import Product
 from forecastbox.products.registry import PRODUCTS, CategoryRegistry, get_categories, get_product, get_product_list
-from qubed import Qube
 
 
 @pytest.fixture(scope="module")

--- a/backend/tests/unit/products/test_selections.py
+++ b/backend/tests/unit/products/test_selections.py
@@ -12,10 +12,11 @@ from pathlib import Path
 from typing import Sequence, cast
 
 import pytest
+from qubed import Qube
+
 from forecastbox.models import SpecifiedModel
 from forecastbox.models.globe import ControlMetadata, GlobalModel
 from forecastbox.products.product import GenericParamProduct, Product
-from qubed import Qube
 
 
 def create_test_product(axis: dict[str, Sequence[str]]) -> Product:

--- a/backend/tests/unit/rjsf/test_from_pydantic.py
+++ b/backend/tests/unit/rjsf/test_from_pydantic.py
@@ -11,6 +11,9 @@ from datetime import date
 from typing import Dict, List, Literal, Optional, Union
 
 import pytest
+from pydantic import BaseModel, Field
+from pydantic.fields import FieldInfo
+
 from forecastbox.rjsf.forms import FieldWithUI
 from forecastbox.rjsf.from_pydantic import (
     PRIMATIVES,
@@ -27,8 +30,6 @@ from forecastbox.rjsf.from_pydantic import (
 )
 from forecastbox.rjsf.jsonSchema import BooleanSchema, IntegerSchema, ObjectSchema, StringSchema
 from forecastbox.rjsf.uiSchema import UIAdditionalProperties, UIField, UIIntegerField, UIObjectField, UIStringField
-from pydantic import BaseModel, Field
-from pydantic.fields import FieldInfo
 
 
 class TestHelperFunctions:

--- a/backend/tests/unit/rjsf/test_jsonSchema.py
+++ b/backend/tests/unit/rjsf/test_jsonSchema.py
@@ -1,4 +1,5 @@
 import pytest
+
 from forecastbox.rjsf import jsonSchema
 
 # Test StringSchema

--- a/backend/tests/unit/scheduling/test_dt_utils.py
+++ b/backend/tests/unit/scheduling/test_dt_utils.py
@@ -2,6 +2,7 @@ import re
 from datetime import datetime
 
 import pytest
+
 from forecastbox.api.scheduling.dt_utils import calculate_next_run, parse_crontab
 
 

--- a/backend/tests/unit/scheduling/test_job_utils.py
+++ b/backend/tests/unit/scheduling/test_job_utils.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import orjson
 import pytest
+
 from forecastbox.api.scheduling.job_utils import deep_union, eval_dynamic_expression, schedule2runnable
 from forecastbox.api.types import ExecutionSpecification
 from forecastbox.schemas.schedule import ScheduleDefinition

--- a/backend/tests/unit/scheduling/test_schedule_runs.py
+++ b/backend/tests/unit/scheduling/test_schedule_runs.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import HTTPException
+
 from forecastbox.api.routers.schedule import GetScheduleRunsResponse, get_schedule_runs
 from forecastbox.db.schedule import JobRecord, ScheduleRun
 from forecastbox.schemas.user import UserRead

--- a/backend/tests/unit/test_updates.py
+++ b/backend/tests/unit/test_updates.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
+
 from forecastbox.api.updates import Release, get_local_release, get_lock_timestamp, get_most_recent_release, get_pylock, save_pylock
 
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -55,13 +55,14 @@ wheels = [
 
 [[package]]
 name = "anemoi-inference"
-version = "0.7.3"
+version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anemoi-transform" },
     { name = "anemoi-utils", extra = ["provenance", "text"] },
     { name = "aniso8601" },
     { name = "anytree" },
+    { name = "deprecation" },
     { name = "earthkit-data" },
     { name = "eccodes" },
     { name = "numpy" },
@@ -72,21 +73,21 @@ dependencies = [
     { name = "semantic-version" },
     { name = "torch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/d1/fc9ebf6b3134ac67c2f2e69352b9a7d81cc5bcba5bc36186d9e255d8b857/anemoi_inference-0.7.3.tar.gz", hash = "sha256:381890d4c497e2bdc4828170bf59433aace8f6019b46b5ee0e823d749b474a1c", size = 1363602, upload-time = "2025-09-24T14:25:40.371Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/d1/3133cb4cdda63109df8609437b3a886983d8375c90148998d6d56b3083a6/anemoi_inference-0.8.1.tar.gz", hash = "sha256:1ceec9e350eb2cd281462843b90be14dd5be6c163c4aece3bd5dedaf07853649", size = 1410543, upload-time = "2025-11-06T09:29:13.089Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/90/e748b70d21ad64c47f7e1e6a18838796f52851b37719363bfa161a882cc0/anemoi_inference-0.7.3-py3-none-any.whl", hash = "sha256:c5aa5601633930c9dcd64f370a658970c115c1a16f86b70205d749e4ddb404c3", size = 194851, upload-time = "2025-09-24T14:25:38.463Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b6/e186d386ecbe317b88d773e278be45bf7ebf353056ce2e73e8577ac1bb25/anemoi_inference-0.8.1-py3-none-any.whl", hash = "sha256:96e94437d6cb108a73956d959dd3bd4f7b5e1fedcbc868d9599d7f5f77b4f364", size = 215857, upload-time = "2025-11-06T09:29:11.947Z" },
 ]
 
 [[package]]
 name = "anemoi-plugins-ecmwf-inference"
-version = "0.1.14"
+version = "0.1.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anemoi-inference" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/4d/f85992cc4c163bd4d8addd66cb4c7fd1a55617bfde4c2ba8dc9e64451d45/anemoi_plugins_ecmwf_inference-0.1.14.tar.gz", hash = "sha256:cde240bb8bcee66243424e10f4002bd4cf62f6a9cf543c85deda47d671186c55", size = 36098, upload-time = "2025-10-03T13:52:15.857Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c1/fd1ba8a9169395bdb6afc4e6a8616e30bec10453a3913eb0072582e8e24e/anemoi_plugins_ecmwf_inference-0.1.18.tar.gz", hash = "sha256:d63ef476230d05214e7029b529616e29aea826085f0d1eaf45306badb0e84043", size = 40119, upload-time = "2025-11-18T16:11:35.976Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/50/ae8c9ca8c4618190243dcfbd1fd5da890f92412f6b710a5eb01484934c59/anemoi_plugins_ecmwf_inference-0.1.14-py3-none-any.whl", hash = "sha256:e59d40add4fe2942d4b04ca72021d54bc15a3c36530394d194646fc2eb4638f4", size = 40708, upload-time = "2025-10-03T13:52:14.081Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c9/63a87a8aeab6fc7e03c0b7f743d318db33f6381fb538a3fded477765288a/anemoi_plugins_ecmwf_inference-0.1.18-py3-none-any.whl", hash = "sha256:c8634cbd321ea74fe202e6775f154d1336f8621cc4ebf7139fc3e52374884999", size = 42579, upload-time = "2025-11-18T16:11:31.524Z" },
 ]
 
 [package.optional-dependencies]
@@ -1021,16 +1022,16 @@ wheels = [
 
 [[package]]
 name = "earthkit-workflows-anemoi"
-version = "0.3.8"
+version = "0.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anemoi-datasets" },
     { name = "anemoi-inference" },
     { name = "earthkit-workflows" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4a/0e/98c5ce0cfb37452e819731bbc8158fc8b57e50ed16f4dd121864c5cebc32/earthkit_workflows_anemoi-0.3.8.tar.gz", hash = "sha256:c572395649955caa3ab0bee4e7d8eff63543f237e4b8772bc12bc5056c2c5460", size = 28740, upload-time = "2025-10-06T10:20:05.577Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/ea/08acbc89ab32e71946e30aada90aca7dde21ebc6cc072ebe9b0e7eb36422/earthkit_workflows_anemoi-0.3.12.tar.gz", hash = "sha256:47b4f0de324116cdc09ffb185c6211d128a37ef1317032a1c193bea7c4718356", size = 28752, upload-time = "2025-11-06T11:08:41.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/10/9c4e8e50a64894370e61bcd34e383fd6cd510f4ef359ba39a9d766a270e1/earthkit_workflows_anemoi-0.3.8-py3-none-any.whl", hash = "sha256:8062d3de359578c866f551fdc65cf71fd428aa0092f86c1531158fe06990cfeb", size = 20348, upload-time = "2025-10-06T10:20:04.459Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/f9/a454f5052d5ae6aea8799203d6420ffa9dae915364f1b441a0b00e9e5ff5/earthkit_workflows_anemoi-0.3.12-py3-none-any.whl", hash = "sha256:00df16a734bf72a8ddb0a431b316ee56e7bc96543333bae43fa6265d10b6f2a6", size = 20366, upload-time = "2025-11-06T11:08:41.066Z" },
 ]
 
 [[package]]
@@ -1418,6 +1419,7 @@ webmars = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "prek" },
     { name = "pytest-asyncio" },
     { name = "pytest-xdist" },
     { name = "ty" },
@@ -1426,15 +1428,15 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite" },
-    { name = "anemoi-inference", specifier = ">=0.7.1" },
-    { name = "anemoi-plugins-ecmwf-inference", extras = ["opendata"], specifier = ">=0.1.10" },
+    { name = "anemoi-inference", specifier = ">=0.8.1" },
+    { name = "anemoi-plugins-ecmwf-inference", extras = ["opendata"], specifier = ">=0.1.17" },
     { name = "anemoi-utils", specifier = ">=0.4.36" },
     { name = "apscheduler" },
     { name = "cloudpickle" },
     { name = "earthkit-plots", marker = "extra == 'plots'", specifier = ">=0.3.5" },
     { name = "earthkit-plots-default-styles", marker = "extra == 'plots'", specifier = ">=0.1" },
     { name = "earthkit-workflows", specifier = ">=0.4.7" },
-    { name = "earthkit-workflows-anemoi", specifier = ">=0.3.4" },
+    { name = "earthkit-workflows-anemoi", specifier = ">=0.3.12" },
     { name = "earthkit-workflows-pproc", git = "https://github.com/ecmwf/earthkit-workflows-pproc" },
     { name = "ecmwf-api-client", marker = "extra == 'webmars'", specifier = ">=1.6.5" },
     { name = "fastapi" },
@@ -1462,6 +1464,7 @@ provides-extras = ["all", "plots", "thermo", "webmars"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "prek" },
     { name = "pytest-asyncio" },
     { name = "pytest-xdist", specifier = ">=3.8" },
     { name = "ty", specifier = ">=0.0.1a23" },
@@ -1525,6 +1528,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
     { url = "https://files.pythonhosted.org/packages/3f/cc/b07000438a29ac5cfb2194bfc128151d52f333cee74dd7dfe3fb733fc16c/greenlet-3.2.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:55e9c5affaa6775e2c6b67659f3a71684de4c549b3dd9afca3bc773533d284fa", size = 1142073, upload-time = "2025-08-07T13:18:21.737Z" },
+    { url = "https://files.pythonhosted.org/packages/67/24/28a5b2fa42d12b3d7e5614145f0bd89714c34c08be6aabe39c14dd52db34/greenlet-3.2.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c9c6de1940a7d828635fbd254d69db79e54619f165ee7ce32fda763a9cb6a58c", size = 1548385, upload-time = "2025-11-04T12:42:11.067Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/05/03f2f0bdd0b0ff9a4f7b99333d57b53a7709c27723ec8123056b084e69cd/greenlet-3.2.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:03c5136e7be905045160b1b9fdca93dd6727b180feeafda6818e6496434ed8c5", size = 1613329, upload-time = "2025-11-04T12:42:12.928Z" },
     { url = "https://files.pythonhosted.org/packages/d8/0f/30aef242fcab550b0b3520b8e3561156857c94288f0332a79928c31a52cf/greenlet-3.2.4-cp311-cp311-win_amd64.whl", hash = "sha256:9c40adce87eaa9ddb593ccb0fa6a07caf34015a29bf8d344811665b573138db9", size = 299100, upload-time = "2025-08-07T13:44:12.287Z" },
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
@@ -1534,6 +1539,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
     { url = "https://files.pythonhosted.org/packages/3f/c7/12381b18e21aef2c6bd3a636da1088b888b97b7a0362fac2e4de92405f97/greenlet-3.2.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:20fb936b4652b6e307b8f347665e2c615540d4b42b3b4c8a321d8286da7e520f", size = 1151142, upload-time = "2025-08-07T13:18:22.981Z" },
+    { url = "https://files.pythonhosted.org/packages/27/45/80935968b53cfd3f33cf99ea5f08227f2646e044568c9b1555b58ffd61c2/greenlet-3.2.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ee7a6ec486883397d70eec05059353b8e83eca9168b9f3f9a361971e77e0bcd0", size = 1564846, upload-time = "2025-11-04T12:42:15.191Z" },
+    { url = "https://files.pythonhosted.org/packages/69/02/b7c30e5e04752cb4db6202a3858b149c0710e5453b71a3b2aec5d78a1aab/greenlet-3.2.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:326d234cbf337c9c3def0676412eb7040a35a768efc92504b947b3e9cfc7543d", size = 1633814, upload-time = "2025-11-04T12:42:17.175Z" },
     { url = "https://files.pythonhosted.org/packages/e9/08/b0814846b79399e585f974bbeebf5580fbe59e258ea7be64d9dfb253c84f/greenlet-3.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:a7d4e128405eea3814a12cc2605e0e6aedb4035bf32697f72deca74de4105e02", size = 299899, upload-time = "2025-08-07T13:38:53.448Z" },
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
@@ -1543,6 +1550,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
     { url = "https://files.pythonhosted.org/packages/a2/15/0d5e4e1a66fab130d98168fe984c509249c833c1a3c16806b90f253ce7b9/greenlet-3.2.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:d25c5091190f2dc0eaa3f950252122edbbadbb682aa7b1ef2f8af0f8c0afefae", size = 1149210, upload-time = "2025-08-07T13:18:24.072Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/53/f9c440463b3057485b8594d7a638bed53ba531165ef0ca0e6c364b5cc807/greenlet-3.2.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6e343822feb58ac4d0a1211bd9399de2b3a04963ddeec21530fc426cc121f19b", size = 1564759, upload-time = "2025-11-04T12:42:19.395Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e4/3bb4240abdd0a8d23f4f88adec746a3099f0d86bfedb623f063b2e3b4df0/greenlet-3.2.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca7f6f1f2649b89ce02f6f229d7c19f680a6238af656f61e0115b24857917929", size = 1634288, upload-time = "2025-11-04T12:42:21.174Z" },
     { url = "https://files.pythonhosted.org/packages/0b/55/2321e43595e6801e105fcfdee02b34c0f996eb71e6ddffca6b10b7e1d771/greenlet-3.2.4-cp313-cp313-win_amd64.whl", hash = "sha256:554b03b6e73aaabec3745364d6239e9e012d64c68ccd0b8430c64ccc14939a8b", size = 299685, upload-time = "2025-08-07T13:24:38.824Z" },
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
@@ -1550,6 +1559,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
+    { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/da/343cd760ab2f92bac1845ca07ee3faea9fe52bee65f7bcb19f16ad7de08b/greenlet-3.2.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:015d48959d4add5d6c9f6c5210ee3803a830dce46356e3bc326d6776bde54681", size = 1680760, upload-time = "2025-11-04T12:42:25.341Z" },
     { url = "https://files.pythonhosted.org/packages/e3/a5/6ddab2b4c112be95601c13428db1d8b6608a8b6039816f2ba09c346c08fc/greenlet-3.2.4-cp314-cp314-win_amd64.whl", hash = "sha256:e37ab26028f12dbb0ff65f29a8d3d44a765c61e729647bf2ddfbbed621726f01", size = 303425, upload-time = "2025-08-07T13:32:27.59Z" },
 ]
 
@@ -2846,6 +2857,32 @@ dependencies = [
     { name = "scipy" },
     { name = "thermofeel" },
     { name = "xarray" },
+]
+
+[[package]]
+name = "prek"
+version = "0.2.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/f5/d18c5981540da731b0dbb3499718256764d4e3c939011e78b7bb3637b626/prek-0.2.19.tar.gz", hash = "sha256:2995be837a97ea9b8d2f27894b1fc763594701bafbc8d26c46f80ea9e2cb28a9", size = 346456, upload-time = "2025-11-26T09:27:22.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/ab/b23d83992e76738c3aeb254739e554f32d11be58121488b124918e461200/prek-0.2.19-py3-none-linux_armv6l.whl", hash = "sha256:8879bd9df431bfa689cd38633e324b76d6579cf1978f186849c75c9d7c0dc6b4", size = 4681449, upload-time = "2025-11-26T09:26:58.126Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/4b/d2289899e3d05e825018e9e6b6d2b5e95e1b877f9b673cda352555b2b778/prek-0.2.19-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3b57000eb18f5621c55ef255da8953aaaa316b013714e05709c76accc24487bf", size = 4754502, upload-time = "2025-11-26T09:27:10.633Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/9a/198336704e8faf86293626d39657136cb42bed7cd046a6fd183c7497e5ec/prek-0.2.19-py3-none-macosx_11_0_arm64.whl", hash = "sha256:598cad01b68fae2732ff552c93e8286071e58796c7f3c461c298ad8618d984ab", size = 4484800, upload-time = "2025-11-26T09:27:06.322Z" },
+    { url = "https://files.pythonhosted.org/packages/12/e6/d0f87337413a79eff029d1eb6a2d2b66d07f8bd59edbd30220d195654ad5/prek-0.2.19-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:dd8e5f36022fcbefbc9750e3f5067a01102b1c0808325489f5614bc012be1136", size = 4684849, upload-time = "2025-11-26T09:26:52.688Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b5/e4f4f0acc8ad1fd967494b962bfabc821807b52a7c68d2bae30c65b588c4/prek-0.2.19-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:721271a31f51c8c7994d24e5e3816a249c482b56fe287ec31e96f47479432201", size = 4608595, upload-time = "2025-11-26T09:26:44.418Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/24/faa519d2b8b9ceba6dd43c3e993ebacfef33ddc4be2b781beef24b9ad79e/prek-0.2.19-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:116bd9152c68be9a77b40af15763ddba73d4744dd606fe6686c3d2e9eb7b52b1", size = 4893501, upload-time = "2025-11-26T09:27:16.515Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/19/2b92c8fbfe9872a233fc326cb969348dd2fc8db0d01323cf822b5c2990ff/prek-0.2.19-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:96aef4dfcf8c3c28d93ee93f78289e07a3ce60e1f2f91d3eb9f023dc75b62216", size = 5318688, upload-time = "2025-11-26T09:27:02.662Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/8e/934b5dff72aaf6df41ae59bf5324f2c3db8a123cb976387e85c16cc639b2/prek-0.2.19-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8a1156a1f525d3f6b69bc1c07a0dea930cb9027f95bcb4d390fe5fe7fe88687e", size = 5261297, upload-time = "2025-11-26T09:27:14.677Z" },
+    { url = "https://files.pythonhosted.org/packages/89/ba/990decf00161eed117fb7c71a9f2cba71879e77bf7a6e17d94659f72cd4e/prek-0.2.19-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:485b152f4a637aa761ab1634a6b9a38cd07cc6d23e3651f2c8eb4d7a507e132c", size = 5328804, upload-time = "2025-11-26T09:26:48.591Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/57/b7b87ee878c45046cb220ecdd257ea0398984b104f983b7eb25a92fe86e2/prek-0.2.19-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7613493f39918247f2d97ebce8b3692fc738aa2ab8a9f76cfa800947756cfa42", size = 4938116, upload-time = "2025-11-26T09:27:00.417Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/50/33b8cd6fe3517be2a4303a72b20341a54b728e9fc0027e0cc65843210ee9/prek-0.2.19-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:a1546907f28b56c940f7d3cd9452052bcd97be31de92bf0a4bd07c4746929a00", size = 4694953, upload-time = "2025-11-26T09:26:46.463Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8d/06b49a443a43a0fbf576e0d068ce4cce2a76367b19f42552f6182c3d06a0/prek-0.2.19-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:7db50ebce756e6d67c4ed1935c6e1bcacf29662c9bfee4a0f401d3fb0385d922", size = 4708769, upload-time = "2025-11-26T09:26:50.737Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d9/1e317d0697a98b2c57e2b4c1f8d3efeb6db86b81ce2df5211fdbb17f8b7c/prek-0.2.19-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:37f03e0796d753a9bd82ed09a7e901474e6a26b9a6ceffa5003a3fa703497a8e", size = 4593381, upload-time = "2025-11-26T09:27:12.592Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f0/0e32a9a7fc7876d08f5b118ecab6e81c5b433ddaa4daaa6c930c46c7d916/prek-0.2.19-py3-none-musllinux_1_1_i686.whl", hash = "sha256:3b0da9f14191e0adfb55e626ce3562d802800bc9aea96bbbdc1374290ef848c9", size = 4787292, upload-time = "2025-11-26T09:27:08.071Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/61/70204d48dd86a472d56dc75d2d9caf8236507a563428cb22fe5c90933978/prek-0.2.19-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:9cef90e8f8d5de9a165f2a81d9ce728bd3b99b65620a8427928e832a43fe4c4b", size = 5053192, upload-time = "2025-11-26T09:26:56.027Z" },
+    { url = "https://files.pythonhosted.org/packages/14/5c/13361ca9aa8ce3bce50430b5f2afb2ea9e44639841a638f998c762c27708/prek-0.2.19-py3-none-win32.whl", hash = "sha256:a6d19d8b10bc4aba18cf1a7902de7bede05671f484adabeac2d96a02ac470ef1", size = 4442525, upload-time = "2025-11-26T09:27:18.678Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d5/bf010982c063ed630bf75c058e2313ba546daa11343fa2ba3116a19f5b69/prek-0.2.19-py3-none-win_amd64.whl", hash = "sha256:34a638a2cb9808b3db8b7020c9cf03d445e9c957a36e09a443a19e1e71a2fb6c", size = 5114204, upload-time = "2025-11-26T09:27:04.784Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e3/42a5fb0f0dc2d0ae117e533e9da8a0fb41850526b27dd5dd5c0f37e878fa/prek-0.2.19-py3-none-win_arm64.whl", hash = "sha256:1a865880cc2362eb0698d938b811a796dfd5bcb49ef7abd02568f0f5e3b7ec88", size = 4796136, upload-time = "2025-11-26T09:27:20.766Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
we didnt have import sorting configured for a while. Adding it to precommit config, and making precommit run as a part of CI

and from the looks of it, the original config was mixing 3rd-party imports with package imports, but now we separate that (which I prefer actually), so theres a bit more changes