### PR TITLE
Add glyph resolution to /blueprint/expand endpoint

### DIFF
--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -41,7 +41,7 @@ from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
 from forecastbox.domain.blueprint.db import upsert_blueprint
 from forecastbox.domain.blueprint.exceptions import BlueprintNotFound
 from forecastbox.domain.glyphs.intrinsic import get_values_and_examples
-from forecastbox.domain.glyphs.resolution import merge_glyph_values
+from forecastbox.domain.glyphs.resolution import ExtractedGlyphs, merge_glyph_values
 from forecastbox.domain.plugin.manager import PluginManager
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.graph import topological_order
@@ -170,14 +170,13 @@ async def validate_expand(
         if extract_result.e is not None:
             block_errors[blockId] += extract_result.e
             continue
-        extracted_glyphs = cast(set[str], extract_result.t)
-        unknown_glyphs = extracted_glyphs - available_glyphs
+        extracted = cast(ExtractedGlyphs, extract_result.t)
+        unknown_glyphs = extracted.glyphs - available_glyphs
         if unknown_glyphs:
             block_errors[blockId] += [f"Unknown glyphs referenced: {unknown_glyphs}"]
             continue
         glyph_resolution.resolve_configurations(blockInstance, all_glyphs)
-        # TODO: optimize to copy only when there was a glyph in the first place
-        resolved_configuration_options[blockId] = blockInstance.configuration_values
+        resolved_configuration_options[blockId] = {k: blockInstance.configuration_values[k] for k in extracted.glyphed_options}
 
         inputs = {input_id: outputs[source_id] for input_id, source_id in blockInstance.input_ids.items()}
         output_or_error = plugin.validator(blockInstance, inputs)

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -82,6 +82,7 @@ class BlueprintValidationExpansion(BaseModel):
     block_errors: dict[BlockInstanceId, list[str]]
     possible_sources: list[PluginBlockFactoryId]
     possible_expansions: dict[BlockInstanceId, list[PluginBlockFactoryId]]
+    resolved_configuration_options: dict[BlockInstanceId, dict[str, str]] = {}
 
 
 class BlueprintSaveCommand(BaseModel):
@@ -130,6 +131,7 @@ async def validate_expand(
         ]
     )
     possible_expansions: dict[BlockInstanceId, list[PluginBlockFactoryId]] = {}
+    resolved_configuration_options: dict[BlockInstanceId, dict[str, str]] = {}
     block_errors: dict[BlockInstanceId, list[str]] = defaultdict(list)
     outputs = {}
 
@@ -174,6 +176,8 @@ async def validate_expand(
             block_errors[blockId] += [f"Unknown glyphs referenced: {unknown_glyphs}"]
             continue
         glyph_resolution.resolve_configurations(blockInstance, all_glyphs)
+        # TODO: optimize to copy only when there was a glyph in the first place
+        resolved_configuration_options[blockId] = dict(blockInstance.configuration_values)
 
         inputs = {input_id: outputs[source_id] for input_id, source_id in blockInstance.input_ids.items()}
         output_or_error = plugin.validator(blockInstance, inputs)
@@ -192,6 +196,7 @@ async def validate_expand(
     return BlueprintValidationExpansion(
         possible_sources=possible_sources,
         possible_expansions=possible_expansions,
+        resolved_configuration_options=resolved_configuration_options,
         block_errors=block_errors,
         global_errors=global_errors,
     )

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -177,7 +177,7 @@ async def validate_expand(
             continue
         glyph_resolution.resolve_configurations(blockInstance, all_glyphs)
         # TODO: optimize to copy only when there was a glyph in the first place
-        resolved_configuration_options[blockId] = dict(blockInstance.configuration_values)
+        resolved_configuration_options[blockId] = blockInstance.configuration_values
 
         inputs = {input_id: outputs[source_id] for input_id, source_id in blockInstance.input_ids.items()}
         output_or_error = plugin.validator(blockInstance, inputs)

--- a/backend/src/forecastbox/domain/glyphs/resolution.py
+++ b/backend/src/forecastbox/domain/glyphs/resolution.py
@@ -11,11 +11,20 @@
 
 import datetime as dt
 import re
+from dataclasses import dataclass
 
 from cascade.low.func import Either
 from fiab_core.fable import BlockInstance
 
 _GLYPH_PATTERN = re.compile(r"\$\{(\w+)\}")
+
+
+@dataclass(frozen=True, eq=True, slots=True)
+class ExtractedGlyphs:
+    glyphs: set[str]
+    """All glyph names referenced across all configuration_values."""
+    glyphed_options: set[str]
+    """Keys from configuration_values that contain at least one glyph reference."""
 
 
 def value_dt2str(value: dt.datetime) -> str:
@@ -34,16 +43,21 @@ def _substitute_glyphs(value: str, glyph_values: dict[str, str]) -> str:
     return _GLYPH_PATTERN.sub(lambda m: glyph_values[m.group(1)], value)
 
 
-def extract_glyphs(blockInstance: BlockInstance) -> Either[set[str], list[str]]:  # type: ignore[invalid-argument]
+def extract_glyphs(blockInstance: BlockInstance) -> Either[ExtractedGlyphs, list[str]]:  # type: ignore[invalid-argument]
     """Extract all ${glyph} references from the blockInstance's configuration_values.
 
-    Always succeeds; returns the set of referenced glyph names. The error branch
-    is reserved for future validation (e.g. malformed templates).
+    Always succeeds; returns an ExtractedGlyphs with the set of referenced glyph names
+    and the set of option keys that contain at least one glyph. The error branch is
+    reserved for future validation (e.g. malformed templates).
     """
     glyphs: set[str] = set()
-    for value in blockInstance.configuration_values.values():
-        glyphs.update(_extract_glyph_names_from_value(value))
-    return Either.ok(glyphs)
+    glyphed_options: set[str] = set()
+    for key, value in blockInstance.configuration_values.items():
+        names = _extract_glyph_names_from_value(value)
+        if names:
+            glyphs.update(names)
+            glyphed_options.add(key)
+    return Either.ok(ExtractedGlyphs(glyphs=glyphs, glyphed_options=glyphed_options))
 
 
 def resolve_configurations(blockInstance: BlockInstance, glyph_values: dict[str, str]) -> None:

--- a/backend/src/forecastbox/domain/run/background.py
+++ b/backend/src/forecastbox/domain/run/background.py
@@ -24,7 +24,7 @@ from typing import cast
 import forecastbox.domain.glyphs.global_db as global_glyph_db
 import forecastbox.domain.run.db as run_db
 from forecastbox.domain.blueprint.service import BlueprintBuilder
-from forecastbox.domain.glyphs.resolution import extract_glyphs, merge_glyph_values
+from forecastbox.domain.glyphs.resolution import ExtractedGlyphs, extract_glyphs, merge_glyph_values
 from forecastbox.domain.run.cascade import ExecutionSpecification, execute_cascade
 from forecastbox.domain.run.compile import compile_builder, resolve_intrinsic_glyph_values
 from forecastbox.domain.run.db import CompilerRuntimeContext
@@ -74,7 +74,9 @@ def execute_background(
         all_glyphs = merge_glyph_values(intrinsic_values, global_values, local_values, compiler_runtime_context.glyphs)
 
         # Persist only the glyphs actually referenced in the builder, keeping the stored context lean.
-        referenced_glyph_names = {name for block in builder.blocks.values() for name in (cast(set[str], extract_glyphs(block).t) or set())}
+        referenced_glyph_names = {
+            name for block in builder.blocks.values() for name in cast(ExtractedGlyphs, extract_glyphs(block).t).glyphs
+        }
         used_glyphs = {k: v for k, v in all_glyphs.items() if k in referenced_glyph_names}
 
         exec_spec = compile_builder(builder, all_glyphs)

--- a/backend/src/forecastbox/domain/run/compile.py
+++ b/backend/src/forecastbox/domain/run/compile.py
@@ -19,7 +19,7 @@ from fiab_core.artifacts import CompositeArtifactId
 from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
 from forecastbox.domain.blueprint.service import BlueprintBuilder
 from forecastbox.domain.glyphs.intrinsic import AvailableIntrinsicGlyphs, get_values_and_examples
-from forecastbox.domain.glyphs.resolution import extract_glyphs, merge_glyph_values, resolve_configurations, value_dt2str
+from forecastbox.domain.glyphs.resolution import merge_glyph_values, resolve_configurations, value_dt2str
 from forecastbox.domain.plugin.manager import PluginManager
 from forecastbox.domain.run.cascade import ExecutionSpecification, RawCascadeJob
 from forecastbox.utility.graph import topological_order

--- a/backend/src/forecastbox/routes/blueprint.py
+++ b/backend/src/forecastbox/routes/blueprint.py
@@ -124,6 +124,7 @@ class BlueprintValidationExpansionResponse(BaseModel):
     block_errors: dict[BlockInstanceId, list[str]]
     possible_sources: list[PluginBlockFactoryId]
     possible_expansions: dict[BlockInstanceId, list[PluginBlockFactoryId]]
+    resolved_configuration_options: dict[BlockInstanceId, dict[str, str]]
 
 
 class GlyphDetail(BaseModel):
@@ -347,6 +348,7 @@ async def expand_blueprint(
         block_errors=result.block_errors,
         possible_sources=result.possible_sources,
         possible_expansions=result.possible_expansions,
+        resolved_configuration_options=result.resolved_configuration_options,
     )
 
 

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -283,10 +283,11 @@ def test_blueprint_expand(tmpdir: Any, backend_client_with_auth: httpx.Client) -
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())
     assert len(response.json()["possible_expansions"]["sink_file"]) == 0
     assert len(response.json()["block_errors"]) == 0
-    resolved_fname = response.json()["resolved_configuration_options"]["sink_file"]["fname"]
-    assert resolved_fname.startswith(f"{tmpdir}/output")
-    assert resolved_fname.endswith(".main.txt")
-    assert "${runId}" not in resolved_fname
+    glyphs_resp = backend_client_with_auth.get("/blueprint/glyphs/list", params={"glyph_type": "intrinsic"})
+    assert glyphs_resp.is_success, glyphs_resp.text
+    run_id_glyph = next(g for g in glyphs_resp.json()["glyphs"] if g["name"] == "runId")
+    expected_run_id = run_id_glyph["valueExample"]
+    assert response.json()["resolved_configuration_options"]["sink_file"]["fname"] == f"{tmpdir}/output{expected_run_id}.main.txt"
 
 
 def test_blueprint_basic_execute(tmpdir: Any, backend_client_with_auth: httpx.Client) -> None:

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -245,6 +245,7 @@ def test_blueprint_expand(tmpdir: Any, backend_client_with_auth: httpx.Client) -
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())
     assert "sink_file" not in response.json()["block_errors"]
     assert len(response.json()["block_errors"]) == 0
+    assert response.json()["resolved_configuration_options"]["sink_file"]["fname"] == f"{tmpdir}/outputtest_expand_value.main.txt"
 
     # A builder with an intrinsic name used as a local glyph key should fail validation
     builder_invalid_local = BlueprintBuilder(
@@ -268,6 +269,7 @@ def test_blueprint_expand(tmpdir: Any, backend_client_with_auth: httpx.Client) -
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder_with_local.model_dump())
     assert "sink_file" not in response.json()["block_errors"]
     assert len(response.json()["global_errors"]) == 0
+    assert response.json()["resolved_configuration_options"]["sink_file"]["fname"] == f"{tmpdir}/outputexpand_local_value.main.txt"
 
     # A known intrinsic glyph (${runId}) should also pass validation
     sink_file_intrinsic = BlockInstance(
@@ -281,6 +283,10 @@ def test_blueprint_expand(tmpdir: Any, backend_client_with_auth: httpx.Client) -
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())
     assert len(response.json()["possible_expansions"]["sink_file"]) == 0
     assert len(response.json()["block_errors"]) == 0
+    resolved_fname = response.json()["resolved_configuration_options"]["sink_file"]["fname"]
+    assert resolved_fname.startswith(f"{tmpdir}/output")
+    assert resolved_fname.endswith(".main.txt")
+    assert "${runId}" not in resolved_fname
 
 
 def test_blueprint_basic_execute(tmpdir: Any, backend_client_with_auth: httpx.Client) -> None:

--- a/backend/tests/unit/domain/glyphs/test_resolution.py
+++ b/backend/tests/unit/domain/glyphs/test_resolution.py
@@ -14,7 +14,7 @@ import datetime as dt
 import pytest
 from fiab_core.fable import BlockInstance, PluginBlockFactoryId, PluginCompositeId
 
-from forecastbox.domain.glyphs.resolution import extract_glyphs, resolve_configurations, value_dt2str
+from forecastbox.domain.glyphs.resolution import ExtractedGlyphs, extract_glyphs, resolve_configurations, value_dt2str
 
 
 def _block(config: dict[str, str]) -> BlockInstance:
@@ -37,42 +37,42 @@ def test_extract_glyphs_no_glyphs() -> None:
     block = _block({"key": "plain_value"})
     result = extract_glyphs(block)
     assert result.e is None
-    assert result.t == set()
+    assert result.t == ExtractedGlyphs(glyphs=set(), glyphed_options=set())
 
 
 def test_extract_glyphs_single() -> None:
     block = _block({"key": "${myVar}"})
     result = extract_glyphs(block)
     assert result.e is None
-    assert result.t == {"myVar"}
+    assert result.t == ExtractedGlyphs(glyphs={"myVar"}, glyphed_options={"key"})
 
 
 def test_extract_glyphs_multiple_in_one_value() -> None:
     block = _block({"key": "${var1}_${var2}"})
     result = extract_glyphs(block)
     assert result.e is None
-    assert result.t == {"var1", "var2"}
+    assert result.t == ExtractedGlyphs(glyphs={"var1", "var2"}, glyphed_options={"key"})
 
 
 def test_extract_glyphs_across_multiple_keys() -> None:
     block = _block({"key1": "${var1}", "key2": "${var2}"})
     result = extract_glyphs(block)
     assert result.e is None
-    assert result.t == {"var1", "var2"}
+    assert result.t == ExtractedGlyphs(glyphs={"var1", "var2"}, glyphed_options={"key1", "key2"})
 
 
 def test_extract_glyphs_deduplicates() -> None:
     block = _block({"a": "${runId}", "b": "prefix_${runId}_suffix"})
     result = extract_glyphs(block)
     assert result.e is None
-    assert result.t == {"runId"}
+    assert result.t == ExtractedGlyphs(glyphs={"runId"}, glyphed_options={"a", "b"})
 
 
 def test_extract_glyphs_mixed_plain_and_template() -> None:
     block = _block({"a": "static", "b": "${dynamic}"})
     result = extract_glyphs(block)
     assert result.e is None
-    assert result.t == {"dynamic"}
+    assert result.t == ExtractedGlyphs(glyphs={"dynamic"}, glyphed_options={"b"})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Improves the `/blueprint/expand` endpoint to additionally return those configuration options where there was a glyph, now with the actual value with all glyphs resolved. In case of intrinsic variables, the same value is used for resolution as is returned by the glyph examples endpoint

cc @liefra 