### PR TITLE
[cd] allow for v1+v2 simultaneously

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           uv sync --extra plots --python "${{ matrix.python_version }}"
           uv run prek --all-files
           mkdir /tmp/tmpFiabHome
-          mkdir src/forecastbox/static && touch src/forecastbox/static/index.html # TODO replace with proper static file build
+          mkdir -p src/forecastbox/static/v1 && touch src/forecastbox/static/v1/index.html # TODO replace with proper static file build
           if [[ "${{ matrix.python_version }}" != "3.13" ]] ; then
             # see tests of the admin/release endpoint for explanation
             export CI_GITHUB_RATELIMIT=yes
@@ -74,7 +74,7 @@ jobs:
           uv sync --extra plots --python "${{ matrix.python_version }}"
           uv run prek --all-files
           mkdir /tmp/tmpFiabHome
-          mkdir src/forecastbox/static && touch src/forecastbox/static/index.html # TODO replace with proper static file build
+          mkdir -p src/forecastbox/static/v1 && touch src/forecastbox/static/v1/index.html # TODO replace with proper static file build
           if [[ "${{ matrix.python_version }}" != "3.13" ]] ; then
             # see tests of the admin/release endpoint for explanation
             export CI_GITHUB_RATELIMIT=yes

--- a/backend/src/forecastbox/config.py
+++ b/backend/src/forecastbox/config.py
@@ -103,6 +103,8 @@ class GeneralSettings(BaseModel):
     launch_browser: bool = True
     """Whether a browser window should be opened after start. Used only when
     standalone.entrypoint.launch_all module is used"""
+    frontend_version: Literal["v1", "v2"] = "v1"
+    """Which of the static subfolders to use for universal routing"""
 
 
 PluginRefreshStrategy = Literal["automatic", "manual"]

--- a/backend/src/forecastbox/entrypoint.py
+++ b/backend/src/forecastbox/entrypoint.py
@@ -185,7 +185,7 @@ async def share_image(request: Request, job_id: str, dataset_id: str):
     return templates.TemplateResponse("share.html", {"request": request, "image_url": image_url, "image_name": f"{job_id}_{dataset_id}"})
 
 
-frontend = os.path.join(os.path.dirname(__file__), "static")
+frontend = os.path.join(os.path.dirname(__file__), f"static/{config.general.frontend_version}")
 
 
 class SPAStaticFiles(StaticFiles):

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,1 @@
+package-lock.json

--- a/justfile
+++ b/justfile
@@ -7,17 +7,24 @@ drun-mongo:
 drun:
     docker run --rm -it --network host --name fiab-be fiab-be
 
-fiabwheel frontend_dir="frontend":
+fiabwheel:
     #!/usr/bin/env bash
-    pushd {{frontend_dir}}
+    pushd frontend
     npm install --force # TODO fix the npm dependencies to get rid of --force !!!
+    npm run prodbuild
+    popd
+
+    pushd frontend-v2
+    npm install
     npm run prodbuild
     popd
 
     pushd backend
     rm -rf src/forecastbox/static
-    ln -s ../../../{{frontend_dir}}/dist src/forecastbox/static
-    find src/forecastbox/static/ -type f | sed 's/.*/include &/' > MANIFEST.in
+    mkdir src/forecastbox/static
+    ln -s ../../../../frontend/dist src/forecastbox/static/v1
+    ln -s ../../../../frontend-v2/dist src/forecastbox/static/v2
+    find -L src/forecastbox/static/ -type f | sed 's/.*/include &/' > MANIFEST.in
     python -m build --installer uv .
 
     mkdir prereqs


### PR DESCRIPTION
During the wheel building, we now build both frontends and copy them into the wheel. We extend config with a frontend_version which allows to specify which is the default index.html etc at launch time.

To demonstrate, try
```
fiab__general__frontend_version=v2 python -m forecastbox.standalone.entrypoint
```
or
```
fiab__general__frontend_version=v1 python -m forecastbox.standalone.entrypoint
```

with a wheel built from this branch

Additionally there was apparently a bug in building the manifest which we fix
