### PR TITLE
[backend] update logging to new cascade api

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "anemoi-utils>=0.4.36",
   "apscheduler",
   "cloudpickle",
-  "earthkit-workflows>=0.8.0",
+  "earthkit-workflows>=0.9.0",
   "earthkit-workflows-anemoi>=0.3.12",
   "earthkit-workflows-pproc",
   "fastapi",

--- a/backend/src/forecastbox/api/routers/gateway.py
+++ b/backend/src/forecastbox/api/routers/gateway.py
@@ -8,7 +8,6 @@
 # nor does it submit to any jurisdiction.
 
 import asyncio
-import datetime as dt
 import logging
 import os
 import select
@@ -31,7 +30,6 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class GatewayProcess:
-    log_path: str | None
     process: BaseProcess
 
     def cleanup(self) -> None:
@@ -87,16 +85,14 @@ async def start_gateway() -> str:
             Globals.gateway.cleanup()
             Globals.gateway = None
 
-    now = dt.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    log_path = None if os.getenv("FIAB_LOGSTDOUT", "nay") == "yea" else f"{Globals.logs_directory.name}/gateway.{now}.txt"
-    logs_directory = None if os.getenv("FIAB_LOGSTDOUT", "nay") == "yea" else Globals.logs_directory.name
+    logs_directory = None if os.getenv("FIAB_LOGSTDOUT", "nay") == "yea" else Globals.logs_directory.name + os.sep
     max_concurrent_jobs = config.cascade.max_concurrent_jobs
     # TODO for some reason changes to os.environ were *not* visible by the child process! Investigate and re-enable:
     # export_recursive(config.model_dump(), config.model_config["env_nested_delimiter"], config.model_config["env_prefix"])
-    process = cascade_platform.get_mp_ctx("gateway").Process(target=launch_cascade, args=(log_path, logs_directory, max_concurrent_jobs))  # type: ignore[unresolved-attribute] # context
+    process = cascade_platform.get_mp_ctx("gateway").Process(target=launch_cascade, args=(logs_directory, max_concurrent_jobs))  # type: ignore[unresolved-attribute] # context
     process.start()
-    Globals.gateway = GatewayProcess(log_path=log_path, process=process)
-    logger.debug(f"spawned new gateway process with pid {process.pid} and logs at {log_path}")
+    Globals.gateway = GatewayProcess(process=process)
+    logger.debug(f"spawned new gateway process with pid {process.pid}")
     return "started"
 
 
@@ -109,31 +105,6 @@ async def get_status() -> str:
         return f"exited with {Globals.gateway.process.exitcode}"
     else:
         return StatusMessage.gateway_running
-
-
-@router.get("/logs")
-async def stream_logs(request: Request) -> EventSourceResponse:
-    """Stream logs from the Cascade Gateway process."""
-
-    if Globals.gateway is None:
-        raise HTTPException(400, "Gateway not running")
-
-    if Globals.gateway.log_path is None:
-        raise HTTPException(400, "Gateway started with logs into stdout")
-
-    async def event_generator():
-        # NOTE consider rewriting to aiofile, eg https://github.com/kuralabs/logserver/blob/master/server/server.py
-
-        pipe = subprocess.Popen(["tail", "-F", Globals.gateway.log_path], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)  # type: ignore[no-matching-overload] # Popen
-        poller = select.poll()
-        poller.register(pipe.stdout)  # type: ignore[invalid-argument-type] # pipe
-
-        while Globals.gateway.process.is_alive() and not (await request.is_disconnected()):
-            while poller.poll(5):
-                yield pipe.stdout.readline()
-            await asyncio.sleep(1)
-
-    return EventSourceResponse(event_generator())
 
 
 @router.post("/kill")

--- a/backend/src/forecastbox/api/routers/job.py
+++ b/backend/src/forecastbox/api/routers/job.py
@@ -400,7 +400,7 @@ async def get_logs(job_id: JobId = Depends(validate_job_id), user: UserRead = De
                     f = ""
                     try:
                         for f in os.listdir(p):
-                            jPref = f"job.{job_id}"
+                            jPref = f"job_{job_id}"
                             if f.startswith("gateway") or f.startswith(jPref):
                                 zf.write(f"{p / f}", arcname=f)
                     except Exception as e:

--- a/backend/src/forecastbox/standalone/launchers.py
+++ b/backend/src/forecastbox/standalone/launchers.py
@@ -57,14 +57,14 @@ def launch_backend():
         pass  # no need to spew stacktrace to log
 
 
-def launch_cascade(log_path: str | None, log_base: str | None, max_concurrent_jobs: int | None):
+def launch_cascade(log_base: str | None, max_concurrent_jobs: int | None):
     config = FIABConfig()
-    # TODO this configuration of log_path is very unsystematic, improve!
-    # TODO we may want this to propagate to controller/executors -- but stripped the gateway.txt etc
-    setup_process(log_path)
-    from cascade.gateway.server import serve
+    from cascade.deployment.logging import LoggingConfig
+    from cascade.gateway.server import main_enp
+
+    loggingConfig = LoggingConfig(path_base=log_base, formatter="line")
 
     try:
-        serve(url=config.cascade.cascade_url, log_base=log_base, max_jobs=max_concurrent_jobs)
+        main_enp(url=config.cascade.cascade_url, loggingConfig=loggingConfig, max_jobs=max_concurrent_jobs)
     except KeyboardInterrupt:
         pass  # no need to spew stacktrace to log

--- a/backend/tests/integration/test_submit_job.py
+++ b/backend/tests/integration/test_submit_job.py
@@ -48,7 +48,7 @@ def test_submit_job(backend_client_with_auth):
     assert len(outputs) == 1
     assert "n1" in outputs[0]["output_ids"]
     # NOTE increased timeout below for mac because of delayed import
-    kw_tm = {"timeout": 20.0} if sys.platform == "darwin" else {}
+    kw_tm = {"timeout": 40.0} if sys.platform == "darwin" else {}
     output = backend_client_with_auth.get(f"/job/{raw_job_id}/results/n1", **kw_tm)
     assert cloudpickle.loads(output.content) == 3
     # NOTE we run the same request again, without timeout, to verify it was indeed delayed import

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1292,7 +1292,7 @@ wheels = [
 
 [[package]]
 name = "earthkit-workflows"
-version = "0.8.0"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "array-api-compat" },
@@ -1311,9 +1311,9 @@ dependencies = [
     { name = "sortedcontainers" },
     { name = "xarray" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/12/8d02d606cfc21c71eb2ce52a6eb14713bf6e47795a01dc0135e09c582a50/earthkit_workflows-0.8.0.tar.gz", hash = "sha256:493adeae992a016cc83beab7801741006f50e437ab9572c489a4f65f2d50d0b3", size = 10665744, upload-time = "2026-02-24T10:06:31.359Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/77/6302a096c6b77061ffdf242c650b010b24fee07c468f4e49c7b7d120b3f1/earthkit_workflows-0.9.0.tar.gz", hash = "sha256:9c6f8f01a399b3b3bb3bde836300aed93372a5e0b7d0da9065eb15b5d1555f95", size = 10668248, upload-time = "2026-03-03T09:07:03.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/13/29e6f9caff2a636a80cfd664a3361829ea189a41151999955cc27509aa24/earthkit_workflows-0.8.0-py3-none-any.whl", hash = "sha256:85345eb5536b258a519bb61aeb4ea144b50ea84fc2f53fa46f98fda3d92e955e", size = 169252, upload-time = "2026-02-24T10:06:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a0/de832a97d091e600585a3223ef956ef6569dfc99f3b286f053126964f562/earthkit_workflows-0.9.0-py3-none-any.whl", hash = "sha256:1d9f9b8416913882a1c731af41134c88e4933f029428839c236d4cc042e17341", size = 173401, upload-time = "2026-03-03T09:07:02.067Z" },
 ]
 
 [[package]]
@@ -1934,7 +1934,7 @@ requires-dist = [
     { name = "cloudpickle" },
     { name = "earthkit-plots", marker = "extra == 'plots'", specifier = ">=0.3.5" },
     { name = "earthkit-plots-default-styles", marker = "extra == 'plots'", specifier = ">=0.1" },
-    { name = "earthkit-workflows", specifier = ">=0.8.0" },
+    { name = "earthkit-workflows", specifier = ">=0.9.0" },
     { name = "earthkit-workflows-anemoi", specifier = ">=0.3.12" },
     { name = "earthkit-workflows-pproc", git = "https://github.com/ecmwf/earthkit-workflows-pproc" },
     { name = "ecmwf-api-client", marker = "extra == 'webmars'", specifier = ">=1.6.5" },


### PR DESCRIPTION
cascade logging moved from a single param to a rich object, we react accordingly -- which simplifies the code as well as opens further configuration options, at the cost of losing the option of streaming the gateway logs via rest endpoint. We could revive that if we wanted, but I find it rather niche
