### PR TITLE
[backend] replace manual include_router with iter modules

### DIFF
--- a/backend/src/forecastbox/entrypoint.py
+++ b/backend/src/forecastbox/entrypoint.py
@@ -25,16 +25,17 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from starlette.exceptions import HTTPException
 
+import forecastbox.api.routers
 import forecastbox.db
 from forecastbox.api.artifacts.manager import join_artifact_manager, submit_refresh_catalog
 from forecastbox.api.plugin.manager import PluginsStatus, join_updater_thread, submit_load_plugins
 from forecastbox.api.plugin.manager import status_brief as status_plugins
 from forecastbox.api.plugin.store import join_stores_thread, submit_initialize_stores
+from forecastbox.api.routers import gateway
 from forecastbox.api.scheduling.scheduler_thread import start_scheduler, status_scheduler, stop_scheduler
 from forecastbox.api.updates import get_local_release
 from forecastbox.db.migrations import migrate
 
-from .api.routers import admin, artifacts, auth, fable, gateway, job, plugin, schedule
 from .config import config
 
 logger = logging.getLogger(__name__)
@@ -74,16 +75,12 @@ app = FastAPI(
 
 templates = Jinja2Templates(directory=Path(__file__).parent / "templates")
 
-
-# TODO replace with iter modules, this is awkward
-app.include_router(job.router, prefix="/api/v1/job")
-app.include_router(admin.router, prefix="/api/v1/admin")
-app.include_router(auth.router, prefix="/api/v1")
-app.include_router(gateway.router, prefix="/api/v1/gateway")
-app.include_router(schedule.router, prefix="/api/v1/schedule")
-app.include_router(fable.router, prefix="/api/v1/fable")
-app.include_router(plugin.router, prefix="/api/v1/plugin")
-app.include_router(artifacts.router, prefix="/api/v1/artifacts")
+for module_info in pkgutil.iter_modules(forecastbox.api.routers.__path__):
+    module_name = module_info.name
+    module = importlib.import_module(f"forecastbox.api.routers.{module_name}")
+    if hasattr(module, "router"):
+        prefix = f"/api/v1/{module_name}" if module_name != "auth" else "/api/v1"
+        app.include_router(module.router, prefix=prefix)
 
 app.add_middleware(
     CORSMiddleware,  # type: ignore[invalid-argument-type]


### PR DESCRIPTION
### Description

The `auth` endpoint has a unique prefix, this is accounted for in the iter modules loop. The `gateway` module is used elsewhere in `entrypoint.py`, so that cannot be removed at the moment.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 