### PR TITLE
refactor: extract generic topological_order to utility/graph.py

### DIFF
--- a/backend/src/forecastbox/domain/blueprint/cascade.py
+++ b/backend/src/forecastbox/domain/blueprint/cascade.py
@@ -7,13 +7,9 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-"""Cascade execution data models: environment, job, and execution specification."""
+"""Cascade execution data models: environment specification."""
 
-from typing import Literal
-
-from cascade.low.core import JobInstance
 from fiab_core.artifacts import CompositeArtifactId
-from fiab_core.fable import BlockInstance, BlockInstanceId
 from pydantic import BaseModel, Field, PositiveInt
 
 
@@ -23,14 +19,3 @@ class EnvironmentSpecification(BaseModel):
     workers_per_host: PositiveInt | None = Field(default=None)
     environment_variables: dict[str, str] = Field(default_factory=dict)
     runtime_artifacts: list[CompositeArtifactId] = Field(default_factory=list)
-
-
-class RawCascadeJob(BaseModel):
-    job_type: Literal["raw_cascade_job"]
-    job_instance: JobInstance
-
-
-class ExecutionSpecification(BaseModel):
-    job: RawCascadeJob  # = Field(discriminator="job_type")
-    environment: EnvironmentSpecification
-    shared: bool = Field(default=False)

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -23,7 +23,7 @@ No HTTP exceptions are raised here; callers are responsible for mapping
 import logging
 from collections import defaultdict
 from itertools import groupby
-from typing import Iterator, cast
+from typing import cast
 
 from earthkit.workflows.compilers import graph2job
 from earthkit.workflows.graph import Graph, deduplicate_nodes
@@ -43,6 +43,7 @@ from forecastbox.domain.blueprint.db import upsert_blueprint
 from forecastbox.domain.blueprint.exceptions import BlueprintNotFound
 from forecastbox.domain.plugin.manager import PluginManager
 from forecastbox.utility.auth import AuthContext
+from forecastbox.utility.graph import topological_order
 
 logger = logging.getLogger(__name__)
 
@@ -96,27 +97,6 @@ class BlueprintSaveCommand(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def _topological_order(blueprint: BlueprintBuilder) -> Iterator[BlockInstanceId]:
-    remaining = {}
-    children: dict[BlockInstanceId, list[BlockInstanceId]] = defaultdict(list)
-    queue: list[BlockInstanceId] = []
-    for blockId, blockInstance in blueprint.blocks.items():
-        l = len(blockInstance.input_ids)
-        if l == 0:
-            queue.append(blockId)
-        else:
-            remaining[blockId] = l
-        for parent in blockInstance.input_ids.values():
-            children[parent].append(blockId)
-    while queue:
-        head = queue.pop(0)
-        yield head
-        for child in children[head]:
-            remaining[child] -= 1
-            if remaining[child] == 0:
-                queue.append(child)
-
-
 def validate_expand(blueprint: BlueprintBuilder) -> BlueprintValidationExpansion:
     """Validate and expand a partially-constructed BlueprintBuilder.
 
@@ -134,7 +114,7 @@ def validate_expand(blueprint: BlueprintBuilder) -> BlueprintValidationExpansion
     possible_expansions: dict[BlockInstanceId, list[PluginBlockFactoryId]] = {}
     block_errors: dict[BlockInstanceId, list[str]] = defaultdict(list)
     outputs = {}
-    for blockId in _topological_order(blueprint):
+    for blockId in topological_order(blueprint.blocks.items(), lambda block: block.input_ids.values()):
         blockInstance = blueprint.blocks[blockId]
         plugin = plugins.get(blockInstance.factory_id.plugin, None)
         if not plugin:
@@ -199,7 +179,7 @@ def compile_builder(blueprint: BlueprintBuilder) -> ExecutionSpecification:
     plugins = PluginManager.plugins
     action_lookup = {}
 
-    for blockId in _topological_order(blueprint):
+    for blockId in topological_order(blueprint.blocks.items(), lambda block: block.input_ids.values()):
         blockInstance = blueprint.blocks[blockId]
         plugin = plugins.get(blockInstance.factory_id.plugin, None)
         if not plugin:

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -25,9 +25,6 @@ from collections import defaultdict
 from itertools import groupby
 from typing import cast
 
-from earthkit.workflows.compilers import graph2job
-from earthkit.workflows.graph import Graph, deduplicate_nodes
-from fiab_core.artifacts import CompositeArtifactId
 from fiab_core.fable import (
     BlockFactoryId,
     BlockInstance,
@@ -38,7 +35,7 @@ from fiab_core.fable import (
 from pydantic import BaseModel
 
 import forecastbox.domain.blueprint.db as _blueprint_db
-from forecastbox.domain.blueprint.cascade import EnvironmentSpecification, ExecutionSpecification, RawCascadeJob
+from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
 from forecastbox.domain.blueprint.db import upsert_blueprint
 from forecastbox.domain.blueprint.exceptions import BlueprintNotFound
 from forecastbox.domain.plugin.manager import PluginManager
@@ -104,7 +101,7 @@ def validate_expand(blueprint: BlueprintBuilder) -> BlueprintValidationExpansion
     The presence of errors does not affect the return (callers decide how to
     surface them).
     """
-    plugins = PluginManager.plugins  # TODO we are avoiding a lock here! See the TODO at api/plugin.py
+    plugins = PluginManager.plugins
     possible_sources = [
         PluginBlockFactoryId(plugin=plugin_id, factory=block_factory_id)
         for plugin_id, plugin in plugins.items()
@@ -153,57 +150,6 @@ def validate_expand(blueprint: BlueprintBuilder) -> BlueprintValidationExpansion
         block_errors=block_errors,
         global_errors=global_errors,
     )
-
-
-def _get_artifacts_list(graph: Graph) -> list[CompositeArtifactId]:
-    payloads = (node.payload for node in graph.nodes())
-    artifactLists = (
-        payload.metadata.get("artifacts", []) for payload in payloads if hasattr(payload, "metadata") and isinstance(payload.metadata, dict)
-    )
-    artifacts = set(
-        artifact
-        for artifactList in artifactLists
-        if isinstance(artifactList, list)
-        for artifact in artifactList
-        if isinstance(artifact, CompositeArtifactId)
-    )
-    return list(artifacts)
-
-
-def compile_builder(blueprint: BlueprintBuilder) -> ExecutionSpecification:
-    """Compile a BlueprintBuilder into an ExecutionSpecification.
-
-    Raises ``ValueError`` if any block cannot be compiled.
-    """
-    graph = Graph([])
-    plugins = PluginManager.plugins
-    action_lookup = {}
-
-    for blockId in topological_order(blueprint.blocks.items(), lambda block: block.input_ids.values()):
-        blockInstance = blueprint.blocks[blockId]
-        plugin = plugins.get(blockInstance.factory_id.plugin, None)
-        if not plugin:
-            logger.debug(f"plugin for {blockId=} not found: {blockInstance.factory_id.plugin}. Available plugins: {plugins.keys()}")
-            raise ValueError(f"plugin for {blockId=} not found: {blockInstance.factory_id.plugin}")
-        result = plugin.compiler(action_lookup, blockId, blockInstance)
-        if result.t is None:
-            raise ValueError(f"compile failed at {blockId=} with {result.e}")
-        action_lookup[blockId] = result.t
-        block_factory = plugin.catalogue.factories[blockInstance.factory_id.factory]
-        if block_factory.kind == "sink":
-            graph += action_lookup[blockId].graph()
-
-    graph = deduplicate_nodes(graph)
-    job_instance = graph2job(graph)
-    job = RawCascadeJob(job_type="raw_cascade_job", job_instance=job_instance)
-
-    graph_artifacts = _get_artifacts_list(graph)
-    if blueprint.environment is not None:
-        merged_artifacts = list(set(blueprint.environment.runtime_artifacts).union(set(graph_artifacts)))
-        environment = blueprint.environment.model_copy(update={"runtime_artifacts": merged_artifacts})
-    else:
-        environment = EnvironmentSpecification(runtime_artifacts=graph_artifacts)
-    return ExecutionSpecification(job=job, environment=environment)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/src/forecastbox/domain/run/cascade.py
+++ b/backend/src/forecastbox/domain/run/cascade.py
@@ -9,15 +9,23 @@
 
 import io
 import logging
+import time
 from pathlib import Path
+from typing import Any, Sequence
 
 import cascade.gateway.api as api
+import cascade.gateway.client as client
 import cloudpickle
 import earthkit.data as ekd
 import numpy as np
 import xarray as xr
 from cascade.gateway.api import decoded_result
+from cascade.low import views as cascade_views
+from cascade.low.core import JobInstanceRich
+from pydantic import BaseModel
 
+from forecastbox.domain.artifact.manager import ArtifactManager, submit_artifact_download
+from forecastbox.domain.blueprint.cascade import ExecutionSpecification
 from forecastbox.utility.config import config
 
 logger = logging.getLogger(__name__)
@@ -62,3 +70,70 @@ def encode_result(result: api.ResultRetrievalResponse) -> tuple[bytes, str]:
         return buf.getvalue(), "application/numpy"
 
     return cloudpickle.dumps(obj), "application/clpkl"
+
+
+class ProductToOutputId(BaseModel):
+    product_name: str
+    product_spec: dict[str, Any]
+    output_ids: Sequence[str]
+
+
+def execute_cascade(spec: ExecutionSpecification) -> tuple[api.SubmitJobResponse, list[ProductToOutputId]]:
+    """Convert spec to JobInstance and submit to cascade api, returning response."""
+    runtime_artifacts = spec.environment.runtime_artifacts
+    if runtime_artifacts:
+        missing_artifacts = [art for art in runtime_artifacts if art not in ArtifactManager.locally_available]
+
+        download_ids = []
+        for artifact_id in missing_artifacts:
+            result = submit_artifact_download(artifact_id)
+            if result.e:
+                error_msg = f"Failed to submit download for {artifact_id}: {result.e}"
+                logger.error(error_msg)
+                return api.SubmitJobResponse(job_id=None, error=error_msg), []
+            download_ids.append(artifact_id)
+
+        if download_ids:
+            max_wait_seconds = 3600
+            start_time = time.time()
+
+            while True:
+                remaining = set(download_ids) - ArtifactManager.locally_available
+
+                if not remaining:
+                    logger.info(f"All runtime artifacts downloaded: {download_ids}")
+                    break
+
+                if time.time() - start_time > max_wait_seconds:
+                    error_msg = "Timeout waiting for runtime artifacts to download"
+                    logger.error(error_msg)
+                    return api.SubmitJobResponse(job_id=None, error=error_msg), []
+
+                time.sleep(1)
+
+    job = spec.job.job_instance
+    sinks = cascade_views.sinks(job)
+    sinks = [s for s in sinks if not s.task.startswith("run_as_earthkit")]
+    job.ext_outputs = sinks
+    product_to_id_mappings = [ProductToOutputId(product_name="All Outputs", product_spec={}, output_ids=[x.task for x in sinks])]
+
+    environment = spec.environment
+    hosts = min(config.cascade.max_hosts, environment.hosts or config.cascade.default_hosts)
+    workers_per_host = min(config.cascade.max_workers_per_host, environment.workers_per_host or config.cascade.default_workers_per_host)
+    env_vars = {"TMPDIR": config.cascade.venv_temp_dir}
+
+    r = api.SubmitJobRequest(
+        job=api.JobSpec(
+            workers_per_host=workers_per_host,
+            hosts=hosts,
+            envvars=env_vars,
+            use_slurm=False,
+            job_instance=JobInstanceRich(jobInstance=job, checkpointSpec=None),
+        )
+    )
+    try:
+        submit_job_response: api.SubmitJobResponse = client.request_response(r, f"{config.cascade.cascade_url}")  # type: ignore
+    except Exception as e:
+        return api.SubmitJobResponse(job_id=None, error=repr(e)), []
+
+    return submit_job_response, product_to_id_mappings

--- a/backend/src/forecastbox/domain/run/cascade.py
+++ b/backend/src/forecastbox/domain/run/cascade.py
@@ -11,7 +11,7 @@ import io
 import logging
 import time
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Literal, Sequence
 
 import cascade.gateway.api as api
 import cascade.gateway.client as client
@@ -21,14 +21,25 @@ import numpy as np
 import xarray as xr
 from cascade.gateway.api import decoded_result
 from cascade.low import views as cascade_views
-from cascade.low.core import JobInstanceRich
-from pydantic import BaseModel
+from cascade.low.core import JobInstance, JobInstanceRich
+from pydantic import BaseModel, Field
 
 from forecastbox.domain.artifact.manager import ArtifactManager, submit_artifact_download
-from forecastbox.domain.blueprint.cascade import ExecutionSpecification
+from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
 from forecastbox.utility.config import config
 
 logger = logging.getLogger(__name__)
+
+
+class RawCascadeJob(BaseModel):
+    job_type: Literal["raw_cascade_job"]
+    job_instance: JobInstance
+
+
+class ExecutionSpecification(BaseModel):
+    job: RawCascadeJob  # = Field(discriminator="job_type")
+    environment: EnvironmentSpecification
+    shared: bool = Field(default=False)
 
 
 def encode_result(result: api.ResultRetrievalResponse) -> tuple[bytes, str]:

--- a/backend/src/forecastbox/domain/run/compile.py
+++ b/backend/src/forecastbox/domain/run/compile.py
@@ -1,0 +1,69 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Compilation of a BlueprintBuilder into an ExecutionSpecification."""
+
+from earthkit.workflows.compilers import graph2job
+from earthkit.workflows.graph import Graph, deduplicate_nodes
+from fiab_core.artifacts import CompositeArtifactId
+
+from forecastbox.domain.blueprint.cascade import EnvironmentSpecification, ExecutionSpecification, RawCascadeJob
+from forecastbox.domain.blueprint.service import BlueprintBuilder
+from forecastbox.domain.plugin.manager import PluginManager
+from forecastbox.utility.graph import topological_order
+
+
+def _get_artifacts_list(graph: Graph) -> list[CompositeArtifactId]:
+    payloads = (node.payload for node in graph.nodes())
+    artifactLists = (
+        payload.metadata.get("artifacts", []) for payload in payloads if hasattr(payload, "metadata") and isinstance(payload.metadata, dict)
+    )
+    artifacts = set(
+        artifact
+        for artifactList in artifactLists
+        if isinstance(artifactList, list)
+        for artifact in artifactList
+        if isinstance(artifact, CompositeArtifactId)
+    )
+    return list(artifacts)
+
+
+def compile_builder(blueprint: BlueprintBuilder) -> ExecutionSpecification:
+    """Compile a BlueprintBuilder into an ExecutionSpecification.
+
+    Raises ``ValueError`` if any block cannot be compiled.
+    """
+    graph = Graph([])
+    plugins = PluginManager.plugins
+    action_lookup = {}
+
+    for blockId in topological_order(blueprint.blocks.items(), lambda block: block.input_ids.values()):
+        blockInstance = blueprint.blocks[blockId]
+        plugin = plugins.get(blockInstance.factory_id.plugin, None)
+        if not plugin:
+            raise ValueError(f"plugin for {blockId=} not found: {blockInstance.factory_id.plugin}")
+        result = plugin.compiler(action_lookup, blockId, blockInstance)
+        if result.t is None:
+            raise ValueError(f"compile failed at {blockId=} with {result.e}")
+        action_lookup[blockId] = result.t
+        block_factory = plugin.catalogue.factories[blockInstance.factory_id.factory]
+        if block_factory.kind == "sink":
+            graph += action_lookup[blockId].graph()
+
+    graph = deduplicate_nodes(graph)
+    job_instance = graph2job(graph)
+    job = RawCascadeJob(job_type="raw_cascade_job", job_instance=job_instance)
+
+    graph_artifacts = _get_artifacts_list(graph)
+    if blueprint.environment is not None:
+        merged_artifacts = list(set(blueprint.environment.runtime_artifacts).union(set(graph_artifacts)))
+        environment = blueprint.environment.model_copy(update={"runtime_artifacts": merged_artifacts})
+    else:
+        environment = EnvironmentSpecification(runtime_artifacts=graph_artifacts)
+    return ExecutionSpecification(job=job, environment=environment)

--- a/backend/src/forecastbox/domain/run/compile.py
+++ b/backend/src/forecastbox/domain/run/compile.py
@@ -13,9 +13,10 @@ from earthkit.workflows.compilers import graph2job
 from earthkit.workflows.graph import Graph, deduplicate_nodes
 from fiab_core.artifacts import CompositeArtifactId
 
-from forecastbox.domain.blueprint.cascade import EnvironmentSpecification, ExecutionSpecification, RawCascadeJob
+from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
 from forecastbox.domain.blueprint.service import BlueprintBuilder
 from forecastbox.domain.plugin.manager import PluginManager
+from forecastbox.domain.run.cascade import ExecutionSpecification, RawCascadeJob
 from forecastbox.utility.graph import topological_order
 
 

--- a/backend/src/forecastbox/domain/run/service.py
+++ b/backend/src/forecastbox/domain/run/service.py
@@ -26,24 +26,20 @@ based on the supplied ``AuthContext``.
 
 import asyncio
 import logging
-import time
 import uuid
-from typing import Any, Sequence, cast
+from typing import cast
 
 import cascade.gateway.api as api
 import cascade.gateway.client as client
-from cascade.low import views as cascade_views
-from cascade.low.core import JobInstanceRich
 from cascade.low.func import Either
-from earthkit.workflows.compilers import graph2job
-from earthkit.workflows.graph import Graph, deduplicate_nodes
 from pydantic import BaseModel
 
 import forecastbox.domain.blueprint.db as blueprint_db
 import forecastbox.domain.run.db as run_db
-from forecastbox.domain.artifact.manager import ArtifactManager, submit_artifact_download
 from forecastbox.domain.blueprint.cascade import EnvironmentSpecification, ExecutionSpecification
-from forecastbox.domain.blueprint.service import BlueprintBuilder, compile_builder
+from forecastbox.domain.blueprint.service import BlueprintBuilder
+from forecastbox.domain.run.cascade import ProductToOutputId, execute_cascade
+from forecastbox.domain.run.compile import compile_builder
 from forecastbox.domain.run.exceptions import RunNotFound
 from forecastbox.schemata.jobs import Blueprint, Run
 from forecastbox.utility.auth import AuthContext
@@ -75,73 +71,6 @@ class ExecuteResult(BaseModel):
     """Logical execution id (Run.id)."""
     attempt_count: int
     """Attempt number; always 1 on a fresh execution."""
-
-
-class ProductToOutputId(BaseModel):
-    product_name: str
-    product_spec: dict[str, Any]
-    output_ids: Sequence[str]
-
-
-def _execute_cascade(spec: ExecutionSpecification) -> tuple[api.SubmitJobResponse, list[ProductToOutputId]]:
-    """Convert spec to JobInstance and submit to cascade api, returning response."""
-    runtime_artifacts = spec.environment.runtime_artifacts
-    if runtime_artifacts:
-        missing_artifacts = [art for art in runtime_artifacts if art not in ArtifactManager.locally_available]
-
-        download_ids = []
-        for artifact_id in missing_artifacts:
-            result = submit_artifact_download(artifact_id)
-            if result.e:
-                error_msg = f"Failed to submit download for {artifact_id}: {result.e}"
-                logger.error(error_msg)
-                return api.SubmitJobResponse(job_id=None, error=error_msg), []
-            download_ids.append(artifact_id)
-
-        if download_ids:
-            max_wait_seconds = 3600
-            start_time = time.time()
-
-            while True:
-                remaining = set(download_ids) - ArtifactManager.locally_available
-
-                if not remaining:
-                    logger.info(f"All runtime artifacts downloaded: {download_ids}")
-                    break
-
-                if time.time() - start_time > max_wait_seconds:
-                    error_msg = "Timeout waiting for runtime artifacts to download"
-                    logger.error(error_msg)
-                    return api.SubmitJobResponse(job_id=None, error=error_msg), []
-
-                time.sleep(1)
-
-    job = spec.job.job_instance
-    sinks = cascade_views.sinks(job)
-    sinks = [s for s in sinks if not s.task.startswith("run_as_earthkit")]
-    job.ext_outputs = sinks
-    product_to_id_mappings = [ProductToOutputId(product_name="All Outputs", product_spec={}, output_ids=[x.task for x in sinks])]
-
-    environment = spec.environment
-    hosts = min(config.cascade.max_hosts, environment.hosts or config.cascade.default_hosts)
-    workers_per_host = min(config.cascade.max_workers_per_host, environment.workers_per_host or config.cascade.default_workers_per_host)
-    env_vars = {"TMPDIR": config.cascade.venv_temp_dir}
-
-    r = api.SubmitJobRequest(
-        job=api.JobSpec(
-            workers_per_host=workers_per_host,
-            hosts=hosts,
-            envvars=env_vars,
-            use_slurm=False,
-            job_instance=JobInstanceRich(jobInstance=job, checkpointSpec=None),
-        )
-    )
-    try:
-        submit_job_response: api.SubmitJobResponse = client.request_response(r, f"{config.cascade.cascade_url}")  # type: ignore
-    except Exception as e:
-        return api.SubmitJobResponse(job_id=None, error=repr(e)), []
-
-    return submit_job_response, product_to_id_mappings
 
 
 async def get_blueprint_for_execution(blueprint_id: str, blueprint_version: int | None) -> Blueprint | None:
@@ -199,7 +128,7 @@ async def execute(
 
     try:
         loop = asyncio.get_running_loop()
-        response, product_to_id_mappings = await loop.run_in_executor(None, _execute_cascade, exec_spec)
+        response, product_to_id_mappings = await loop.run_in_executor(None, execute_cascade, exec_spec)
         cascade_job_id = response.job_id or str(uuid.uuid4())
 
         update_kwargs: dict[str, object] = {"cascade_job_id": cascade_job_id}

--- a/backend/src/forecastbox/domain/run/service.py
+++ b/backend/src/forecastbox/domain/run/service.py
@@ -36,9 +36,9 @@ from pydantic import BaseModel
 
 import forecastbox.domain.blueprint.db as blueprint_db
 import forecastbox.domain.run.db as run_db
-from forecastbox.domain.blueprint.cascade import EnvironmentSpecification, ExecutionSpecification
+from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
 from forecastbox.domain.blueprint.service import BlueprintBuilder
-from forecastbox.domain.run.cascade import ProductToOutputId, execute_cascade
+from forecastbox.domain.run.cascade import ExecutionSpecification, ProductToOutputId, execute_cascade
 from forecastbox.domain.run.compile import compile_builder
 from forecastbox.domain.run.exceptions import RunNotFound
 from forecastbox.schemata.jobs import Blueprint, Run

--- a/backend/src/forecastbox/routes/run.py
+++ b/backend/src/forecastbox/routes/run.py
@@ -28,9 +28,8 @@ from pydantic import BaseModel
 
 import forecastbox.domain.run.db as run_db
 import forecastbox.domain.run.service as run_service
-from forecastbox.domain.run.cascade import encode_result
+from forecastbox.domain.run.cascade import ProductToOutputId, encode_result
 from forecastbox.domain.run.exceptions import RunAccessDenied, RunNotFound
-from forecastbox.domain.run.service import ProductToOutputId
 from forecastbox.entrypoint.auth.users import get_auth_context
 from forecastbox.routes.gateway import Globals
 from forecastbox.utility.auth import AuthContext

--- a/backend/src/forecastbox/utility/graph.py
+++ b/backend/src/forecastbox/utility/graph.py
@@ -1,0 +1,45 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from collections import defaultdict
+from collections.abc import Callable, Iterable, Iterator
+from typing import TypeVar
+
+TNodeId = TypeVar("TNodeId")
+TNode = TypeVar("TNode")
+
+
+def topological_order(
+    graph: Iterable[tuple[TNodeId, TNode]],
+    parent_extractor: Callable[[TNode], Iterable[TNodeId]],
+) -> Iterator[TNodeId]:
+    """Yield node IDs in topological order using Kahn's algorithm.
+
+    ``graph`` is an iterable of ``(node_id, node)`` pairs. ``parent_extractor``
+    returns the IDs of a node's parents (i.e. its dependencies). Nodes whose
+    entire dependency chain forms a cycle are silently omitted from the output.
+    """
+    remaining: dict[TNodeId, int] = {}
+    children: dict[TNodeId, list[TNodeId]] = defaultdict(list)
+    queue: list[TNodeId] = []
+    for node_id, node in graph:
+        parents = list(parent_extractor(node))
+        if not parents:
+            queue.append(node_id)
+        else:
+            remaining[node_id] = len(parents)
+        for parent in parents:
+            children[parent].append(node_id)
+    while queue:
+        head = queue.pop(0)
+        yield head
+        for child in children[head]:
+            remaining[child] -= 1
+            if remaining[child] == 0:
+                queue.append(child)

--- a/backend/tests/integration/test_submit_job.py
+++ b/backend/tests/integration/test_submit_job.py
@@ -9,8 +9,8 @@ import httpx
 import pytest
 from cascade.low.builders import JobBuilder, TaskBuilder
 
-from forecastbox.domain.blueprint.cascade import (
-    EnvironmentSpecification,
+from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
+from forecastbox.domain.run.cascade import (
     ExecutionSpecification,
     RawCascadeJob,
 )

--- a/backend/tests/nonpytest/blueprint.py
+++ b/backend/tests/nonpytest/blueprint.py
@@ -6,8 +6,9 @@ from datetime import datetime, timedelta
 import httpx
 from fiab_core.fable import BlockInstance, PluginBlockFactoryId, PluginCompositeId
 
-from forecastbox.domain.blueprint.cascade import EnvironmentSpecification, ExecutionSpecification, RawCascadeJob
+from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
 from forecastbox.domain.blueprint.service import BlueprintBuilder
+from forecastbox.domain.run.cascade import ExecutionSpecification, RawCascadeJob
 from forecastbox.entrypoint.main import launch_all
 from forecastbox.utility.config import FIABConfig
 

--- a/backend/tests/unit/test_graph.py
+++ b/backend/tests/unit/test_graph.py
@@ -1,0 +1,96 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Unit tests for forecastbox.utility.graph."""
+
+from forecastbox.utility.graph import topological_order
+
+
+def _graph(edges: dict[str, list[str]]) -> list[tuple[str, list[str]]]:
+    """Build a (node_id, parents) list from a {node_id: [parent_ids]} dict."""
+    return list(edges.items())
+
+
+def _topo(edges: dict[str, list[str]]) -> list[str]:
+    return list(topological_order(_graph(edges), lambda parents: parents))
+
+
+def _precedes(result: list[str], before: str, after: str) -> bool:
+    return result.index(before) < result.index(after)
+
+
+def test_empty_graph() -> None:
+    assert _topo({}) == []
+
+
+def test_single_node() -> None:
+    assert _topo({"A": []}) == ["A"]
+
+
+def test_linear_chain() -> None:
+    # C depends on B depends on A
+    result = _topo({"A": [], "B": ["A"], "C": ["B"]})
+    assert result == ["A", "B", "C"]
+
+
+def test_diamond() -> None:
+    # A → B, A → C, B → D, C → D
+    result = _topo({"A": [], "B": ["A"], "C": ["A"], "D": ["B", "C"]})
+    assert result[0] == "A"
+    assert result[-1] == "D"
+    assert _precedes(result, "B", "D")
+    assert _precedes(result, "C", "D")
+
+
+def test_multiple_roots() -> None:
+    # A and B are independent roots, C depends on both
+    result = _topo({"A": [], "B": [], "C": ["A", "B"]})
+    assert set(result[:2]) == {"A", "B"}
+    assert result[-1] == "C"
+
+
+def test_all_independent_nodes() -> None:
+    result = _topo({"X": [], "Y": [], "Z": []})
+    assert set(result) == {"X", "Y", "Z"}
+
+
+def test_wide_fan_out() -> None:
+    # A feeds B, C, D, E
+    result = _topo({"A": [], "B": ["A"], "C": ["A"], "D": ["A"], "E": ["A"]})
+    assert result[0] == "A"
+    assert set(result[1:]) == {"B", "C", "D", "E"}
+
+
+def test_cycle_nodes_omitted() -> None:
+    # A → B → C → B (cycle between B and C); A has no parents so it is yielded
+    result = _topo({"A": [], "B": ["A", "C"], "C": ["B"]})
+    assert "A" in result
+    # B and C form a cycle and should be omitted
+    assert "B" not in result
+    assert "C" not in result
+
+
+def test_non_string_node_ids() -> None:
+    graph = [(1, []), (2, [1]), (3, [2])]
+    result = list(topological_order(iter(graph), lambda parents: parents))
+    assert result == [1, 2, 3]
+
+
+def test_preserves_all_reachable_nodes() -> None:
+    edges = {
+        "start": [],
+        "a": ["start"],
+        "b": ["start"],
+        "c": ["a", "b"],
+        "end": ["c"],
+    }
+    result = _topo(edges)
+    assert set(result) == set(edges.keys())
+    assert result[0] == "start"
+    assert result[-1] == "end"


### PR DESCRIPTION
Preparing for variables implementation -- clearing some separations of concerns between run and blueprint domains

1. Topological Order moves to a new module utility/graph
2. Move compilation from blueprint domain to run domain