### PR TITLE
[backend] fix hanging bug after pytest

### DIFF
--- a/backend/forecastbox/standalone/procs.py
+++ b/backend/forecastbox/standalone/procs.py
@@ -4,6 +4,8 @@
 """
 
 import logging
+import os
+import signal
 from dataclasses import dataclass
 from multiprocessing import Process, connection
 
@@ -22,9 +24,16 @@ class ChildProcessGroup:
 
     def shutdown(self):
         for p in self.procs:
-            p.terminate()
-            p.join(1)
-            p.kill()
+            if p.is_alive():
+                # p.interrupt() # TODO after 3.14 add
+                os.kill(p.pid, signal.SIGINT)
+                p.join(3)
+            if p.is_alive():
+                p.terminate()
+                p.join(3)
+            if p.is_alive():
+                p.kill()
+                p.join(3)
 
 
 def previous_cleanup():

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -96,7 +96,7 @@ lint.ignore = [ "E731" ]
 log_cli = true
 log_cli_level = "DEBUG"
 testpaths = [ "tests" ]
-addopts = "-n0 -s"      # NOTE stick to 0 *or* have random server ports in the integration tests
+addopts = "-n0 -s --log-disable findlibs"      # NOTE stick to 0 *or* have random server ports in the integration tests
 # TODO once the diagnostic_/prognostic_ warning addressed, remove
 filterwarnings = [
     "error",

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -97,9 +97,12 @@ def backend_client() -> Generator[httpx.Client, None, None]:
         if shutdown_event is not None:
             shutdown_event.set()
         if p is not None:
-            p.join(timeout=2)
+            p.join(timeout=3)
             if p.is_alive():
                 p.terminate()
+            p.join(timeout=3)
+            if p.is_alive():
+                p.kill()
         if handles is not None:
             handles.shutdown()
         if td is not None:


### PR DESCRIPTION
for some python versions (3.13.x+) we were not terminating correctly, causing eg pytest to hang forever

we fix that by correctly sending SIGINT first at the graceful exit, because some python multiprocessing resources require that for a clean exit (as opposed to just SIGTERM)

we additionally register a SIGTERM handler in the launcher app, to react to an outer SIGTERM correctly as well

lastly, we reduce the log pollution during pytests due to findlibs