### PR TITLE
[fiab-core] allow default for configuration options

### DIFF
--- a/backend/packages/fiab-core/src/fiab_core/fable.py
+++ b/backend/packages/fiab-core/src/fiab_core/fable.py
@@ -25,7 +25,9 @@ class BlockConfigurationOption(BaseModel):
     """Extended description, possibly with example values and their effect"""
     value_type: str
     """Will be used when deserializing the actual value"""
-    # TODO do we want Literal instead of str for values? Do we prefer nesting or flattening for complex config?
+    # TODO do we want Literal instead of str for values? Probably `str` since this will need to be parsed anyway
+    # TODO do we prefer nesting or flattening for complex config? Ideally we support both, its just about the type system
+    default_value: str | None = None
 
 
 BlockKind = Literal["source", "transform", "product", "sink"]


### PR DESCRIPTION
So this trivial PR is about providing default values for configuration options in blocks

We have two ways of approaching this:
1/ the default is inputted by the backend _after_ the user does not fill the value
2/ the default is inputted by the frontend _before_ the user fills any value

I would be leaning towards the 2/, but completely happy with 1/ as well (which can still display the default value to the user -- with the change in this PR, the default value propagates to the catalogue thus frontend has it at its disposal)

The default can refer to glyphs, so you can have a default equal to "${submitDatetime}". Out of the box, this would work only for intrinsic glyphs. You can of course put a new glyph in here as well, but we currently don't have any means for like "once this plugin is installed, it should set a default global glyph value" or something. Do we envision a need for that?

Note: we need to distinguish between "" default (a legitimate value of empty string), and None default (meaning there is no default set). Ideally, if you ever want a `None` as a user-provided input value, please assume it will come as `"None"` string, not as a `None` value. But even better, don't want a `None` provided by the user :)