### PR TITLE
[hotfix]: restore lib dirs and its files which got removed during frontend dir renaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .venv
 *.swp
 
-frontend/**/lib
 data_dir
 *.ckpt
 dist

--- a/frontend/src/lib/globalErrorHandler.ts
+++ b/frontend/src/lib/globalErrorHandler.ts
@@ -1,0 +1,80 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { createLogger } from './logger'
+import { showToast } from './toast'
+
+const log = createLogger('GlobalError')
+
+/**
+ * Extracts a user-friendly message from an error of unknown type.
+ */
+function extractErrorMessage(reason: unknown): string {
+  if (reason instanceof Error) {
+    return reason.message
+  }
+  if (typeof reason === 'string') {
+    return reason
+  }
+  return 'An unexpected error occurred'
+}
+
+/**
+ * Sets up global error handlers for uncaught errors and unhandled promise rejections.
+ * Should be called once at application startup (in main.tsx).
+ *
+ * These handlers:
+ * 1. Log errors using the centralized logger
+ * 2. Show user-friendly toast notifications
+ * 3. Allow default browser error handling to continue
+ */
+export function setupGlobalErrorHandlers(): void {
+  // Handle uncaught synchronous errors
+  window.onerror = (
+    message: string | Event,
+    source?: string,
+    lineno?: number,
+    colno?: number,
+    error?: Error,
+  ): boolean => {
+    log.error('Uncaught error:', {
+      message,
+      source,
+      lineno,
+      colno,
+      error: error?.stack || error,
+    })
+
+    showToast.error(
+      'An unexpected error occurred',
+      'Please try refreshing the page',
+    )
+
+    // Return false to allow default browser error handling (e.g., DevTools logging)
+    return false
+  }
+
+  // Handle unhandled promise rejections
+  window.addEventListener(
+    'unhandledrejection',
+    (event: PromiseRejectionEvent) => {
+      const reason = event.reason
+
+      log.error('Unhandled promise rejection:', {
+        reason:
+          reason instanceof Error ? reason.stack || reason.message : reason,
+      })
+
+      showToast.error(extractErrorMessage(reason))
+    },
+  )
+
+  log.info('Global error handlers initialized')
+}

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -1,0 +1,84 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * i18next Configuration
+ * Internationalization setup for the FIAB application
+ */
+
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+
+// Import translation resources by namespace
+import commonEN from '@/locales/en/common.json'
+import statusEN from '@/locales/en/status.json'
+import landingEN from '@/locales/en/landing.json'
+import authEN from '@/locales/en/auth.json'
+import errorsEN from '@/locales/en/errors.json'
+import validationEN from '@/locales/en/validation.json'
+import dashboardEN from '@/locales/en/dashboard.json'
+import pluginsEN from '@/locales/en/plugins.json'
+import sourcesEN from '@/locales/en/sources.json'
+import executionsEN from '@/locales/en/executions.json'
+
+// Translation resources organized by namespace
+const resources = {
+  en: {
+    common: commonEN,
+    status: statusEN,
+    landing: landingEN,
+    auth: authEN,
+    errors: errorsEN,
+    validation: validationEN,
+    dashboard: dashboardEN,
+    plugins: pluginsEN,
+    sources: sourcesEN,
+    executions: executionsEN,
+  },
+}
+
+// Initialize i18next
+i18n
+  .use(initReactI18next) // Passes i18n down to react-i18next to make it available for all the components
+  .init({
+    resources,
+    lng: 'en', // Default language
+    fallbackLng: 'en', // Fallback language if translation not found
+
+    // Namespace configuration
+    defaultNS: 'common', // Default namespace for translations
+    ns: [
+      'common',
+      'status',
+      'landing',
+      'auth',
+      'errors',
+      'validation',
+      'dashboard',
+      'plugins',
+      'sources',
+      'executions',
+    ],
+
+    // Interpolation options
+    interpolation: {
+      escapeValue: false, // React already escapes values
+    },
+
+    // React options
+    react: {
+      useSuspense: false, // Disable Suspense to avoid loading issues
+    },
+
+    // Debug in development
+    debug: import.meta.env.DEV,
+  })
+
+export default i18n

--- a/frontend/src/lib/logger.ts
+++ b/frontend/src/lib/logger.ts
@@ -1,0 +1,129 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Centralized logging utility with environment-aware log levels.
+ *
+ * In development: All log levels are visible
+ * In production: Only 'error' level logs are visible (unless VITE_DEBUG=true)
+ *
+ * Usage:
+ * ```ts
+ * import { createLogger } from '@/lib/logger'
+ *
+ * const log = createLogger('MyComponent')
+ * log.debug('Debug message', { data })
+ * log.info('Info message')
+ * log.warn('Warning message')
+ * log.error('Error message', error)
+ * ```
+ */
+
+type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
+/**
+ * Determines if a log at the given level should be output.
+ * - In development: all levels are logged
+ * - In production: only 'error' level (unless VITE_DEBUG=true)
+ */
+function shouldLog(level: LogLevel): boolean {
+  const isDev = import.meta.env.DEV
+  const debugEnabled = import.meta.env.VITE_DEBUG === 'true'
+
+  // In production, only log errors unless debug is explicitly enabled
+  if (!isDev && !debugEnabled) {
+    return level === 'error'
+  }
+
+  return true
+}
+
+/**
+ * Formats a log message with a prefix tag.
+ */
+function formatMessage(prefix: string, message: string): string {
+  return `[${prefix}] ${message}`
+}
+
+/**
+ * Maps log levels to console methods.
+ */
+const CONSOLE_METHODS = {
+  debug: console.debug,
+  info: console.log,
+  warn: console.warn,
+  error: console.error,
+} as const
+
+/**
+ * Core logger object with methods for each log level.
+ * Prefer using `createLogger()` to create a scoped logger.
+ */
+export const logger = {
+  debug: (prefix: string, message: string, ...data: Array<unknown>): void => {
+    if (shouldLog('debug')) {
+      CONSOLE_METHODS.debug(formatMessage(prefix, message), ...data)
+    }
+  },
+
+  info: (prefix: string, message: string, ...data: Array<unknown>): void => {
+    if (shouldLog('info')) {
+      CONSOLE_METHODS.info(formatMessage(prefix, message), ...data)
+    }
+  },
+
+  warn: (prefix: string, message: string, ...data: Array<unknown>): void => {
+    if (shouldLog('warn')) {
+      CONSOLE_METHODS.warn(formatMessage(prefix, message), ...data)
+    }
+  },
+
+  error: (prefix: string, message: string, ...data: Array<unknown>): void => {
+    if (shouldLog('error')) {
+      CONSOLE_METHODS.error(formatMessage(prefix, message), ...data)
+    }
+  },
+}
+
+/**
+ * Logger interface returned by createLogger.
+ */
+export interface ScopedLogger {
+  debug: (message: string, ...data: Array<unknown>) => void
+  info: (message: string, ...data: Array<unknown>) => void
+  warn: (message: string, ...data: Array<unknown>) => void
+  error: (message: string, ...data: Array<unknown>) => void
+}
+
+/**
+ * Creates a scoped logger with a fixed prefix.
+ *
+ * @param prefix - The prefix to prepend to all log messages (e.g., component or module name)
+ * @returns A logger object with debug, info, warn, and error methods
+ *
+ * @example
+ * ```ts
+ * const log = createLogger('AuthProvider')
+ * log.info('User logged in', { userId: '123' })
+ * // Output: [AuthProvider] User logged in { userId: '123' }
+ * ```
+ */
+export function createLogger(prefix: string): ScopedLogger {
+  return {
+    debug: (message: string, ...data: Array<unknown>) =>
+      logger.debug(prefix, message, ...data),
+    info: (message: string, ...data: Array<unknown>) =>
+      logger.info(prefix, message, ...data),
+    warn: (message: string, ...data: Array<unknown>) =>
+      logger.warn(prefix, message, ...data),
+    error: (message: string, ...data: Array<unknown>) =>
+      logger.error(prefix, message, ...data),
+  }
+}

--- a/frontend/src/lib/queryClient.ts
+++ b/frontend/src/lib/queryClient.ts
@@ -1,0 +1,87 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * TanStack Query configuration
+ * Centralized setup for React Query client with global error handling
+ */
+
+import { MutationCache, QueryCache, QueryClient } from '@tanstack/react-query'
+import { createLogger } from './logger'
+import { showToast } from './toast'
+import { QUERY_CONSTANTS } from '@/utils/constants'
+
+const log = createLogger('QueryClient')
+
+/**
+ * Global query cache with error handling.
+ * Logs errors and optionally shows toast for failed queries.
+ */
+const queryCache = new QueryCache({
+  onError: (error, query) => {
+    log.error('Query failed:', {
+      queryKey: query.queryKey,
+      error: error instanceof Error ? error.message : error,
+    })
+
+    // Only show toast for queries that had data before (user-initiated refetches)
+    // This avoids showing toasts for initial loads that might have their own error UI
+    if (query.state.data !== undefined) {
+      showToast.error(
+        'Failed to refresh data',
+        error instanceof Error ? error.message : 'Please try again',
+      )
+    }
+  },
+})
+
+/**
+ * Global mutation cache with error handling.
+ * Logs errors and shows toast for failed mutations.
+ */
+const mutationCache = new MutationCache({
+  onError: (error, _variables, _context, mutation) => {
+    log.error('Mutation failed:', {
+      mutationKey: mutation.options.mutationKey,
+      error: error instanceof Error ? error.message : error,
+    })
+
+    // Show toast for all mutation failures since they represent user actions
+    showToast.error(
+      'Operation failed',
+      error instanceof Error ? error.message : 'Please try again',
+    )
+  },
+})
+
+/**
+ * Default query options for all queries
+ */
+const defaultQueryOptions = {
+  queries: {
+    // Refetch on window focus in development, but not in production
+    refetchOnWindowFocus: import.meta.env.DEV,
+    // Retry failed requests 3 times with exponential backoff
+    retry: QUERY_CONSTANTS.RETRY.DEFAULT,
+    // Stale time: 30 seconds (data is considered fresh for this duration)
+    staleTime: QUERY_CONSTANTS.STALE_TIMES.DEFAULT,
+    // Cache time: 5 minutes (unused data is kept in cache for this duration)
+    gcTime: QUERY_CONSTANTS.CACHE_TIMES.DEFAULT,
+  },
+}
+
+/**
+ * Create and configure the QueryClient instance with global error handling
+ */
+export const queryClient = new QueryClient({
+  queryCache,
+  mutationCache,
+  defaultOptions: defaultQueryOptions,
+})

--- a/frontend/src/lib/storage-keys.ts
+++ b/frontend/src/lib/storage-keys.ts
@@ -1,0 +1,114 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Client-Side Storage Keys
+ *
+ * Single source of truth for all localStorage keys and Zustand persistence keys.
+ * All client-side storage uses the `fiab.` namespace prefix for consistency
+ * and to avoid collisions with other applications.
+ *
+ * Key naming convention:
+ * - Prefix: `fiab.`
+ * - Categories: `auth` (authentication), `store` (Zustand stores)
+ * - Format: `fiab.{category}.{name}` using kebab-case
+ *
+ * @see AGENTS.md for full documentation on storage conventions
+ */
+
+/**
+ * Storage key constants - single source of truth
+ *
+ * Usage:
+ * ```typescript
+ * import { STORAGE_KEYS } from '@/lib/storage-keys'
+ *
+ * localStorage.getItem(STORAGE_KEYS.auth.anonymousId)
+ * ```
+ */
+export const STORAGE_KEYS = {
+  /**
+   * Authentication-related storage keys (direct localStorage)
+   */
+  auth: {
+    /** Tracks whether user explicitly logged out (authenticated mode only) */
+    logoutFlag: 'fiab.auth.logout-flag',
+    /** Anonymous user UUID persisted across sessions */
+    anonymousId: 'fiab.auth.anonymous-id',
+    /** Post-login redirect URL for deep linking */
+    redirectUrl: 'fiab.auth.redirect-url',
+  },
+
+  /**
+   * Fable-related storage keys (direct localStorage)
+   */
+  fable: {
+    /** Metadata for saved fable configurations (title, comments, summary) */
+    metadata: 'fiab.fable.metadata',
+  },
+
+  /**
+   * Zustand store persistence keys
+   */
+  stores: {
+    /** UI preferences (theme, layout) */
+    ui: 'fiab.store.ui',
+    /** Cached application configuration */
+    config: 'fiab.store.config',
+    /** Fable builder UI preferences */
+    fableBuilder: 'fiab.store.fable-builder',
+    /** Client-side job metadata (name, description, tags, fable snapshot) */
+    jobMetadata: 'fiab.store.job-metadata',
+  },
+} as const
+
+/**
+ * Store versions for Zustand persist middleware
+ *
+ * Increment when schema changes require migration.
+ * The `migrate` function in each store handles transformations.
+ *
+ * Usage:
+ * ```typescript
+ * import { STORE_VERSIONS } from '@/lib/storage-keys'
+ *
+ * persist(store, {
+ *   version: STORE_VERSIONS.ui,
+ *   migrate: (state, version) => { ... }
+ * })
+ * ```
+ */
+export const STORE_VERSIONS = {
+  ui: 4, // v4: Removed sidebar state
+  config: 1,
+  fableBuilder: 2, // v2: Removed configDisplayMode, added isMiniMapOpen
+  jobMetadata: 1,
+} as const
+
+/**
+ * Clear all FIAB storage keys
+ *
+ * Useful for debugging or complete logout/reset scenarios.
+ * Removes all keys with the `fiab.` prefix.
+ */
+export function clearAllFiabStorage(): void {
+  const keysToRemove: Array<string> = []
+
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (key?.startsWith('fiab.')) {
+      keysToRemove.push(key)
+    }
+  }
+
+  for (const key of keysToRemove) {
+    localStorage.removeItem(key)
+  }
+}

--- a/frontend/src/lib/toast.ts
+++ b/frontend/src/lib/toast.ts
@@ -1,0 +1,90 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { toast } from 'sonner'
+
+/**
+ * Toast notification utilities for user-facing messages.
+ *
+ * Usage:
+ * ```ts
+ * import { showToast } from '@/lib/toast'
+ *
+ * showToast.success('Operation completed')
+ * showToast.error('Something went wrong', 'Please try again')
+ * showToast.apiError(error, { retry: () => refetch() })
+ * ```
+ */
+export const showToast = {
+  /**
+   * Show a success toast notification.
+   */
+  success: (message: string, description?: string) =>
+    toast.success(message, { description }),
+
+  /**
+   * Show an error toast notification.
+   */
+  error: (message: string, description?: string) =>
+    toast.error(message, { description }),
+
+  /**
+   * Show a warning toast notification.
+   */
+  warning: (message: string, description?: string) =>
+    toast.warning(message, { description }),
+
+  /**
+   * Show an info toast notification.
+   */
+  info: (message: string, description?: string) =>
+    toast.info(message, { description }),
+
+  /**
+   * Show an API error toast with optional retry action.
+   * Extracts message from Error object and optionally provides a retry button.
+   */
+  apiError: (error: Error, options?: { retry?: () => void }) => {
+    const message = error.message || 'An error occurred'
+    if (options?.retry) {
+      toast.error(message, {
+        action: {
+          label: 'Retry',
+          onClick: options.retry,
+        },
+      })
+    } else {
+      toast.error(message)
+    }
+  },
+
+  /**
+   * Show a loading toast that can be updated later.
+   * Returns the toast ID for updating/dismissing.
+   */
+  loading: (message: string) => toast.loading(message),
+
+  /**
+   * Dismiss a specific toast by ID or all toasts.
+   */
+  dismiss: (toastId?: string | number) => toast.dismiss(toastId),
+
+  /**
+   * Show a promise-based toast that updates based on promise state.
+   */
+  promise: <T>(
+    promise: Promise<T>,
+    messages: {
+      loading: string
+      success: string | ((data: T) => string)
+      error: string | ((error: Error) => string)
+    },
+  ) => toast.promise(promise, messages),
+}

--- a/frontend/src/lib/url-state.ts
+++ b/frontend/src/lib/url-state.ts
@@ -1,0 +1,53 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import lzString from 'lz-string'
+import type { z } from 'zod'
+import { createLogger } from '@/lib/logger'
+
+const log = createLogger('URLState')
+
+const MAX_SAFE_STATE_LENGTH = 1800
+
+export function encodeStateToURL<T>(state: T): string {
+  return lzString.compressToEncodedURIComponent(JSON.stringify(state))
+}
+
+export function decodeStateFromURL<T>(
+  encoded: string,
+  schema: z.ZodSchema<T>,
+): T | null {
+  try {
+    const json = lzString.decompressFromEncodedURIComponent(encoded)
+    if (!json) return null
+    return schema.parse(JSON.parse(json))
+  } catch (error) {
+    log.warn('Failed to decode state from URL:', error)
+    return null
+  }
+}
+
+export function isStateTooLarge(encoded: string): boolean {
+  return encoded.length > MAX_SAFE_STATE_LENGTH
+}
+
+export function getCompressionStats<T>(state: T): {
+  originalSize: number
+  compressedSize: number
+  ratio: number
+} {
+  const json = JSON.stringify(state)
+  const compressed = encodeStateToURL(state)
+  return {
+    originalSize: json.length,
+    compressedSize: compressed.length,
+    ratio: compressed.length / json.length,
+  }
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,57 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+import type { ClassValue } from 'clsx'
+
+export function cn(...inputs: Array<ClassValue>) {
+  return twMerge(clsx(inputs))
+}
+
+/**
+ * Validate that a redirect URL is safe (internal only)
+ *
+ * Prevents open redirect vulnerabilities by ensuring:
+ * - URL starts with "/" (relative path)
+ * - URL does NOT start with "//" (protocol-relative, would allow external redirects)
+ * - URL does NOT contain backslashes (IE compatibility issue)
+ *
+ * @param url - The URL to validate
+ * @returns true if the URL is a safe internal redirect (type guard narrows to string)
+ */
+export function isValidInternalRedirect(url: string | null): url is string {
+  if (!url) return false
+
+  // Must start with single forward slash
+  if (!url.startsWith('/')) return false
+
+  // Must NOT start with // (protocol-relative URL)
+  if (url.startsWith('//')) return false
+
+  // Must NOT contain backslashes (IE treats them as forward slashes)
+  if (url.includes('\\')) return false
+
+  return true
+}
+
+/**
+ * Check if a URL is external
+ *
+ * External URLs start with:
+ * - http:// or https:// (absolute URLs)
+ * - // (protocol-relative URLs)
+ *
+ * @param url - The URL to check
+ * @returns true if the URL is external
+ */
+export function isExternalUrl(url: string): boolean {
+  return /^(https?:)?\/\//.test(url)
+}

--- a/frontend/tests/unit/lib/i18n.test.ts
+++ b/frontend/tests/unit/lib/i18n.test.ts
@@ -1,0 +1,96 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { describe, expect, it } from 'vitest'
+import i18n from '@/lib/i18n'
+
+describe('i18n', () => {
+  describe('initialization', () => {
+    it('exports i18n instance', () => {
+      expect(i18n).toBeDefined()
+    })
+
+    it('has default language set to English', () => {
+      expect(i18n.language).toBe('en')
+    })
+
+    it('has fallback language set to English', () => {
+      expect(i18n.options.fallbackLng).toContain('en')
+    })
+  })
+
+  describe('namespaces', () => {
+    it('has common namespace', () => {
+      expect(i18n.options.ns).toContain('common')
+    })
+
+    it('has status namespace', () => {
+      expect(i18n.options.ns).toContain('status')
+    })
+
+    it('has landing namespace', () => {
+      expect(i18n.options.ns).toContain('landing')
+    })
+
+    it('has auth namespace', () => {
+      expect(i18n.options.ns).toContain('auth')
+    })
+
+    it('has errors namespace', () => {
+      expect(i18n.options.ns).toContain('errors')
+    })
+
+    it('has validation namespace', () => {
+      expect(i18n.options.ns).toContain('validation')
+    })
+
+    it('has dashboard namespace', () => {
+      expect(i18n.options.ns).toContain('dashboard')
+    })
+
+    it('has plugins namespace', () => {
+      expect(i18n.options.ns).toContain('plugins')
+    })
+
+    it('has sources namespace', () => {
+      expect(i18n.options.ns).toContain('sources')
+    })
+
+    it('has common as default namespace', () => {
+      expect(i18n.options.defaultNS).toBe('common')
+    })
+  })
+
+  describe('configuration', () => {
+    it('has interpolation escapeValue disabled', () => {
+      expect(i18n.options.interpolation?.escapeValue).toBe(false)
+    })
+
+    it('has React Suspense disabled', () => {
+      expect(i18n.options.react?.useSuspense).toBe(false)
+    })
+  })
+
+  describe('translations', () => {
+    it('can translate keys from common namespace', () => {
+      // The translation should either return the translated value or the key itself
+      // Using t function directly with defaultValue option to bypass strict key typing
+      const key = 'common:appName'
+      const result = i18n.t(key, { defaultValue: key })
+      expect(result).toBeDefined()
+    })
+
+    it('returns key for unknown translations', () => {
+      const key = 'unknown.key.that.does.not.exist'
+      const result = i18n.t(key, { defaultValue: key })
+      expect(result).toBe('unknown.key.that.does.not.exist')
+    })
+  })
+})

--- a/frontend/tests/unit/lib/logger.test.ts
+++ b/frontend/tests/unit/lib/logger.test.ts
@@ -1,0 +1,117 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock console methods BEFORE importing the logger module
+// This ensures the logger captures the mocked methods
+const mockDebug = vi.fn()
+const mockLog = vi.fn()
+const mockWarn = vi.fn()
+const mockError = vi.fn()
+
+vi.stubGlobal('console', {
+  ...console,
+  debug: mockDebug,
+  log: mockLog,
+  warn: mockWarn,
+  error: mockError,
+})
+
+// Import after mocking
+const { createLogger, logger } = await import('@/lib/logger')
+
+describe('createLogger', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates a scoped logger with prefix', () => {
+    const log = createLogger('TestComponent')
+
+    expect(log).toHaveProperty('debug')
+    expect(log).toHaveProperty('info')
+    expect(log).toHaveProperty('warn')
+    expect(log).toHaveProperty('error')
+  })
+
+  it('debug method exists and is callable', () => {
+    const log = createLogger('Test')
+    expect(() => log.debug('test message')).not.toThrow()
+    expect(mockDebug).toHaveBeenCalledWith('[Test] test message')
+  })
+
+  it('info method exists and is callable', () => {
+    const log = createLogger('Test')
+    expect(() => log.info('test message')).not.toThrow()
+    expect(mockLog).toHaveBeenCalledWith('[Test] test message')
+  })
+
+  it('warn method exists and is callable', () => {
+    const log = createLogger('Test')
+    expect(() => log.warn('test message')).not.toThrow()
+    expect(mockWarn).toHaveBeenCalledWith('[Test] test message')
+  })
+
+  it('error method exists and is callable', () => {
+    const log = createLogger('Test')
+    expect(() => log.error('test message')).not.toThrow()
+    expect(mockError).toHaveBeenCalledWith('[Test] test message')
+  })
+
+  it('accepts additional data arguments', () => {
+    const log = createLogger('Test')
+    expect(() => log.info('message', { data: 'value' }, 123)).not.toThrow()
+    expect(mockLog).toHaveBeenCalledWith(
+      '[Test] message',
+      { data: 'value' },
+      123,
+    )
+  })
+})
+
+describe('logger', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('has debug method', () => {
+    expect(logger.debug).toBeDefined()
+    expect(typeof logger.debug).toBe('function')
+  })
+
+  it('has info method', () => {
+    expect(logger.info).toBeDefined()
+    expect(typeof logger.info).toBe('function')
+  })
+
+  it('has warn method', () => {
+    expect(logger.warn).toBeDefined()
+    expect(typeof logger.warn).toBe('function')
+  })
+
+  it('has error method', () => {
+    expect(logger.error).toBeDefined()
+    expect(typeof logger.error).toBe('function')
+  })
+
+  it('debug accepts prefix, message, and data', () => {
+    expect(() =>
+      logger.debug('Prefix', 'message', { key: 'value' }),
+    ).not.toThrow()
+    expect(mockDebug).toHaveBeenCalledWith('[Prefix] message', { key: 'value' })
+  })
+
+  it('error logs are always output', () => {
+    // Error logs should work regardless of environment
+    logger.error('Test', 'error message')
+    expect(mockError).toHaveBeenCalledWith('[Test] error message')
+  })
+})

--- a/frontend/tests/unit/lib/queryClient.test.ts
+++ b/frontend/tests/unit/lib/queryClient.test.ts
@@ -1,0 +1,121 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { queryClient } from '@/lib/queryClient'
+
+// Mock dependencies
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+vi.mock('@/lib/toast', () => ({
+  showToast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  },
+}))
+
+describe('queryClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    // Clear any cached queries
+    queryClient.clear()
+  })
+
+  describe('initialization', () => {
+    it('exports queryClient instance', () => {
+      expect(queryClient).toBeDefined()
+    })
+
+    it('has query cache', () => {
+      expect(queryClient.getQueryCache()).toBeDefined()
+    })
+
+    it('has mutation cache', () => {
+      expect(queryClient.getMutationCache()).toBeDefined()
+    })
+  })
+
+  describe('default options', () => {
+    it('has default stale time configured', () => {
+      const defaults = queryClient.getDefaultOptions()
+      expect(defaults.queries?.staleTime).toBeDefined()
+    })
+
+    it('has default gc time configured', () => {
+      const defaults = queryClient.getDefaultOptions()
+      expect(defaults.queries?.gcTime).toBeDefined()
+    })
+
+    it('has retry configured', () => {
+      const defaults = queryClient.getDefaultOptions()
+      expect(defaults.queries?.retry).toBeDefined()
+    })
+  })
+
+  describe('query management', () => {
+    it('can set and get query data', () => {
+      queryClient.setQueryData(['test-key'], { data: 'test-value' })
+      const data = queryClient.getQueryData(['test-key'])
+      expect(data).toEqual({ data: 'test-value' })
+    })
+
+    it('can invalidate queries', async () => {
+      queryClient.setQueryData(['test-key'], { data: 'test-value' })
+      await queryClient.invalidateQueries({ queryKey: ['test-key'] })
+
+      const query = queryClient.getQueryCache().find({ queryKey: ['test-key'] })
+      expect(query?.state.isInvalidated).toBe(true)
+    })
+
+    it('can clear all queries', () => {
+      queryClient.setQueryData(['key1'], { data: 1 })
+      queryClient.setQueryData(['key2'], { data: 2 })
+
+      queryClient.clear()
+
+      expect(queryClient.getQueryData(['key1'])).toBeUndefined()
+      expect(queryClient.getQueryData(['key2'])).toBeUndefined()
+    })
+  })
+
+  describe('query cache', () => {
+    it('caches query results', () => {
+      queryClient.setQueryData(['cached-query'], { result: 'cached' })
+
+      const cache = queryClient.getQueryCache()
+      const query = cache.find({ queryKey: ['cached-query'] })
+
+      expect(query).toBeDefined()
+      expect(query?.state.data).toEqual({ result: 'cached' })
+    })
+
+    it('can find queries by partial key', () => {
+      queryClient.setQueryData(['users', 'list'], { users: [] })
+      queryClient.setQueryData(['users', 'detail', '1'], { id: '1' })
+
+      const cache = queryClient.getQueryCache()
+      const queries = cache.findAll({ queryKey: ['users'] })
+
+      expect(queries.length).toBe(2)
+    })
+  })
+})

--- a/frontend/tests/unit/lib/storage-keys.test.ts
+++ b/frontend/tests/unit/lib/storage-keys.test.ts
@@ -1,0 +1,116 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  STORAGE_KEYS,
+  STORE_VERSIONS,
+  clearAllFiabStorage,
+} from '@/lib/storage-keys'
+
+describe('STORAGE_KEYS', () => {
+  describe('auth keys', () => {
+    it('has logout flag key with correct prefix', () => {
+      expect(STORAGE_KEYS.auth.logoutFlag).toBe('fiab.auth.logout-flag')
+    })
+
+    it('has anonymous ID key with correct prefix', () => {
+      expect(STORAGE_KEYS.auth.anonymousId).toBe('fiab.auth.anonymous-id')
+    })
+
+    it('has redirect URL key with correct prefix', () => {
+      expect(STORAGE_KEYS.auth.redirectUrl).toBe('fiab.auth.redirect-url')
+    })
+  })
+
+  describe('store keys', () => {
+    it('has UI store key with correct prefix', () => {
+      expect(STORAGE_KEYS.stores.ui).toBe('fiab.store.ui')
+    })
+
+    it('has config store key with correct prefix', () => {
+      expect(STORAGE_KEYS.stores.config).toBe('fiab.store.config')
+    })
+
+    it('has fable builder store key with correct prefix', () => {
+      expect(STORAGE_KEYS.stores.fableBuilder).toBe('fiab.store.fable-builder')
+    })
+  })
+
+  describe('all keys use fiab prefix', () => {
+    it('all auth keys start with fiab.', () => {
+      Object.values(STORAGE_KEYS.auth).forEach((key) => {
+        expect(key).toMatch(/^fiab\./)
+      })
+    })
+
+    it('all store keys start with fiab.', () => {
+      Object.values(STORAGE_KEYS.stores).forEach((key) => {
+        expect(key).toMatch(/^fiab\./)
+      })
+    })
+  })
+})
+
+describe('STORE_VERSIONS', () => {
+  it('has UI store version', () => {
+    expect(STORE_VERSIONS.ui).toBe(4)
+  })
+
+  it('has config store version', () => {
+    expect(STORE_VERSIONS.config).toBe(1)
+  })
+
+  it('has fable builder store version', () => {
+    expect(STORE_VERSIONS.fableBuilder).toBe(2)
+  })
+})
+
+describe('clearAllFiabStorage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('removes all keys with fiab. prefix', () => {
+    localStorage.setItem('fiab.test.one', 'value1')
+    localStorage.setItem('fiab.test.two', 'value2')
+    localStorage.setItem('fiab.auth.token', 'secret')
+
+    clearAllFiabStorage()
+
+    expect(localStorage.getItem('fiab.test.one')).toBeNull()
+    expect(localStorage.getItem('fiab.test.two')).toBeNull()
+    expect(localStorage.getItem('fiab.auth.token')).toBeNull()
+  })
+
+  it('preserves keys without fiab. prefix', () => {
+    localStorage.setItem('other-app-key', 'preserve-me')
+    localStorage.setItem('another-key', 'also-preserve')
+    localStorage.setItem('fiab.should-remove', 'remove-me')
+
+    clearAllFiabStorage()
+
+    expect(localStorage.getItem('other-app-key')).toBe('preserve-me')
+    expect(localStorage.getItem('another-key')).toBe('also-preserve')
+    expect(localStorage.getItem('fiab.should-remove')).toBeNull()
+  })
+
+  it('handles empty localStorage', () => {
+    expect(() => clearAllFiabStorage()).not.toThrow()
+  })
+
+  it('handles localStorage with no fiab keys', () => {
+    localStorage.setItem('some-key', 'value')
+
+    clearAllFiabStorage()
+
+    expect(localStorage.getItem('some-key')).toBe('value')
+  })
+})

--- a/frontend/tests/unit/lib/toast.test.ts
+++ b/frontend/tests/unit/lib/toast.test.ts
@@ -1,0 +1,142 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
+import { showToast } from '@/lib/toast'
+
+// Mock sonner
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+    promise: vi.fn(),
+  },
+}))
+
+describe('showToast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('success', () => {
+    it('calls toast.success with message', () => {
+      showToast.success('Operation completed')
+      expect(toast.success).toHaveBeenCalledWith('Operation completed', {
+        description: undefined,
+      })
+    })
+
+    it('calls toast.success with message and description', () => {
+      showToast.success('Saved', 'Your changes have been saved')
+      expect(toast.success).toHaveBeenCalledWith('Saved', {
+        description: 'Your changes have been saved',
+      })
+    })
+  })
+
+  describe('error', () => {
+    it('calls toast.error with message', () => {
+      showToast.error('Something went wrong')
+      expect(toast.error).toHaveBeenCalledWith('Something went wrong', {
+        description: undefined,
+      })
+    })
+
+    it('calls toast.error with message and description', () => {
+      showToast.error('Error', 'Please try again')
+      expect(toast.error).toHaveBeenCalledWith('Error', {
+        description: 'Please try again',
+      })
+    })
+  })
+
+  describe('warning', () => {
+    it('calls toast.warning with message', () => {
+      showToast.warning('Be careful')
+      expect(toast.warning).toHaveBeenCalledWith('Be careful', {
+        description: undefined,
+      })
+    })
+  })
+
+  describe('info', () => {
+    it('calls toast.info with message', () => {
+      showToast.info('Did you know?')
+      expect(toast.info).toHaveBeenCalledWith('Did you know?', {
+        description: undefined,
+      })
+    })
+  })
+
+  describe('apiError', () => {
+    it('shows error with message from Error object', () => {
+      const error = new Error('Network request failed')
+      showToast.apiError(error)
+      expect(toast.error).toHaveBeenCalledWith('Network request failed')
+    })
+
+    it('shows default message when error has no message', () => {
+      const error = new Error()
+      showToast.apiError(error)
+      expect(toast.error).toHaveBeenCalledWith('An error occurred')
+    })
+
+    it('includes retry action when provided', () => {
+      const error = new Error('Failed')
+      const retry = vi.fn()
+      showToast.apiError(error, { retry })
+
+      expect(toast.error).toHaveBeenCalledWith('Failed', {
+        action: {
+          label: 'Retry',
+          onClick: retry,
+        },
+      })
+    })
+  })
+
+  describe('loading', () => {
+    it('calls toast.loading with message', () => {
+      showToast.loading('Processing...')
+      expect(toast.loading).toHaveBeenCalledWith('Processing...')
+    })
+  })
+
+  describe('dismiss', () => {
+    it('calls toast.dismiss with toast ID', () => {
+      showToast.dismiss('toast-123')
+      expect(toast.dismiss).toHaveBeenCalledWith('toast-123')
+    })
+
+    it('calls toast.dismiss without ID to dismiss all', () => {
+      showToast.dismiss()
+      expect(toast.dismiss).toHaveBeenCalledWith(undefined)
+    })
+  })
+
+  describe('promise', () => {
+    it('calls toast.promise with promise and messages', () => {
+      const promise = Promise.resolve('result')
+      const messages = {
+        loading: 'Loading...',
+        success: 'Done!',
+        error: 'Failed',
+      }
+
+      showToast.promise(promise, messages)
+      expect(toast.promise).toHaveBeenCalledWith(promise, messages)
+    })
+  })
+})

--- a/frontend/tests/unit/lib/url-state.test.ts
+++ b/frontend/tests/unit/lib/url-state.test.ts
@@ -1,0 +1,268 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+import {
+  decodeStateFromURL,
+  encodeStateToURL,
+  getCompressionStats,
+  isStateTooLarge,
+} from '@/lib/url-state'
+
+// Mock logger to suppress expected error output in tests
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}))
+
+describe('encodeStateToURL', () => {
+  it('encodes simple string', () => {
+    const encoded = encodeStateToURL('hello')
+    expect(typeof encoded).toBe('string')
+    expect(encoded.length).toBeGreaterThan(0)
+  })
+
+  it('encodes object', () => {
+    const state = { name: 'test', value: 42 }
+    const encoded = encodeStateToURL(state)
+    expect(typeof encoded).toBe('string')
+  })
+
+  it('encodes array', () => {
+    const state = [1, 2, 3, 'a', 'b', 'c']
+    const encoded = encodeStateToURL(state)
+    expect(typeof encoded).toBe('string')
+  })
+
+  it('encodes complex nested object', () => {
+    const state = {
+      user: { name: 'John', age: 30 },
+      settings: { theme: 'dark', notifications: true },
+      items: [1, 2, 3],
+    }
+    const encoded = encodeStateToURL(state)
+    expect(typeof encoded).toBe('string')
+  })
+
+  it('produces URL-safe string', () => {
+    const state = { query: 'hello world', special: '&=?' }
+    const encoded = encodeStateToURL(state)
+    // Should not contain characters that need URL encoding
+    expect(encoded).not.toMatch(/[+/=]/)
+  })
+})
+
+describe('decodeStateFromURL', () => {
+  const schema = z.object({
+    name: z.string(),
+    value: z.number(),
+  })
+
+  it('decodes valid encoded state', () => {
+    const original = { name: 'test', value: 42 }
+    const encoded = encodeStateToURL(original)
+    const decoded = decodeStateFromURL(encoded, schema)
+
+    expect(decoded).toEqual(original)
+  })
+
+  it('returns null for invalid encoded string', () => {
+    const decoded = decodeStateFromURL('invalid-base64', schema)
+    expect(decoded).toBeNull()
+  })
+
+  it('returns null for empty string', () => {
+    const decoded = decodeStateFromURL('', schema)
+    expect(decoded).toBeNull()
+  })
+
+  it('returns null when schema validation fails', () => {
+    const wrongSchema = z.object({
+      different: z.string(),
+    })
+
+    const original = { name: 'test', value: 42 }
+    const encoded = encodeStateToURL(original)
+    const decoded = decodeStateFromURL(encoded, wrongSchema)
+
+    expect(decoded).toBeNull()
+  })
+
+  it('validates types according to schema', () => {
+    const strictSchema = z.object({
+      count: z.number().min(0).max(100),
+      enabled: z.boolean(),
+    })
+
+    const valid = { count: 50, enabled: true }
+    const encoded = encodeStateToURL(valid)
+    const decoded = decodeStateFromURL(encoded, strictSchema)
+
+    expect(decoded).toEqual(valid)
+  })
+
+  it('handles nested objects', () => {
+    const nestedSchema = z.object({
+      user: z.object({
+        name: z.string(),
+      }),
+      items: z.array(z.number()),
+    })
+
+    const original = { user: { name: 'John' }, items: [1, 2, 3] }
+    const encoded = encodeStateToURL(original)
+    const decoded = decodeStateFromURL(encoded, nestedSchema)
+
+    expect(decoded).toEqual(original)
+  })
+})
+
+describe('isStateTooLarge', () => {
+  it('returns false for small encoded string', () => {
+    const encoded = encodeStateToURL({ a: 1 })
+    expect(isStateTooLarge(encoded)).toBe(false)
+  })
+
+  it('returns true for very large encoded string', () => {
+    // LZ compression is very effective, so we need truly random-ish data
+    // to defeat compression and exceed 1800 characters
+    const largeState = {
+      data: Array(500)
+        .fill(0)
+        .map((_, i) => ({
+          id: `unique-id-${i}-${Math.random().toString(36)}`,
+          timestamp: Date.now() + i,
+          value: Math.random().toString(36).substring(2, 15),
+          nested: {
+            field1: `value-${i}-${Math.random()}`,
+            field2: i * Math.random(),
+          },
+        })),
+    }
+    const encoded = encodeStateToURL(largeState)
+    expect(encoded.length).toBeGreaterThan(1800)
+    expect(isStateTooLarge(encoded)).toBe(true)
+  })
+
+  it('uses 1800 character threshold correctly', () => {
+    // Test just under threshold
+    const smallEncoded = 'a'.repeat(1800)
+    expect(isStateTooLarge(smallEncoded)).toBe(false)
+
+    // Test just over threshold
+    const largeEncoded = 'a'.repeat(1801)
+    expect(isStateTooLarge(largeEncoded)).toBe(true)
+  })
+})
+
+describe('getCompressionStats', () => {
+  it('returns original and compressed sizes', () => {
+    const state = { name: 'test', value: 42 }
+    const stats = getCompressionStats(state)
+
+    expect(stats.originalSize).toBeGreaterThan(0)
+    expect(stats.compressedSize).toBeGreaterThan(0)
+    expect(typeof stats.ratio).toBe('number')
+  })
+
+  it('calculates correct original size', () => {
+    const state = { name: 'test' }
+    const stats = getCompressionStats(state)
+
+    expect(stats.originalSize).toBe(JSON.stringify(state).length)
+  })
+
+  it('calculates correct compressed size', () => {
+    const state = { name: 'test' }
+    const stats = getCompressionStats(state)
+    const encoded = encodeStateToURL(state)
+
+    expect(stats.compressedSize).toBe(encoded.length)
+  })
+
+  it('calculates compression ratio', () => {
+    const state = { name: 'test' }
+    const stats = getCompressionStats(state)
+
+    expect(stats.ratio).toBe(stats.compressedSize / stats.originalSize)
+  })
+
+  it('shows compression benefit for repetitive data', () => {
+    const repetitiveState = {
+      items: Array(100)
+        .fill(0)
+        .map(() => ({
+          type: 'item',
+          status: 'active',
+          category: 'default',
+        })),
+    }
+    const stats = getCompressionStats(repetitiveState)
+
+    // LZ compression should be effective for repetitive data
+    expect(stats.ratio).toBeLessThan(1)
+  })
+})
+
+describe('round-trip encoding/decoding', () => {
+  it('preserves data through encode/decode cycle', () => {
+    const testCases = [
+      { schema: z.string(), data: 'hello world' },
+      { schema: z.number(), data: 42 },
+      { schema: z.boolean(), data: true },
+      { schema: z.array(z.number()), data: [1, 2, 3, 4, 5] },
+      {
+        schema: z.object({ name: z.string(), age: z.number() }),
+        data: { name: 'John', age: 30 },
+      },
+    ]
+
+    for (const { schema, data } of testCases) {
+      const encoded = encodeStateToURL(data)
+      // Cast to z.ZodSchema<unknown> since we're testing multiple schema types
+      const decoded = decodeStateFromURL(
+        encoded,
+        schema as z.ZodSchema<unknown>,
+      )
+      expect(decoded).toEqual(data)
+    }
+  })
+
+  it('handles special characters', () => {
+    const schema = z.object({
+      text: z.string(),
+    })
+
+    const specialChars = {
+      text: 'Hello & goodbye! Special: <>&"\' Unicode: ',
+    }
+    const encoded = encodeStateToURL(specialChars)
+    const decoded = decodeStateFromURL(encoded, schema)
+
+    expect(decoded).toEqual(specialChars)
+  })
+
+  it('handles unicode characters', () => {
+    const schema = z.object({
+      greeting: z.string(),
+    })
+
+    const unicode = { greeting: '' }
+    const encoded = encodeStateToURL(unicode)
+    const decoded = decodeStateFromURL(encoded, schema)
+
+    expect(decoded).toEqual(unicode)
+  })
+})

--- a/frontend/tests/unit/lib/utils.test.ts
+++ b/frontend/tests/unit/lib/utils.test.ts
@@ -1,0 +1,102 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { cn, isExternalUrl, isValidInternalRedirect } from '@/lib/utils'
+
+describe('cn', () => {
+  it('merges class names', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar')
+  })
+
+  it('handles conditional classes', () => {
+    // Use a variable that eslint cannot statically analyze
+    const condition = Math.random() > 2 // Always false but not statically known
+    expect(cn('foo', condition && 'bar', 'baz')).toBe('foo baz')
+  })
+
+  it('handles undefined and null values', () => {
+    expect(cn('foo', undefined, null, 'bar')).toBe('foo bar')
+  })
+
+  it('merges conflicting Tailwind classes correctly', () => {
+    // twMerge should keep the last conflicting class
+    expect(cn('p-4', 'p-8')).toBe('p-8')
+    expect(cn('text-red-500', 'text-blue-500')).toBe('text-blue-500')
+  })
+
+  it('handles empty inputs', () => {
+    expect(cn()).toBe('')
+    expect(cn('')).toBe('')
+  })
+})
+
+describe('isValidInternalRedirect', () => {
+  it('accepts valid internal paths', () => {
+    expect(isValidInternalRedirect('/dashboard')).toBe(true)
+    expect(isValidInternalRedirect('/users/profile')).toBe(true)
+    expect(isValidInternalRedirect('/')).toBe(true)
+    expect(isValidInternalRedirect('/path?query=value')).toBe(true)
+  })
+
+  it('rejects null and empty values', () => {
+    expect(isValidInternalRedirect(null)).toBe(false)
+    expect(isValidInternalRedirect('')).toBe(false)
+  })
+
+  it('rejects external URLs with protocols', () => {
+    expect(isValidInternalRedirect('https://evil.com')).toBe(false)
+    expect(isValidInternalRedirect('http://evil.com')).toBe(false)
+  })
+
+  it('rejects protocol-relative URLs', () => {
+    // Protocol-relative URLs can redirect to external sites
+    expect(isValidInternalRedirect('//evil.com')).toBe(false)
+    expect(isValidInternalRedirect('//evil.com/path')).toBe(false)
+  })
+
+  it('rejects URLs with backslashes (IE compatibility)', () => {
+    // IE treats backslashes as forward slashes
+    expect(isValidInternalRedirect('/foo\\bar')).toBe(false)
+    expect(isValidInternalRedirect('\\\\evil.com')).toBe(false)
+  })
+
+  it('rejects relative paths without leading slash', () => {
+    expect(isValidInternalRedirect('dashboard')).toBe(false)
+    expect(isValidInternalRedirect('path/to/page')).toBe(false)
+  })
+})
+
+describe('isExternalUrl', () => {
+  it('identifies external URLs with https', () => {
+    expect(isExternalUrl('https://example.com')).toBe(true)
+    expect(isExternalUrl('https://example.com/path')).toBe(true)
+  })
+
+  it('identifies external URLs with http', () => {
+    expect(isExternalUrl('http://example.com')).toBe(true)
+  })
+
+  it('identifies protocol-relative URLs as external', () => {
+    expect(isExternalUrl('//example.com')).toBe(true)
+    expect(isExternalUrl('//cdn.example.com/asset.js')).toBe(true)
+  })
+
+  it('identifies internal paths as non-external', () => {
+    expect(isExternalUrl('/dashboard')).toBe(false)
+    expect(isExternalUrl('/users/profile')).toBe(false)
+    expect(isExternalUrl('/')).toBe(false)
+  })
+
+  it('identifies relative paths as non-external', () => {
+    expect(isExternalUrl('dashboard')).toBe(false)
+    expect(isExternalUrl('path/to/page')).toBe(false)
+  })
+})


### PR DESCRIPTION
During the renaming process from frontend-v2 to frontend, all directories named `lib` were ignored due to a `.gitignore` rule from the previous frontend. 

These files have now been restored and the relevant `.gitignore` rule has been removed.
 