### PR TITLE
[backend] fix datasetid bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ venv
 
 **/_version.py
 backend/MANIFEST.in
+
+*.grib


### PR DESCRIPTION
for some dataset ids (too long, too slashy, proxy-mangled) we did not serve the results. It is a bad idea to have potentially arbitrary strings used in url paths

thus we move the dataset_id parameter from path param to request param

this is done by marking the original route deprecated, and introducing a new route for this. Additionally, we deprecate the route for result availability, that one is additionally potentially ambigous -- but its functionality is well served by another route

after frontend migrates, we delete the deprecated routes