### PR TITLE
Dont require static/index.html for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
           uv sync --extra plots --python "${{ matrix.python_version }}" --all-packages
           uv run prek --all-files
           mkdir /tmp/tmpFiabHome
-          mkdir src/forecastbox/static && touch src/forecastbox/static/index.html # TODO replace with proper static file build
+          # TODO utilize a proper static file build, instead of relying on integration tests index.html
           if [[ "${{ matrix.python_version }}" != "3.13" ]] ; then
             # see tests of the admin/release endpoint for explanation
             export CI_GITHUB_RATELIMIT=yes

--- a/backend/src/forecastbox/entrypoint/app.py
+++ b/backend/src/forecastbox/entrypoint/app.py
@@ -128,7 +128,7 @@ async def share_image(request: Request, job_id: str, dataset_id: str) -> HTMLRes
     return templates.TemplateResponse(request, "share.html", {"image_url": image_url, "image_name": f"{job_id}_{dataset_id}"})
 
 
-frontend = os.path.join(os.path.dirname(os.path.dirname(__file__)), "static")
+frontend = os.environ.get("FIAB_TEST_FRONTEND") or os.path.join(os.path.dirname(os.path.dirname(__file__)), "static")
 
 
 class SPAStaticFiles(StaticFiles):

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -101,6 +101,7 @@ def backend_client() -> Generator[httpx.Client, None, None]:
         td = tempfile.TemporaryDirectory()
         td_data = tempfile.TemporaryDirectory()
         os.environ["FIAB_ROOT"] = td.name
+        os.environ["FIAB_TEST_FRONTEND"] = str(pathlib.Path(__file__).parent / "static")
         (pathlib.Path(td.name) / "pylock.toml.timestamp").write_text("1761908420:d0.0.1")
         # we need to monkeypath this, because of eager import this was already initialised
         # to user's personal config file

--- a/backend/tests/integration/static/index.html
+++ b/backend/tests/integration/static/index.html
@@ -1,0 +1,1 @@
+<!doctype html><html><body>test</body></html>


### PR DESCRIPTION
Just make it easier to run integration tests in a fresh checkout, by "mocking" the static html file there. Sadly we cant mock due to this happening in a different process, and I prefered envvar over extending configuration, since I dont think regular users should even view this as configurable