### PR TITLE
[backend] add fable persistence

### DIFF
--- a/backend/forecastbox/api/fable.py
+++ b/backend/forecastbox/api/fable.py
@@ -10,7 +10,7 @@ from forecastbox.api.types.fable import (
     BlockFactoryCatalogue,
     BlockFactoryId,
     BlockKind,
-    FableBuilder,
+    FableBuilderV1,
     FableValidationExpansion,
 )
 
@@ -101,7 +101,7 @@ blocksOfKind: dict[BlockKind, list[BlockFactoryId]] = {
 }
 
 
-def validate_expand(fable: FableBuilder) -> FableValidationExpansion:
+def validate_expand(fable: FableBuilderV1) -> FableValidationExpansion:
     possible_sources = blocksOfKind["source"]
     possible_expansions = {}
     block_errors = defaultdict(list)
@@ -143,7 +143,7 @@ def validate_expand(fable: FableBuilder) -> FableValidationExpansion:
     )
 
 
-def compile(fable: FableBuilder) -> RawCascadeJob:
+def compile(fable: FableBuilderV1) -> RawCascadeJob:
     # TODO instead something very much like api.execution.forecast_products_to_cascade
     return RawCascadeJob(
         job_type="raw_cascade_job",

--- a/backend/forecastbox/api/types/fable.py
+++ b/backend/forecastbox/api/types/fable.py
@@ -63,12 +63,12 @@ class BlockInstance(BaseModel):
     """Keys come from factory's `inputs`, values are other blocks in the (partial) fable"""
 
 
-class FableBuilder(BaseModel):
+class FableBuilderV1(BaseModel):
     blocks: dict[BlockInstanceId, BlockInstance]
 
 
 class FableValidationExpansion(BaseModel):
-    """When user submits invalid FableBuilder, backend returns a structured validation result and completion options"""
+    """When user submits invalid FableBuilderV1, backend returns a structured validation result and completion options"""
 
     global_errors: list[str]
     block_errors: dict[BlockInstanceId, list[str]]

--- a/backend/forecastbox/db/fable.py
+++ b/backend/forecastbox/db/fable.py
@@ -1,0 +1,82 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import datetime as dt
+import logging
+import uuid
+from typing import Optional
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from forecastbox.api.types.fable import FableBuilderV1
+from forecastbox.config import config
+from forecastbox.db.core import addAndCommit, dbRetry, executeAndCommit, querySingle
+from forecastbox.schemas.fable import Base, FableRecord
+
+logger = logging.getLogger(__name__)
+
+async_url = f"sqlite+aiosqlite:///{config.db.sqlite_jobdb_path}"
+async_engine = create_async_engine(async_url, pool_pre_ping=True)
+async_session_maker = async_sessionmaker(async_engine, expire_on_commit=False)
+
+
+async def create_db_and_tables():
+    async with async_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+async def get_fable_builder(fable_builder_id: str) -> Optional[FableBuilderV1]:
+    query = select(FableRecord).where(FableRecord.fable_builder_id == fable_builder_id)
+    record = await querySingle(query, async_session_maker)
+    if record:  # type: ignore
+        return FableBuilderV1.model_validate(record.fable_builder_v1)
+    return None
+
+
+async def upsert_fable_builder(builder: FableBuilderV1, fable_builder_id: Optional[str], tags: list[str], created_by_user: str) -> str:
+    ref_time = dt.datetime.now()
+    returned_id: str
+
+    if fable_builder_id:
+        # Attempt to update an existing record
+        query = select(FableRecord.created_by).where(FableRecord.fable_builder_id == fable_builder_id)
+        existing_created_by = await querySingle(query, async_session_maker)
+
+        if not existing_created_by:
+            raise KeyError(f"FableBuilderV1 with ID {fable_builder_id} not found")
+
+        if existing_created_by.created_by != created_by_user:
+            raise PermissionError("User not authorized to modify this fable builder")
+
+        stmt = (
+            update(FableRecord)
+            .where(FableRecord.fable_builder_id == fable_builder_id)
+            .values(
+                fable_builder_v1=builder.model_dump(mode="json"),
+                updated_at=ref_time,
+                tags=tags,
+            )
+        )
+        await executeAndCommit(stmt, async_session_maker)
+        returned_id = fable_builder_id
+    else:
+        # Insert a new record
+        new_id = str(uuid.uuid4())
+        entity = FableRecord(
+            fable_builder_id=new_id,
+            fable_builder_v1=builder.model_dump(mode="json"),
+            created_at=ref_time,
+            updated_at=ref_time,
+            created_by=created_by_user,
+            tags=tags,
+        )
+        await addAndCommit(entity, async_session_maker)
+        returned_id = new_id
+    return returned_id

--- a/backend/forecastbox/schemas/fable.py
+++ b/backend/forecastbox/schemas/fable.py
@@ -1,0 +1,24 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from sqlalchemy import JSON, Column, DateTime, String
+from sqlalchemy.orm import declarative_base
+
+from forecastbox.schemas.job import Base
+
+
+class FableRecord(Base):
+    __tablename__ = "fable_records"
+
+    fable_builder_id = Column(String(255), primary_key=True, nullable=False)
+    fable_builder_v1 = Column(JSON, nullable=False)
+    created_at = Column(DateTime, nullable=False)
+    updated_at = Column(DateTime, nullable=False)
+    created_by = Column(String(255), nullable=True)
+    tags = Column(JSON, nullable=True)


### PR DESCRIPTION
@liefra just so that you can persist/retrieve the graph builders

btw we started calling them Fables, as in Forecast as BLock Expression, to separate from existing graph/action/job etc concepts. And the individual blocks of those graphs are, well, Blocks :) . The dev team uses these terms now, but the Stakeholders are not yet aware of it -- so lets not necessarily propagate it to UI just yet (though I would like that myself, as the biased author)

for now its just basic builder & author & tags -- with no assumption on tags, maybe we would utilize that for like "favourites", or "research", or anything. I generally like tags on db level, either exposed directly in UI, or as atomic enabler of different things, ie, in the UI you would perhaps generate some tags yourself for different user journeys, like "save work in progress" would put some specific tag, while "starring" a fable builder would put a different specific tag, etc. In which case I'll add a retrieve-all-fablebuilders-by-tag or something I guess

or feel free to propose any other extensions to this, now or later :) 