### PR TITLE
[frontend] Add glyphs UI: API migration, admin page, and fable builder integration

### DIFF
--- a/frontend/mocks/handlers/fable.handlers.ts
+++ b/frontend/mocks/handlers/fable.handlers.ts
@@ -50,6 +50,43 @@ const fableVersions: Record<string, number> = Object.fromEntries(
   Object.keys(mockSavedFables).map((id) => [id, 1]),
 )
 
+interface MockGlobalGlyph {
+  global_glyph_id: string
+  key: string
+  value: string
+  public: boolean
+  created_by: string | null
+  created_at: string
+  updated_at: string
+}
+
+const mockGlobalGlyphs: Array<MockGlobalGlyph> = []
+let glyphIdCounter = 1
+
+const mockIntrinsicGlyphs = [
+  {
+    name: 'runId',
+    display_name: 'Run ID',
+    valueExample: '550e8400-e29b-41d4-a716-446655440000',
+  },
+  {
+    name: 'submitDatetime',
+    display_name:
+      'Submit Datetime (fixed at first submission, preserved on restart)',
+    valueExample: '2026-04-10 12:00:00',
+  },
+  {
+    name: 'startDatetime',
+    display_name: 'Start Datetime (updated on every restart)',
+    valueExample: '2026-04-10 12:00:00',
+  },
+  {
+    name: 'attemptCount',
+    display_name: 'Attempt Count (incremented on every restart)',
+    valueExample: '1',
+  },
+]
+
 export const fableHandlers = [
   http.get(API_ENDPOINTS.fable.catalogue, async () => {
     await delay(300)
@@ -225,6 +262,91 @@ export const fableHandlers = [
       page: 1,
       page_size: 50,
     })
+  }),
+
+  http.get(API_ENDPOINTS.fable.glyphsList, async ({ request }) => {
+    await delay(200)
+    const url = new URL(request.url)
+    const glyphType = url.searchParams.get('glyph_type') ?? 'intrinsic'
+
+    if (glyphType === 'intrinsic') {
+      return HttpResponse.json({
+        glyphs: mockIntrinsicGlyphs,
+        total: mockIntrinsicGlyphs.length,
+        page: 1,
+        page_size: mockIntrinsicGlyphs.length,
+      })
+    }
+
+    // global
+    const page = Number(url.searchParams.get('page') ?? '1')
+    const pageSize = Number(url.searchParams.get('page_size') ?? '50')
+    const start = (page - 1) * pageSize
+    const slice = mockGlobalGlyphs.slice(start, start + pageSize)
+    return HttpResponse.json({
+      glyphs: slice.map((g) => ({
+        name: g.key,
+        display_name: g.key,
+        valueExample: g.value,
+      })),
+      total: mockGlobalGlyphs.length,
+      page,
+      page_size: pageSize,
+    })
+  }),
+
+  http.post(API_ENDPOINTS.fable.glyphsGlobalPost, async ({ request }) => {
+    await delay(300)
+    const body = (await request.json()) as {
+      key: string
+      value: string
+      public?: boolean
+    }
+
+    const intrinsicNames = new Set(mockIntrinsicGlyphs.map((g) => g.name))
+    if (intrinsicNames.has(body.key)) {
+      return HttpResponse.json(
+        {
+          detail: `Key '${body.key}' is reserved as an intrinsic glyph and cannot be overridden.`,
+        },
+        { status: 422 },
+      )
+    }
+
+    const existing = mockGlobalGlyphs.find((g) => g.key === body.key)
+    const now = new Date().toISOString()
+    if (existing) {
+      existing.value = body.value
+      existing.public = body.public ?? false
+      existing.updated_at = now
+      return HttpResponse.json(existing)
+    }
+
+    const newGlyph: MockGlobalGlyph = {
+      global_glyph_id: `glyph-${String(glyphIdCounter++).padStart(3, '0')}`,
+      key: body.key,
+      value: body.value,
+      public: body.public ?? false,
+      created_by: 'mock-user-123',
+      created_at: now,
+      updated_at: now,
+    }
+    mockGlobalGlyphs.push(newGlyph)
+    return HttpResponse.json(newGlyph)
+  }),
+
+  http.get(API_ENDPOINTS.fable.glyphsGlobalGet, async ({ request }) => {
+    await delay(200)
+    const url = new URL(request.url)
+    const id = url.searchParams.get('global_glyph_id')
+    const glyph = mockGlobalGlyphs.find((g) => g.global_glyph_id === id)
+    if (!glyph) {
+      return HttpResponse.json(
+        { detail: `GlobalGlyph '${id}' not found.` },
+        { status: 404 },
+      )
+    }
+    return HttpResponse.json(glyph)
   }),
 
   http.get(API_ENDPOINTS.fable.get, async ({ request }) => {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -625,9 +625,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@dotenvx/dotenvx": {
-      "version": "1.60.2",
-      "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.60.2.tgz",
-      "integrity": "sha512-r4AznHUvfLONuWdoSIQtut6Ez/ym+lGXRtDvRaoAEMEhAmwSoK24jRsfR28vcb3ygWm7qeYOcbZolhtseJl6mA==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.61.0.tgz",
+      "integrity": "sha512-utL3cpZoFzflyqUkjYbxYujI6STBTmO5LFn4bbin/NZnRWN6wQ7eErhr3/Vpa5h/jicPFC6kTa42r940mQftJQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1296,73 +1296,39 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.5"
+        "minimatch": "^10.2.4"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@eslint/core": "^0.17.0"
+        "@eslint/core": "^1.2.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -1370,120 +1336,54 @@
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ajv": "^6.14.0",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.5",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@eslint/core": "^0.17.0",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -3587,43 +3487,22 @@
         "eslint": "^9.0.0 || ^10.0.0"
       }
     },
-    "node_modules/@tanstack/eslint-config/node_modules/@eslint/js": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
-      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "eslint": "^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@tanstack/eslint-plugin-query": {
-      "version": "5.96.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.96.2.tgz",
-      "integrity": "sha512-OsXCATZ+YmG8TyHrunfYy2IDB+dqY87en2im2A60JPgDAg66cCoHTzJWbe9uH8Cw9/K3NiKYlyyo1erVFu3qFw==",
+      "version": "5.97.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.97.0.tgz",
+      "integrity": "sha512-0/py2lxpUaCHKZeaOcTUVGHsbmr7719bh4ruj++HXgJQN8AtPvoPODyc8eOYTi/gZqr0LA2ZHH3ohSMrD3im+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^8.48.0"
+        "@typescript-eslint/utils": "^8.58.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": "^5.4.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": "^5.4.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3661,9 +3540,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.96.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.96.2.tgz",
-      "integrity": "sha512-hzI6cTVh4KNRk8UtoIBS7Lv9g6BnJPXvBKsvYH1aGWvv0347jT3BnSvztOE+kD76XGvZnRC/t6qdW1CaIfwCeA==",
+      "version": "5.97.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.97.0.tgz",
+      "integrity": "sha512-QdpLP5VzVMgo4VtaPppRA2W04UFjIqX+bxke/ZJhE5cfd5UPkRzqIAJQt9uXkQJjqE8LBOMbKv7f8HCsZltXlg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3692,12 +3571,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.96.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.96.2.tgz",
-      "integrity": "sha512-sYyzzJT4G0g02azzJ8o55VFFV31XvFpdUpG+unxS0vSaYsJnSPKGoI6WdPwUucJL1wpgGfwfmntNX/Ub1uOViA==",
+      "version": "5.97.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.97.0.tgz",
+      "integrity": "sha512-y4So4eGcQoK2WVMAcDNZE9ofB/p5v1OlKvtc1F3uqHwrtifobT7q+ZnXk2mRkc8E84HKYSlAE9z6HXl2V0+ySQ==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.96.2"
+        "@tanstack/query-core": "5.97.0"
       },
       "funding": {
         "type": "github",
@@ -4153,6 +4032,13 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4797,15 +4683,15 @@
       }
     },
     "node_modules/@vitest/browser": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.3.tgz",
-      "integrity": "sha512-CS9KjO2vijuBlbwz0JIgC0YuoI1BuqWI5ziD3Nll6jkpNYtWdjPMVgGynQ9vZovjsECeUqEeNjWrypP414d0CQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.4.tgz",
+      "integrity": "sha512-TrNaY/yVOwxtrxNsDUC/wQ56xSwplpytTeRAqF/197xV/ZddxxulBsxR6TrhVMyniJmp9in8d5u0AcDaNRY30w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@blazediff/core": "1.9.1",
-        "@vitest/mocker": "4.1.3",
-        "@vitest/utils": "4.1.3",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "magic-string": "^0.30.21",
         "pngjs": "^7.0.0",
         "sirv": "^3.0.2",
@@ -4816,18 +4702,18 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.1.3"
+        "vitest": "4.1.4"
       }
     },
     "node_modules/@vitest/browser-playwright": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.3.tgz",
-      "integrity": "sha512-D3Q+YozvSpiFaLPgd6/OMbyqEIZeucSe6AHJJ7VnNJKQhIyBE60TlBZlxzwM8bvjzQE9ZnYWQCPeCw5pnhbiNg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.4.tgz",
+      "integrity": "sha512-q3PchVhZINX23Pv+RERgAtDlp6wzVkID/smOPnZ5YGWpeWUe3jMNYppeVh15j4il3G7JIJty1d1Kicpm0HSMig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/browser": "4.1.3",
-        "@vitest/mocker": "4.1.3",
+        "@vitest/browser": "4.1.4",
+        "@vitest/mocker": "4.1.4",
         "tinyrainbow": "^3.1.0"
       },
       "funding": {
@@ -4835,7 +4721,7 @@
       },
       "peerDependencies": {
         "playwright": "*",
-        "vitest": "4.1.3"
+        "vitest": "4.1.4"
       },
       "peerDependenciesMeta": {
         "playwright": {
@@ -4844,14 +4730,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.3.tgz",
-      "integrity": "sha512-/MBdrkA8t6hbdCWFKs09dPik774xvs4Z6L4bycdCxYNLHM8oZuRyosumQMG19LUlBsB6GeVpL1q4kFFazvyKGA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
+      "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.3",
+        "@vitest/utils": "4.1.4",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -4865,8 +4751,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.3",
-        "vitest": "4.1.3"
+        "@vitest/browser": "4.1.4",
+        "vitest": "4.1.4"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -4875,16 +4761,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.3.tgz",
-      "integrity": "sha512-CW8Q9KMtXDGHj0vCsqui0M5KqRsu0zm0GNDW7Gd3U7nZ2RFpPKSCpeCXoT+/+5zr1TNlsoQRDEz+LzZUyq6gnQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.3",
-        "@vitest/utils": "4.1.3",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -4893,13 +4779,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.3.tgz",
-      "integrity": "sha512-XN3TrycitDQSzGRnec/YWgoofkYRhouyVQj4YNsJ5r/STCUFqMrP4+oxEv3e7ZbLi4og5kIHrZwekDJgw6hcjw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.3",
+        "@vitest/spy": "4.1.4",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -4920,9 +4806,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.3.tgz",
-      "integrity": "sha512-hYqqwuMbpkkBodpRh4k4cQSOELxXky1NfMmQvOfKvV8zQHz8x8Dla+2wzElkMkBvSAJX5TRGHJAQvK0TcOafwg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4933,13 +4819,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.3.tgz",
-      "integrity": "sha512-VwgOz5MmT0KhlUj40h02LWDpUBVpflZ/b7xZFA25F29AJzIrE+SMuwzFf0b7t4EXdwRNX61C3B6auIXQTR3ttA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.3",
+        "@vitest/utils": "4.1.4",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -4947,14 +4833,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.3.tgz",
-      "integrity": "sha512-9l+k/J9KG5wPJDX9BcFFzhhwNjwkRb8RsnYhaT1vPY7OufxmQFc9sZzScRCPTiETzl37mrIWVY9zxzmdVeJwDQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.3",
-        "@vitest/utils": "4.1.3",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -4963,9 +4849,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.3.tgz",
-      "integrity": "sha512-ujj5Uwxagg4XUIfAUyRQxAg631BP6e9joRiN99mr48Bg9fRs+5mdUElhOoZ6rP5mBr8Bs3lmrREnkrQWkrsTCw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4973,13 +4859,13 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.3.tgz",
-      "integrity": "sha512-xBPy+43o1fgMLUDlufUXh7tlT/Es8uS5eiyBY2PyPfFYSGpApZskLw65DROoDz+rgYkPuAmb20Mv9Z9g1WQE7w==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.4.tgz",
+      "integrity": "sha512-EgFR7nlj5iTDYZYCvavjFokNYwr3c3ry0sFiCg+N7B233Nwp+NNx7eoF/XvMWDCKY71xXAG3kFkt97ZHBJVL8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.3",
+        "@vitest/utils": "4.1.4",
         "fflate": "^0.8.2",
         "flatted": "^3.4.2",
         "pathe": "^2.0.3",
@@ -4991,17 +4877,17 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.1.3"
+        "vitest": "4.1.4"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.3.tgz",
-      "integrity": "sha512-Pc/Oexse/khOWsGB+w3q4yzA4te7W4gpZZAvk+fr8qXfTURZUMj5i7kuxsNK5mP/dEB6ao3jfr0rs17fHhbHdw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.3",
+        "@vitest/pretty-format": "4.1.4",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -5202,16 +5088,14 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
+      "peer": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -5345,9 +5229,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.16",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.16.tgz",
-      "integrity": "sha512-Lyf3aK28zpsD1yQMiiHD4RvVb6UdMoo8xzG2XzFIfR9luPzOpcBlAsT/qfB1XWS1bxWT+UtE4WmQgsp297FYOA==",
+      "version": "2.10.17",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.17.tgz",
+      "integrity": "sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -5549,18 +5433,13 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -5768,14 +5647,6 @@
       "engines": {
         "node": ">= 12.0.0"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
@@ -6401,9 +6272,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.333",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.333.tgz",
-      "integrity": "sha512-skNh4FsE+IpCJV7xAQGbQ4eyOGvcEctVBAk7a5KPzxC3alES9rLrT+2IsPRPgeQr8LVxdJr8BHQ9481+TOr0xg==",
+      "version": "1.5.334",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.334.tgz",
+      "integrity": "sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -6568,34 +6439,31 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
+      "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.2",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
-        "@eslint/plugin-kit": "^0.4.1",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.4",
+        "@eslint/config-helpers": "^0.5.4",
+        "@eslint/core": "^1.2.0",
+        "@eslint/plugin-kit": "^0.7.0",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "ajv": "^6.14.0",
-        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -6605,8 +6473,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.5",
+        "minimatch": "^10.2.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -6614,7 +6481,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -6822,17 +6689,19 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -6851,24 +6720,37 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+    "node_modules/eslint/node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
-      "license": "MIT",
+      "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint/node_modules/glob-parent": {
@@ -6883,20 +6765,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/espree": {
@@ -7822,9 +7690,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "26.0.3",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.3.tgz",
-      "integrity": "sha512-1571kXINxHKY7LksWp8wP+zP0YqHSSpl/OW0Y0owFEf2H3s8gCAffWaZivcz14rMkOvn3R/psiQxVsR9t2Nafg==",
+      "version": "26.0.4",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.4.tgz",
+      "integrity": "sha512-gXF7U9bfioXPLv7mw8Qt2nfO7vij5MyINvPgVv99pX3fL1Y01pw2mKBFrlYpRxRCl2wz3ISenj6VsMJT2isfuA==",
       "funding": [
         {
           "type": "individual",
@@ -8812,14 +8680,6 @@
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/log-symbols": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
@@ -8859,9 +8719,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
-      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -9113,9 +8973,9 @@
       "license": "MIT"
     },
     "node_modules/msw": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.13.1.tgz",
-      "integrity": "sha512-4wjFzJ+osaUDS2OakrXSl5tCFBUbzsaHbi5QRycRtVciOuYmnWn16CpNxcqh3UyslFkHbzKaj/GfYr7Hn67QPQ==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.13.2.tgz",
+      "integrity": "sha512-go2H1TIERKkC48pXiwec5l6sbNqYuvqOk3/vHGo1Zd+pq/H63oFawDQerH+WQdUw/flJFHDG7F+QdWMwhntA/A==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -9243,6 +9103,22 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/msw/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/msw/node_modules/mute-stream": {
@@ -9589,19 +9465,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ora/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/outvariant": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
@@ -9744,9 +9607,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.3.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.2.tgz",
-      "integrity": "sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==",
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -10058,20 +9921,6 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
@@ -10155,9 +10004,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -10218,24 +10067,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.5"
       }
     },
     "node_modules/react-globe.gl": {
@@ -10931,19 +10780,6 @@
         "shadcn": "dist/index.js"
       }
     },
-    "node_modules/shadcn/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/shadcn/node_modules/cli-spinners": {
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
@@ -11103,14 +10939,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11370,20 +11206,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -12168,19 +11990,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.3.tgz",
-      "integrity": "sha512-DBc4Tx0MPNsqb9isoyOq00lHftVx/KIU44QOm2q59npZyLUkENn8TMFsuzuO+4U2FUa9rgbbPt3udrP25GcjXw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.3",
-        "@vitest/mocker": "4.1.3",
-        "@vitest/pretty-format": "4.1.3",
-        "@vitest/runner": "4.1.3",
-        "@vitest/snapshot": "4.1.3",
-        "@vitest/spy": "4.1.3",
-        "@vitest/utils": "4.1.3",
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -12208,12 +12030,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.3",
-        "@vitest/browser-preview": "4.1.3",
-        "@vitest/browser-webdriverio": "4.1.3",
-        "@vitest/coverage-istanbul": "4.1.3",
-        "@vitest/coverage-v8": "4.1.3",
-        "@vitest/ui": "4.1.3",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -12404,6 +12226,22 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/wrap-ansi/node_modules/string-width": {

--- a/frontend/public/mockServiceWorker.js
+++ b/frontend/public/mockServiceWorker.js
@@ -7,7 +7,7 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.13.1'
+const PACKAGE_VERSION = '2.13.2'
 const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -71,8 +71,12 @@ export const API_ENDPOINTS = {
     list: `${API_PREFIX}/blueprint/list`,
     /** POST - Delete a fable definition */
     delete: `${API_PREFIX}/blueprint/delete`,
-    /** GET - List available automatic variables for configuration interpolation */
-    variablesList: `${API_PREFIX}/blueprint/variables/list`,
+    /** GET - List available intrinsic glyphs for ${glyph} interpolation in block configs */
+    glyphsList: `${API_PREFIX}/blueprint/glyphs/list`,
+    /** POST - Create or update a global glyph */
+    glyphsGlobalPost: `${API_PREFIX}/blueprint/glyphs/global/post`,
+    /** GET - Get a global glyph by ID */
+    glyphsGlobalGet: `${API_PREFIX}/blueprint/glyphs/global/get`,
   },
 
   /**

--- a/frontend/src/api/endpoints/fable.ts
+++ b/frontend/src/api/endpoints/fable.ts
@@ -14,7 +14,6 @@
  * API functions for fable (configuration builder) operations.
  */
 
-import { z } from 'zod'
 import type {
   BlockFactoryCatalogue,
   BlueprintDeleteRequest,
@@ -25,7 +24,10 @@ import type {
   FableUpsertRequest,
   FableUpsertResponse,
   FableValidationExpansion,
-  VariableDetail,
+  GlobalGlyphPostRequest,
+  GlobalGlyphResponse,
+  GlyphDetail,
+  GlyphListResponse,
 } from '@/api/types/fable.types'
 import { apiClient } from '@/api/client'
 import { API_ENDPOINTS } from '@/api/endpoints'
@@ -35,7 +37,8 @@ import {
   FableRetrieveResponseSchema,
   FableUpsertResponseSchema,
   FableValidationExpansionSchema,
-  VariableDetailSchema,
+  GlobalGlyphResponseSchema,
+  GlyphListResponseSchema,
   normalizeCatalogueKeys,
 } from '@/api/types/fable.types'
 
@@ -137,10 +140,51 @@ export async function deleteBlueprint(
 }
 
 /**
- * List available automatic variables for ${variable} interpolation in block configs
+ * List available intrinsic glyphs for ${glyph} interpolation in block configs
  */
-export async function getAvailableVariables(): Promise<Array<VariableDetail>> {
-  return apiClient.get(API_ENDPOINTS.fable.variablesList, {
-    schema: z.array(VariableDetailSchema),
+export async function getAvailableGlyphs(): Promise<Array<GlyphDetail>> {
+  const response: GlyphListResponse = await apiClient.get(
+    API_ENDPOINTS.fable.glyphsList,
+    {
+      params: { glyph_type: 'intrinsic' },
+      schema: GlyphListResponseSchema,
+    },
+  )
+  return response.glyphs
+}
+
+/**
+ * List global glyphs (paginated)
+ */
+export async function listGlobalGlyphs(
+  page: number = 1,
+  pageSize: number = 50,
+): Promise<GlyphListResponse> {
+  return apiClient.get(API_ENDPOINTS.fable.glyphsList, {
+    params: { glyph_type: 'global', page, page_size: pageSize },
+    schema: GlyphListResponseSchema,
+  })
+}
+
+/**
+ * Create or update a global glyph
+ */
+export async function createGlobalGlyph(
+  request: GlobalGlyphPostRequest,
+): Promise<GlobalGlyphResponse> {
+  return apiClient.post(API_ENDPOINTS.fable.glyphsGlobalPost, request, {
+    schema: GlobalGlyphResponseSchema,
+  })
+}
+
+/**
+ * Get a global glyph by ID
+ */
+export async function getGlobalGlyph(
+  globalGlyphId: string,
+): Promise<GlobalGlyphResponse> {
+  return apiClient.get(API_ENDPOINTS.fable.glyphsGlobalGet, {
+    params: { global_glyph_id: globalGlyphId },
+    schema: GlobalGlyphResponseSchema,
   })
 }

--- a/frontend/src/api/hooks/useFable.ts
+++ b/frontend/src/api/hooks/useFable.ts
@@ -18,15 +18,21 @@ import type {
   FableRetrieveResponse,
   FableUpsertResponse,
   FableValidationExpansion,
+  GlobalGlyphPostRequest,
+  GlobalGlyphResponse,
+  GlyphDetail,
+  GlyphListResponse,
   PluginBlockFactoryId,
-  VariableDetail,
 } from '@/api/types/fable.types'
 import {
+  createGlobalGlyph,
   deleteBlueprint,
   expandFable,
-  getAvailableVariables,
+  getAvailableGlyphs,
   getCatalogue,
+  getGlobalGlyph,
   listBlueprints,
+  listGlobalGlyphs,
   retrieveFable,
   updateBlueprint,
   upsertFable,
@@ -43,7 +49,11 @@ export const fableKeys = {
   detail: (id: string) => [...fableKeys.all, 'detail', id] as const,
   validation: (fable: FableBuilderV1) =>
     [...fableKeys.all, 'validation', JSON.stringify(fable)] as const,
-  variables: () => [...fableKeys.all, 'variables'] as const,
+  glyphs: () => [...fableKeys.all, 'glyphs'] as const,
+  globalGlyphsBase: () => [...fableKeys.all, 'globalGlyphs'] as const,
+  globalGlyphs: (page?: number, pageSize?: number) =>
+    [...fableKeys.all, 'globalGlyphs', page, pageSize] as const,
+  globalGlyph: (id: string) => [...fableKeys.all, 'globalGlyph', id] as const,
 }
 
 export function useBlockCatalogue(language?: string) {
@@ -221,15 +231,53 @@ export function useDeleteBlueprint() {
 }
 
 /**
- * Fetch available automatic variables for ${variable} interpolation in block configs.
- * Variables are static (e.g., runId, submitDatetime), so we cache aggressively.
+ * Fetch available intrinsic glyphs for ${glyph} interpolation in block configs.
+ * Intrinsic glyphs are static (e.g., runId, submitDatetime), so we cache aggressively.
  */
-export function useAvailableVariables() {
-  return useQuery<Array<VariableDetail>>({
-    queryKey: fableKeys.variables(),
-    queryFn: getAvailableVariables,
-    staleTime: 30 * 60 * 1000, // 30 minutes — variables change rarely
+export function useAvailableGlyphs() {
+  return useQuery<Array<GlyphDetail>>({
+    queryKey: fableKeys.glyphs(),
+    queryFn: getAvailableGlyphs,
+    staleTime: 30 * 60 * 1000, // 30 minutes — intrinsic glyphs change rarely
     gcTime: 60 * 60 * 1000, // 1 hour
+  })
+}
+
+/**
+ * List global glyphs (paginated)
+ */
+export function useListGlobalGlyphs(page: number = 1, pageSize: number = 50) {
+  return useQuery<GlyphListResponse>({
+    queryKey: fableKeys.globalGlyphs(page, pageSize),
+    queryFn: () => listGlobalGlyphs(page, pageSize),
+    staleTime: QUERY_CONSTANTS.STALE_TIMES.DEFAULT,
+  })
+}
+
+/**
+ * Get a single global glyph by ID
+ */
+export function useGlobalGlyph(globalGlyphId: string | null | undefined) {
+  return useQuery<GlobalGlyphResponse>({
+    queryKey: fableKeys.globalGlyph(globalGlyphId ?? ''),
+    queryFn: () => getGlobalGlyph(globalGlyphId!),
+    enabled: !!globalGlyphId,
+  })
+}
+
+/**
+ * Create or update a global glyph
+ */
+export function useCreateGlobalGlyph() {
+  const queryClient = useQueryClient()
+
+  return useMutation<GlobalGlyphResponse, Error, GlobalGlyphPostRequest>({
+    mutationFn: createGlobalGlyph,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: fableKeys.globalGlyphsBase(),
+      })
+    },
   })
 }
 

--- a/frontend/src/api/types/fable.types.ts
+++ b/frontend/src/api/types/fable.types.ts
@@ -97,16 +97,46 @@ export const FableBuilderV1Schema = z.object({
 export type FableBuilderV1 = z.infer<typeof FableBuilderV1Schema>
 
 /**
- * Automatic variable available for ${variable} interpolation in block configuration values.
- * Returned by GET /api/v1/blueprint/variables/list
+ * Intrinsic glyph available for ${glyph} interpolation in block configuration values.
+ * Returned by GET /api/v1/blueprint/glyphs/list?glyph_type=intrinsic
  */
-export const VariableDetailSchema = z.object({
+export const GlyphDetailSchema = z.object({
   name: z.string(),
   display_name: z.string(),
   valueExample: z.string(),
 })
 
-export type VariableDetail = z.infer<typeof VariableDetailSchema>
+export type GlyphDetail = z.infer<typeof GlyphDetailSchema>
+
+/** Paginated response from GET /api/v1/blueprint/glyphs/list */
+export const GlyphListResponseSchema = z.object({
+  glyphs: z.array(GlyphDetailSchema),
+  total: z.number(),
+  page: z.number(),
+  page_size: z.number(),
+})
+
+export type GlyphListResponse = z.infer<typeof GlyphListResponseSchema>
+
+/** POST /blueprint/glyphs/global/post — outbound request */
+export interface GlobalGlyphPostRequest {
+  key: string
+  value: string
+  public?: boolean
+}
+
+/** Response from global glyph endpoints */
+export const GlobalGlyphResponseSchema = z.object({
+  global_glyph_id: z.string(),
+  key: z.string(),
+  value: z.string(),
+  public: z.boolean(),
+  created_by: z.string().nullable(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+
+export type GlobalGlyphResponse = z.infer<typeof GlobalGlyphResponseSchema>
 
 export const FableValidationExpansionSchema = z.object({
   global_errors: z.array(z.string()),

--- a/frontend/src/components/base/fields/fields/StringField.tsx
+++ b/frontend/src/components/base/fields/fields/StringField.tsx
@@ -8,7 +8,20 @@
  * does it submit to any jurisdiction.
  */
 
+import { useCallback, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Input } from '@/components/ui/input'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { useGlyphContext } from '@/features/fable-builder/context/GlyphContext'
+import { GlyphAutocomplete } from '@/features/fable-builder/components/shared/GlyphAutocomplete'
+import {
+  containsGlyphs,
+  resolveGlyphValue,
+} from '@/features/fable-builder/utils/glyph-display'
 
 export interface StringFieldProps {
   id: string
@@ -19,6 +32,24 @@ export interface StringFieldProps {
   className?: string
 }
 
+/**
+ * Detects an open ${ pattern before the cursor position and returns the
+ * partial filter text, or null if autocomplete should not trigger.
+ */
+function detectGlyphTrigger(value: string, cursorPos: number): string | null {
+  const before = value.slice(0, cursorPos)
+  const triggerIndex = before.lastIndexOf('${')
+  if (triggerIndex === -1) return null
+
+  const afterTrigger = before.slice(triggerIndex + 2)
+  // Only trigger if we haven't closed the brace yet
+  if (afterTrigger.includes('}')) return null
+  // Only allow word characters in the partial
+  if (!/^\w*$/.test(afterTrigger)) return null
+
+  return afterTrigger
+}
+
 export function StringField({
   id,
   value,
@@ -27,15 +58,134 @@ export function StringField({
   disabled,
   className,
 }: StringFieldProps) {
+  const { t } = useTranslation('glyphs')
+  const glyphs = useGlyphContext()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [autocompleteFilter, setAutocompleteFilter] = useState<string | null>(
+    null,
+  )
+  const [cursorPos, setCursorPos] = useState(0)
+
+  const hasGlyphs = glyphs.length > 0
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = e.target.value
+      const pos = e.target.selectionStart ?? newValue.length
+      setCursorPos(pos)
+      onChange(newValue)
+
+      if (hasGlyphs) {
+        setAutocompleteFilter(detectGlyphTrigger(newValue, pos))
+      }
+    },
+    [onChange, hasGlyphs],
+  )
+
+  const handleKeyUp = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      const pos = e.currentTarget.selectionStart ?? value.length
+      setCursorPos(pos)
+      if (hasGlyphs) {
+        setAutocompleteFilter(detectGlyphTrigger(value, pos))
+      }
+    },
+    [value, hasGlyphs],
+  )
+
+  const handleSelect = useCallback(
+    (glyphName: string) => {
+      // Find the ${ trigger position before cursor
+      const before = value.slice(0, cursorPos)
+      const triggerIndex = before.lastIndexOf('${')
+      if (triggerIndex === -1) return
+
+      const newValue =
+        value.slice(0, triggerIndex) +
+        '${' +
+        glyphName +
+        '}' +
+        value.slice(cursorPos)
+      onChange(newValue)
+      setAutocompleteFilter(null)
+
+      // Restore focus and move cursor after the inserted glyph
+      requestAnimationFrame(() => {
+        const input = inputRef.current
+        if (input) {
+          input.focus()
+          const newPos = triggerIndex + glyphName.length + 3 // ${ + name + }
+          input.setSelectionRange(newPos, newPos)
+        }
+      })
+    },
+    [value, cursorPos, onChange],
+  )
+
+  const handleClose = useCallback(() => {
+    setAutocompleteFilter(null)
+  }, [])
+
+  const handleBlur = useCallback(() => {
+    // Delay close to allow mousedown on autocomplete items
+    setTimeout(() => setAutocompleteFilter(null), 150)
+  }, [])
+
+  // Build resolved preview
+  const showPreview = hasGlyphs && containsGlyphs(value)
+  const resolvedPreview = showPreview
+    ? resolveGlyphValue(
+        value,
+        Object.fromEntries(glyphs.map((g) => [g.name, g.valueExample])),
+      )
+    : null
+
   return (
-    <Input
-      id={id}
-      type="text"
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      placeholder={placeholder}
-      disabled={disabled}
-      className={className}
-    />
+    <div className="relative">
+      <Input
+        ref={inputRef}
+        id={id}
+        type="text"
+        value={value}
+        onChange={handleChange}
+        onKeyUp={handleKeyUp}
+        onBlur={handleBlur}
+        placeholder={placeholder}
+        disabled={disabled}
+        spellCheck={hasGlyphs ? false : undefined}
+        autoComplete="off"
+        className={className}
+      />
+
+      {autocompleteFilter !== null && (
+        <div className="absolute top-full right-0 left-0 z-50 mt-1">
+          <GlyphAutocomplete
+            glyphs={glyphs}
+            filter={autocompleteFilter}
+            onSelect={handleSelect}
+            onClose={handleClose}
+          />
+        </div>
+      )}
+
+      {resolvedPreview && resolvedPreview !== value && (
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <div className="mt-1 truncate text-sm text-muted-foreground italic" />
+            }
+          >
+            {t('panel.resolvesTo')}{' '}
+            <span className="font-mono">{resolvedPreview}</span>
+          </TooltipTrigger>
+          <TooltipContent
+            side="bottom"
+            className="max-w-96 font-mono break-all"
+          >
+            {resolvedPreview}
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </div>
   )
 }

--- a/frontend/src/features/executions/components/ExecutionNode.tsx
+++ b/frontend/src/features/executions/components/ExecutionNode.tsx
@@ -24,10 +24,7 @@ const NODE_TYPE_TO_KIND: Record<string, BlockKind> = {
   sinkBlock: 'sink',
 }
 
-export const ExecutionNode = memo(function ExecutionNode({
-  data,
-  type,
-}: NodeProps) {
+export const ExecutionNode = memo(function ({ data, type }: NodeProps) {
   const nodeData = data as FableNodeData
   const showConfig = useShowConfig()
   const kind = NODE_TYPE_TO_KIND[type] ?? 'source'

--- a/frontend/src/features/executions/components/ExecutionStatusHeader.tsx
+++ b/frontend/src/features/executions/components/ExecutionStatusHeader.tsx
@@ -210,6 +210,7 @@ export function ExecutionStatusHeader({
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
                 <AlertDialogTrigger
+                  nativeButton={false}
                   render={
                     <DropdownMenuItem
                       variant="destructive"

--- a/frontend/src/features/fable-builder/components/FableBuilderPage.tsx
+++ b/frontend/src/features/fable-builder/components/FableBuilderPage.tsx
@@ -25,6 +25,7 @@ import { useURLStateSync } from '@/features/fable-builder/hooks/useURLStateSync'
 import { getPreset } from '@/features/fable-builder/presets/presets'
 import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
 import { useMedia } from '@/hooks/useMedia'
+import { GlyphProvider } from '@/features/fable-builder/context/GlyphContext'
 import { LoadingSpinner } from '@/components/common/LoadingSpinner'
 import { toValidationState } from '@/api/types/fable.types'
 import {
@@ -208,30 +209,32 @@ export function FableBuilderPage({
   }
 
   return (
-    <div
-      className="flex min-w-0 flex-col"
-      style={{ height: 'calc(100vh - 60px)' }}
-    >
-      <FableBuilderHeader fableId={fableId} catalogue={catalogue} />
+    <GlyphProvider>
+      <div
+        className="flex min-w-0 flex-col"
+        style={{ height: 'calc(100vh - 60px)' }}
+      >
+        <FableBuilderHeader fableId={fableId} catalogue={catalogue} />
 
-      {validationError && (
-        <Alert variant="destructive" className="mx-4 mt-2">
-          <AlertCircle className="h-4 w-4" />
-          <AlertTitle>Validation Error</AlertTitle>
-          <AlertDescription>
-            {getValidationErrorMessage(validationError)}
-          </AlertDescription>
-        </Alert>
-      )}
-
-      <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
-        {step === 'edit' ? (
-          <EditStep catalogue={catalogue} isDesktop={isDesktop} mode={mode} />
-        ) : (
-          <ReviewStepComponent catalogue={catalogue} />
+        {validationError && (
+          <Alert variant="destructive" className="mx-4 mt-2">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Validation Error</AlertTitle>
+            <AlertDescription>
+              {getValidationErrorMessage(validationError)}
+            </AlertDescription>
+          </Alert>
         )}
+
+        <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
+          {step === 'edit' ? (
+            <EditStep catalogue={catalogue} isDesktop={isDesktop} mode={mode} />
+          ) : (
+            <ReviewStepComponent catalogue={catalogue} />
+          )}
+        </div>
       </div>
-    </div>
+    </GlyphProvider>
   )
 }
 

--- a/frontend/src/features/fable-builder/components/form-mode/mini-graph/AddBlockNode.tsx
+++ b/frontend/src/features/fable-builder/components/form-mode/mini-graph/AddBlockNode.tsx
@@ -42,7 +42,7 @@ export type AddBlockNodeType = Node<AddBlockNodeData>
  * - Plus icon + "Add [Kind]" text
  * - onClick → dropdown to select block type
  */
-export const AddBlockNode = memo(function AddBlockNode({
+export const AddBlockNode = memo(function ({
   data,
 }: NodeProps<AddBlockNodeType>) {
   const { kind, addOptions, onAddBlock } = data

--- a/frontend/src/features/fable-builder/components/form-mode/mini-graph/MiniPipelineNode.tsx
+++ b/frontend/src/features/fable-builder/components/form-mode/mini-graph/MiniPipelineNode.tsx
@@ -65,7 +65,7 @@ export type MiniPipelineNodeType = Node<MiniPipelineNodeData>
  * - Highlight ring when isCurrentBlock
  * - onClick main area → navigate to block
  */
-export const MiniPipelineNode = memo(function MiniPipelineNode({
+export const MiniPipelineNode = memo(function ({
   data,
 }: NodeProps<MiniPipelineNodeType>) {
   const {

--- a/frontend/src/features/fable-builder/components/graph-mode/AddNodeButton.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/AddNodeButton.tsx
@@ -53,7 +53,7 @@ const POPOVER_SIDE: Record<string, 'top' | 'bottom' | 'left' | 'right'> = {
   RL: 'left',
 }
 
-export const AddNodeButton = memo(function AddNodeButton({
+export const AddNodeButton = memo(function ({
   sourceBlockId,
   possibleExpansions,
   catalogue,

--- a/frontend/src/features/fable-builder/components/graph-mode/FableEdge.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/FableEdge.tsx
@@ -147,7 +147,7 @@ function getEdgePath({
   }
 }
 
-export const FableEdgeComponent = memo(function FableEdgeComponent({
+export const FableEdgeComponent = memo(function ({
   id,
   sourceX,
   sourceY,

--- a/frontend/src/features/fable-builder/components/graph-mode/nodes/BlockNode.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/nodes/BlockNode.tsx
@@ -52,6 +52,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { parseGlyphSegments } from '@/features/fable-builder/utils/glyph-display'
 import { cn } from '@/lib/utils'
 
 export type FableNode = Node<FableNodeData>
@@ -66,7 +67,7 @@ const OUTPUT_POSITIONS: Record<'TB' | 'LR', Position> = {
   LR: Position.Right,
 }
 
-export const BlockNode = memo(function BlockNode({
+export const BlockNode = memo(function ({
   id,
   data,
   selected,
@@ -289,6 +290,12 @@ export const BlockNode = memo(function BlockNode({
           <div className="flex flex-wrap gap-1.5">
             {configSummary.map(([key, value]) => {
               const stringValue = String(value)
+              const truncated =
+                stringValue.length > 15
+                  ? `${stringValue.slice(0, 15)}...`
+                  : stringValue
+              const segments = parseGlyphSegments(truncated)
+              const hasGlyphs = segments.some((s) => s.isGlyph)
               return (
                 <span
                   key={key}
@@ -299,9 +306,20 @@ export const BlockNode = memo(function BlockNode({
                     metadata.color,
                   )}
                 >
-                  {stringValue.length > 15
-                    ? `${stringValue.slice(0, 15)}...`
-                    : stringValue}
+                  {hasGlyphs
+                    ? segments.map((seg, i) =>
+                        seg.isGlyph ? (
+                          <span
+                            key={i}
+                            className="rounded bg-primary/15 px-0.5 font-mono text-primary"
+                          >
+                            {seg.text}
+                          </span>
+                        ) : (
+                          <span key={i}>{seg.text}</span>
+                        ),
+                      )
+                    : truncated}
                 </span>
               )
             })}

--- a/frontend/src/features/fable-builder/components/graph-mode/nodes/InlineBlockNode.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/nodes/InlineBlockNode.tsx
@@ -58,7 +58,7 @@ import { cn } from '@/lib/utils'
 
 export type FableNode = Node<FableNodeData>
 
-export const InlineBlockNode = memo(function InlineBlockNode({
+export const InlineBlockNode = memo(function ({
   id,
   data,
   selected,

--- a/frontend/src/features/fable-builder/components/layout/ConfigPanel.tsx
+++ b/frontend/src/features/fable-builder/components/layout/ConfigPanel.tsx
@@ -9,9 +9,8 @@
  */
 
 import { useMemo } from 'react'
-import { AlertCircle, Braces, Link2, Trash2, X } from 'lucide-react'
+import { AlertCircle, Link2, Trash2, X } from 'lucide-react'
 import type { BlockFactoryCatalogue } from '@/api/types/fable.types'
-import { useAvailableVariables } from '@/api/hooks/useFable'
 import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
 import {
   BLOCK_KIND_METADATA,
@@ -42,6 +41,7 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
 import { Badge } from '@/components/ui/badge'
+import { GlyphReferencePanel } from '@/features/fable-builder/components/shared/GlyphReferencePanel'
 import { cn } from '@/lib/utils'
 
 interface ConfigPanelProps {
@@ -190,7 +190,7 @@ export function ConfigPanel({ catalogue }: ConfigPanelProps): React.ReactNode {
                 />
               ))}
             </div>
-            <VariablesHint />
+            <GlyphReferencePanel />
           </div>
         )}
 
@@ -231,37 +231,6 @@ export function ConfigPanel({ catalogue }: ConfigPanelProps): React.ReactNode {
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>
-      </div>
-    </div>
-  )
-}
-
-function VariablesHint(): React.ReactNode {
-  const { data: variables } = useAvailableVariables()
-
-  if (!variables || variables.length === 0) return null
-
-  return (
-    <div className="rounded-md border border-dashed border-border bg-muted/30 p-3">
-      <div className="mb-1.5 flex items-center gap-1.5 text-sm font-medium text-muted-foreground">
-        <Braces className="h-3.5 w-3.5" />
-        Available Variables
-        <span className="rounded bg-amber-100 px-1.5 py-0.5 text-xs font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-400">
-          WIP
-        </span>
-      </div>
-      <div className="space-y-1">
-        {variables.map((v) => (
-          <div key={v.name} className="flex items-baseline gap-2 text-sm">
-            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-sm">
-              {'${' + v.name + '}'}
-            </code>
-            <span className="text-muted-foreground">
-              {v.display_name}
-              <span className="ml-1 opacity-60">e.g. {v.valueExample}</span>
-            </span>
-          </div>
-        ))}
       </div>
     </div>
   )

--- a/frontend/src/features/fable-builder/components/shared/GlyphAutocomplete.tsx
+++ b/frontend/src/features/fable-builder/components/shared/GlyphAutocomplete.tsx
@@ -1,0 +1,170 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * GlyphAutocomplete Component
+ *
+ * Dropdown list of available glyphs, triggered when user types ${ in a config field.
+ * Supports keyboard navigation (arrow keys + Enter) and filtering by partial input.
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { GlyphInfo } from '@/features/fable-builder/hooks/useAllGlyphs'
+import { P } from '@/components/base/typography'
+import { cn } from '@/lib/utils'
+
+interface GlyphAutocompleteProps {
+  glyphs: Array<GlyphInfo>
+  filter: string
+  onSelect: (glyphName: string) => void
+  onClose: () => void
+}
+
+export function GlyphAutocomplete({
+  glyphs,
+  filter,
+  onSelect,
+  onClose,
+}: GlyphAutocompleteProps) {
+  const { t } = useTranslation('glyphs')
+  const [activeIndex, setActiveIndex] = useState(0)
+  const listRef = useRef<HTMLDivElement>(null)
+
+  const query = filter.toLowerCase()
+  const filtered = glyphs.filter(
+    (g) =>
+      g.name.toLowerCase().includes(query) ||
+      g.displayName.toLowerCase().includes(query),
+  )
+
+  const intrinsic = filtered.filter((g) => g.type === 'intrinsic')
+  const global = filtered.filter((g) => g.type === 'global')
+  const allItems = [...global, ...intrinsic]
+
+  useEffect(() => {
+    setActiveIndex(0)
+  }, [filter])
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setActiveIndex((i) => Math.min(i + 1, allItems.length - 1))
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setActiveIndex((i) => Math.max(i - 1, 0))
+      } else if (e.key === 'Enter' && allItems.length > 0) {
+        e.preventDefault()
+        onSelect(allItems[activeIndex].name)
+      } else if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [allItems, activeIndex, onSelect, onClose])
+
+  // Scroll active item into view
+  useEffect(() => {
+    const list = listRef.current
+    if (!list) return
+    const active = list.querySelector('[data-active="true"]')
+    active?.scrollIntoView({ block: 'nearest' })
+  }, [activeIndex])
+
+  if (allItems.length === 0) return null
+
+  let itemIndex = 0
+
+  return (
+    <div
+      ref={listRef}
+      className="max-h-48 overflow-y-auto rounded-md border border-border bg-popover p-1 shadow-md"
+    >
+      {global.length > 0 && (
+        <>
+          <P className="px-2 py-1 text-sm font-medium text-muted-foreground">
+            {t('panel.global')}
+          </P>
+          {global.map((g) => {
+            const idx = itemIndex++
+            return (
+              <AutocompleteItem
+                key={g.name}
+                glyph={g}
+                active={idx === activeIndex}
+                onSelect={() => onSelect(g.name)}
+                onHover={() => setActiveIndex(idx)}
+              />
+            )
+          })}
+        </>
+      )}
+      {intrinsic.length > 0 && (
+        <>
+          {global.length > 0 && <div className="my-1 border-t border-border" />}
+          <P className="px-2 py-1 text-sm font-medium text-muted-foreground">
+            {t('panel.intrinsic')}
+          </P>
+          {intrinsic.map((g) => {
+            const idx = itemIndex++
+            return (
+              <AutocompleteItem
+                key={g.name}
+                glyph={g}
+                active={idx === activeIndex}
+                onSelect={() => onSelect(g.name)}
+                onHover={() => setActiveIndex(idx)}
+              />
+            )
+          })}
+        </>
+      )}
+    </div>
+  )
+}
+
+function AutocompleteItem({
+  glyph,
+  active,
+  onSelect,
+  onHover,
+}: {
+  glyph: GlyphInfo
+  active: boolean
+  onSelect: () => void
+  onHover: () => void
+}) {
+  return (
+    <button
+      type="button"
+      data-active={active}
+      onMouseDown={(e) => {
+        e.preventDefault() // Prevent input blur
+        onSelect()
+      }}
+      onMouseEnter={onHover}
+      className={cn(
+        'flex w-full items-baseline gap-2 rounded px-2 py-1.5 text-left text-sm',
+        active && 'bg-accent text-accent-foreground',
+      )}
+    >
+      <code className="shrink-0 font-mono text-sm font-medium">
+        {glyph.name}
+      </code>
+      <span className="min-w-0 truncate text-muted-foreground">
+        {glyph.type === 'intrinsic' ? glyph.displayName : glyph.valueExample}
+      </span>
+    </button>
+  )
+}

--- a/frontend/src/features/fable-builder/components/shared/GlyphReferencePanel.tsx
+++ b/frontend/src/features/fable-builder/components/shared/GlyphReferencePanel.tsx
@@ -1,0 +1,207 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * GlyphReferencePanel Component
+ *
+ * Shows available intrinsic and global glyphs in the config panel.
+ * Click a glyph to copy ${key} to clipboard. Link to admin page for management.
+ */
+
+import { useState } from 'react'
+import {
+  Braces,
+  ChevronDown,
+  ChevronRight,
+  Copy,
+  ExternalLink,
+  HelpCircle,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Link } from '@tanstack/react-router'
+import type { GlyphInfo } from '@/features/fable-builder/hooks/useAllGlyphs'
+import { useAllGlyphs } from '@/features/fable-builder/hooks/useAllGlyphs'
+import { showToast } from '@/lib/toast'
+import { P } from '@/components/base/typography'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+export function GlyphReferencePanel() {
+  const { t } = useTranslation('glyphs')
+  const { glyphs, isLoading } = useAllGlyphs()
+  const [intrinsicOpen, setIntrinsicOpen] = useState(false)
+  const [globalOpen, setGlobalOpen] = useState(true)
+
+  if (isLoading) return null
+
+  const intrinsicGlyphs = glyphs.filter((g) => g.type === 'intrinsic')
+  const globalGlyphs = glyphs.filter((g) => g.type === 'global')
+
+  function handleCopy(name: string) {
+    const ref = '${' + name + '}'
+    navigator.clipboard.writeText(ref)
+    showToast.success(t('panel.copied'), ref)
+  }
+
+  return (
+    <div className="rounded-md border border-dashed border-border bg-muted/30">
+      {/* Header */}
+      <div className="flex items-center justify-between p-3 pb-0">
+        <div className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground">
+          <Braces className="h-3.5 w-3.5" />
+          {t('panel.title')}
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <button
+                  type="button"
+                  className="text-muted-foreground/60 hover:text-muted-foreground"
+                />
+              }
+            >
+              <HelpCircle className="h-3.5 w-3.5" />
+            </TooltipTrigger>
+            <TooltipContent
+              side="bottom"
+              className="max-w-80 whitespace-pre-line"
+            >
+              {t('panel.help')}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+        <Link
+          to="/admin/glyphs"
+          className="flex items-center gap-1 text-sm text-primary hover:underline"
+        >
+          {t('panel.manage')}
+          <ExternalLink className="h-3 w-3" />
+        </Link>
+      </div>
+
+      {/* Global section */}
+      <GlyphSection
+        title={t('panel.global')}
+        open={globalOpen}
+        onToggle={() => setGlobalOpen(!globalOpen)}
+      >
+        {globalGlyphs.length > 0 ? (
+          globalGlyphs.map((g) => (
+            <GlyphRow
+              key={g.name}
+              glyph={g}
+              onCopy={handleCopy}
+              exampleLabel={t('panel.example')}
+            />
+          ))
+        ) : (
+          <div className="px-3 pb-2 text-sm text-muted-foreground">
+            {t('panel.noGlobal')}{' '}
+            <Link to="/admin/glyphs" className="text-primary hover:underline">
+              {t('panel.createOne')}
+            </Link>
+          </div>
+        )}
+      </GlyphSection>
+
+      {/* Intrinsic section */}
+      <GlyphSection
+        title={t('panel.intrinsic')}
+        open={intrinsicOpen}
+        onToggle={() => setIntrinsicOpen(!intrinsicOpen)}
+      >
+        {intrinsicGlyphs.map((g) => (
+          <GlyphRow
+            key={g.name}
+            glyph={g}
+            onCopy={handleCopy}
+            exampleLabel={t('panel.example')}
+          />
+        ))}
+      </GlyphSection>
+    </div>
+  )
+}
+
+function GlyphSection({
+  title,
+  open,
+  onToggle,
+  children,
+}: {
+  title: string
+  open: boolean
+  onToggle: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <div className="border-t border-border/50">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center gap-1.5 px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground"
+      >
+        {open ? (
+          <ChevronDown className="h-3.5 w-3.5" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5" />
+        )}
+        {title}
+      </button>
+      {open && <div className="space-y-0.5 pb-2">{children}</div>}
+    </div>
+  )
+}
+
+function GlyphRow({
+  glyph,
+  onCopy,
+  exampleLabel,
+}: {
+  glyph: GlyphInfo
+  onCopy: (name: string) => void
+  exampleLabel: string
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <button
+            type="button"
+            onClick={() => onCopy(glyph.name)}
+            className={cn(
+              'group flex w-full items-center gap-2 rounded px-3 py-1 text-left text-sm',
+              'transition-colors hover:bg-muted/80',
+            )}
+          />
+        }
+      >
+        <code className="shrink-0 rounded bg-muted px-1.5 py-0.5 font-mono text-sm">
+          {'${' + glyph.name + '}'}
+        </code>
+        <P className="min-w-0 truncate text-sm text-muted-foreground">
+          {glyph.type === 'intrinsic' ? glyph.displayName : glyph.valueExample}
+        </P>
+        <Copy className="ml-auto h-3 w-3 shrink-0 text-muted-foreground/0 transition-colors group-hover:text-muted-foreground" />
+      </TooltipTrigger>
+      <TooltipContent side="left">
+        <div className="space-y-1">
+          <div className="font-medium">{glyph.displayName}</div>
+          <div className="font-mono text-muted-foreground">
+            {exampleLabel} {glyph.valueExample}
+          </div>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/frontend/src/features/fable-builder/context/GlyphContext.tsx
+++ b/frontend/src/features/fable-builder/context/GlyphContext.tsx
@@ -1,0 +1,32 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Context for providing glyph data to the fable builder component tree.
+ * Consumed by StringField for autocomplete and resolved value preview.
+ */
+
+import { createContext, useContext } from 'react'
+import type { ReactNode } from 'react'
+import type { GlyphInfo } from '@/features/fable-builder/hooks/useAllGlyphs'
+import { useAllGlyphs } from '@/features/fable-builder/hooks/useAllGlyphs'
+
+const GlyphContext = createContext<Array<GlyphInfo>>([])
+
+export function GlyphProvider({ children }: { children: ReactNode }) {
+  const { glyphs } = useAllGlyphs()
+  return (
+    <GlyphContext.Provider value={glyphs}>{children}</GlyphContext.Provider>
+  )
+}
+
+export function useGlyphContext(): Array<GlyphInfo> {
+  return useContext(GlyphContext)
+}

--- a/frontend/src/features/fable-builder/hooks/useAllGlyphs.ts
+++ b/frontend/src/features/fable-builder/hooks/useAllGlyphs.ts
@@ -1,0 +1,61 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Hook that merges intrinsic and global glyphs into a single typed list.
+ */
+
+import { useMemo } from 'react'
+import { useAvailableGlyphs, useListGlobalGlyphs } from '@/api/hooks/useFable'
+
+export interface GlyphInfo {
+  name: string
+  displayName: string
+  valueExample: string
+  type: 'intrinsic' | 'global'
+}
+
+export function useAllGlyphs(): {
+  glyphs: Array<GlyphInfo>
+  isLoading: boolean
+} {
+  const { data: intrinsic, isLoading: intrinsicLoading } = useAvailableGlyphs()
+  const { data: globalData, isLoading: globalLoading } = useListGlobalGlyphs()
+
+  const glyphs = useMemo(() => {
+    const result: Array<GlyphInfo> = []
+
+    if (intrinsic) {
+      for (const g of intrinsic) {
+        result.push({
+          name: g.name,
+          displayName: g.display_name,
+          valueExample: g.valueExample,
+          type: 'intrinsic',
+        })
+      }
+    }
+
+    if (globalData?.glyphs) {
+      for (const g of globalData.glyphs) {
+        result.push({
+          name: g.name,
+          displayName: g.display_name,
+          valueExample: g.valueExample,
+          type: 'global',
+        })
+      }
+    }
+
+    return result
+  }, [intrinsic, globalData])
+
+  return { glyphs, isLoading: intrinsicLoading || globalLoading }
+}

--- a/frontend/src/features/fable-builder/utils/glyph-display.ts
+++ b/frontend/src/features/fable-builder/utils/glyph-display.ts
@@ -1,0 +1,80 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Glyph display utilities for parsing and rendering ${...} references.
+ */
+
+export interface GlyphSegment {
+  text: string
+  isGlyph: boolean
+}
+
+const GLYPH_PATTERN = /(\$\{\w+\})/g
+
+/**
+ * Split a config value into segments of plain text and glyph references.
+ *
+ * Example: "/data/${runId}/output" → [
+ *   { text: "/data/", isGlyph: false },
+ *   { text: "${runId}", isGlyph: true },
+ *   { text: "/output", isGlyph: false },
+ * ]
+ */
+export function parseGlyphSegments(value: string): Array<GlyphSegment> {
+  const segments: Array<GlyphSegment> = []
+  let lastIndex = 0
+
+  for (const match of value.matchAll(GLYPH_PATTERN)) {
+    const matchIndex = match.index
+    if (matchIndex > lastIndex) {
+      segments.push({
+        text: value.slice(lastIndex, matchIndex),
+        isGlyph: false,
+      })
+    }
+    segments.push({ text: match[0], isGlyph: true })
+    lastIndex = matchIndex + match[0].length
+  }
+
+  if (lastIndex < value.length) {
+    segments.push({ text: value.slice(lastIndex), isGlyph: false })
+  }
+
+  return segments
+}
+
+/**
+ * Check if a value contains any glyph references.
+ */
+export function containsGlyphs(value: string): boolean {
+  return GLYPH_PATTERN.test(value)
+}
+
+/**
+ * Extract the glyph key from a reference like "${runId}" → "runId"
+ */
+export function extractGlyphKey(ref: string): string {
+  return ref.slice(2, -1)
+}
+
+/**
+ * Resolve a config value by substituting glyph references with their values.
+ * Unknown glyphs are left as-is.
+ */
+export function resolveGlyphValue(
+  value: string,
+  glyphValues: Record<string, string>,
+): string {
+  return value.replace(GLYPH_PATTERN, (match) => {
+    const key = extractGlyphKey(match)
+    return glyphValues[key] ?? match
+  })
+}

--- a/frontend/src/features/glyphs/components/GlyphFormDialog.tsx
+++ b/frontend/src/features/glyphs/components/GlyphFormDialog.tsx
@@ -1,0 +1,176 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * GlyphFormDialog Component
+ *
+ * Dialog for creating or editing a global glyph.
+ */
+
+import { useState } from 'react'
+import { AlertCircle, Loader2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import type { GlyphDetail } from '@/api/types/fable.types'
+import { useCreateGlobalGlyph } from '@/api/hooks/useFable'
+import { showToast } from '@/lib/toast'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+import { P } from '@/components/base/typography'
+
+interface GlyphFormDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  editGlyph?: GlyphDetail
+}
+
+export function GlyphFormDialog({
+  open,
+  onOpenChange,
+  editGlyph,
+}: GlyphFormDialogProps) {
+  const { t } = useTranslation('glyphs')
+  const isEditing = !!editGlyph
+
+  const [key, setKey] = useState(editGlyph?.name ?? '')
+  const [value, setValue] = useState(editGlyph?.valueExample ?? '')
+  const [isPublic, setIsPublic] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const createGlyph = useCreateGlobalGlyph()
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) {
+      setKey('')
+      setValue('')
+      setIsPublic(false)
+      setError(null)
+    }
+    onOpenChange(nextOpen)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+
+    const trimmedKey = key.trim()
+    const trimmedValue = value.trim()
+
+    if (!trimmedKey || !trimmedValue) return
+
+    try {
+      await createGlyph.mutateAsync({
+        key: trimmedKey,
+        value: trimmedValue,
+        public: isPublic,
+      })
+      showToast.success(
+        isEditing ? t('actions.updateSuccess') : t('actions.createSuccess'),
+        trimmedKey,
+      )
+      handleOpenChange(false)
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : 'An unexpected error occurred'
+      setError(message)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            {isEditing ? t('form.editTitle') : t('form.title')}
+          </DialogTitle>
+          <DialogDescription>{t('page.description')}</DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="glyph-key">{t('form.key')}</Label>
+            <Input
+              id="glyph-key"
+              value={key}
+              onChange={(e) => setKey(e.target.value)}
+              placeholder={t('form.keyPlaceholder')}
+              disabled={isEditing}
+            />
+            <P className="text-sm text-muted-foreground">{t('form.keyHelp')}</P>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="glyph-value">{t('form.value')}</Label>
+            <Input
+              id="glyph-value"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              placeholder={t('form.valuePlaceholder')}
+            />
+          </div>
+
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label htmlFor="glyph-public">{t('form.public')}</Label>
+              <P className="text-sm text-muted-foreground">
+                {t('form.publicHelp')}
+              </P>
+            </div>
+            <Switch
+              id="glyph-public"
+              checked={isPublic}
+              onCheckedChange={setIsPublic}
+            />
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+            >
+              {t('actions.cancel')}
+            </Button>
+            <Button
+              type="submit"
+              disabled={!key.trim() || !value.trim() || createGlyph.isPending}
+            >
+              {createGlyph.isPending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  {t('actions.saving')}
+                </>
+              ) : (
+                t('actions.save')
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/features/glyphs/components/GlyphListItem.tsx
+++ b/frontend/src/features/glyphs/components/GlyphListItem.tsx
@@ -1,0 +1,63 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * GlyphListItem Component
+ *
+ * A single glyph row in the global glyphs list.
+ */
+
+import { Braces, Pencil } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import type { GlyphDetail } from '@/api/types/fable.types'
+import { Button } from '@/components/ui/button'
+import { P } from '@/components/base/typography'
+
+interface GlyphListItemProps {
+  glyph: GlyphDetail
+  onEdit: (glyph: GlyphDetail) => void
+}
+
+export function GlyphListItem({ glyph, onEdit }: GlyphListItemProps) {
+  const { t } = useTranslation('glyphs')
+
+  return (
+    <div className="p-6 transition-colors hover:bg-muted/50">
+      <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center">
+        <div className="mt-1 shrink-0 sm:mt-0">
+          <Braces className="h-5 w-5 text-muted-foreground" />
+        </div>
+
+        <div className="grow">
+          <div className="mb-1">
+            <code className="rounded bg-muted px-2 py-0.5 font-mono text-sm font-medium">
+              {'${' + glyph.name + '}'}
+            </code>
+          </div>
+          <P className="line-clamp-1 text-muted-foreground">
+            {glyph.valueExample}
+          </P>
+        </div>
+
+        <div className="mt-2 flex w-full items-center justify-end sm:mt-0 sm:w-auto">
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            onClick={() => onEdit(glyph)}
+          >
+            <Pencil className="h-4 w-4" />
+            {t('actions.edit')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/glyphs/components/GlyphsPage.tsx
+++ b/frontend/src/features/glyphs/components/GlyphsPage.tsx
@@ -1,0 +1,199 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * GlyphsPage Component
+ *
+ * Admin page for listing and managing global glyph definitions.
+ */
+
+import { useState } from 'react'
+import { Braces, ChevronLeft, ChevronRight, Plus, Search } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import type { GlyphDetail } from '@/api/types/fable.types'
+import { useListGlobalGlyphs } from '@/api/hooks/useFable'
+import { GlyphFormDialog } from '@/features/glyphs/components/GlyphFormDialog'
+import { GlyphListItem } from '@/features/glyphs/components/GlyphListItem'
+import { LoadingSpinner } from '@/components/common/LoadingSpinner'
+import { PageHeader } from '@/components/common/PageHeader'
+import { H2, P } from '@/components/base/typography'
+import { Button } from '@/components/ui/button'
+import { Card } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { useUiStore } from '@/stores/uiStore'
+import { cn } from '@/lib/utils'
+
+const PAGE_SIZE = 10
+
+export function GlyphsPage() {
+  const { t } = useTranslation('glyphs')
+  const layoutMode = useUiStore((state) => state.layoutMode)
+  const dashboardVariant = useUiStore((state) => state.dashboardVariant)
+  const panelShadow = useUiStore((state) => state.panelShadow)
+  const [page, setPage] = useState(1)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editGlyph, setEditGlyph] = useState<GlyphDetail | undefined>()
+
+  const { data, isLoading, isError, error } = useListGlobalGlyphs(
+    page,
+    PAGE_SIZE,
+  )
+
+  function handleCreate() {
+    setEditGlyph(undefined)
+    setDialogOpen(true)
+  }
+
+  function handleEdit(glyph: GlyphDetail) {
+    setEditGlyph(glyph)
+    setDialogOpen(true)
+  }
+
+  const containerClass = cn(
+    'mx-auto space-y-8 px-4 py-8 sm:px-6 lg:px-8',
+    layoutMode === 'boxed' ? 'max-w-7xl' : 'max-w-none',
+  )
+
+  if (isLoading) {
+    return (
+      <div className={containerClass}>
+        <PageHeader
+          title={t('page.title')}
+          description={t('page.description')}
+        />
+        <div className="flex justify-center py-12">
+          <LoadingSpinner text={t('list.loading')} />
+        </div>
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div className={containerClass}>
+        <PageHeader
+          title={t('page.title')}
+          description={t('page.description')}
+        />
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-6 text-center">
+          <P className="text-destructive">{error.message}</P>
+        </div>
+      </div>
+    )
+  }
+
+  const glyphs = data?.glyphs ?? []
+  const totalPages = Math.max(1, Math.ceil((data?.total ?? 0) / PAGE_SIZE))
+
+  let filteredGlyphs = glyphs
+  if (searchQuery) {
+    const query = searchQuery.toLowerCase()
+    filteredGlyphs = glyphs.filter(
+      (g) =>
+        g.name.toLowerCase().includes(query) ||
+        g.valueExample.toLowerCase().includes(query),
+    )
+  }
+
+  return (
+    <div className={containerClass}>
+      <PageHeader
+        title={t('page.title')}
+        description={t('page.description')}
+        actions={
+          <Button onClick={handleCreate} className="gap-1.5">
+            <Plus className="h-4 w-4" />
+            {t('actions.create')}
+          </Button>
+        }
+      />
+
+      <Card
+        className="overflow-hidden"
+        variant={dashboardVariant}
+        shadow={panelShadow}
+      >
+        <div className="flex flex-col items-start justify-between gap-4 border-b border-border p-6 sm:flex-row sm:items-center">
+          <H2 className="text-xl font-semibold">{t('page.title')}</H2>
+
+          <div className="flex w-full items-center gap-3 sm:w-auto">
+            <div className="relative flex-1 sm:flex-initial">
+              <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-muted-foreground">
+                <Search className="h-4 w-4" />
+              </span>
+              <Input
+                type="text"
+                placeholder={t('filter.searchPlaceholder')}
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="w-full pl-10 sm:w-64"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="divide-y divide-border">
+          {filteredGlyphs.length > 0 ? (
+            filteredGlyphs.map((glyph) => (
+              <GlyphListItem
+                key={glyph.name}
+                glyph={glyph}
+                onEdit={handleEdit}
+              />
+            ))
+          ) : (
+            <div className="flex flex-col items-center gap-3 p-12 text-center text-muted-foreground">
+              <Braces className="h-10 w-10 text-muted-foreground/50" />
+              <div>
+                <P className="font-medium">{t('empty.title')}</P>
+                <P className="text-sm">{t('empty.description')}</P>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {totalPages > 1 && (
+          <div className="border-t border-border p-4 text-center">
+            <div className="flex items-center justify-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page <= 1}
+                onClick={() => setPage((p) => p - 1)}
+              >
+                <ChevronLeft className="mr-1 h-4 w-4" />
+                {t('pagination.previous')}
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                {t('pagination.page', { current: page, total: totalPages })}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= totalPages}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                {t('pagination.next')}
+                <ChevronRight className="ml-1 h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        )}
+      </Card>
+
+      <GlyphFormDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        editGlyph={editGlyph}
+      />
+    </div>
+  )
+}

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -29,6 +29,7 @@ import artifactsEN from '@/locales/en/artifacts.json'
 import executionsEN from '@/locales/en/executions.json'
 import schedulesEN from '@/locales/en/schedules.json'
 import configureEN from '@/locales/en/configure.json'
+import glyphsEN from '@/locales/en/glyphs.json'
 
 // Translation resources organized by namespace
 const resources = {
@@ -45,6 +46,7 @@ const resources = {
     executions: executionsEN,
     schedules: schedulesEN,
     configure: configureEN,
+    glyphs: glyphsEN,
   },
 }
 
@@ -71,6 +73,7 @@ i18n
       'executions',
       'schedules',
       'configure',
+      'glyphs',
     ],
 
     // Interpolation options

--- a/frontend/src/locales/en/glyphs.json
+++ b/frontend/src/locales/en/glyphs.json
@@ -1,0 +1,60 @@
+{
+  "page": {
+    "title": "Global Glyphs",
+    "description": "Manage global glyph definitions used in fable configuration interpolation."
+  },
+  "list": {
+    "loading": "Loading glyphs..."
+  },
+  "filter": {
+    "searchPlaceholder": "Search by key or value..."
+  },
+  "empty": {
+    "title": "No global glyphs",
+    "description": "Create a global glyph to use ${glyph} interpolation across all fable configurations."
+  },
+  "table": {
+    "key": "Key",
+    "value": "Value"
+  },
+  "actions": {
+    "create": "Create Glyph",
+    "edit": "Edit",
+    "save": "Save",
+    "saving": "Saving...",
+    "cancel": "Cancel",
+    "createSuccess": "Glyph created",
+    "updateSuccess": "Glyph updated"
+  },
+  "form": {
+    "title": "Create Global Glyph",
+    "editTitle": "Edit Global Glyph",
+    "key": "Key",
+    "keyPlaceholder": "e.g. myVariable",
+    "keyHelp": "Used as ${key} in fable configurations",
+    "value": "Value",
+    "valuePlaceholder": "The value to interpolate",
+    "public": "Public",
+    "publicHelp": "Public glyphs are visible to all users (admin only)"
+  },
+  "pagination": {
+    "previous": "Previous",
+    "next": "Next",
+    "page": "Page {{current}} of {{total}}"
+  },
+  "panel": {
+    "title": "Available Glyphs",
+    "manage": "Manage",
+    "help": "Use ${name} syntax in block configuration values to reference dynamic glyphs.\n\nIntrinsic — system-provided, always available (e.g., runId, submitDatetime). startDatetime and attemptCount update on each retry.\n\nGlobal — user-defined key-value pairs shared across fables. Manage them via the admin page.\n\nContext — injected automatically per-execution (e.g., by the scheduler). Not shown here.\n\nPrecedence: Intrinsic → Global → Context.\nPinned glyphs (startDatetime, attemptCount) always use the intrinsic value.",
+    "intrinsic": "Intrinsic",
+    "global": "Global",
+    "noGlobal": "No global glyphs yet.",
+    "createOne": "Create one",
+    "copied": "Copied",
+    "example": "e.g.",
+    "resolvesTo": "resolves to"
+  },
+  "autocomplete": {
+    "filter": "Filter glyphs..."
+  }
+}

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -23,8 +23,10 @@ import { Route as AuthenticatedSchedulesScheduleIdRouteImport } from './routes/_
 import { Route as AuthenticatedExecutionsJobIdRouteImport } from './routes/_authenticated/executions.$jobId'
 import { Route as AuthenticatedConfigureFableIdRouteImport } from './routes/_authenticated/configure.$fableId'
 import { Route as AuthenticatedAdminPluginsRouteImport } from './routes/_authenticated/admin/plugins'
+import { Route as AuthenticatedAdminGlyphsRouteImport } from './routes/_authenticated/admin/glyphs'
 import { Route as AuthenticatedAdminArtifactsRouteImport } from './routes/_authenticated/admin/artifacts'
 import { Route as AuthenticatedAdminPluginsIndexRouteImport } from './routes/_authenticated/admin/plugins.index'
+import { Route as AuthenticatedAdminGlyphsIndexRouteImport } from './routes/_authenticated/admin/glyphs.index'
 import { Route as AuthenticatedAdminArtifactsIndexRouteImport } from './routes/_authenticated/admin/artifacts.index'
 import { Route as AuthenticatedAdminPluginsPluginIdRouteImport } from './routes/_authenticated/admin/plugins.$pluginId'
 import { Route as AuthenticatedAdminArtifactsArtifactIdRouteImport } from './routes/_authenticated/admin/artifacts.$artifactId'
@@ -104,6 +106,12 @@ const AuthenticatedAdminPluginsRoute =
     path: '/plugins',
     getParentRoute: () => AuthenticatedAdminRoute,
   } as any)
+const AuthenticatedAdminGlyphsRoute =
+  AuthenticatedAdminGlyphsRouteImport.update({
+    id: '/glyphs',
+    path: '/glyphs',
+    getParentRoute: () => AuthenticatedAdminRoute,
+  } as any)
 const AuthenticatedAdminArtifactsRoute =
   AuthenticatedAdminArtifactsRouteImport.update({
     id: '/artifacts',
@@ -115,6 +123,12 @@ const AuthenticatedAdminPluginsIndexRoute =
     id: '/',
     path: '/',
     getParentRoute: () => AuthenticatedAdminPluginsRoute,
+  } as any)
+const AuthenticatedAdminGlyphsIndexRoute =
+  AuthenticatedAdminGlyphsIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedAdminGlyphsRoute,
   } as any)
 const AuthenticatedAdminArtifactsIndexRoute =
   AuthenticatedAdminArtifactsIndexRouteImport.update({
@@ -143,6 +157,7 @@ export interface FileRoutesByFullPath {
   '/dashboard': typeof AuthenticatedDashboardRoute
   '/presets': typeof AuthenticatedPresetsRoute
   '/admin/artifacts': typeof AuthenticatedAdminArtifactsRouteWithChildren
+  '/admin/glyphs': typeof AuthenticatedAdminGlyphsRouteWithChildren
   '/admin/plugins': typeof AuthenticatedAdminPluginsRouteWithChildren
   '/configure/$fableId': typeof AuthenticatedConfigureFableIdRoute
   '/executions/$jobId': typeof AuthenticatedExecutionsJobIdRoute
@@ -153,6 +168,7 @@ export interface FileRoutesByFullPath {
   '/admin/artifacts/$artifactId': typeof AuthenticatedAdminArtifactsArtifactIdRoute
   '/admin/plugins/$pluginId': typeof AuthenticatedAdminPluginsPluginIdRoute
   '/admin/artifacts/': typeof AuthenticatedAdminArtifactsIndexRoute
+  '/admin/glyphs/': typeof AuthenticatedAdminGlyphsIndexRoute
   '/admin/plugins/': typeof AuthenticatedAdminPluginsIndexRoute
 }
 export interface FileRoutesByTo {
@@ -170,6 +186,7 @@ export interface FileRoutesByTo {
   '/admin/artifacts/$artifactId': typeof AuthenticatedAdminArtifactsArtifactIdRoute
   '/admin/plugins/$pluginId': typeof AuthenticatedAdminPluginsPluginIdRoute
   '/admin/artifacts': typeof AuthenticatedAdminArtifactsIndexRoute
+  '/admin/glyphs': typeof AuthenticatedAdminGlyphsIndexRoute
   '/admin/plugins': typeof AuthenticatedAdminPluginsIndexRoute
 }
 export interface FileRoutesById {
@@ -182,6 +199,7 @@ export interface FileRoutesById {
   '/_authenticated/dashboard': typeof AuthenticatedDashboardRoute
   '/_authenticated/presets': typeof AuthenticatedPresetsRoute
   '/_authenticated/admin/artifacts': typeof AuthenticatedAdminArtifactsRouteWithChildren
+  '/_authenticated/admin/glyphs': typeof AuthenticatedAdminGlyphsRouteWithChildren
   '/_authenticated/admin/plugins': typeof AuthenticatedAdminPluginsRouteWithChildren
   '/_authenticated/configure/$fableId': typeof AuthenticatedConfigureFableIdRoute
   '/_authenticated/executions/$jobId': typeof AuthenticatedExecutionsJobIdRoute
@@ -192,6 +210,7 @@ export interface FileRoutesById {
   '/_authenticated/admin/artifacts/$artifactId': typeof AuthenticatedAdminArtifactsArtifactIdRoute
   '/_authenticated/admin/plugins/$pluginId': typeof AuthenticatedAdminPluginsPluginIdRoute
   '/_authenticated/admin/artifacts/': typeof AuthenticatedAdminArtifactsIndexRoute
+  '/_authenticated/admin/glyphs/': typeof AuthenticatedAdminGlyphsIndexRoute
   '/_authenticated/admin/plugins/': typeof AuthenticatedAdminPluginsIndexRoute
 }
 export interface FileRouteTypes {
@@ -204,6 +223,7 @@ export interface FileRouteTypes {
     | '/dashboard'
     | '/presets'
     | '/admin/artifacts'
+    | '/admin/glyphs'
     | '/admin/plugins'
     | '/configure/$fableId'
     | '/executions/$jobId'
@@ -214,6 +234,7 @@ export interface FileRouteTypes {
     | '/admin/artifacts/$artifactId'
     | '/admin/plugins/$pluginId'
     | '/admin/artifacts/'
+    | '/admin/glyphs/'
     | '/admin/plugins/'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -231,6 +252,7 @@ export interface FileRouteTypes {
     | '/admin/artifacts/$artifactId'
     | '/admin/plugins/$pluginId'
     | '/admin/artifacts'
+    | '/admin/glyphs'
     | '/admin/plugins'
   id:
     | '__root__'
@@ -242,6 +264,7 @@ export interface FileRouteTypes {
     | '/_authenticated/dashboard'
     | '/_authenticated/presets'
     | '/_authenticated/admin/artifacts'
+    | '/_authenticated/admin/glyphs'
     | '/_authenticated/admin/plugins'
     | '/_authenticated/configure/$fableId'
     | '/_authenticated/executions/$jobId'
@@ -252,6 +275,7 @@ export interface FileRouteTypes {
     | '/_authenticated/admin/artifacts/$artifactId'
     | '/_authenticated/admin/plugins/$pluginId'
     | '/_authenticated/admin/artifacts/'
+    | '/_authenticated/admin/glyphs/'
     | '/_authenticated/admin/plugins/'
   fileRoutesById: FileRoutesById
 }
@@ -361,6 +385,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAdminPluginsRouteImport
       parentRoute: typeof AuthenticatedAdminRoute
     }
+    '/_authenticated/admin/glyphs': {
+      id: '/_authenticated/admin/glyphs'
+      path: '/glyphs'
+      fullPath: '/admin/glyphs'
+      preLoaderRoute: typeof AuthenticatedAdminGlyphsRouteImport
+      parentRoute: typeof AuthenticatedAdminRoute
+    }
     '/_authenticated/admin/artifacts': {
       id: '/_authenticated/admin/artifacts'
       path: '/artifacts'
@@ -374,6 +405,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/admin/plugins/'
       preLoaderRoute: typeof AuthenticatedAdminPluginsIndexRouteImport
       parentRoute: typeof AuthenticatedAdminPluginsRoute
+    }
+    '/_authenticated/admin/glyphs/': {
+      id: '/_authenticated/admin/glyphs/'
+      path: '/'
+      fullPath: '/admin/glyphs/'
+      preLoaderRoute: typeof AuthenticatedAdminGlyphsIndexRouteImport
+      parentRoute: typeof AuthenticatedAdminGlyphsRoute
     }
     '/_authenticated/admin/artifacts/': {
       id: '/_authenticated/admin/artifacts/'
@@ -417,6 +455,20 @@ const AuthenticatedAdminArtifactsRouteWithChildren =
     AuthenticatedAdminArtifactsRouteChildren,
   )
 
+interface AuthenticatedAdminGlyphsRouteChildren {
+  AuthenticatedAdminGlyphsIndexRoute: typeof AuthenticatedAdminGlyphsIndexRoute
+}
+
+const AuthenticatedAdminGlyphsRouteChildren: AuthenticatedAdminGlyphsRouteChildren =
+  {
+    AuthenticatedAdminGlyphsIndexRoute: AuthenticatedAdminGlyphsIndexRoute,
+  }
+
+const AuthenticatedAdminGlyphsRouteWithChildren =
+  AuthenticatedAdminGlyphsRoute._addFileChildren(
+    AuthenticatedAdminGlyphsRouteChildren,
+  )
+
 interface AuthenticatedAdminPluginsRouteChildren {
   AuthenticatedAdminPluginsPluginIdRoute: typeof AuthenticatedAdminPluginsPluginIdRoute
   AuthenticatedAdminPluginsIndexRoute: typeof AuthenticatedAdminPluginsIndexRoute
@@ -436,6 +488,7 @@ const AuthenticatedAdminPluginsRouteWithChildren =
 
 interface AuthenticatedAdminRouteChildren {
   AuthenticatedAdminArtifactsRoute: typeof AuthenticatedAdminArtifactsRouteWithChildren
+  AuthenticatedAdminGlyphsRoute: typeof AuthenticatedAdminGlyphsRouteWithChildren
   AuthenticatedAdminPluginsRoute: typeof AuthenticatedAdminPluginsRouteWithChildren
   AuthenticatedAdminIndexRoute: typeof AuthenticatedAdminIndexRoute
 }
@@ -443,6 +496,7 @@ interface AuthenticatedAdminRouteChildren {
 const AuthenticatedAdminRouteChildren: AuthenticatedAdminRouteChildren = {
   AuthenticatedAdminArtifactsRoute:
     AuthenticatedAdminArtifactsRouteWithChildren,
+  AuthenticatedAdminGlyphsRoute: AuthenticatedAdminGlyphsRouteWithChildren,
   AuthenticatedAdminPluginsRoute: AuthenticatedAdminPluginsRouteWithChildren,
   AuthenticatedAdminIndexRoute: AuthenticatedAdminIndexRoute,
 }

--- a/frontend/src/routes/_authenticated/admin/glyphs.index.tsx
+++ b/frontend/src/routes/_authenticated/admin/glyphs.index.tsx
@@ -1,0 +1,22 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Glyphs List Page Route
+ *
+ * Admin page for managing global glyph definitions.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+import { GlyphsPage } from '@/features/glyphs/components/GlyphsPage'
+
+export const Route = createFileRoute('/_authenticated/admin/glyphs/')({
+  component: GlyphsPage,
+})

--- a/frontend/src/routes/_authenticated/admin/glyphs.tsx
+++ b/frontend/src/routes/_authenticated/admin/glyphs.tsx
@@ -1,0 +1,25 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Glyphs Layout Route
+ *
+ * Layout wrapper for all glyph-related routes.
+ */
+
+import { Outlet, createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/_authenticated/admin/glyphs')({
+  component: GlyphsLayout,
+})
+
+function GlyphsLayout() {
+  return <Outlet />
+}

--- a/frontend/src/types/i18next.d.ts
+++ b/frontend/src/types/i18next.d.ts
@@ -26,6 +26,7 @@ import type artifactsEN from '@/locales/en/artifacts.json'
 import type executionsEN from '@/locales/en/executions.json'
 import type schedulesEN from '@/locales/en/schedules.json'
 import type configureEN from '@/locales/en/configure.json'
+import type glyphsEN from '@/locales/en/glyphs.json'
 
 declare module 'i18next' {
   interface CustomTypeOptions {
@@ -43,6 +44,7 @@ declare module 'i18next' {
       executions: typeof executionsEN
       schedules: typeof schedulesEN
       configure: typeof configureEN
+      glyphs: typeof glyphsEN
     }
   }
 }


### PR DESCRIPTION
Aligns the frontend with the backend "variables → glyphs" rename (backend #359), adds an admin page for managing global glyphs, and integrates glyphs into the fable builder with autocomplete, visual indicators, and resolved value preview.

### API migration alignment
- Update endpoint path from `/blueprint/variables/list` to `/blueprint/glyphs/list` and handle new paginated `GlyphListResponse` shape
- Rename `VariableDetail` → `GlyphDetail`, `useAvailableVariables` → `useAvailableGlyphs`
- Add `glyph_type=intrinsic` query param for intrinsic glyphs listing
- Add endpoint paths, Zod schemas, API functions, and TanStack Query hooks for global glyph create/get/list
- Add MSW mock handlers with intrinsic glyph data (runId, submitDatetime, startDatetime, attemptCount)

### Global glyphs admin page (`/admin/glyphs`)
- Paginated list with search filtering and empty state
- Create/edit dialog (upsert by key) with public visibility toggle
- i18n namespace, route files under existing admin auth guard

### Fable builder integration
- **Reference panel** — replaces WIP hint with grouped Global/Intrinsic sections, click-to-copy, help tooltip explaining glyph types and precedence, "Manage" link to admin page
- **Autocomplete** — dropdown triggered by `${` in string config fields, filtered as you type, keyboard navigation, grouped by type
- **Glyph-aware badges** — `${...}` references highlighted with distinct styling in block node config summaries
- **Resolved value preview** — "resolves to" line below config fields containing glyph references, with tooltip for full value

### Shared infrastructure
- `useAllGlyphs` hook merging intrinsic + global sources
- `GlyphContext` provider for zero-prop-drilling glyph data
- `parseGlyphSegments` / `resolveGlyphValue` utilities

### Housekeeping
- Fix `AlertDialogTrigger` nativeButton warning in ExecutionStatusHeader
- Fix query invalidation for global glyphs list refresh
- Simplify functional component naming to fix pre-existing `no-shadow` lint warnings


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 