### PR TITLE
[backend] ext for the broken ci

### DIFF
--- a/backend/forecastbox/standalone/entrypoint.py
+++ b/backend/forecastbox/standalone/entrypoint.py
@@ -16,7 +16,7 @@ import logging
 import signal
 import sys
 import webbrowser
-from multiprocessing import Process, set_start_method
+from multiprocessing import Process, get_context
 
 import forecastbox.standalone.service
 from forecastbox.config import FIABConfig, validate_runtime
@@ -29,7 +29,6 @@ logger = logging.getLogger(__name__ if __name__ != "__main__" else __package__)
 
 
 def launch_all(config: FIABConfig, attempts: int = 20) -> ChildProcessGroup:
-    set_start_method("forkserver", force=True)  # NOTE force because of pytest
     setup_process()
     logger.info("main process starting")
     logger.debug(f"loaded config {config.model_dump()}")
@@ -41,7 +40,8 @@ def launch_all(config: FIABConfig, attempts: int = 20) -> ChildProcessGroup:
             config.model_config["env_nested_delimiter"],
             config.model_config["env_prefix"],
         )
-        backend = Process(target=launch_backend)
+        # TODO migrate to cascade_platform -- but we *need* forkserver for linux. Mind service.py here as well
+        backend = get_context("forkserver").Process(target=launch_backend)
         backend.start()
         handle = ChildProcessGroup([backend])
         spawn_gateway = True

--- a/backend/forecastbox/standalone/service.py
+++ b/backend/forecastbox/standalone/service.py
@@ -1,7 +1,7 @@
 """Utility functions related to the backend running as a service, as well as entrypoint to start it"""
 
 import logging
-from multiprocessing import Process, freeze_support, set_start_method
+from multiprocessing import Process, freeze_support, get_context
 
 import psutil
 
@@ -37,7 +37,6 @@ if __name__ == "__main__":
     validate_runtime(config)
 
     freeze_support()
-    set_start_method("forkserver")
     setup_process()
 
     if not config.api.allow_service:
@@ -49,7 +48,7 @@ if __name__ == "__main__":
         config.model_config["env_nested_delimiter"],
         config.model_config["env_prefix"],
     )
-    backend = Process(target=launch_backend)
+    backend = get_context("forkserver").Process(target=launch_backend)
     backend.start()
     handle = ChildProcessGroup([backend])
     if backend.pid:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -97,13 +97,12 @@ log_cli = true
 log_cli_level = "DEBUG"
 testpaths = [ "tests" ]
 addopts = "-n0 -s --log-disable findlibs"      # NOTE stick to 0 *or* have random server ports in the integration tests
-# NOTE this is hotfix disabled because it completely destroys the test suite on macos
 # TODO once the diagnostic_/prognostic_ warning addressed, remove
-# filterwarnings = [
-#     "error",
-#     'ignore:diagnostic_variables is unsupported:deprecation.UnsupportedWarning',
-#     'ignore:prognostic_variables is unsupported:deprecation.UnsupportedWarning'
-# ]
+filterwarnings = [
+    "error",
+    'ignore:diagnostic_variables is unsupported:deprecation.UnsupportedWarning',
+    'ignore:prognostic_variables is unsupported:deprecation.UnsupportedWarning'
+]
 
 [tool.mypy]
 plugins = "pydantic.mypy"


### PR DESCRIPTION
tl;dr -- its complicated but now its kinda ok

longer read:
1. so we have this protection against "running two instances of fiab" at the same machine, because of how we would conflict on ports for UI, canibalise gateway, etc... The protection is basically there-can-be-only-on, when we start we identify other possible fiabs and kill them
2. the way this protection was implemented was like "lets find other processes launched using the same python executable". This is kinda safe because we assume that all fiab processes are launched using one dedicated venv, ie, we dont end up killing more
3. however, with the original implementation it was possible to kill children of the triggering process -- they are launched using the same executable! But of course, when we start, there are no children yet, so nothing is wrong...
4. ... except when this is executed using pytest. There, it is possible that the pytest framework has initialized the forkserver machinery and created the resource tracker etc processes -- this happens on mac almost always, and on linux almost never. Which are generally robust, ie, when they die they get relaunched, which is what was happening, and dully reported as warnings
5. In a recent PR, I introduced a best practice of failing in the presence of warnings. However, this caused the CI to fail, because there now was the (originally harmless) warning of resource manager restarting

Thus I make the there-can-be-only-one thing a bit more robust: I don't kill immediate children, and I'm a bit more careful about setting the start context. It is not perfect (grandchildren are still killed), but does not bring down the test suite down anymore


