### PR TITLE
Feat/variables4: Local Glyphs in Builders

### DIFF
--- a/backend/src/forecastbox/domain/blueprint/db.py
+++ b/backend/src/forecastbox/domain/blueprint/db.py
@@ -34,9 +34,7 @@ async def upsert_blueprint(
     blueprint_id: str | None = None,
     source: BlueprintSource,
     created_by: str | None,
-    blocks: dict | None = None,
-    environment_spec: dict | None = None,
-    local_glyphs: dict | None = None,
+    builder: dict | None = None,
     display_name: str | None = None,
     display_description: str | None = None,
     tags: list[str] | None = None,
@@ -97,9 +95,7 @@ async def upsert_blueprint(
                     display_name=display_name,
                     display_description=display_description,
                     tags=tags,
-                    blocks=blocks,
-                    environment_spec=environment_spec,
-                    local_glyphs=local_glyphs,
+                    builder=builder,
                     is_deleted=False,
                 )
             )

--- a/backend/src/forecastbox/domain/blueprint/db.py
+++ b/backend/src/forecastbox/domain/blueprint/db.py
@@ -36,6 +36,7 @@ async def upsert_blueprint(
     created_by: str | None,
     blocks: dict | None = None,
     environment_spec: dict | None = None,
+    local_glyphs: dict | None = None,
     display_name: str | None = None,
     display_description: str | None = None,
     tags: list[str] | None = None,
@@ -98,6 +99,7 @@ async def upsert_blueprint(
                     tags=tags,
                     blocks=blocks,
                     environment_spec=environment_spec,
+                    local_glyphs=local_glyphs,
                     is_deleted=False,
                 )
             )

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -99,21 +99,36 @@ class BlueprintSaveCommand(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-async def validate_expand(blueprint: BlueprintBuilder, auth_context: AuthContext) -> BlueprintValidationExpansion:
+async def validate_expand(
+    blueprint: BlueprintBuilder, auth_context: AuthContext, *, validate_only: bool = False
+) -> BlueprintValidationExpansion:
     """Validate and expand a partially-constructed BlueprintBuilder.
 
     Returns structured validation errors and possible completion options.
     The presence of errors does not affect the return (callers decide how to
     surface them). Intrinsic and global glyphs visible to the caller, along
     with local glyphs defined on the builder, are all considered known.
+
+    When ``validate_only`` is True, ``possible_sources`` and
+    ``possible_expansions`` are omitted from the result (saves work when the
+    caller only needs error checking), and the blueprint is deep-copied so
+    that ``resolve_configurations`` mutations do not affect the caller's object.
+    When ``validate_only`` is False (the default, used by the expand endpoint),
+    the passed-in blueprint may be mutated in place and expansion data is computed.
     """
     plugins = PluginManager.plugins
-    possible_sources = [
-        PluginBlockFactoryId(plugin=plugin_id, factory=block_factory_id)
-        for plugin_id, plugin in plugins.items()
-        for block_factory_id, block_factory in plugin.catalogue.factories.items()
-        if block_factory.kind == "source" and not block_factory.inputs
-    ]
+    if validate_only:
+        blueprint = blueprint.model_copy(deep=True)
+    possible_sources = (
+        []
+        if validate_only
+        else [
+            PluginBlockFactoryId(plugin=plugin_id, factory=block_factory_id)
+            for plugin_id, plugin in plugins.items()
+            for block_factory_id, block_factory in plugin.catalogue.factories.items()
+            if block_factory.kind == "source" and not block_factory.inputs
+        ]
+    )
     possible_expansions: dict[BlockInstanceId, list[PluginBlockFactoryId]] = {}
     block_errors: dict[BlockInstanceId, list[str]] = defaultdict(list)
     outputs = {}
@@ -167,11 +182,12 @@ async def validate_expand(blueprint: BlueprintBuilder, auth_context: AuthContext
             continue
         outputs[blockId] = output_or_error.t
 
-        possible_expansions[blockId] = [
-            PluginBlockFactoryId(plugin=any_plugin_id, factory=block_factory_id)
-            for any_plugin_id, any_plugin in plugins.items()
-            for block_factory_id in any_plugin.expander(output_or_error.t)
-        ]
+        if not validate_only:
+            possible_expansions[blockId] = [
+                PluginBlockFactoryId(plugin=any_plugin_id, factory=block_factory_id)
+                for any_plugin_id, any_plugin in plugins.items()
+                for block_factory_id in any_plugin.expander(output_or_error.t)
+            ]
 
     return BlueprintValidationExpansion(
         possible_sources=possible_sources,

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -241,9 +241,9 @@ async def load_builder(blueprint_id: str, version: int | None = None) -> Bluepri
     blueprint = await _blueprint_db.get_blueprint(blueprint_id, version)
     if blueprint is None:
         raise BlueprintNotFound(f"Blueprint {blueprint_id!r} not found.")
-    if blueprint.builder is None:  # ty:ignore[truthy-bool]
+    if blueprint.builder is None:
         raise BlueprintNotFound(f"Blueprint {blueprint_id!r} has no builder spec.")
-    builder = BlueprintBuilder.model_validate(blueprint.builder)  # ty:ignore[arg-type]
+    builder = BlueprintBuilder.model_validate(blueprint.builder)
     return BlueprintRetrieveResult(
         blueprint_id=str(blueprint.blueprint_id),  # ty:ignore[invalid-argument-type]
         blueprint_version=cast(int, blueprint.version),

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -202,15 +202,12 @@ async def save_builder(
     Raises ``BlueprintNotFound`` or ``BlueprintAccessDenied`` from the db layer.
     """
     source: str = "user_defined" if payload.display_name is not None else "oneoff_execution"
-    env = payload.builder.environment
     blueprint_id, version = await upsert_blueprint(
         auth_context=auth_context,
         blueprint_id=blueprint_id,
         source=source,
         created_by=auth_context.user_id,
-        blocks=payload.builder.model_dump(mode="json")["blocks"],
-        environment_spec=env.model_dump(mode="json") if env is not None else None,
-        local_glyphs=payload.builder.local_glyphs if payload.builder.local_glyphs else None,
+        builder=payload.builder.model_dump(mode="json"),
         display_name=payload.display_name,
         display_description=payload.display_description,
         tags=payload.tags if payload.tags else None,
@@ -228,13 +225,9 @@ async def load_builder(blueprint_id: str, version: int | None = None) -> Bluepri
     blueprint = await _blueprint_db.get_blueprint(blueprint_id, version)
     if blueprint is None:
         raise BlueprintNotFound(f"Blueprint {blueprint_id!r} not found.")
-    if blueprint.blocks is None:
+    if blueprint.builder is None:  # ty:ignore[truthy-bool]
         raise BlueprintNotFound(f"Blueprint {blueprint_id!r} has no builder spec.")
-    builder = BlueprintBuilder(blocks=blueprint.blocks)  # ty:ignore[invalid-argument-type]
-    if blueprint.environment_spec is not None:
-        builder.environment = EnvironmentSpecification.model_validate(blueprint.environment_spec)
-    if blueprint.local_glyphs:
-        builder.local_glyphs = blueprint.local_glyphs  # ty:ignore[invalid-assignment]
+    builder = BlueprintBuilder.model_validate(blueprint.builder)  # ty:ignore[arg-type]
     return BlueprintRetrieveResult(
         blueprint_id=str(blueprint.blueprint_id),  # ty:ignore[invalid-argument-type]
         blueprint_version=cast(int, blueprint.version),

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -41,6 +41,7 @@ from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
 from forecastbox.domain.blueprint.db import upsert_blueprint
 from forecastbox.domain.blueprint.exceptions import BlueprintNotFound
 from forecastbox.domain.glyphs.intrinsic import get_values_and_examples
+from forecastbox.domain.glyphs.resolution import merge_glyph_values
 from forecastbox.domain.plugin.manager import PluginManager
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.graph import topological_order
@@ -52,6 +53,7 @@ class BlueprintBuilder(BaseModel):
     # NOTE warning -- this class is used by the web api. Be careful about changes here
     blocks: dict[BlockInstanceId, BlockInstance]
     environment: EnvironmentSpecification | None = None
+    local_glyphs: dict[str, str] = {}
 
 
 class BlueprintSaveResult(BaseModel):
@@ -102,8 +104,8 @@ async def validate_expand(blueprint: BlueprintBuilder, auth_context: AuthContext
 
     Returns structured validation errors and possible completion options.
     The presence of errors does not affect the return (callers decide how to
-    surface them). Intrinsic and global glyphs visible to the caller are both
-    considered known.
+    surface them). Intrinsic and global glyphs visible to the caller, along
+    with local glyphs defined on the builder, are all considered known.
     """
     plugins = PluginManager.plugins
     possible_sources = [
@@ -115,9 +117,20 @@ async def validate_expand(blueprint: BlueprintBuilder, auth_context: AuthContext
     possible_expansions: dict[BlockInstanceId, list[PluginBlockFactoryId]] = {}
     block_errors: dict[BlockInstanceId, list[str]] = defaultdict(list)
     outputs = {}
+
+    intrinsic_values = cast(dict[str, str], get_values_and_examples())
     global_glyphs = {str(row.key): str(row.value) for row in await global_glyph_db.list_global_glyphs(auth_context)}
-    available_glyphs = set(get_values_and_examples().keys()).union(global_glyphs.keys())
-    glyph_values: dict[str, str] = {**global_glyphs, **cast(dict[str, str], get_values_and_examples())}
+    local_glyphs = blueprint.local_glyphs
+
+    all_glyphs = merge_glyph_values(intrinsic_values, global_glyphs, local_glyphs, {})
+    available_glyphs = set(all_glyphs.keys())
+
+    global_errors: list[str] = []
+    intrinsic_names = set(intrinsic_values.keys())
+    colliding_keys = set(local_glyphs.keys()) & intrinsic_names
+    for key in sorted(colliding_keys):
+        global_errors.append(f"Local glyph key {key!r} is reserved as an intrinsic glyph and cannot be overridden.")
+
     for blockId in topological_order(blueprint.blocks.items(), lambda block: block.input_ids.values()):
         blockInstance = blueprint.blocks[blockId]
         plugin = plugins.get(blockInstance.factory_id.plugin, None)
@@ -145,7 +158,7 @@ async def validate_expand(blueprint: BlueprintBuilder, auth_context: AuthContext
         if unknown_glyphs:
             block_errors[blockId] += [f"Unknown glyphs referenced: {unknown_glyphs}"]
             continue
-        glyph_resolution.resolve_configurations(blockInstance, glyph_values)
+        glyph_resolution.resolve_configurations(blockInstance, all_glyphs)
 
         inputs = {input_id: outputs[source_id] for input_id, source_id in blockInstance.input_ids.items()}
         output_or_error = plugin.validator(blockInstance, inputs)
@@ -159,8 +172,6 @@ async def validate_expand(blueprint: BlueprintBuilder, auth_context: AuthContext
             for any_plugin_id, any_plugin in plugins.items()
             for block_factory_id in any_plugin.expander(output_or_error.t)
         ]
-
-    global_errors: list[str] = []
 
     return BlueprintValidationExpansion(
         possible_sources=possible_sources,
@@ -199,6 +210,7 @@ async def save_builder(
         created_by=auth_context.user_id,
         blocks=payload.builder.model_dump(mode="json")["blocks"],
         environment_spec=env.model_dump(mode="json") if env is not None else None,
+        local_glyphs=payload.builder.local_glyphs if payload.builder.local_glyphs else None,
         display_name=payload.display_name,
         display_description=payload.display_description,
         tags=payload.tags if payload.tags else None,
@@ -221,6 +233,8 @@ async def load_builder(blueprint_id: str, version: int | None = None) -> Bluepri
     builder = BlueprintBuilder(blocks=blueprint.blocks)  # ty:ignore[invalid-argument-type]
     if blueprint.environment_spec is not None:
         builder.environment = EnvironmentSpecification.model_validate(blueprint.environment_spec)
+    if blueprint.local_glyphs:
+        builder.local_glyphs = blueprint.local_glyphs  # ty:ignore[invalid-assignment]
     return BlueprintRetrieveResult(
         blueprint_id=str(blueprint.blueprint_id),  # ty:ignore[invalid-argument-type]
         blueprint_version=cast(int, blueprint.version),

--- a/backend/src/forecastbox/domain/glyphs/resolution.py
+++ b/backend/src/forecastbox/domain/glyphs/resolution.py
@@ -11,6 +11,7 @@
 
 import datetime as dt
 import re
+from typing import TYPE_CHECKING
 
 from cascade.low.func import Either
 from fiab_core.fable import BlockInstance
@@ -54,3 +55,22 @@ def resolve_configurations(blockInstance: BlockInstance, glyph_values: dict[str,
     """
     for key, value in blockInstance.configuration_values.items():
         blockInstance.configuration_values[key] = _substitute_glyphs(value, glyph_values)
+
+
+def merge_glyph_values(
+    intrinsic_values: dict[str, str],
+    global_values: dict[str, str],
+    local_values: dict[str, str],
+    context_values: dict[str, str],
+) -> dict[str, str]:
+    """Merge glyphs from all four sources into a single resolution map.
+
+    Resolution order (lowest to highest precedence): intrinsic < global < local < context.
+    Intrinsic pinned keys (``startDatetime``, ``attemptCount``) always win regardless,
+    so that each restart records its own actual values.
+    """
+    merged = {**intrinsic_values, **global_values, **local_values, **context_values}
+    for pinned in ("startDatetime", "attemptCount"):
+        if pinned in intrinsic_values:
+            merged[pinned] = intrinsic_values[pinned]
+    return merged

--- a/backend/src/forecastbox/domain/glyphs/resolution.py
+++ b/backend/src/forecastbox/domain/glyphs/resolution.py
@@ -11,7 +11,6 @@
 
 import datetime as dt
 import re
-from typing import TYPE_CHECKING
 
 from cascade.low.func import Either
 from fiab_core.fable import BlockInstance

--- a/backend/src/forecastbox/domain/run/background.py
+++ b/backend/src/forecastbox/domain/run/background.py
@@ -25,9 +25,9 @@ import forecastbox.domain.glyphs.global_db as global_glyph_db
 import forecastbox.domain.run.db as run_db
 from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
 from forecastbox.domain.blueprint.service import BlueprintBuilder
-from forecastbox.domain.glyphs.resolution import extract_glyphs
+from forecastbox.domain.glyphs.resolution import extract_glyphs, merge_glyph_values
 from forecastbox.domain.run.cascade import ExecutionSpecification, execute_cascade
-from forecastbox.domain.run.compile import compile_builder, merge_glyph_values, resolve_intrinsic_glyph_values
+from forecastbox.domain.run.compile import compile_builder, resolve_intrinsic_glyph_values
 from forecastbox.domain.run.db import CompilerRuntimeContext
 from forecastbox.schemata.jobs import Blueprint
 from forecastbox.utility.auth import AuthContext
@@ -69,12 +69,14 @@ def execute_background(
         global_rows = list(cast(list, run_async(global_glyph_db.list_global_glyphs(auth_context))))
         global_values: dict[str, str] = {str(row.key): str(row.value) for row in global_rows}
 
-        all_glyphs = merge_glyph_values(intrinsic_values, global_values, compiler_runtime_context.glyphs)
-
         builder = BlueprintBuilder(
             blocks=blueprint.blocks,  # ty:ignore[invalid-argument-type]
             environment=EnvironmentSpecification.model_validate(blueprint.environment_spec) if blueprint.environment_spec else None,
+            local_glyphs=dict(blueprint.local_glyphs) if blueprint.local_glyphs else {},  # ty:ignore[no-matching-overload]
         )
+        local_values: dict[str, str] = builder.local_glyphs
+
+        all_glyphs = merge_glyph_values(intrinsic_values, global_values, local_values, compiler_runtime_context.glyphs)
 
         # Persist only the glyphs actually referenced in the builder, keeping the stored context lean.
         referenced_glyph_names = {name for block in builder.blocks.values() for name in (cast(set[str], extract_glyphs(block).t) or set())}

--- a/backend/src/forecastbox/domain/run/background.py
+++ b/backend/src/forecastbox/domain/run/background.py
@@ -68,7 +68,7 @@ def execute_background(
         global_rows = list(cast(list, run_async(global_glyph_db.list_global_glyphs(auth_context))))
         global_values: dict[str, str] = {str(row.key): str(row.value) for row in global_rows}
 
-        builder = BlueprintBuilder.model_validate(blueprint.builder)  # ty:ignore[arg-type]
+        builder = BlueprintBuilder.model_validate(blueprint.builder)
         local_values: dict[str, str] = builder.local_glyphs
 
         all_glyphs = merge_glyph_values(intrinsic_values, global_values, local_values, compiler_runtime_context.glyphs)

--- a/backend/src/forecastbox/domain/run/background.py
+++ b/backend/src/forecastbox/domain/run/background.py
@@ -23,7 +23,6 @@ from typing import cast
 
 import forecastbox.domain.glyphs.global_db as global_glyph_db
 import forecastbox.domain.run.db as run_db
-from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
 from forecastbox.domain.blueprint.service import BlueprintBuilder
 from forecastbox.domain.glyphs.resolution import extract_glyphs, merge_glyph_values
 from forecastbox.domain.run.cascade import ExecutionSpecification, execute_cascade
@@ -69,11 +68,7 @@ def execute_background(
         global_rows = list(cast(list, run_async(global_glyph_db.list_global_glyphs(auth_context))))
         global_values: dict[str, str] = {str(row.key): str(row.value) for row in global_rows}
 
-        builder = BlueprintBuilder(
-            blocks=blueprint.blocks,  # ty:ignore[invalid-argument-type]
-            environment=EnvironmentSpecification.model_validate(blueprint.environment_spec) if blueprint.environment_spec else None,
-            local_glyphs=dict(blueprint.local_glyphs) if blueprint.local_glyphs else {},  # ty:ignore[no-matching-overload]
-        )
+        builder = BlueprintBuilder.model_validate(blueprint.builder)  # ty:ignore[arg-type]
         local_values: dict[str, str] = builder.local_glyphs
 
         all_glyphs = merge_glyph_values(intrinsic_values, global_values, local_values, compiler_runtime_context.glyphs)

--- a/backend/src/forecastbox/domain/run/compile.py
+++ b/backend/src/forecastbox/domain/run/compile.py
@@ -19,28 +19,10 @@ from fiab_core.artifacts import CompositeArtifactId
 from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
 from forecastbox.domain.blueprint.service import BlueprintBuilder
 from forecastbox.domain.glyphs.intrinsic import AvailableIntrinsicGlyphs, get_values_and_examples
-from forecastbox.domain.glyphs.resolution import extract_glyphs, resolve_configurations, value_dt2str
+from forecastbox.domain.glyphs.resolution import extract_glyphs, merge_glyph_values, resolve_configurations, value_dt2str
 from forecastbox.domain.plugin.manager import PluginManager
 from forecastbox.domain.run.cascade import ExecutionSpecification, RawCascadeJob
 from forecastbox.utility.graph import topological_order
-
-
-def merge_glyph_values(
-    intrinsic_values: dict[str, str],
-    global_values: dict[str, str],
-    context_values: dict[str, str],
-) -> dict[str, str]:
-    """Merge glyphs from all three sources into a single resolution map.
-
-    Resolution order (lowest to highest precedence): intrinsic < global < context.
-    Intrinsic pinned keys (``startDatetime``, ``attemptCount``) always win regardless,
-    so that each restart records its own actual values.
-    """
-    merged = {**intrinsic_values, **global_values, **context_values}
-    for pinned in ("startDatetime", "attemptCount"):
-        if pinned in intrinsic_values:
-            merged[pinned] = intrinsic_values[pinned]
-    return merged
 
 
 def resolve_intrinsic_glyph_values(

--- a/backend/src/forecastbox/domain/run/service.py
+++ b/backend/src/forecastbox/domain/run/service.py
@@ -92,7 +92,7 @@ async def execute(
     database layer.  Experiment metadata is stored on the row when provided and
     preserved on restart.
     """
-    if not blueprint.blocks:
+    if not blueprint.builder:
         return Either.error(f"Blueprint {blueprint.blueprint_id!r} has no compilable blocks")
 
     blueprint_id = str(blueprint.blueprint_id)  # ty:ignore[invalid-argument-type]

--- a/backend/src/forecastbox/routes/blueprint.py
+++ b/backend/src/forecastbox/routes/blueprint.py
@@ -177,7 +177,17 @@ async def create_blueprint(
     request: BlueprintCreateRequest,
     auth_context: AuthContext = Depends(get_auth_context),
 ) -> BlueprintCreateResponse:
-    """Create a new blueprint from a BlueprintBuilder."""
+    """Create a new blueprint from a BlueprintBuilder.
+
+    Returns 422 if the builder fails validation (unknown plugins, undefined
+    glyphs, config errors, intrinsic glyph key collisions, etc.).
+    """
+    validation = await blueprint_service.validate_expand(request.builder, auth_context, validate_only=True)
+    if validation.global_errors or validation.block_errors:
+        raise HTTPException(
+            status_code=422,
+            detail={"global_errors": validation.global_errors, "block_errors": validation.block_errors},
+        )
     payload = BlueprintSaveCommand(
         builder=request.builder,
         display_name=request.display_name,
@@ -249,8 +259,16 @@ async def update_blueprint(
     """Add a new version to an existing blueprint.
 
     ``version`` must match the current latest version; returns 409 if it does not.
+    Returns 422 if the builder fails validation (unknown plugins, undefined
+    glyphs, config errors, intrinsic glyph key collisions, etc.).
     Returns the new version number on success.
     """
+    validation = await blueprint_service.validate_expand(request.builder, auth_context, validate_only=True)
+    if validation.global_errors or validation.block_errors:
+        raise HTTPException(
+            status_code=422,
+            detail={"global_errors": validation.global_errors, "block_errors": validation.block_errors},
+        )
     payload = BlueprintSaveCommand(
         builder=request.builder,
         display_name=request.display_name,
@@ -323,7 +341,7 @@ async def expand_blueprint(
     Returns 200 regardless of whether validation errors are present; callers must
     inspect the returned error fields.
     """
-    result = await blueprint_service.validate_expand(blueprint, auth_context)
+    result = await blueprint_service.validate_expand(blueprint, auth_context, validate_only=False)
     return BlueprintValidationExpansionResponse(
         global_errors=result.global_errors,
         block_errors=result.block_errors,

--- a/backend/src/forecastbox/schemata/jobs.py
+++ b/backend/src/forecastbox/schemata/jobs.py
@@ -64,6 +64,8 @@ class Blueprint(Base):
     blocks = Column(JSON, nullable=True)
     # stores the forecastbox.domain.blueprint.cascade.EnvironmentSpecification
     environment_spec = Column(JSON, nullable=True)
+    # stores local glyphs dict[str, str] from BlueprintBuilder
+    local_glyphs = Column(JSON, nullable=True)
 
     is_deleted = Column(Boolean, nullable=False, default=False)
 

--- a/backend/src/forecastbox/schemata/jobs.py
+++ b/backend/src/forecastbox/schemata/jobs.py
@@ -60,10 +60,9 @@ class Blueprint(Base):
     display_description = Column(String(1024), nullable=True)
     tags = Column(JSON, nullable=True)
 
-    # Payload stored as JSON to avoid over-normalisation
-    # stores the blocks field of forecastbox.api.types.blueprint.BlueprintBuilder
+    # stores the forecastbox.domain.blueprint.BlueprintBuilder
     blocks = Column(JSON, nullable=True)
-    # stores forecastbox.api.types.jobs.EnvironmentSpecification
+    # stores the forecastbox.domain.blueprint.cascade.EnvironmentSpecification
     environment_spec = Column(JSON, nullable=True)
 
     is_deleted = Column(Boolean, nullable=False, default=False)

--- a/backend/src/forecastbox/schemata/jobs.py
+++ b/backend/src/forecastbox/schemata/jobs.py
@@ -60,12 +60,8 @@ class Blueprint(Base):
     display_description = Column(String(1024), nullable=True)
     tags = Column(JSON, nullable=True)
 
-    # stores the forecastbox.domain.blueprint.BlueprintBuilder
-    blocks = Column(JSON, nullable=True)
-    # stores the forecastbox.domain.blueprint.cascade.EnvironmentSpecification
-    environment_spec = Column(JSON, nullable=True)
-    # stores local glyphs dict[str, str] from BlueprintBuilder
-    local_glyphs = Column(JSON, nullable=True)
+    # stores the full forecastbox.domain.blueprint.service.BlueprintBuilder as JSON
+    builder = Column(JSON, nullable=True)
 
     is_deleted = Column(Boolean, nullable=False, default=False)
 

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -86,7 +86,7 @@ def _make_builder_full(tmpdir: str) -> BlueprintBuilder:
     )
     source_time = BlockInstance(
         factory_id=PluginBlockFactoryId(plugin=testPluginId, factory="source_text"),
-        configuration_values={"text": "${submitDatetime};${startDatetime};${basicExecuteGlobalGlyph}"},
+        configuration_values={"text": "${submitDatetime};${startDatetime};${basicExecuteGlobalGlyph};${blueprintExecuteLocalGlyph}"},
         input_ids={},
     )
     sink_time = BlockInstance(
@@ -102,7 +102,8 @@ def _make_builder_full(tmpdir: str) -> BlueprintBuilder:
             "sink_main": sink_main,
             "source_time": source_time,
             "sink_time": sink_time,
-        }
+        },
+        local_glyphs={"blueprintExecuteLocalGlyph": "local_glyph_value"},
     )
 
 
@@ -245,6 +246,29 @@ def test_blueprint_expand(tmpdir: Any, backend_client_with_auth: httpx.Client) -
     assert "sink_file" not in response.json()["block_errors"]
     assert len(response.json()["block_errors"]) == 0
 
+    # A builder with an intrinsic name used as a local glyph key should fail validation
+    builder_invalid_local = BlueprintBuilder(
+        blocks=dict(blocks),
+        local_glyphs={"runId": "should-not-be-allowed"},
+    )
+    response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder_invalid_local.model_dump())
+    assert len(response.json()["global_errors"]) > 0
+
+    # A block using a local glyph defined on the builder should pass validation
+    sink_file_local = BlockInstance(
+        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory="sink_file"),
+        configuration_values={"fname": f"{tmpdir}/output${{blueprintExpandLocalGlyph}}.main.txt"},
+        input_ids={"data": "product_join"},
+    )
+    blocks["sink_file"] = sink_file_local
+    builder_with_local = BlueprintBuilder(
+        blocks=dict(blocks),
+        local_glyphs={"blueprintExpandLocalGlyph": "expand_local_value"},
+    )
+    response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder_with_local.model_dump())
+    assert "sink_file" not in response.json()["block_errors"]
+    assert len(response.json()["global_errors"]) == 0
+
     # A known intrinsic glyph (${runId}) should also pass validation
     sink_file_intrinsic = BlockInstance(
         factory_id=PluginBlockFactoryId(plugin=testPluginId, factory="sink_file"),
@@ -294,6 +318,7 @@ def test_blueprint_basic_execute(tmpdir: Any, backend_client_with_auth: httpx.Cl
     assert _time_parts[0] == created_at_sec
     assert compare_with_tolerance(_time_parts[1], _dt.fromisoformat(created_at_sec))
     assert _time_parts[2] == "initial_value"
+    assert _time_parts[3] == "local_glyph_value"
     outputTime.unlink()
 
     list_resp = backend_client_with_auth.get("/run/list")
@@ -347,6 +372,7 @@ def test_blueprint_basic_execute(tmpdir: Any, backend_client_with_auth: httpx.Cl
     assert _time_parts_r[0] == created_at_sec
     assert compare_with_tolerance(_time_parts_r[1], _dt.fromisoformat(created_at_restarted))
     assert _time_parts_r[2] == "initial_value"
+    assert _time_parts_r[3] == "local_glyph_value"
 
     avail_resp = backend_client_with_auth.get("/run/outputAvailability", params={"run_id": run_id})
     assert avail_resp.is_success, avail_resp.text

--- a/backend/tests/integration/test_schedule.py
+++ b/backend/tests/integration/test_schedule.py
@@ -17,7 +17,7 @@ import time
 from typing import Any
 
 import httpx
-from fiab_core.fable import BlockInstance, PluginBlockFactoryId, PluginCompositeId
+from fiab_core.fable import BlockInstance, PluginBlockFactoryId
 
 from forecastbox.domain.blueprint.service import BlueprintBuilder
 from forecastbox.domain.blueprint.service import BlueprintSaveCommand as BlueprintSaveRequest
@@ -52,10 +52,9 @@ def ensure_completed_v2(backend_client: httpx.Client, job_id: str, sleep: float 
 
 def _save_blueprint(client: httpx.Client) -> tuple[str, int]:
     """Save a minimal BlueprintBuilder and return (blueprint_id, version)."""
-    plugin_id = PluginCompositeId(store="ecmwf", local="ecmwf-base")
     source = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=plugin_id, factory="ekdSource"),
-        configuration_values={"source": "ecmwf-open-data", "date": "2026-01-01", "expver": "0001"},
+        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory="source_42"),
+        configuration_values={},
         input_ids={},
     )
     builder = BlueprintBuilder(blocks={"source1": source})

--- a/backend/tests/unit/domain/run/test_compile.py
+++ b/backend/tests/unit/domain/run/test_compile.py
@@ -1,4 +1,4 @@
-from forecastbox.domain.run.compile import merge_glyph_values
+from forecastbox.domain.glyphs.resolution import merge_glyph_values
 
 # ---------------------------------------------------------------------------
 # merge_glyph_values
@@ -6,34 +6,34 @@ from forecastbox.domain.run.compile import merge_glyph_values
 
 
 def test_merge_glyph_values_intrinsic_only() -> None:
-    result = merge_glyph_values({"runId": "abc"}, {}, {})
+    result = merge_glyph_values({"runId": "abc"}, {}, {}, {})
     assert result == {"runId": "abc"}
 
 
 def test_merge_glyph_values_context_only() -> None:
-    result = merge_glyph_values({}, {}, {"date": "20260101T00"})
+    result = merge_glyph_values({}, {}, {}, {"date": "20260101T00"})
     assert result == {"date": "20260101T00"}
 
 
 def test_merge_glyph_values_context_overrides_intrinsic() -> None:
-    result = merge_glyph_values({"runId": "abc", "submitDatetime": "2026-01-01 00:00:00"}, {}, {"runId": "custom"})
+    result = merge_glyph_values({"runId": "abc", "submitDatetime": "2026-01-01 00:00:00"}, {}, {}, {"runId": "custom"})
     assert result == {"runId": "custom", "submitDatetime": "2026-01-01 00:00:00"}
 
 
 def test_merge_glyph_values_all_combined() -> None:
-    result = merge_glyph_values({"runId": "abc"}, {"globalKey": "globalVal"}, {"date": "20260101T00"})
+    result = merge_glyph_values({"runId": "abc"}, {"globalKey": "globalVal"}, {}, {"date": "20260101T00"})
     assert result == {"runId": "abc", "globalKey": "globalVal", "date": "20260101T00"}
 
 
 def test_merge_glyph_values_context_overrides_global() -> None:
     """context_values take precedence over global_values for the same key."""
-    result = merge_glyph_values({}, {"sharedKey": "globalVal"}, {"sharedKey": "contextVal"})
+    result = merge_glyph_values({}, {"sharedKey": "globalVal"}, {}, {"sharedKey": "contextVal"})
     assert result == {"sharedKey": "contextVal"}
 
 
 def test_merge_glyph_values_global_overrides_intrinsic() -> None:
     """global_values take precedence over intrinsic_values (except pinned keys)."""
-    result = merge_glyph_values({"runId": "abc"}, {"runId": "global_override"}, {})
+    result = merge_glyph_values({"runId": "abc"}, {"runId": "global_override"}, {}, {})
     assert result == {"runId": "global_override"}
 
 
@@ -42,6 +42,7 @@ def test_merge_glyph_values_start_datetime_not_overridable() -> None:
     result = merge_glyph_values(
         {"startDatetime": "2026-01-01 12:00:00"},
         {"startDatetime": "global-value"},
+        {"startDatetime": "local-value"},
         {"startDatetime": "2025-01-01 00:00:00"},
     )
     assert result == {"startDatetime": "2026-01-01 12:00:00"}
@@ -52,9 +53,33 @@ def test_merge_glyph_values_start_datetime_preserved_alongside_context() -> None
     result = merge_glyph_values(
         {"runId": "abc", "startDatetime": "2026-04-07 10:00:00", "submitDatetime": "2026-01-01 00:00:00"},
         {"globalKey": "gval"},
+        {},
         {"runId": "custom", "startDatetime": "old-value", "date": "20260407T10"},
     )
     assert result["startDatetime"] == "2026-04-07 10:00:00"
     assert result["runId"] == "custom"
     assert result["date"] == "20260407T10"
     assert result["globalKey"] == "gval"
+
+
+def test_merge_glyph_values_local_overrides_global() -> None:
+    """local_values take precedence over global_values for the same key."""
+    result = merge_glyph_values({}, {"sharedKey": "globalVal"}, {"sharedKey": "localVal"}, {})
+    assert result == {"sharedKey": "localVal"}
+
+
+def test_merge_glyph_values_context_overrides_local() -> None:
+    """context_values take precedence over local_values for the same key."""
+    result = merge_glyph_values({}, {}, {"sharedKey": "localVal"}, {"sharedKey": "contextVal"})
+    assert result == {"sharedKey": "contextVal"}
+
+
+def test_merge_glyph_values_local_not_overridable_for_pinned() -> None:
+    """Local values cannot override pinned intrinsic keys like startDatetime."""
+    result = merge_glyph_values(
+        {"startDatetime": "2026-01-01 12:00:00"},
+        {},
+        {"startDatetime": "local-value"},
+        {},
+    )
+    assert result == {"startDatetime": "2026-01-01 12:00:00"}

--- a/backend/tests/unit/test_jobs.py
+++ b/backend/tests/unit/test_jobs.py
@@ -81,7 +81,7 @@ async def test_jobs_blueprint_insert_and_get(mem_session_maker_both: async_sessi
         source="user_defined",
         created_by="user1",
         display_name="My job",
-        blocks={"source1": {}},
+        builder={"blocks": {"source1": {}}, "environment": None, "local_glyphs": {}},
         tags=["tag1"],
     )
     assert v1 == 1

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1983,6 +1983,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "qubed" },
     { name = "sse-starlette" },
+    { name = "starlette" },
     { name = "toml" },
     { name = "uvicorn" },
 ]
@@ -2049,6 +2050,7 @@ requires-dist = [
     { name = "python-multipart" },
     { name = "qubed" },
     { name = "sse-starlette" },
+    { name = "starlette", specifier = ">=1.0" },
     { name = "thermofeel", marker = "extra == 'thermo'", specifier = ">=2.1.1" },
     { name = "toml" },
     { name = "uvicorn" },


### PR DESCRIPTION
1/ Adds a new field `local_glyphs` to blueprint builder. This will allow the users to define glyphs with scope of only that particular blueprint, eg when a value needs to be repeated across configuration options. This local glyph is saved in the blueprint -- meaning this is playing along with the usage of blueprints as "templates" for other jobs
2/ tests for the above
3/ Adds a `validate` call for `blueprint/{create, update}` routes -- meaning if the blueprint did not pass `/expand` call (which validates under the hood) or the call was omitted, the save is not allowed (and thus an execution-time failure is prevented). A well behaved client is expected to call expand on their own, so this is just a safety measure, not a feature change
4/ internal changes to db schemata for more simplicity


cc @liefra 