### PR TITLE
[backend] speed up start time

### DIFF
--- a/backend/src/forecastbox/products/__init__.py
+++ b/backend/src/forecastbox/products/__init__.py
@@ -7,7 +7,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-from . import ensemble, forecast, plots, standard, thermal
+from . import ensemble, forecast, standard, thermal
 from .definitions import DESCRIPTIONS, LABELS
 
-__all__ = ["DESCRIPTIONS", "LABELS", "ensemble", "forecast", "thermal", "extreme", "standard", "plots"]
+__all__ = ["DESCRIPTIONS", "LABELS", "ensemble", "forecast", "thermal", "extreme", "standard"]

--- a/backend/tests/integration/test_submit_job.py
+++ b/backend/tests/integration/test_submit_job.py
@@ -1,5 +1,6 @@
 import io
 import os
+import sys
 import time
 import zipfile
 
@@ -60,6 +61,11 @@ def test_submit_job(backend_client_with_auth):
     outputs = backend_client_with_auth.get(f"/job/{raw_job_id}/outputs").raise_for_status().json()
     assert len(outputs) == 1
     assert "n1" in outputs[0]["output_ids"]
+    # NOTE increased timeout below for mac because of delayed import
+    kw_tm = {"timeout": 20.0} if sys.platform == "darwin" else {}
+    output = backend_client_with_auth.get(f"/job/{raw_job_id}/results/n1", **kw_tm)
+    assert cloudpickle.loads(output.content) == 3
+    # NOTE we run the same request again, without timeout, to verify it was indeed delayed import
     output = backend_client_with_auth.get(f"/job/{raw_job_id}/results/n1")
     assert cloudpickle.loads(output.content) == 3
 


### PR DESCRIPTION
minor reorgs around imports, should have no observable functional/product change

changes forecastbox.entrypoint and fiab_core.fable improt cumtime from
3507069, 1189976
to
719129, 766472
respectively, on my ubuntu (those imports are the two top level hitters)

the reason for doing these is that fresh installs on mac are still prone to timeout, and I'd rather do this minor change than tweak startup limits further. I understand this is a "to-be-removed" code, so I'm not doing any systematic solution


note: after tweaking the imports, tests started to fail because one call started to take 12 seconds instead of 0 on mac. That is the first request that requires a cascade job to complete -- so my guess is that because of some imports not happening by backend, the cache is less populated or something, so those imports actually start to happen at this point. I've added a repetition of that request to verify its indeed something like this. The fact that we had to fix test as a consequence is for me another sign that the speedup is substantial :) 