### PR TITLE
[docs] update backend setup instructions

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -4,16 +4,20 @@ See project's [readme](https://github.com/ecmwf/forecast-in-a-box/blob/main/READ
 
 ## Setup
 There are two options:
-1. create manually a `venv` and install this as an editable package into it,
+1. use `uv` to create a virtual environment and install this as an editable
+   package into it,
 2. use the [`fiab.sh`](../scripts/fiab.sh) script.
 
 The first gives you more control, the second brings more automation -- but both choices are ultimately fine and lead to the same result.
 
-For the first option, active your venv of choice, and then:
+For the first option, do the following:
 ```
 mkdir -p ~/.fiab
-uv pip install --prerelease=allow --upgrade -e .[test] # the --prerelease will eventually disapper, check whether pyproject contains any `dev` pins
-pytest backend # just to ensure all is good
+cd backend
+uv sync --prerelease allow --upgrade  # TODO: --prerelease will eventually disapper
+mkdir src/forecastbox/static && touch src/forecastbox/static/index.html  # TODO: replace
+. .venv/bin/activate
+pytest tests/  # just to ensure all is good
 ```
 
 For the second option, check the `fiab.sh` first -- it is configurable via envvars which are listed at the script's start.


### PR DESCRIPTION
### Description

This PR provides backend setup instructions that allow the developer to successfully run tests. It essentially replaces the `uv pip install` with `uv sync`.

The previous setup instructions introduced the following four problems ~that are OS independent and one problem which occurs at least on Linux machines~. This PR solves problems 1-4 ~but leaves problem 5 untouched for now~.

Note that my proposed change with `uv sync` installs the environment in editable mode by default (see https://docs.astral.sh/uv/concepts/projects/sync/#editable-installation) as well as all dependencies in the `dev` dependency group (see https://docs.astral.sh/uv/concepts/projects/dependencies/#default-groups).

In principle one could keep the `pip install` syntax, but that would require a new section in the `pyproject.toml` for `project.optional-dependencies` (see e.g., https://github.com/Netflix/dispatch/blob/dd2837e82a0bf5565b1b4b4b91ea30b7262d4061/pyproject.toml#L100-L116 and https://github.com/Netflix/dispatch/blob/dd2837e82a0bf5565b1b4b4b91ea30b7262d4061/.github/workflows/python.yml#L46)

### Problem 1 

```
uv pip install --prerelease=allow --upgrade -e .[test]
```

results in 

> warning: The package forecast-in-a-box @ file:///home/jf01/dev/forecast-in-a-box-bad-backend-docs/backend does not have an extra named test

since there is no extra called `[test]`. Specifying `[dev]` does not resolve that issue either since the `pyproject.toml` does not expose an extra named `dev` either, or at the very least `pip` is unable to parse it as we might expect

>  warning: The package forecast-in-a-box @ file:///home/jf01/dev/forecast-in-a-box-bad-backend-docs/backend does not have an extra named dev

The fact that dev dependencies are not successfully installed using the `pip install` approach is already known, and documented in the code https://github.com/ecmwf/forecast-in-a-box/blob/1e10b0960a2142638c7c60d7fab4dfe77a4cbbd6/.github/workflows/cd.yml#L85-L88

### Problem 2

The correct call to `pytest` should be `pytest tests/` from `backend` as the cwd. Calling `pytest backend` or `pytest .` where the cwd is `backend` results in the following error:

```shell
======================================== test session starts =========================================
platform linux -- Python 3.12.4, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/jf01/dev/forecast-in-a-box/backend
configfile: pyproject.toml
plugins: asyncio-1.3.0, anyio-4.12.1, xdist-3.8.0, mock-3.15.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting ... 
---------------------------------------- live log collection -----------------------------------------
INFO     numexpr.utils:utils.py:151 Note: NumExpr detected 28 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 16.
INFO     numexpr.utils:utils.py:164 NumExpr defaulting to 16 threads.
collected 188 items / 1 error                                                                        

=============================================== ERRORS ===============================================
___________________ ERROR collecting packages/fiab-plugin-ecmwf/tests/test_base.py ___________________
import file mismatch:
imported module 'test_base' has this __file__ attribute:
  /home/jf01/dev/forecast-in-a-box/backend/packages/fiab-core/tests/test_base.py
which is not the same as the test file we want to collect:
  /home/jf01/dev/forecast-in-a-box/backend/packages/fiab-plugin-ecmwf/tests/test_base.py
HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules
====================================== short test summary info =======================================
ERROR packages/fiab-plugin-ecmwf/tests/test_base.py
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
========================================== 1 error in 1.32s ==========================================
```

### Problem 3

Since the dev dependencies were not installed, running `pytest tests/` where cwd is `backend` results in a module not found error since many dependencies such as `pytest_asyncio` were never installed:

```shell
============================= test session starts ==============================
platform linux -- Python 3.12.4, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/jf01/dev/forecast-in-a-box-bad-backend-docs/backend
configfile: pyproject.toml
plugins: anyio-4.12.1, xdist-3.8.0

----------------------------- live log collection ------------------------------
INFO     numexpr.utils:utils.py:151 Note: NumExpr detected 28 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 16.
INFO     numexpr.utils:utils.py:164 NumExpr defaulting to 16 threads.
collected 159 items / 3 errors

==================================== ERRORS ====================================
______ ERROR collecting tests/unit/scheduling/test_experiment_runnable.py ______
tests/unit/scheduling/test_experiment_runnable.py:51: in <module>
    @pytest.mark.asyncio
     ^^^^^^^^^^^^^^^^^^^
.venv/lib/python3.12/site-packages/_pytest/mark/structures.py:597: in __getattr__
    warnings.warn(
E   pytest.PytestUnknownMarkWarning: Unknown pytest.mark.asyncio - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
___________________ ERROR collecting tests/unit/test_jobs.py ___________________
ImportError while importing test module '/home/jf01/dev/forecast-in-a-box-bad-backend-docs/backend/tests/unit/test_jobs.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../miniconda3/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/unit/test_jobs.py:20: in <module>
    import pytest_asyncio
E   ModuleNotFoundError: No module named 'pytest_asyncio'
```

### Problem 4

Without creating the `index.html` file in `src/forecastbox/static` the tests will fail. This solution is drawn from the `ci.yml` here:

https://github.com/ecmwf/forecast-in-a-box/blob/1e10b0960a2142638c7c60d7fab4dfe77a4cbbd6/.github/workflows/ci.yml#L82

### Problem 5 (at least on Linux machines)

Edit: This must be a local install problem. Was unable to reproduce it. I'm leaving it here as documentation in case someone else happens to encounter it.

The `--prerelease allow` flag results in a compatibility issue with `odclib` on Linux machines:

```shell
error: Distribution `odclib==1.6.2.dev20250529 @ registry+https://pypi.org/simple` can't be installed 
because it doesn't have a source distribution or wheel for the current platform

hint: You're on Linux (`manylinux_2_39_x86_64`), but `odclib` (v1.6.2.dev20250529) only has wheels 
for the following platform: `macosx_13_0_arm64`; consider adding "sys_platform == 'linux' and 
platform_machine == 'x86_64'" to `tool.uv.required-environments` to ensure uv resolves to a version 
with compatible wheels
```

This is clearly an upstream issue, and *might* be worth documenting in the `backend/README.md`, I can do this if needed.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 