### PR TITLE
[frontend] Activity monitor + universal glyph field support

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -50,7 +50,7 @@
         "eslint-plugin-license-header": "^0.9.0",
         "i18next-cli": "^1.34.1",
         "msw": "^2.12.7",
-        "prettier": "3.8.1",
+        "prettier": "3.8.2",
         "prettier-plugin-tailwindcss": "^0.7.2",
         "rollup-plugin-visualizer": "^7.0.1",
         "shadcn": "^4.0.5",
@@ -516,16 +516,15 @@
       }
     },
     "node_modules/@base-ui/react": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.3.0.tgz",
-      "integrity": "sha512-FwpKqZbPz14AITp1CVgf4AjhKPe1OeeVKSBMdgD10zbFlj3QSWelmtCMLi2+/PFZZcIm3l87G7rwtCZJwHyXWA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.4.0.tgz",
+      "integrity": "sha512-QcqdVbr/+ba2/RAKJIV1PV6S02Q5+r6a4Eym8ndBw+ZbBILkkmQAyRxXCg/pArrHnkrGeU8goe26aw0h6eE8pg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
-        "@base-ui/utils": "0.2.6",
+        "@babel/runtime": "^7.29.2",
+        "@base-ui/utils": "0.2.7",
         "@floating-ui/react-dom": "^2.1.8",
         "@floating-ui/utils": "^0.2.11",
-        "tabbable": "^6.4.0",
         "use-sync-external-store": "^1.6.0"
       },
       "engines": {
@@ -536,7 +535,9 @@
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
+        "@date-fns/tz": "^1.2.0",
         "@types/react": "^17 || ^18 || ^19",
+        "date-fns": "^4.0.0",
         "react": "^17 || ^18 || ^19",
         "react-dom": "^17 || ^18 || ^19"
       },
@@ -547,12 +548,12 @@
       }
     },
     "node_modules/@base-ui/utils": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.6.tgz",
-      "integrity": "sha512-yQ+qeuqohwhsNpoYDqqXaLllYAkPCP4vYdDrVo8FQXaAPfHWm1pG/Vm+jmGTA5JFS0BAIjookyapuJFY8F9PIw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.7.tgz",
+      "integrity": "sha512-nXYKhiL/0JafyJE8PfcflipGftOftlIwKd72rU15iZ1M5yqgg5J9P8NHU71GReDuXco5MJA/eVQqUT5WRqX9sA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.28.6",
+        "@babel/runtime": "^7.29.2",
         "@floating-ui/utils": "^0.2.11",
         "reselect": "^5.1.1",
         "use-sync-external-store": "^1.6.0"
@@ -616,6 +617,13 @@
       "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
       "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
       "license": "MIT"
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@dimforge/rapier3d-compat": {
       "version": "0.12.0",
@@ -1434,9 +1442,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3488,9 +3496,9 @@
       }
     },
     "node_modules/@tanstack/eslint-plugin-query": {
-      "version": "5.97.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.97.0.tgz",
-      "integrity": "sha512-0/py2lxpUaCHKZeaOcTUVGHsbmr7719bh4ruj++HXgJQN8AtPvoPODyc8eOYTi/gZqr0LA2ZHH3ohSMrD3im+g==",
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.99.0.tgz",
+      "integrity": "sha512-jVp1AEL7S7BeuQvH5SN1F5UdrNW/AbryKDeWUUMeAKNzh9C+Ik/bRSa/HeuJLlmaN+WOUkdDFbtCK0go7BxnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3540,9 +3548,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.97.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.97.0.tgz",
-      "integrity": "sha512-QdpLP5VzVMgo4VtaPppRA2W04UFjIqX+bxke/ZJhE5cfd5UPkRzqIAJQt9uXkQJjqE8LBOMbKv7f8HCsZltXlg==",
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.0.tgz",
+      "integrity": "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3571,12 +3579,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.97.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.97.0.tgz",
-      "integrity": "sha512-y4So4eGcQoK2WVMAcDNZE9ofB/p5v1OlKvtc1F3uqHwrtifobT7q+ZnXk2mRkc8E84HKYSlAE9z6HXl2V0+ySQ==",
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.0.tgz",
+      "integrity": "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.97.0"
+        "@tanstack/query-core": "5.99.0"
       },
       "funding": {
         "type": "github",
@@ -3587,14 +3595,14 @@
       }
     },
     "node_modules/@tanstack/react-router": {
-      "version": "1.168.10",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.168.10.tgz",
-      "integrity": "sha512-/RmDlOwDkCug609KdPB3U+U1zmrtadJpvsmRg2zEn8TRCKRNri7dYZIjQZbNg8PgUiRL4T6njrZBV1ChzblNaA==",
+      "version": "1.168.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.168.21.tgz",
+      "integrity": "sha512-slnitYiHHmU52eMWtW8JbV9EMT5q6mRMbTA5yepBmJAnj5WZDrDRsLY/TuUrdD97A4W7/25tEQRoqc1G2X0oCw==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/history": "1.161.6",
         "@tanstack/react-store": "^0.9.3",
-        "@tanstack/router-core": "1.168.9",
+        "@tanstack/router-core": "1.168.15",
         "isbot": "^5.1.22"
       },
       "engines": {
@@ -3628,15 +3636,15 @@
       }
     },
     "node_modules/@tanstack/router-core": {
-      "version": "1.168.9",
-      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.168.9.tgz",
-      "integrity": "sha512-18oeEwEDyXOIuO1VBP9ACaK7tYHZUjynGDCoUh/5c/BNhia9vCJCp9O0LfhZXOorDc/PmLSgvmweFhVmIxF10g==",
+      "version": "1.168.15",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.168.15.tgz",
+      "integrity": "sha512-Wr0424NDtD8fT/uALobMZ9DdcfsTyXtW5IPR++7zvW8/7RaIOeaqXpVDId8ywaGtqPWLWOfaUg2zUtYtukoXYA==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/history": "1.161.6",
-        "cookie-es": "^2.0.0",
-        "seroval": "^1.4.2",
-        "seroval-plugins": "^1.4.2"
+        "cookie-es": "^3.0.0",
+        "seroval": "^1.5.0",
+        "seroval-plugins": "^1.5.0"
       },
       "bin": {
         "intent": "bin/intent.js"
@@ -3650,17 +3658,17 @@
       }
     },
     "node_modules/@tanstack/router-generator": {
-      "version": "1.166.24",
-      "resolved": "https://registry.npmjs.org/@tanstack/router-generator/-/router-generator-1.166.24.tgz",
-      "integrity": "sha512-vdaGKwuH+r+DPe6R1mjk+TDDmDH6NTG7QqwxHqGEvOH4aGf9sPjhmRKNJZqQr8cPIbfp6u5lXyZ1TeDcSNMVEA==",
+      "version": "1.166.32",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-generator/-/router-generator-1.166.32.tgz",
+      "integrity": "sha512-VuusKwEXcgKq+myq1JQfZogY8scTXIIeFls50dJ/UXgCXWp5n14iFreYNlg41wURcak2oA3M+t2TVfD0xUUD6g==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/router-core": "1.168.9",
+        "@babel/types": "^7.28.5",
+        "@tanstack/router-core": "1.168.15",
         "@tanstack/router-utils": "1.161.6",
         "@tanstack/virtual-file-routes": "1.161.7",
+        "magic-string": "^0.30.21",
         "prettier": "^3.5.0",
-        "recast": "^0.23.11",
-        "source-map": "^0.7.4",
         "tsx": "^4.19.2",
         "zod": "^3.24.2"
       },
@@ -3682,9 +3690,9 @@
       }
     },
     "node_modules/@tanstack/router-plugin": {
-      "version": "1.167.12",
-      "resolved": "https://registry.npmjs.org/@tanstack/router-plugin/-/router-plugin-1.167.12.tgz",
-      "integrity": "sha512-StEHcctCuFI5taSjO+lhR/yQ+EK63BdyYa+ne6FoNQPB3MMrOUrz2ZVnbqILRLkh2b+p2EfBKt65sgAKdKygPQ==",
+      "version": "1.167.22",
+      "resolved": "https://registry.npmjs.org/@tanstack/router-plugin/-/router-plugin-1.167.22.tgz",
+      "integrity": "sha512-wYPzIvBK8bcmXVUpZfSgGBXOrfBAdF4odKevz6rejio5rEd947NtKDF5R7eYdwlAOmRqYpLJnJ1QHkc5t8bY4w==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.5",
@@ -3693,8 +3701,8 @@
         "@babel/template": "^7.27.2",
         "@babel/traverse": "^7.28.5",
         "@babel/types": "^7.28.5",
-        "@tanstack/router-core": "1.168.9",
-        "@tanstack/router-generator": "1.166.24",
+        "@tanstack/router-core": "1.168.15",
+        "@tanstack/router-generator": "1.166.32",
         "@tanstack/router-utils": "1.161.6",
         "@tanstack/virtual-file-routes": "1.161.7",
         "chokidar": "^3.6.0",
@@ -3713,9 +3721,9 @@
       },
       "peerDependencies": {
         "@rsbuild/core": ">=1.0.2",
-        "@tanstack/react-router": "^1.168.10",
-        "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0",
-        "vite-plugin-solid": "^2.11.10",
+        "@tanstack/react-router": "^1.168.21",
+        "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0",
+        "vite-plugin-solid": "^2.11.10 || ^3.0.0-0",
         "webpack": ">=5.92.0"
       },
       "peerDependenciesMeta": {
@@ -4063,13 +4071,13 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "25.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
-      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/react": {
@@ -4137,17 +4145,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
-      "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
+      "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.58.1",
-        "@typescript-eslint/type-utils": "8.58.1",
-        "@typescript-eslint/utils": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/type-utils": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -4160,7 +4168,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.58.1",
+        "@typescript-eslint/parser": "^8.58.2",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -4176,16 +4184,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
-      "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
+      "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4201,14 +4209,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
-      "integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
+      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.1",
-        "@typescript-eslint/types": "^8.58.1",
+        "@typescript-eslint/tsconfig-utils": "^8.58.2",
+        "@typescript-eslint/types": "^8.58.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4223,14 +4231,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
-      "integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
+      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1"
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4241,9 +4249,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
-      "integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
+      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4258,15 +4266,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.1.tgz",
-      "integrity": "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
+      "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1",
-        "@typescript-eslint/utils": "8.58.1",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -4283,9 +4291,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
-      "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4297,16 +4305,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
-      "integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
+      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.1",
-        "@typescript-eslint/tsconfig-utils": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1",
+        "@typescript-eslint/project-service": "8.58.2",
+        "@typescript-eslint/tsconfig-utils": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -4338,16 +4346,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
-      "integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1"
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4362,13 +4370,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
-      "integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
+      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/types": "8.58.2",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -5179,6 +5187,7 @@
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
       "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.1"
@@ -5229,9 +5238,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.17",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.17.tgz",
-      "integrity": "sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==",
+      "version": "2.10.18",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz",
+      "integrity": "sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -5403,9 +5412,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001787",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
-      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -5693,9 +5702,9 @@
       }
     },
     "node_modules/cookie-es": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-2.0.1.tgz",
-      "integrity": "sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
       "license": "MIT"
     },
     "node_modules/cookie-signature": {
@@ -6213,9 +6222,9 @@
       "peer": true
     },
     "node_modules/dotenv": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
-      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -6272,9 +6281,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.334",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.334.tgz",
-      "integrity": "sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==",
+      "version": "1.5.336",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz",
+      "integrity": "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -6789,6 +6798,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -7499,9 +7509,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
-      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
+      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7721,9 +7731,9 @@
       }
     },
     "node_modules/i18next-cli": {
-      "version": "1.51.7",
-      "resolved": "https://registry.npmjs.org/i18next-cli/-/i18next-cli-1.51.7.tgz",
-      "integrity": "sha512-Mf9cjzVqCTJLNFwRBYDzico1LydEbdFaYKmR8yoGegBeYhDPtMZrPYFtFnPHaUOnW91cyVB617QTzJL8v44goA==",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/i18next-cli/-/i18next-cli-1.53.0.tgz",
+      "integrity": "sha512-PLdcdECr/DrzBGUC5YS6FEwZAsU+n8ycGu3Ra7sqNt/SLkHoDGtEja74eqk1gG83IB0JtIhAz+fv2/VaV8Qztw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8170,9 +8180,9 @@
       }
     },
     "node_modules/isbot": {
-      "version": "5.1.37",
-      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.37.tgz",
-      "integrity": "sha512-5bcicX81xf6NlTEV8rWdg7Pk01LFizDetuYGHx6d/f6y3lR2/oo8IfxjzJqn1UdDEyCcwT9e7NRloj8DwCYujQ==",
+      "version": "5.1.38",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.38.tgz",
+      "integrity": "sha512-Cus2702JamTNMEY4zTP+TShgq/3qzjvGcBC4XMOV45BLaxD4iUFENkqu7ZhFeSzwNsCSZLjnGlihDQznnpnEEA==",
       "license": "Unlicense",
       "engines": {
         "node": ">=18"
@@ -8973,9 +8983,9 @@
       "license": "MIT"
     },
     "node_modules/msw": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.13.2.tgz",
-      "integrity": "sha512-go2H1TIERKkC48pXiwec5l6sbNqYuvqOk3/vHGo1Zd+pq/H63oFawDQerH+WQdUw/flJFHDG7F+QdWMwhntA/A==",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.13.3.tgz",
+      "integrity": "sha512-/F49bxavkNGfreMlrKmTxZs6YorjfMbbDLd89Q3pWi+cXGtQQNXXaHt4MkXN7li91xnQJ24HWXqW9QDm5id33w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -8991,7 +9001,7 @@
         "outvariant": "^1.4.3",
         "path-to-regexp": "^6.3.0",
         "picocolors": "^1.1.1",
-        "rettime": "^0.10.1",
+        "rettime": "^0.11.7",
         "statuses": "^2.0.2",
         "strict-event-emitter": "^0.5.1",
         "tough-cookie": "^6.0.0",
@@ -9607,9 +9617,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
-      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -9812,9 +9822,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
+      "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -10261,6 +10271,7 @@
       "version": "0.23.11",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
       "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ast-types": "^0.16.1",
@@ -10277,6 +10288,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -10355,9 +10367,9 @@
       }
     },
     "node_modules/rettime": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.10.1.tgz",
-      "integrity": "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==",
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.7.tgz",
+      "integrity": "sha512-DoAm1WjR1eH7z8sHPtvvUMIZh4/CSKkGCz6CxPqOrEAnOGtOuHSnSE9OC+razqxKuf4ub7pAYyl/vZV0vGs5tg==",
       "dev": true,
       "license": "MIT"
     },
@@ -11056,6 +11068,7 @@
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
       "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 12"
@@ -11105,9 +11118,9 @@
       "license": "MIT"
     },
     "node_modules/stdin-discarder": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.1.tgz",
-      "integrity": "sha512-reExS1kSGoElkextOcPkel4NE99S0BWxjUHQeDFnR8S993JxpPX7KU4MNmO19NXhlJp+8dmdCbKQVNgLJh2teA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+      "integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11223,12 +11236,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/tabbable": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
-      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
-      "license": "MIT"
     },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
@@ -11387,6 +11394,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinybench": {
@@ -11659,16 +11667,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.1.tgz",
-      "integrity": "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
+      "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.58.1",
-        "@typescript-eslint/parser": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1",
-        "@typescript-eslint/utils": "8.58.1"
+        "@typescript-eslint/eslint-plugin": "8.58.2",
+        "@typescript-eslint/parser": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -11683,9 +11691,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "devOptional": true,
       "license": "MIT"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -70,7 +70,7 @@
     "eslint-plugin-license-header": "^0.9.0",
     "i18next-cli": "^1.34.1",
     "msw": "^2.12.7",
-    "prettier": "3.8.1",
+    "prettier": "3.8.2",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "rollup-plugin-visualizer": "^7.0.1",
     "shadcn": "^4.0.5",

--- a/frontend/public/mockServiceWorker.js
+++ b/frontend/public/mockServiceWorker.js
@@ -7,7 +7,7 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.13.2'
+const PACKAGE_VERSION = '2.13.3'
 const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -111,10 +111,18 @@ async function request<T>(
 
       try {
         const errorData = (await response.json()) as ApiError
-        // FastAPI returns errors as { detail: "..." }, our schema uses { message: "..." }
-        const detail = (errorData as unknown as { detail?: string }).detail
-        errorMessage = errorData.message || detail || errorMessage
-        errorDetails = errorData.details
+        // FastAPI returns errors as { detail: "..." } (string or object),
+        // our schema uses { message: "..." }
+        const detail = (errorData as unknown as { detail?: unknown }).detail
+        if (typeof detail === 'string') {
+          errorMessage = errorData.message || detail || errorMessage
+        } else if (typeof detail === 'object' && detail !== null) {
+          errorMessage = errorData.message || `HTTP ${response.status}`
+          errorDetails = detail
+        } else {
+          errorMessage = errorData.message || errorMessage
+        }
+        if (!errorDetails) errorDetails = errorData.details
       } catch {
         // If response is not JSON, use the status text
       }

--- a/frontend/src/api/types/fable.types.ts
+++ b/frontend/src/api/types/fable.types.ts
@@ -92,6 +92,7 @@ export type BlockInstance = z.infer<typeof BlockInstanceSchema>
 
 export const FableBuilderV1Schema = z.object({
   blocks: z.record(z.string(), BlockInstanceSchema),
+  local_glyphs: z.record(z.string(), z.string()).optional(),
 })
 
 export type FableBuilderV1 = z.infer<typeof FableBuilderV1Schema>
@@ -330,6 +331,7 @@ export function getBlockKindIcon(kind: BlockKind): LucideIcon {
 export function createEmptyFable(): FableBuilderV1 {
   return {
     blocks: {},
+    local_glyphs: {},
   }
 }
 

--- a/frontend/src/components/base/fields/fields/DateTimeField.tsx
+++ b/frontend/src/components/base/fields/fields/DateTimeField.tsx
@@ -8,7 +8,8 @@
  * does it submit to any jurisdiction.
  */
 
-import { Input } from '@/components/ui/input'
+import { GlyphFieldWrapper } from './GlyphFieldWrapper'
+import { InputGroupInput } from '@/components/ui/input-group'
 
 export interface DateTimeFieldProps {
   id: string
@@ -30,14 +31,22 @@ export function DateTimeField({
   className,
 }: DateTimeFieldProps) {
   return (
-    <Input
+    <GlyphFieldWrapper
       id={id}
-      type={isDateOnly ? 'date' : 'datetime-local'}
       value={value}
-      onChange={(e) => onChange(e.target.value)}
+      onChange={onChange}
       placeholder={placeholder}
       disabled={disabled}
       className={className}
-    />
+    >
+      <InputGroupInput
+        id={id}
+        type={isDateOnly ? 'date' : 'datetime-local'}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        disabled={disabled}
+      />
+    </GlyphFieldWrapper>
   )
 }

--- a/frontend/src/components/base/fields/fields/EnumField.tsx
+++ b/frontend/src/components/base/fields/fields/EnumField.tsx
@@ -8,6 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
+import { GlyphFieldWrapper } from './GlyphFieldWrapper'
 import {
   Select,
   SelectContent,
@@ -36,21 +37,34 @@ export function EnumField({
   className,
 }: EnumFieldProps) {
   return (
-    <Select
-      value={value || null}
-      onValueChange={(newValue) => onChange(newValue ?? '')}
+    <GlyphFieldWrapper
+      id={id}
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
       disabled={disabled}
+      className={className}
     >
-      <SelectTrigger id={id} className={className}>
-        <SelectValue placeholder={placeholder} />
-      </SelectTrigger>
-      <SelectContent>
-        {options.map((option) => (
-          <SelectItem key={option} value={option}>
-            {option}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+      <Select
+        value={value || null}
+        onValueChange={(newValue) => onChange(newValue ?? '')}
+        disabled={disabled}
+      >
+        <SelectTrigger
+          id={id}
+          data-slot="input-group-control"
+          className="flex-1 border-0 shadow-none ring-0 focus-visible:ring-0"
+        >
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((option) => (
+            <SelectItem key={option} value={option}>
+              {option}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </GlyphFieldWrapper>
   )
 }

--- a/frontend/src/components/base/fields/fields/GlyphFieldWrapper.tsx
+++ b/frontend/src/components/base/fields/fields/GlyphFieldWrapper.tsx
@@ -1,0 +1,190 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * GlyphFieldWrapper — Dual-mode container for any field type.
+ *
+ * Uses InputGroup to integrate the glyph toggle button directly into the field.
+ * In "concrete" mode the specialized widget (date picker, dropdown, etc.) is
+ * shown; in "glyph" mode a GlyphTextInput replaces it. The toggle button sits
+ * at the inline-start of the InputGroup.
+ *
+ * The "resolves to" preview is rendered below the InputGroup, outside of it,
+ * so it doesn't affect the field height.
+ *
+ * Auto-detects glyph values on mount. The toggle only appears when glyphs are
+ * available in context.
+ */
+
+import { useEffect, useState } from 'react'
+import { Braces } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { GlyphTextInput } from './GlyphTextInput'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+} from '@/components/ui/input-group'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { useGlyphContext } from '@/features/fable-builder/context/GlyphContext'
+import {
+  containsGlyphs,
+  resolveGlyphValue,
+} from '@/features/fable-builder/utils/glyph-display'
+import { cn } from '@/lib/utils'
+
+export interface GlyphFieldWrapperProps {
+  id: string
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  disabled?: boolean
+  className?: string
+  /** The specialized widget (must use InputGroupInput or data-slot="input-group-control") */
+  children: React.ReactNode
+}
+
+type FieldMode = 'concrete' | 'glyph'
+
+export function GlyphFieldWrapper({
+  id,
+  value,
+  onChange,
+  placeholder,
+  disabled,
+  className,
+  children,
+}: GlyphFieldWrapperProps) {
+  const { t } = useTranslation('glyphs')
+  const glyphs = useGlyphContext()
+  const hasGlyphs = glyphs.length > 0
+
+  const [mode, setMode] = useState<FieldMode>(() =>
+    containsGlyphs(value) ? 'glyph' : 'concrete',
+  )
+  const [autoTrigger, setAutoTrigger] = useState(false)
+
+  // Auto-switch to glyph mode if value changes externally to contain glyphs
+  useEffect(() => {
+    if (containsGlyphs(value) && mode === 'concrete') {
+      setMode('glyph')
+    }
+  }, [value, mode])
+
+  // If no glyphs available, always render concrete mode without the wrapper
+  if (!hasGlyphs) {
+    return <>{children}</>
+  }
+
+  const valueHasGlyphs = containsGlyphs(value)
+  const canSwitchToConcrete = mode === 'glyph' && !valueHasGlyphs
+
+  function handleToggle() {
+    if (mode === 'concrete') {
+      setAutoTrigger(!value)
+      setMode('glyph')
+    } else if (canSwitchToConcrete) {
+      setAutoTrigger(false)
+      setMode('concrete')
+    }
+  }
+
+  const toggleTooltip =
+    mode === 'concrete'
+      ? t('field.switchToGlyph')
+      : valueHasGlyphs
+        ? t('field.cannotSwitchBack')
+        : t('field.switchToConcrete')
+
+  // Resolved preview — rendered below the InputGroup
+  const resolvedPreview =
+    mode === 'glyph' && valueHasGlyphs
+      ? resolveGlyphValue(
+          value,
+          Object.fromEntries(glyphs.map((g) => [g.name, g.valueExample])),
+        )
+      : null
+
+  return (
+    <div>
+      <InputGroup
+        data-disabled={disabled || undefined}
+        className={cn(mode === 'glyph' && 'border-primary/30')}
+      >
+        {mode === 'glyph' ? (
+          <GlyphTextInput
+            id={id}
+            value={value}
+            onChange={onChange}
+            placeholder={placeholder ?? t('field.glyphPlaceholder')}
+            disabled={disabled}
+            className={className}
+            grouped
+            autoTrigger={autoTrigger}
+            onBlurEmpty={() => {
+              setAutoTrigger(false)
+              setMode('concrete')
+            }}
+          />
+        ) : (
+          children
+        )}
+        <InputGroupAddon align="inline-start">
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <InputGroupButton
+                  data-testid="glyph-toggle"
+                  size="icon-xs"
+                  variant={mode === 'glyph' ? 'default' : 'ghost'}
+                  onClick={handleToggle}
+                  disabled={disabled || (mode === 'glyph' && valueHasGlyphs)}
+                  aria-label={toggleTooltip}
+                  className={cn(
+                    mode === 'glyph'
+                      ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+                      : 'text-muted-foreground/60 hover:text-muted-foreground',
+                  )}
+                />
+              }
+            >
+              <Braces className="h-3.5 w-3.5" />
+            </TooltipTrigger>
+            <TooltipContent side="right">{toggleTooltip}</TooltipContent>
+          </Tooltip>
+          <div className="h-5 w-px bg-border" />
+        </InputGroupAddon>
+      </InputGroup>
+
+      {resolvedPreview && resolvedPreview !== value && (
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <div className="mt-1 truncate text-sm text-muted-foreground italic" />
+            }
+          >
+            {t('panel.resolvesTo')}{' '}
+            <span className="font-mono">{resolvedPreview}</span>
+          </TooltipTrigger>
+          <TooltipContent
+            side="bottom"
+            className="max-w-96 font-mono break-all"
+          >
+            {resolvedPreview}
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/base/fields/fields/GlyphTextInput.tsx
+++ b/frontend/src/components/base/fields/fields/GlyphTextInput.tsx
@@ -1,0 +1,248 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * GlyphTextInput — Reusable glyph-aware text input.
+ *
+ * Provides ${…} autocomplete triggered by typing `${`, a "resolves to" preview,
+ * and keyboard navigation. Extracted from StringField so it can be reused by
+ * GlyphFieldWrapper when any field type switches to glyph mode.
+ *
+ * When `grouped` is true, renders an InputGroupInput (for use inside an
+ * InputGroup) instead of a standalone Input.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Input } from '@/components/ui/input'
+import { InputGroupInput } from '@/components/ui/input-group'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { useGlyphContext } from '@/features/fable-builder/context/GlyphContext'
+import { GlyphAutocomplete } from '@/features/fable-builder/components/shared/GlyphAutocomplete'
+import {
+  containsGlyphs,
+  resolveGlyphValue,
+} from '@/features/fable-builder/utils/glyph-display'
+
+export interface GlyphTextInputProps {
+  id: string
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+  disabled?: boolean
+  className?: string
+  /** When true, renders InputGroupInput instead of Input (for use inside InputGroup) */
+  grouped?: boolean
+  /** When true, auto-inserts ${ and opens the autocomplete on mount */
+  autoTrigger?: boolean
+  /** Called when the input blurs with an empty value (used by wrapper to exit glyph mode) */
+  onBlurEmpty?: () => void
+}
+
+/**
+ * Detects an open ${ pattern before the cursor position and returns the
+ * partial filter text, or null if autocomplete should not trigger.
+ */
+function detectGlyphTrigger(value: string, cursorPos: number): string | null {
+  const before = value.slice(0, cursorPos)
+  const triggerIndex = before.lastIndexOf('${')
+  if (triggerIndex === -1) return null
+
+  const afterTrigger = before.slice(triggerIndex + 2)
+  // Only trigger if we haven't closed the brace yet
+  if (afterTrigger.includes('}')) return null
+  // Only allow word characters in the partial
+  if (!/^\w*$/.test(afterTrigger)) return null
+
+  return afterTrigger
+}
+
+export function GlyphTextInput({
+  id,
+  value,
+  onChange,
+  placeholder,
+  disabled,
+  className,
+  grouped = false,
+  autoTrigger = false,
+  onBlurEmpty,
+}: GlyphTextInputProps) {
+  const { t } = useTranslation('glyphs')
+  const glyphs = useGlyphContext()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [autocompleteFilter, setAutocompleteFilter] = useState<string | null>(
+    null,
+  )
+  const [cursorPos, setCursorPos] = useState(0)
+
+  const hasGlyphs = glyphs.length > 0
+
+  // Auto-insert ${ and open autocomplete when entering glyph mode on an empty field
+  const didAutoTrigger = useRef(false)
+  useEffect(() => {
+    if (autoTrigger && hasGlyphs && !value && !didAutoTrigger.current) {
+      didAutoTrigger.current = true
+      onChange('${')
+      setCursorPos(2)
+      setAutocompleteFilter('')
+      requestAnimationFrame(() => {
+        const input = inputRef.current
+        if (input) {
+          input.focus()
+          input.setSelectionRange(2, 2)
+        }
+      })
+    }
+  }, [autoTrigger, hasGlyphs, value, onChange])
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = e.target.value
+      const pos = e.target.selectionStart ?? newValue.length
+      setCursorPos(pos)
+      onChange(newValue)
+
+      if (hasGlyphs) {
+        setAutocompleteFilter(detectGlyphTrigger(newValue, pos))
+      }
+    },
+    [onChange, hasGlyphs],
+  )
+
+  const handleKeyUp = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      const pos = e.currentTarget.selectionStart ?? value.length
+      setCursorPos(pos)
+      if (hasGlyphs) {
+        setAutocompleteFilter(detectGlyphTrigger(value, pos))
+      }
+    },
+    [value, hasGlyphs],
+  )
+
+  const handleSelect = useCallback(
+    (glyphName: string) => {
+      // Find the ${ trigger position before cursor
+      const before = value.slice(0, cursorPos)
+      const triggerIndex = before.lastIndexOf('${')
+      if (triggerIndex === -1) return
+
+      const newValue =
+        value.slice(0, triggerIndex) +
+        '${' +
+        glyphName +
+        '}' +
+        value.slice(cursorPos)
+      onChange(newValue)
+      setAutocompleteFilter(null)
+
+      // Restore focus and move cursor after the inserted glyph
+      requestAnimationFrame(() => {
+        const input = inputRef.current
+        if (input) {
+          input.focus()
+          const newPos = triggerIndex + glyphName.length + 3 // ${ + name + }
+          input.setSelectionRange(newPos, newPos)
+        }
+      })
+    },
+    [value, cursorPos, onChange],
+  )
+
+  const handleClose = useCallback(() => {
+    setAutocompleteFilter(null)
+  }, [])
+
+  const handleBlur = useCallback(() => {
+    // Delay close to allow mousedown on autocomplete items
+    setTimeout(() => {
+      setAutocompleteFilter(null)
+      // If the field is empty on blur, signal the wrapper to exit glyph mode
+      if (onBlurEmpty && !inputRef.current?.value) {
+        onBlurEmpty()
+      }
+    }, 150)
+  }, [onBlurEmpty])
+
+  // Build resolved preview
+  const showPreview = hasGlyphs && containsGlyphs(value)
+  const resolvedPreview = showPreview
+    ? resolveGlyphValue(
+        value,
+        Object.fromEntries(glyphs.map((g) => [g.name, g.valueExample])),
+      )
+    : null
+
+  const inputProps = {
+    ref: inputRef,
+    id,
+    type: 'text' as const,
+    value,
+    onChange: handleChange,
+    onKeyUp: handleKeyUp,
+    onBlur: handleBlur,
+    placeholder,
+    disabled,
+    spellCheck: hasGlyphs ? false : undefined,
+    autoComplete: 'off' as const,
+    className,
+  }
+
+  const autocompleteDropdown = autocompleteFilter !== null && (
+    <div className="absolute top-full right-0 left-0 z-50 mt-1">
+      <GlyphAutocomplete
+        glyphs={glyphs}
+        filter={autocompleteFilter}
+        onSelect={handleSelect}
+        onClose={handleClose}
+      />
+    </div>
+  )
+
+  const previewElement = resolvedPreview && resolvedPreview !== value && (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <div className="mt-1 truncate text-sm text-muted-foreground italic" />
+        }
+      >
+        {t('panel.resolvesTo')}{' '}
+        <span className="font-mono">{resolvedPreview}</span>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" className="max-w-96 font-mono break-all">
+        {resolvedPreview}
+      </TooltipContent>
+    </Tooltip>
+  )
+
+  // When grouped (inside InputGroup), only render the input inline.
+  // The autocomplete and preview are rendered outside via the wrapper.
+  if (grouped) {
+    return (
+      <>
+        <InputGroupInput {...inputProps} />
+        {autocompleteDropdown}
+      </>
+    )
+  }
+
+  return (
+    <div className="relative">
+      <Input {...inputProps} />
+      {autocompleteDropdown}
+      {previewElement}
+    </div>
+  )
+}

--- a/frontend/src/components/base/fields/fields/ListField.tsx
+++ b/frontend/src/components/base/fields/fields/ListField.tsx
@@ -10,9 +10,10 @@
 
 import { useCallback, useState } from 'react'
 import { X } from 'lucide-react'
+import { GlyphFieldWrapper } from './GlyphFieldWrapper'
 import type { KeyboardEvent } from 'react'
 import { Badge } from '@/components/ui/badge'
-import { Input } from '@/components/ui/input'
+import { InputGroupInput } from '@/components/ui/input-group'
 import { cn } from '@/lib/utils'
 
 export interface ListFieldProps {
@@ -43,6 +44,34 @@ function serializeListValue(items: Array<string>): string {
 }
 
 export function ListField({
+  id,
+  value,
+  onChange,
+  placeholder = 'Add item...',
+  disabled,
+  className,
+}: ListFieldProps) {
+  return (
+    <GlyphFieldWrapper
+      id={id}
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+      disabled={disabled}
+      className={className}
+    >
+      <ListFieldConcrete
+        id={id}
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        disabled={disabled}
+      />
+    </GlyphFieldWrapper>
+  )
+}
+
+function ListFieldConcrete({
   id,
   value,
   onChange,
@@ -84,28 +113,30 @@ export function ListField({
 
   return (
     <div className={cn('space-y-2', className)}>
-      <div className="flex flex-wrap gap-1.5">
-        {items.map((item, index) => (
-          <Badge
-            key={`${item}-${index}`}
-            variant="secondary"
-            className="gap-1 pr-1"
-          >
-            {item}
-            {!disabled && (
-              <button
-                type="button"
-                onClick={() => removeItem(index)}
-                className="ml-1 rounded-full p-0.5 transition-colors hover:bg-muted-foreground/20"
-                aria-label={`Remove ${item}`}
-              >
-                <X className="h-3 w-3" />
-              </button>
-            )}
-          </Badge>
-        ))}
-      </div>
-      <Input
+      {items.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {items.map((item, index) => (
+            <Badge
+              key={`${item}-${index}`}
+              variant="secondary"
+              className="gap-1 pr-1"
+            >
+              {item}
+              {!disabled && (
+                <button
+                  type="button"
+                  onClick={() => removeItem(index)}
+                  className="ml-1 rounded-full p-0.5 transition-colors hover:bg-muted-foreground/20"
+                  aria-label={`Remove ${item}`}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              )}
+            </Badge>
+          ))}
+        </div>
+      )}
+      <InputGroupInput
         id={id}
         type="text"
         value={inputValue}

--- a/frontend/src/components/base/fields/fields/NumberField.tsx
+++ b/frontend/src/components/base/fields/fields/NumberField.tsx
@@ -8,7 +8,8 @@
  * does it submit to any jurisdiction.
  */
 
-import { Input } from '@/components/ui/input'
+import { GlyphFieldWrapper } from './GlyphFieldWrapper'
+import { InputGroupInput } from '@/components/ui/input-group'
 
 export interface NumberFieldProps {
   id: string
@@ -30,15 +31,23 @@ export function NumberField({
   className,
 }: NumberFieldProps) {
   return (
-    <Input
+    <GlyphFieldWrapper
       id={id}
-      type="number"
-      step={isInteger ? '1' : 'any'}
       value={value}
-      onChange={(e) => onChange(e.target.value)}
+      onChange={onChange}
       placeholder={placeholder}
       disabled={disabled}
       className={className}
-    />
+    >
+      <InputGroupInput
+        id={id}
+        type="number"
+        step={isInteger ? '1' : 'any'}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        disabled={disabled}
+      />
+    </GlyphFieldWrapper>
   )
 }

--- a/frontend/src/components/base/fields/fields/StringField.tsx
+++ b/frontend/src/components/base/fields/fields/StringField.tsx
@@ -8,20 +8,8 @@
  * does it submit to any jurisdiction.
  */
 
-import { useCallback, useRef, useState } from 'react'
-import { useTranslation } from 'react-i18next'
-import { Input } from '@/components/ui/input'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
-import { useGlyphContext } from '@/features/fable-builder/context/GlyphContext'
-import { GlyphAutocomplete } from '@/features/fable-builder/components/shared/GlyphAutocomplete'
-import {
-  containsGlyphs,
-  resolveGlyphValue,
-} from '@/features/fable-builder/utils/glyph-display'
+import { GlyphFieldWrapper } from './GlyphFieldWrapper'
+import { InputGroupInput } from '@/components/ui/input-group'
 
 export interface StringFieldProps {
   id: string
@@ -33,23 +21,9 @@ export interface StringFieldProps {
 }
 
 /**
- * Detects an open ${ pattern before the cursor position and returns the
- * partial filter text, or null if autocomplete should not trigger.
+ * String config field — uses GlyphFieldWrapper for consistent visual treatment.
+ * In concrete mode: plain text input. In glyph mode: text input with autocomplete.
  */
-function detectGlyphTrigger(value: string, cursorPos: number): string | null {
-  const before = value.slice(0, cursorPos)
-  const triggerIndex = before.lastIndexOf('${')
-  if (triggerIndex === -1) return null
-
-  const afterTrigger = before.slice(triggerIndex + 2)
-  // Only trigger if we haven't closed the brace yet
-  if (afterTrigger.includes('}')) return null
-  // Only allow word characters in the partial
-  if (!/^\w*$/.test(afterTrigger)) return null
-
-  return afterTrigger
-}
-
 export function StringField({
   id,
   value,
@@ -58,134 +32,23 @@ export function StringField({
   disabled,
   className,
 }: StringFieldProps) {
-  const { t } = useTranslation('glyphs')
-  const glyphs = useGlyphContext()
-  const inputRef = useRef<HTMLInputElement>(null)
-  const [autocompleteFilter, setAutocompleteFilter] = useState<string | null>(
-    null,
-  )
-  const [cursorPos, setCursorPos] = useState(0)
-
-  const hasGlyphs = glyphs.length > 0
-
-  const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const newValue = e.target.value
-      const pos = e.target.selectionStart ?? newValue.length
-      setCursorPos(pos)
-      onChange(newValue)
-
-      if (hasGlyphs) {
-        setAutocompleteFilter(detectGlyphTrigger(newValue, pos))
-      }
-    },
-    [onChange, hasGlyphs],
-  )
-
-  const handleKeyUp = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement>) => {
-      const pos = e.currentTarget.selectionStart ?? value.length
-      setCursorPos(pos)
-      if (hasGlyphs) {
-        setAutocompleteFilter(detectGlyphTrigger(value, pos))
-      }
-    },
-    [value, hasGlyphs],
-  )
-
-  const handleSelect = useCallback(
-    (glyphName: string) => {
-      // Find the ${ trigger position before cursor
-      const before = value.slice(0, cursorPos)
-      const triggerIndex = before.lastIndexOf('${')
-      if (triggerIndex === -1) return
-
-      const newValue =
-        value.slice(0, triggerIndex) +
-        '${' +
-        glyphName +
-        '}' +
-        value.slice(cursorPos)
-      onChange(newValue)
-      setAutocompleteFilter(null)
-
-      // Restore focus and move cursor after the inserted glyph
-      requestAnimationFrame(() => {
-        const input = inputRef.current
-        if (input) {
-          input.focus()
-          const newPos = triggerIndex + glyphName.length + 3 // ${ + name + }
-          input.setSelectionRange(newPos, newPos)
-        }
-      })
-    },
-    [value, cursorPos, onChange],
-  )
-
-  const handleClose = useCallback(() => {
-    setAutocompleteFilter(null)
-  }, [])
-
-  const handleBlur = useCallback(() => {
-    // Delay close to allow mousedown on autocomplete items
-    setTimeout(() => setAutocompleteFilter(null), 150)
-  }, [])
-
-  // Build resolved preview
-  const showPreview = hasGlyphs && containsGlyphs(value)
-  const resolvedPreview = showPreview
-    ? resolveGlyphValue(
-        value,
-        Object.fromEntries(glyphs.map((g) => [g.name, g.valueExample])),
-      )
-    : null
-
   return (
-    <div className="relative">
-      <Input
-        ref={inputRef}
+    <GlyphFieldWrapper
+      id={id}
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+      disabled={disabled}
+      className={className}
+    >
+      <InputGroupInput
         id={id}
         type="text"
         value={value}
-        onChange={handleChange}
-        onKeyUp={handleKeyUp}
-        onBlur={handleBlur}
+        onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
         disabled={disabled}
-        spellCheck={hasGlyphs ? false : undefined}
-        autoComplete="off"
-        className={className}
       />
-
-      {autocompleteFilter !== null && (
-        <div className="absolute top-full right-0 left-0 z-50 mt-1">
-          <GlyphAutocomplete
-            glyphs={glyphs}
-            filter={autocompleteFilter}
-            onSelect={handleSelect}
-            onClose={handleClose}
-          />
-        </div>
-      )}
-
-      {resolvedPreview && resolvedPreview !== value && (
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <div className="mt-1 truncate text-sm text-muted-foreground italic" />
-            }
-          >
-            {t('panel.resolvesTo')}{' '}
-            <span className="font-mono">{resolvedPreview}</span>
-          </TooltipTrigger>
-          <TooltipContent
-            side="bottom"
-            className="max-w-96 font-mono break-all"
-          >
-            {resolvedPreview}
-          </TooltipContent>
-        </Tooltip>
-      )}
-    </div>
+    </GlyphFieldWrapper>
   )
 }

--- a/frontend/src/components/common/ActivityMonitor.tsx
+++ b/frontend/src/components/common/ActivityMonitor.tsx
@@ -1,0 +1,233 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * ActivityMonitor Component
+ *
+ * Header icon with badge showing active long-running tasks.
+ * Click to open a popover with task details, progress, and navigation.
+ */
+
+import { useMemo } from 'react'
+import { formatDistanceToNow } from 'date-fns'
+import {
+  AlertCircle,
+  Bell,
+  Blocks,
+  Check,
+  ChevronRight,
+  Download,
+  HelpCircle,
+  Play,
+  X,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Link } from '@tanstack/react-router'
+import type { ActivityTask, ActivityTaskType } from '@/stores/activityStore'
+import { useActivityStore } from '@/stores/activityStore'
+import { useActivityCollector } from '@/hooks/useActivityCollector'
+import { P } from '@/components/base/typography'
+import { Button } from '@/components/ui/button'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+const TYPE_CONFIG: Record<
+  ActivityTaskType,
+  { icon: typeof Bell; badgeColor: string }
+> = {
+  plugin: { icon: Blocks, badgeColor: 'bg-purple-500' },
+  download: { icon: Download, badgeColor: 'bg-blue-500' },
+  job: { icon: Play, badgeColor: 'bg-emerald-500' },
+}
+
+export function ActivityMonitor() {
+  const { t } = useTranslation('common')
+  useActivityCollector()
+
+  const tasks = useActivityStore((state) => state.tasks)
+  const clearCompleted = useActivityStore((state) => state.clearCompleted)
+
+  const taskList = useMemo(() => {
+    const items = Object.values(tasks).filter(
+      (item): item is ActivityTask => item !== undefined,
+    )
+    return items.sort((a, b) => {
+      // Active first, then by most recent
+      if (a.status === 'active' && b.status !== 'active') return -1
+      if (a.status !== 'active' && b.status === 'active') return 1
+      return b.startedAt - a.startedAt
+    })
+  }, [tasks])
+
+  const activeCount = taskList.filter((task) => task.status === 'active').length
+  const hasCompleted = taskList.some((task) => task.status !== 'active')
+  const hasFailed = taskList.some((task) => task.status === 'failed')
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon"
+            className="relative text-muted-foreground"
+            aria-label={t('activity.label')}
+          />
+        }
+      >
+        <Bell className={cn('h-5 w-5', activeCount > 0 && 'animate-pulse')} />
+        {activeCount > 0 && (
+          <span
+            className={cn(
+              'absolute -top-0.5 -right-0.5 flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] font-bold text-white',
+              hasFailed ? 'bg-destructive' : 'bg-primary',
+            )}
+          >
+            {activeCount}
+          </span>
+        )}
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80 p-0">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border px-4 py-3">
+          <div className="flex items-center gap-1.5">
+            <P className="text-sm font-medium">{t('activity.title')}</P>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
+                    className="text-muted-foreground/60 hover:text-muted-foreground"
+                  />
+                }
+              >
+                <HelpCircle className="h-3.5 w-3.5" />
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="max-w-64">
+                {t('activity.help')}
+              </TooltipContent>
+            </Tooltip>
+          </div>
+          {hasCompleted && (
+            <button
+              type="button"
+              onClick={clearCompleted}
+              className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+            >
+              <X className="h-3 w-3" />
+              {t('activity.clear')}
+            </button>
+          )}
+        </div>
+
+        {/* Task list or empty state */}
+        {taskList.length > 0 ? (
+          <div className="max-h-72 divide-y divide-border overflow-y-auto">
+            {taskList.map((task) => (
+              <ActivityTaskRow key={task.id} task={task} />
+            ))}
+          </div>
+        ) : (
+          <div className="px-4 py-6 text-center text-sm text-muted-foreground">
+            {t('activity.empty')}
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+function ActivityTaskRow({ task }: { task: ActivityTask }) {
+  const StatusIcon = getStatusIcon(task)
+  const statusColor = getStatusColor(task)
+
+  const timeAgo = formatDistanceToNow(task.completedAt ?? task.startedAt, {
+    addSuffix: true,
+  })
+
+  const content = (
+    <div
+      className={cn(
+        'group flex items-center gap-3 px-4 py-3 transition-colors',
+        task.navigateTo && 'hover:bg-muted/50',
+        task.status !== 'active' && 'opacity-60',
+      )}
+    >
+      {/* Type/status icon */}
+      <div
+        className={cn(
+          'flex h-8 w-8 shrink-0 items-center justify-center rounded-full',
+          statusColor,
+        )}
+      >
+        <StatusIcon className="h-4 w-4 text-white" />
+      </div>
+
+      {/* Content */}
+      <div className="min-w-0 flex-1">
+        <P className="truncate text-sm font-medium">{task.label}</P>
+        <div className="flex items-center gap-2">
+          <P className="truncate text-sm text-muted-foreground">
+            {task.description}
+          </P>
+        </div>
+        {/* Progress bar for downloads */}
+        {task.type === 'download' &&
+          task.status === 'active' &&
+          task.progress != null && (
+            <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+              <div
+                className="h-full rounded-full bg-blue-500 transition-all duration-300"
+                style={{ width: `${task.progress}%` }}
+              />
+            </div>
+          )}
+        {/* Time */}
+        <P className="mt-0.5 text-sm text-muted-foreground/60">{timeAgo}</P>
+      </div>
+
+      {/* Navigation chevron */}
+      {task.navigateTo && (
+        <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground/0 transition-colors group-hover:text-muted-foreground" />
+      )}
+    </div>
+  )
+
+  if (task.navigateTo) {
+    return (
+      <Link to={task.navigateTo} className="block">
+        {content}
+      </Link>
+    )
+  }
+
+  return content
+}
+
+function getStatusIcon(task: ActivityTask) {
+  if (task.status === 'completed') return Check
+  if (task.status === 'failed') return AlertCircle
+  return TYPE_CONFIG[task.type].icon
+}
+
+function getStatusColor(task: ActivityTask): string {
+  if (task.status === 'completed') return 'bg-muted-foreground/50'
+  if (task.status === 'failed') return 'bg-destructive'
+  return TYPE_CONFIG[task.type].badgeColor
+}

--- a/frontend/src/components/layout/AuthenticatedHeader.tsx
+++ b/frontend/src/components/layout/AuthenticatedHeader.tsx
@@ -49,6 +49,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { Logo } from '@/components/common/Logo'
+import { ActivityMonitor } from '@/components/common/ActivityMonitor'
 import { NavToggle } from '@/components/layout/NavToggle'
 import { StatusDetailsPopover } from '@/components/common/StatusDetailsPopover'
 import { StatusIndicator } from '@/components/common/StatusIndicator'
@@ -117,6 +118,9 @@ export function AuthenticatedHeader() {
               showLabel={trafficLightStatus !== 'green'}
             />
           </StatusDetailsPopover>
+
+          {/* Activity Monitor */}
+          <ActivityMonitor />
 
           {/* Help Button */}
           <Button

--- a/frontend/src/features/executions/components/ExecutionDetailPage.tsx
+++ b/frontend/src/features/executions/components/ExecutionDetailPage.tsx
@@ -31,6 +31,7 @@ import { useDeleteJob, useJobStatus, useRestartJob } from '@/api/hooks/useJobs'
 import { LoadingSpinner } from '@/components/common/LoadingSpinner'
 import { Button } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { useActivityStore } from '@/stores/activityStore'
 import { useUiStore } from '@/stores/uiStore'
 import { P } from '@/components/base/typography'
 import { cn } from '@/lib/utils'
@@ -59,6 +60,15 @@ export function ExecutionDetailPage() {
       { runId: jobId, attemptCount: jobData!.attempt_count },
       {
         onSuccess: () => {
+          useActivityStore.getState().addTask({
+            id: `job:${jobId}`,
+            type: 'job',
+            label: fableData?.display_name ?? `Job ${jobId.slice(0, 8)}`,
+            description: `Restarting (attempt ${jobData!.attempt_count + 1})`,
+            status: 'active',
+            startedAt: Date.now(),
+            navigateTo: `/executions/${jobId}`,
+          })
           showToast.success(t('actions.restartJob'))
         },
         onError: (error) => {

--- a/frontend/src/features/executions/components/SubmitJobDialog.tsx
+++ b/frontend/src/features/executions/components/SubmitJobDialog.tsx
@@ -36,6 +36,7 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { useActivityStore } from '@/stores/activityStore'
 import { cn } from '@/lib/utils'
 
 type SubmitMode = 'run' | 'schedule'
@@ -165,6 +166,16 @@ function SubmitJobForm({
         tags: finalTags,
         fableId,
         environment,
+      })
+
+      useActivityStore.getState().addTask({
+        id: `job:${response.run_id}`,
+        type: 'job',
+        label: trimmedName ?? `Job ${response.run_id.slice(0, 8)}`,
+        description: 'Submitted',
+        status: 'active',
+        startedAt: Date.now(),
+        navigateTo: `/executions/${response.run_id}`,
       })
 
       showToast.success(t('submit.title'), trimmedName ?? undefined)

--- a/frontend/src/features/fable-builder/components/SaveConfigPopover.tsx
+++ b/frontend/src/features/fable-builder/components/SaveConfigPopover.tsx
@@ -20,6 +20,7 @@ import {
   BLOCK_KIND_ORDER,
   getBlocksByKind,
 } from '@/api/types/fable.types'
+import { ApiClientError } from '@/api/client'
 import { useFableRetrieve, useUpsertFable } from '@/api/hooks/useFable'
 import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
 import { showToast } from '@/lib/toast'
@@ -215,10 +216,25 @@ export function SaveConfigPopover({
         asCopy ? t('configure:save.savedAsNew') : t('configure:save.saved'),
       )
     } catch (error) {
-      showToast.error(
-        t('configure:save.saveFailed'),
-        error instanceof Error ? error.message : String(error),
-      )
+      let description: string
+      if (
+        error instanceof ApiClientError &&
+        error.status === 422 &&
+        error.details
+      ) {
+        const detail = error.details as {
+          global_errors?: Array<string>
+          block_errors?: Record<string, Array<string>>
+        }
+        const messages = [
+          ...(detail.global_errors ?? []),
+          ...Object.values(detail.block_errors ?? {}).flat(),
+        ]
+        description = messages.join('; ') || error.message
+      } else {
+        description = error instanceof Error ? error.message : String(error)
+      }
+      showToast.error(t('configure:save.saveFailed'), description)
     }
   }
 

--- a/frontend/src/features/fable-builder/components/shared/GlyphAutocomplete.tsx
+++ b/frontend/src/features/fable-builder/components/shared/GlyphAutocomplete.tsx
@@ -47,7 +47,8 @@ export function GlyphAutocomplete({
 
   const intrinsic = filtered.filter((g) => g.type === 'intrinsic')
   const global = filtered.filter((g) => g.type === 'global')
-  const allItems = [...global, ...intrinsic]
+  const local = filtered.filter((g) => g.type === 'local')
+  const allItems = [...local, ...global, ...intrinsic]
 
   useEffect(() => {
     setActiveIndex(0)
@@ -91,8 +92,28 @@ export function GlyphAutocomplete({
       ref={listRef}
       className="max-h-48 overflow-y-auto rounded-md border border-border bg-popover p-1 shadow-md"
     >
+      {local.length > 0 && (
+        <>
+          <P className="px-2 py-1 text-sm font-medium text-muted-foreground">
+            {t('panel.local')}
+          </P>
+          {local.map((g) => {
+            const idx = itemIndex++
+            return (
+              <AutocompleteItem
+                key={g.name}
+                glyph={g}
+                active={idx === activeIndex}
+                onSelect={() => onSelect(g.name)}
+                onHover={() => setActiveIndex(idx)}
+              />
+            )
+          })}
+        </>
+      )}
       {global.length > 0 && (
         <>
+          {local.length > 0 && <div className="my-1 border-t border-border" />}
           <P className="px-2 py-1 text-sm font-medium text-muted-foreground">
             {t('panel.global')}
           </P>
@@ -112,7 +133,9 @@ export function GlyphAutocomplete({
       )}
       {intrinsic.length > 0 && (
         <>
-          {global.length > 0 && <div className="my-1 border-t border-border" />}
+          {(local.length > 0 || global.length > 0) && (
+            <div className="my-1 border-t border-border" />
+          )}
           <P className="px-2 py-1 text-sm font-medium text-muted-foreground">
             {t('panel.intrinsic')}
           </P>

--- a/frontend/src/features/fable-builder/components/shared/GlyphReferencePanel.tsx
+++ b/frontend/src/features/fable-builder/components/shared/GlyphReferencePanel.tsx
@@ -11,23 +11,30 @@
 /**
  * GlyphReferencePanel Component
  *
- * Shows available intrinsic and global glyphs in the config panel.
+ * Shows available intrinsic, global, and local glyphs in the config panel.
  * Click a glyph to copy ${key} to clipboard. Link to admin page for management.
+ * Local glyphs can be added, edited, and removed inline.
  */
 
 import { useState } from 'react'
 import {
   Braces,
+  Check,
   ChevronDown,
   ChevronRight,
   Copy,
   ExternalLink,
   HelpCircle,
+  Pencil,
+  Plus,
+  Trash2,
+  X,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Link } from '@tanstack/react-router'
 import type { GlyphInfo } from '@/features/fable-builder/hooks/useAllGlyphs'
 import { useAllGlyphs } from '@/features/fable-builder/hooks/useAllGlyphs'
+import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
 import { showToast } from '@/lib/toast'
 import { P } from '@/components/base/typography'
 import {
@@ -37,16 +44,22 @@ import {
 } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 
+const EMPTY_GLYPHS: Record<string, string> = {}
+
 export function GlyphReferencePanel() {
   const { t } = useTranslation('glyphs')
-  const { glyphs, isLoading } = useAllGlyphs()
+  const localGlyphs =
+    useFableBuilderStore((state) => state.fable.local_glyphs) ?? EMPTY_GLYPHS
+  const { glyphs, isLoading } = useAllGlyphs(localGlyphs)
   const [intrinsicOpen, setIntrinsicOpen] = useState(false)
   const [globalOpen, setGlobalOpen] = useState(true)
+  const [localOpen, setLocalOpen] = useState(true)
 
   if (isLoading) return null
 
   const intrinsicGlyphs = glyphs.filter((g) => g.type === 'intrinsic')
   const globalGlyphs = glyphs.filter((g) => g.type === 'global')
+  const localGlyphList = glyphs.filter((g) => g.type === 'local')
 
   function handleCopy(name: string) {
     const ref = '${' + name + '}'
@@ -88,6 +101,17 @@ export function GlyphReferencePanel() {
           <ExternalLink className="h-3 w-3" />
         </Link>
       </div>
+
+      {/* Local section */}
+      <LocalGlyphSection
+        title={t('panel.local')}
+        tooltip={t('panel.localTooltip')}
+        open={localOpen}
+        onToggle={() => setLocalOpen(!localOpen)}
+        glyphs={localGlyphList}
+        onCopy={handleCopy}
+        exampleLabel={t('panel.example')}
+      />
 
       {/* Global section */}
       <GlyphSection
@@ -160,6 +184,285 @@ function GlyphSection({
       </button>
       {open && <div className="space-y-0.5 pb-2">{children}</div>}
     </div>
+  )
+}
+
+function LocalGlyphSection({
+  title,
+  tooltip,
+  open,
+  onToggle,
+  glyphs,
+  onCopy,
+  exampleLabel,
+}: {
+  title: string
+  tooltip: string
+  open: boolean
+  onToggle: () => void
+  glyphs: Array<GlyphInfo>
+  onCopy: (name: string) => void
+  exampleLabel: string
+}) {
+  const { t } = useTranslation('glyphs')
+  const setLocalGlyph = useFableBuilderStore((state) => state.setLocalGlyph)
+  const removeLocalGlyph = useFableBuilderStore(
+    (state) => state.removeLocalGlyph,
+  )
+  const [editingKey, setEditingKey] = useState<string | null>(null)
+  const [editValue, setEditValue] = useState('')
+  const [isAdding, setIsAdding] = useState(false)
+  const [newKey, setNewKey] = useState('')
+  const [newValue, setNewValue] = useState('')
+
+  function handleStartEdit(glyph: GlyphInfo) {
+    setEditingKey(glyph.name)
+    setEditValue(glyph.valueExample)
+  }
+
+  function handleSaveEdit() {
+    if (editingKey && editValue.trim()) {
+      setLocalGlyph(editingKey, editValue.trim())
+      setEditingKey(null)
+      setEditValue('')
+    }
+  }
+
+  function handleCancelEdit() {
+    setEditingKey(null)
+    setEditValue('')
+  }
+
+  function handleAdd() {
+    const key = newKey.trim()
+    const value = newValue.trim()
+    if (key && value) {
+      setLocalGlyph(key, value)
+      setNewKey('')
+      setNewValue('')
+      setIsAdding(false)
+    }
+  }
+
+  function handleCancelAdd() {
+    setNewKey('')
+    setNewValue('')
+    setIsAdding(false)
+  }
+
+  return (
+    <div className="border-t border-border/50">
+      <div className="flex w-full items-center gap-1.5 px-3 py-2">
+        <button
+          type="button"
+          onClick={onToggle}
+          className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground"
+        >
+          {open ? (
+            <ChevronDown className="h-3.5 w-3.5" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5" />
+          )}
+          {title}
+        </button>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                className="text-muted-foreground/60 hover:text-muted-foreground"
+              />
+            }
+          >
+            <HelpCircle className="h-3 w-3" />
+          </TooltipTrigger>
+          <TooltipContent side="bottom" className="max-w-64">
+            {tooltip}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+      {open && (
+        <div className="space-y-0.5 pb-2">
+          {glyphs.length > 0
+            ? glyphs.map((g) =>
+                editingKey === g.name ? (
+                  <div
+                    key={g.name}
+                    className="flex items-center gap-1.5 px-3 py-1"
+                  >
+                    <code className="shrink-0 rounded bg-muted px-1.5 py-0.5 font-mono text-sm">
+                      {'${' + g.name + '}'}
+                    </code>
+                    <input
+                      type="text"
+                      value={editValue}
+                      onChange={(e) => setEditValue(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') handleSaveEdit()
+                        if (e.key === 'Escape') handleCancelEdit()
+                      }}
+                      className="min-w-0 flex-1 rounded border border-border bg-background px-1.5 py-0.5 text-sm focus:ring-1 focus:ring-ring focus:outline-none"
+                      autoFocus
+                    />
+                    <button
+                      type="button"
+                      onClick={handleSaveEdit}
+                      className="shrink-0 text-muted-foreground hover:text-foreground"
+                    >
+                      <Check className="h-3.5 w-3.5" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleCancelEdit}
+                      className="shrink-0 text-muted-foreground hover:text-foreground"
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                ) : (
+                  <LocalGlyphRow
+                    key={g.name}
+                    glyph={g}
+                    onCopy={onCopy}
+                    onEdit={() => handleStartEdit(g)}
+                    onDelete={() => removeLocalGlyph(g.name)}
+                    exampleLabel={exampleLabel}
+                  />
+                ),
+              )
+            : !isAdding && (
+                <div className="px-3 pb-1 text-sm text-muted-foreground">
+                  {t('panel.noLocal')} {t('panel.addLocalHint')}
+                </div>
+              )}
+
+          {isAdding ? (
+            <div className="flex items-center gap-1.5 px-3 py-1">
+              <input
+                type="text"
+                value={newKey}
+                onChange={(e) => setNewKey(e.target.value)}
+                placeholder={t('panel.localKeyPlaceholder')}
+                className="w-20 shrink-0 rounded border border-border bg-background px-1.5 py-0.5 font-mono text-sm focus:ring-1 focus:ring-ring focus:outline-none"
+                autoFocus
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleAdd()
+                  if (e.key === 'Escape') handleCancelAdd()
+                }}
+              />
+              <input
+                type="text"
+                value={newValue}
+                onChange={(e) => setNewValue(e.target.value)}
+                placeholder={t('panel.localValuePlaceholder')}
+                className="min-w-0 flex-1 rounded border border-border bg-background px-1.5 py-0.5 text-sm focus:ring-1 focus:ring-ring focus:outline-none"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleAdd()
+                  if (e.key === 'Escape') handleCancelAdd()
+                }}
+              />
+              <button
+                type="button"
+                onClick={handleAdd}
+                disabled={!newKey.trim() || !newValue.trim()}
+                className="shrink-0 text-muted-foreground hover:text-foreground disabled:opacity-40"
+              >
+                <Check className="h-3.5 w-3.5" />
+              </button>
+              <button
+                type="button"
+                onClick={handleCancelAdd}
+                className="shrink-0 text-muted-foreground hover:text-foreground"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setIsAdding(true)}
+              className="flex w-full items-center gap-1.5 px-3 py-1 text-sm text-muted-foreground hover:text-foreground"
+            >
+              <Plus className="h-3.5 w-3.5" />
+              {t('panel.addLocal')}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function LocalGlyphRow({
+  glyph,
+  onCopy,
+  onEdit,
+  onDelete,
+  exampleLabel,
+}: {
+  glyph: GlyphInfo
+  onCopy: (name: string) => void
+  onEdit: () => void
+  onDelete: () => void
+  exampleLabel: string
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <div
+            className={cn(
+              'group flex w-full items-center gap-2 rounded px-3 py-1 text-left text-sm',
+              'transition-colors hover:bg-muted/80',
+            )}
+          />
+        }
+      >
+        <button
+          type="button"
+          onClick={() => onCopy(glyph.name)}
+          className="flex min-w-0 flex-1 items-center gap-2"
+        >
+          <code className="shrink-0 rounded bg-muted px-1.5 py-0.5 font-mono text-sm">
+            {'${' + glyph.name + '}'}
+          </code>
+          <P className="min-w-0 truncate text-sm text-muted-foreground">
+            {glyph.valueExample}
+          </P>
+        </button>
+        <div className="flex shrink-0 items-center gap-0.5 text-muted-foreground/0 transition-colors group-hover:text-muted-foreground">
+          <button
+            type="button"
+            onClick={onEdit}
+            className="hover:text-foreground"
+          >
+            <Pencil className="h-3 w-3" />
+          </button>
+          <button
+            type="button"
+            onClick={onDelete}
+            className="hover:text-destructive"
+          >
+            <Trash2 className="h-3 w-3" />
+          </button>
+          <button
+            type="button"
+            onClick={() => onCopy(glyph.name)}
+            className="hover:text-foreground"
+          >
+            <Copy className="h-3 w-3" />
+          </button>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent side="left">
+        <div className="space-y-1">
+          <div className="font-medium">{'${' + glyph.name + '}'}</div>
+          <div className="font-mono text-muted-foreground">
+            {exampleLabel} {glyph.valueExample}
+          </div>
+        </div>
+      </TooltipContent>
+    </Tooltip>
   )
 }
 

--- a/frontend/src/features/fable-builder/context/GlyphContext.tsx
+++ b/frontend/src/features/fable-builder/context/GlyphContext.tsx
@@ -17,11 +17,17 @@ import { createContext, useContext } from 'react'
 import type { ReactNode } from 'react'
 import type { GlyphInfo } from '@/features/fable-builder/hooks/useAllGlyphs'
 import { useAllGlyphs } from '@/features/fable-builder/hooks/useAllGlyphs'
+import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
 
-const GlyphContext = createContext<Array<GlyphInfo>>([])
+const EMPTY_GLYPHS: Record<string, string> = {}
+
+/** Exported for test use — wrap with `<TestGlyphProvider>` to inject test glyphs */
+export const GlyphContext = createContext<Array<GlyphInfo>>([])
 
 export function GlyphProvider({ children }: { children: ReactNode }) {
-  const { glyphs } = useAllGlyphs()
+  const localGlyphs =
+    useFableBuilderStore((state) => state.fable.local_glyphs) ?? EMPTY_GLYPHS
+  const { glyphs } = useAllGlyphs(localGlyphs)
   return (
     <GlyphContext.Provider value={glyphs}>{children}</GlyphContext.Provider>
   )

--- a/frontend/src/features/fable-builder/hooks/useAllGlyphs.ts
+++ b/frontend/src/features/fable-builder/hooks/useAllGlyphs.ts
@@ -15,14 +15,16 @@
 import { useMemo } from 'react'
 import { useAvailableGlyphs, useListGlobalGlyphs } from '@/api/hooks/useFable'
 
+export type GlyphType = 'intrinsic' | 'global' | 'local'
+
 export interface GlyphInfo {
   name: string
   displayName: string
   valueExample: string
-  type: 'intrinsic' | 'global'
+  type: GlyphType
 }
 
-export function useAllGlyphs(): {
+export function useAllGlyphs(localGlyphs?: Record<string, string>): {
   glyphs: Array<GlyphInfo>
   isLoading: boolean
 } {
@@ -54,8 +56,19 @@ export function useAllGlyphs(): {
       }
     }
 
+    if (localGlyphs) {
+      for (const [key, value] of Object.entries(localGlyphs)) {
+        result.push({
+          name: key,
+          displayName: key,
+          valueExample: value,
+          type: 'local',
+        })
+      }
+    }
+
     return result
-  }, [intrinsic, globalData])
+  }, [intrinsic, globalData, localGlyphs])
 
   return { glyphs, isLoading: intrinsicLoading || globalLoading }
 }

--- a/frontend/src/features/fable-builder/stores/fableBuilderStore.ts
+++ b/frontend/src/features/fable-builder/stores/fableBuilderStore.ts
@@ -112,6 +112,8 @@ interface FableBuilderState {
   setAutoLayout: (enabled: boolean) => void
   setLayoutDirection: (direction: LayoutDirection) => void
   setNodesLocked: (locked: boolean) => void
+  setLocalGlyph: (key: string, value: string) => void
+  removeLocalGlyph: (key: string) => void
   setValidationState: (state: FableValidationState | null) => void
   setIsValidating: (validating: boolean) => void
   setSubmitDialogOpen: (open: boolean) => void
@@ -496,6 +498,28 @@ export const useFableBuilderStore = create<FableBuilderState>()(
         setAutoLayout: (enabled) => set({ autoLayout: enabled }),
         setLayoutDirection: (direction) => set({ layoutDirection: direction }),
         setNodesLocked: (locked) => set({ nodesLocked: locked }),
+
+        setLocalGlyph: (key, value) => {
+          const { fable } = get()
+          set({
+            fable: {
+              ...fable,
+              local_glyphs: { ...(fable.local_glyphs ?? {}), [key]: value },
+            },
+            isDirty: true,
+            validationState: null,
+          })
+        },
+
+        removeLocalGlyph: (key) => {
+          const { fable } = get()
+          const { [key]: _removed, ...rest } = fable.local_glyphs ?? {}
+          set({
+            fable: { ...fable, local_glyphs: rest },
+            isDirty: true,
+            validationState: null,
+          })
+        },
 
         setValidationState: (state) =>
           set({

--- a/frontend/src/features/fable-builder/utils/glyph-display.ts
+++ b/frontend/src/features/fable-builder/utils/glyph-display.ts
@@ -55,7 +55,9 @@ export function parseGlyphSegments(value: string): Array<GlyphSegment> {
  * Check if a value contains any glyph references.
  */
 export function containsGlyphs(value: string): boolean {
-  return GLYPH_PATTERN.test(value)
+  // Use a fresh regex — GLYPH_PATTERN has the `g` flag which makes .test()
+  // stateful (advances lastIndex), causing alternating true/false results.
+  return /\$\{\w+\}/.test(value)
 }
 
 /**

--- a/frontend/src/hooks/useActivityCollector.ts
+++ b/frontend/src/hooks/useActivityCollector.ts
@@ -1,0 +1,187 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Activity Collector Hook
+ *
+ * Mounted once in the app shell. Watches existing data sources
+ * (model downloads, forecast jobs) and feeds the activity store.
+ *
+ * Plugin operations are reported directly by the plugin page
+ * via useActivityStore.addTask() since plugin mutations don't
+ * have globally observable mutation keys.
+ *
+ * IMPORTANT: Effects read the activity store via getState() (non-reactive)
+ * to avoid infinite re-render loops. Only external data sources (downloads,
+ * job list) are in dependency arrays.
+ */
+
+import { useEffect, useRef } from 'react'
+import { useArtifacts, useDownloadModel } from '@/api/hooks/useArtifacts'
+import { useJobsStatus } from '@/api/hooks/useJobs'
+import { isTerminalStatus } from '@/api/types/job.types'
+import { useActivityStore } from '@/stores/activityStore'
+
+const COMPLETION_RETENTION_MS = 15_000
+
+/**
+ * Sync model downloads from the download store into the activity store.
+ */
+function useCollectDownloads() {
+  const { downloads } = useDownloadModel()
+  const { artifacts } = useArtifacts()
+  const prevKeysRef = useRef<Set<string>>(new Set())
+
+  useEffect(() => {
+    const { tasks, addTask, updateTask } = useActivityStore.getState()
+    const currentKeys = new Set(Object.keys(downloads))
+
+    // Build a name lookup from the artifacts list
+    const nameByKey = new Map<string, string>()
+    for (const a of artifacts) {
+      nameByKey.set(a.encodedId, a.displayName)
+    }
+
+    // Add or update active downloads
+    for (const [key, dl] of Object.entries(downloads)) {
+      const id = `download:${key}`
+      const label = nameByKey.get(key) ?? key.replace('--', '/')
+      const progress = dl.progress
+      const description =
+        dl.status === 'submitting'
+          ? 'Starting download...'
+          : `Downloading ${progress}%`
+
+      const existing = tasks[id]
+      if (existing) {
+        updateTask(id, { progress, description })
+      } else {
+        addTask({
+          id,
+          type: 'download',
+          label,
+          description,
+          status: 'active',
+          progress,
+          startedAt: Date.now(),
+          navigateTo: '/admin/artifacts',
+        })
+      }
+    }
+
+    // Detect completed downloads (were in prev, not in current)
+    for (const key of prevKeysRef.current) {
+      if (!currentKeys.has(key)) {
+        const id = `download:${key}`
+        const task = tasks[id]
+        if (task && task.status === 'active') {
+          updateTask(id, {
+            status: 'completed',
+            description: 'Download complete',
+            progress: 100,
+            completedAt: Date.now(),
+          })
+        }
+      }
+    }
+
+    prevKeysRef.current = currentKeys
+  }, [downloads, artifacts])
+}
+
+/**
+ * Sync forecast jobs from the job list into the activity store.
+ */
+function useCollectJobs() {
+  const { data } = useJobsStatus(1, 20)
+
+  useEffect(() => {
+    if (!data?.runs) return
+    const { tasks, addTask, updateTask } = useActivityStore.getState()
+
+    for (const job of data.runs) {
+      const id = `job:${job.run_id}`
+      const label = `Job ${job.run_id.slice(0, 8)}`
+      const isTerminal = isTerminalStatus(job.status)
+
+      const existingTask = tasks[id]
+      if (existingTask) {
+        // Update existing
+        if (isTerminal && existingTask.status === 'active') {
+          updateTask(id, {
+            status: job.status === 'completed' ? 'completed' : 'failed',
+            description:
+              job.status === 'completed'
+                ? 'Completed'
+                : `Failed: ${job.error ?? 'Unknown error'}`,
+            completedAt: Date.now(),
+          })
+        } else if (!isTerminal) {
+          updateTask(id, { description: capitalize(job.status) })
+        }
+      } else if (!isTerminal) {
+        // Add new active job (only if not already added by SubmitJobDialog)
+        addTask({
+          id,
+          type: 'job',
+          label,
+          description: capitalize(job.status),
+          status: 'active',
+          startedAt: new Date(job.created_at).getTime(),
+          navigateTo: `/executions/${job.run_id}`,
+        })
+      }
+    }
+  }, [data])
+}
+
+/**
+ * Auto-remove completed/failed tasks after retention period.
+ */
+function useRetentionCleanup() {
+  const tasks = useActivityStore((state) => state.tasks)
+
+  useEffect(() => {
+    const completedTasks = Object.values(tasks).filter(
+      (item): item is NonNullable<typeof item> =>
+        item !== undefined && item.status !== 'active' && !!item.completedAt,
+    )
+
+    if (completedTasks.length === 0) return
+
+    const timers: Array<ReturnType<typeof setTimeout>> = []
+    for (const task of completedTasks) {
+      // completedAt is guaranteed non-undefined by the filter above
+      const elapsed = Date.now() - task.completedAt!
+      const remaining = Math.max(0, COMPLETION_RETENTION_MS - elapsed)
+      timers.push(
+        setTimeout(
+          () => useActivityStore.getState().removeTask(task.id),
+          remaining,
+        ),
+      )
+    }
+
+    return () => timers.forEach(clearTimeout)
+  }, [tasks])
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+/**
+ * Mount this hook once in the app shell to collect activity from all sources.
+ */
+export function useActivityCollector() {
+  useCollectDownloads()
+  useCollectJobs()
+  useRetentionCleanup()
+}

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -17,6 +17,13 @@
   "clear": "Clear",
   "yes": "Yes",
   "no": "No",
+  "activity": {
+    "label": "Notifications",
+    "title": "Notifications",
+    "help": "Monitor long-running tasks such as model downloads, plugin installations, and forecast job executions.",
+    "clear": "Clear",
+    "empty": "No active tasks"
+  },
   "nav": {
     "label": "Main navigation",
     "overview": "Overview",

--- a/frontend/src/locales/en/glyphs.json
+++ b/frontend/src/locales/en/glyphs.json
@@ -45,16 +45,29 @@
   "panel": {
     "title": "Available Glyphs",
     "manage": "Manage",
-    "help": "Use ${name} syntax in block configuration values to reference dynamic glyphs.\n\nIntrinsic — system-provided, always available (e.g., runId, submitDatetime). startDatetime and attemptCount update on each retry.\n\nGlobal — user-defined key-value pairs shared across fables. Manage them via the admin page.\n\nContext — injected automatically per-execution (e.g., by the scheduler). Not shown here.\n\nPrecedence: Intrinsic → Global → Context.\nPinned glyphs (startDatetime, attemptCount) always use the intrinsic value.",
+    "help": "Use ${name} syntax in block configuration values to reference dynamic glyphs.\n\nIntrinsic — system-provided, always available (e.g., runId, submitDatetime). startDatetime and attemptCount update on each retry.\n\nGlobal — user-defined key-value pairs shared across fables. Manage them via the admin page.\n\nLocal — scoped to this blueprint only. Override global glyphs of the same name.\n\nContext — injected automatically per-execution (e.g., by the scheduler). Not shown here.\n\nPrecedence: Intrinsic → Global → Local → Context.\nPinned glyphs (startDatetime, attemptCount) always use the intrinsic value.",
     "intrinsic": "Intrinsic",
     "global": "Global",
+    "local": "Local",
+    "localTooltip": "Glyphs scoped to this blueprint. Override global glyphs of the same name.",
     "noGlobal": "No global glyphs yet.",
+    "noLocal": "No local glyphs.",
+    "addLocalHint": "Add one to override a global value for this blueprint only.",
     "createOne": "Create one",
+    "addLocal": "Add",
+    "localKeyPlaceholder": "key",
+    "localValuePlaceholder": "value",
     "copied": "Copied",
     "example": "e.g.",
     "resolvesTo": "resolves to"
   },
   "autocomplete": {
     "filter": "Filter glyphs..."
+  },
+  "field": {
+    "switchToGlyph": "Use a glyph expression",
+    "switchToConcrete": "Use the value picker",
+    "cannotSwitchBack": "Clear the glyph expression to switch back",
+    "glyphPlaceholder": "e.g. $\\{glyphName}"
   }
 }

--- a/frontend/src/routes/_authenticated/admin/plugins.index.tsx
+++ b/frontend/src/routes/_authenticated/admin/plugins.index.tsx
@@ -44,6 +44,7 @@ import { PluginsPageHeader } from '@/features/plugins/components/PluginsPageHead
 import { UninstalledPluginsSection } from '@/features/plugins/components/UninstalledPluginsSection'
 import { UpdatesAvailableSection } from '@/features/plugins/components/UpdatesAvailableSection'
 import { cn } from '@/lib/utils'
+import { useActivityStore } from '@/stores/activityStore'
 import { useUiStore } from '@/stores/uiStore'
 import { getPluginStatusError } from '@/types/status.types'
 
@@ -159,6 +160,51 @@ function PluginsPage() {
     }
   }, [plugins, searchQuery, statusFilter, capabilityFilter])
 
+  // Activity tracking for long-running plugin ops
+  const addActivity = useActivityStore((state) => state.addTask)
+
+  function getPluginName(compositeId: PluginCompositeId): string {
+    const match = plugins.find(
+      (p) =>
+        p.id.store === compositeId.store && p.id.local === compositeId.local,
+    )
+    return match?.name ?? `${compositeId.store}/${compositeId.local}`
+  }
+
+  function trackPluginOp(
+    compositeId: PluginCompositeId,
+    op: string,
+    mutation: { mutateAsync: (id: PluginCompositeId) => Promise<void> },
+  ) {
+    const id = `plugin:${compositeId.store}/${compositeId.local}:${op}`
+    const name = getPluginName(compositeId)
+    addActivity({
+      id,
+      type: 'plugin',
+      label: name,
+      description: `${op}...`,
+      status: 'active',
+      startedAt: Date.now(),
+      navigateTo: `/admin/plugins/${encodePluginId(compositeId)}`,
+    })
+    mutation.mutateAsync(compositeId).then(
+      () => {
+        useActivityStore.getState().updateTask(id, {
+          status: 'completed',
+          description: 'Done',
+          completedAt: Date.now(),
+        })
+      },
+      () => {
+        useActivityStore.getState().updateTask(id, {
+          status: 'failed',
+          description: 'Failed',
+          completedAt: Date.now(),
+        })
+      },
+    )
+  }
+
   // Handlers
   const handleToggle = (compositeId: PluginCompositeId, enabled: boolean) => {
     if (enabled) {
@@ -169,15 +215,15 @@ function PluginsPage() {
   }
 
   const handleInstall = (compositeId: PluginCompositeId) => {
-    installPlugin.mutate(compositeId)
+    trackPluginOp(compositeId, 'Installing', installPlugin)
   }
 
   const handleUninstall = (compositeId: PluginCompositeId) => {
-    uninstallPlugin.mutate(compositeId)
+    trackPluginOp(compositeId, 'Uninstalling', uninstallPlugin)
   }
 
   const handleUpdate = (compositeId: PluginCompositeId) => {
-    updatePlugin.mutate(compositeId)
+    trackPluginOp(compositeId, 'Updating', updatePlugin)
   }
 
   const handleRefresh = () => {

--- a/frontend/src/stores/activityStore.ts
+++ b/frontend/src/stores/activityStore.ts
@@ -1,0 +1,96 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Activity Store
+ *
+ * Tracks all long-running tasks across the application:
+ * plugin operations, model downloads, and forecast jobs.
+ */
+
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+
+export type ActivityTaskType = 'plugin' | 'download' | 'job'
+export type ActivityTaskStatus = 'active' | 'completed' | 'failed'
+
+export interface ActivityTask {
+  id: string
+  type: ActivityTaskType
+  label: string
+  description: string
+  status: ActivityTaskStatus
+  progress?: number
+  startedAt: number
+  completedAt?: number
+  navigateTo?: string
+}
+
+interface ActivityState {
+  tasks: Partial<Record<string, ActivityTask>>
+  addTask: (task: ActivityTask) => void
+  updateTask: (id: string, updates: Partial<ActivityTask>) => void
+  removeTask: (id: string) => void
+  clearCompleted: () => void
+}
+
+export const useActivityStore = create<ActivityState>()(
+  devtools(
+    (set) => ({
+      tasks: {},
+
+      addTask: (task) =>
+        set(
+          (state) => ({ tasks: { ...state.tasks, [task.id]: task } }),
+          undefined,
+          'addTask',
+        ),
+
+      updateTask: (id, updates) =>
+        set(
+          (state) => {
+            const existing = state.tasks[id]
+            if (!existing) return state
+            return {
+              tasks: { ...state.tasks, [id]: { ...existing, ...updates } },
+            }
+          },
+          undefined,
+          'updateTask',
+        ),
+
+      removeTask: (id) =>
+        set(
+          (state) => {
+            const { [id]: _, ...rest } = state.tasks
+            return { tasks: rest }
+          },
+          undefined,
+          'removeTask',
+        ),
+
+      clearCompleted: () =>
+        set(
+          (state) => {
+            const tasks: Record<string, ActivityTask> = {}
+            for (const [id, task] of Object.entries(state.tasks)) {
+              if (task && task.status === 'active') {
+                tasks[id] = task
+              }
+            }
+            return { tasks }
+          },
+          undefined,
+          'clearCompleted',
+        ),
+    }),
+    { name: 'ActivityStore' },
+  ),
+)

--- a/frontend/tests/integration/components/fields/glyph-field-wrapper.test.tsx
+++ b/frontend/tests/integration/components/fields/glyph-field-wrapper.test.tsx
@@ -1,0 +1,365 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * GlyphFieldWrapper Integration Tests
+ *
+ * Tests the dual-mode (concrete/glyph) behavior across field types,
+ * including toggle, auto-detect, auto-trigger, blur-exit, and resolved preview.
+ */
+
+import { useState } from 'react'
+import { userEvent } from 'vitest/browser'
+import { describe, expect, it } from 'vitest'
+import { renderWithProviders } from '@tests/utils/render'
+import type { GlyphInfo } from '@/features/fable-builder/hooks/useAllGlyphs'
+import { GlyphFieldWrapper } from '@/components/base/fields/fields/GlyphFieldWrapper'
+import { InputGroupInput } from '@/components/ui/input-group'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { GlyphContext } from '@/features/fable-builder/context/GlyphContext'
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const TEST_GLYPHS: Array<GlyphInfo> = [
+  {
+    name: 'expver',
+    displayName: 'Experiment Version',
+    valueExample: '0001',
+    type: 'global',
+  },
+  {
+    name: 'runId',
+    displayName: 'Run ID',
+    valueExample: 'abc-123',
+    type: 'intrinsic',
+  },
+  {
+    name: 'forecastDate',
+    displayName: 'Forecast Date',
+    valueExample: '2026-04-11',
+    type: 'global',
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Controlled wrappers
+// ---------------------------------------------------------------------------
+
+function WithGlyphs({
+  children,
+  glyphs = TEST_GLYPHS,
+}: {
+  children: React.ReactNode
+  glyphs?: Array<GlyphInfo>
+}) {
+  return (
+    <GlyphContext.Provider value={glyphs}>{children}</GlyphContext.Provider>
+  )
+}
+
+function ControlledStringField(props: { initialValue?: string }) {
+  const [value, setValue] = useState(props.initialValue ?? '')
+  return (
+    <WithGlyphs>
+      <GlyphFieldWrapper id="test-field" value={value} onChange={setValue}>
+        <InputGroupInput
+          id="test-field"
+          type="text"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        />
+      </GlyphFieldWrapper>
+      <span data-testid="current-value">{value}</span>
+    </WithGlyphs>
+  )
+}
+
+function ControlledDateField(props: { initialValue?: string }) {
+  const [value, setValue] = useState(props.initialValue ?? '')
+  return (
+    <WithGlyphs>
+      <GlyphFieldWrapper id="test-field" value={value} onChange={setValue}>
+        <InputGroupInput
+          id="test-field"
+          type="date"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        />
+      </GlyphFieldWrapper>
+      <span data-testid="current-value">{value}</span>
+    </WithGlyphs>
+  )
+}
+
+function ControlledNumberField(props: { initialValue?: string }) {
+  const [value, setValue] = useState(props.initialValue ?? '')
+  return (
+    <WithGlyphs>
+      <GlyphFieldWrapper id="test-field" value={value} onChange={setValue}>
+        <InputGroupInput
+          id="test-field"
+          type="number"
+          step="1"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        />
+      </GlyphFieldWrapper>
+      <span data-testid="current-value">{value}</span>
+    </WithGlyphs>
+  )
+}
+
+function ControlledEnumField(props: { initialValue?: string }) {
+  const [value, setValue] = useState(props.initialValue ?? '')
+  return (
+    <WithGlyphs>
+      <GlyphFieldWrapper id="test-field" value={value} onChange={setValue}>
+        <Select value={value || null} onValueChange={(v) => setValue(v ?? '')}>
+          <SelectTrigger
+            id="test-field"
+            data-slot="input-group-control"
+            className="flex-1 border-0 shadow-none ring-0 focus-visible:ring-0"
+          >
+            <SelectValue placeholder="Select..." />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="opt1">opt1</SelectItem>
+            <SelectItem value="opt2">opt2</SelectItem>
+          </SelectContent>
+        </Select>
+      </GlyphFieldWrapper>
+      <span data-testid="current-value">{value}</span>
+    </WithGlyphs>
+  )
+}
+
+function NoGlyphsStringField() {
+  const [value, setValue] = useState('')
+  return (
+    <WithGlyphs glyphs={[]}>
+      <GlyphFieldWrapper id="test-field" value={value} onChange={setValue}>
+        <InputGroupInput
+          id="test-field"
+          type="text"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        />
+      </GlyphFieldWrapper>
+    </WithGlyphs>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GlyphFieldWrapper Integration', () => {
+  describe('Toggle visibility', () => {
+    it('shows glyph toggle when glyphs are available', async () => {
+      const screen = await renderWithProviders(<ControlledStringField />)
+      const toggle = screen.getByRole('button', { name: /glyph/i })
+      await expect.element(toggle).toBeVisible()
+    })
+
+    it('hides glyph toggle when no glyphs are available', async () => {
+      const screen = await renderWithProviders(<NoGlyphsStringField />)
+      await expect.element(screen.getByRole('textbox')).toBeVisible()
+      await expect
+        .element(screen.getByRole('button', { name: /glyph/i }))
+        .not.toBeInTheDocument()
+    })
+
+    it('shows toggle on date fields', async () => {
+      const screen = await renderWithProviders(<ControlledDateField />)
+      await expect
+        .element(screen.getByRole('button', { name: /glyph/i }))
+        .toBeVisible()
+    })
+
+    it('shows toggle on number fields', async () => {
+      const screen = await renderWithProviders(<ControlledNumberField />)
+      await expect
+        .element(screen.getByRole('button', { name: /glyph/i }))
+        .toBeVisible()
+    })
+
+    it('shows toggle on enum fields', async () => {
+      const screen = await renderWithProviders(<ControlledEnumField />)
+      await expect
+        .element(screen.getByRole('button', { name: /glyph/i }))
+        .toBeVisible()
+    })
+  })
+
+  describe('Mode switching', () => {
+    it('switches date field to glyph mode on toggle click', async () => {
+      const screen = await renderWithProviders(<ControlledDateField />)
+      await screen.getByRole('button', { name: /glyph/i }).click()
+
+      // Text input should appear (glyph mode)
+      const textInput = screen.getByRole('textbox')
+      await expect.element(textInput).toBeVisible()
+    })
+
+    it('switches date field back to concrete mode via double toggle', async () => {
+      const screen = await renderWithProviders(
+        <ControlledDateField initialValue="2026-04-11" />,
+      )
+
+      // Toggle to glyph mode
+      await screen.getByTestId('glyph-toggle').click()
+      await expect
+        .element(screen.getByRole('textbox'))
+        .toHaveValue('2026-04-11')
+
+      // Close autocomplete then toggle back
+      await userEvent.keyboard('{Escape}')
+      await screen.getByTestId('glyph-toggle').click()
+
+      // Value preserved through the round-trip
+      await expect
+        .element(screen.getByTestId('current-value'))
+        .toHaveTextContent('2026-04-11')
+    })
+  })
+
+  describe('Auto-detect glyph values', () => {
+    it('starts in glyph mode when value contains ${...}', async () => {
+      const screen = await renderWithProviders(
+        <ControlledDateField initialValue="${forecastDate}" />,
+      )
+      // Should render as text input (glyph mode), not date picker
+      const textInput = screen.getByRole('textbox')
+      await expect.element(textInput).toBeVisible()
+      await expect.element(textInput).toHaveValue('${forecastDate}')
+    })
+
+    it('starts in concrete mode for plain values', async () => {
+      const screen = await renderWithProviders(
+        <ControlledNumberField initialValue="42" />,
+      )
+      // Number input renders inside InputGroup — query by attribute
+      const input = screen.getByRole('spinbutton')
+      await expect.element(input).toBeVisible()
+    })
+  })
+
+  describe('Resolved preview', () => {
+    it('shows "resolves to" preview for glyph values', async () => {
+      const screen = await renderWithProviders(
+        <ControlledStringField initialValue="${expver}" />,
+      )
+      await expect.element(screen.getByText(/resolves to/i)).toBeVisible()
+      await expect.element(screen.getByText('0001')).toBeVisible()
+    })
+
+    it('does not show preview when value has no glyphs', async () => {
+      const screen = await renderWithProviders(
+        <ControlledStringField initialValue="plain text" />,
+      )
+      await expect
+        .element(screen.getByText(/resolves to/i))
+        .not.toBeInTheDocument()
+    })
+  })
+
+  describe('Auto-trigger on empty field', () => {
+    it('auto-inserts ${ when toggling on an empty field', async () => {
+      const screen = await renderWithProviders(<ControlledDateField />)
+      await screen.getByRole('button', { name: /glyph/i }).click()
+
+      await expect
+        .element(screen.getByTestId('current-value'))
+        .toHaveTextContent('${')
+    })
+  })
+
+  describe('Blur-exit from glyph mode', () => {
+    it('returns to concrete mode when toggling on enum field', async () => {
+      const screen = await renderWithProviders(
+        <ControlledEnumField initialValue="opt1" />,
+      )
+
+      // Start in concrete mode — combobox visible
+      await expect.element(screen.getByRole('combobox')).toBeVisible()
+
+      // Toggle to glyph mode
+      await screen.getByTestId('glyph-toggle').click()
+      await expect.element(screen.getByRole('textbox')).toBeVisible()
+
+      // Close autocomplete then toggle back
+      await userEvent.keyboard('{Escape}')
+      await screen.getByTestId('glyph-toggle').click()
+
+      // Combobox should be back
+      await expect.element(screen.getByRole('combobox')).toBeVisible()
+    })
+  })
+
+  describe('Prevents switching back with glyph value', () => {
+    it('disables toggle when value contains a glyph', async () => {
+      const screen = await renderWithProviders(
+        <ControlledDateField initialValue="${forecastDate}" />,
+      )
+      const toggle = screen.getByRole('button', { name: /glyph/i })
+      await expect.element(toggle).toBeDisabled()
+    })
+  })
+
+  describe('All field types support glyph entry', () => {
+    it('string field', async () => {
+      const screen = await renderWithProviders(<ControlledStringField />)
+      await screen.getByRole('button', { name: /glyph/i }).click()
+      const input = screen.getByRole('textbox')
+      await input.fill('${expver}')
+      await expect
+        .element(screen.getByTestId('current-value'))
+        .toHaveTextContent('${expver}')
+    })
+
+    it('number field', async () => {
+      const screen = await renderWithProviders(<ControlledNumberField />)
+      await screen.getByRole('button', { name: /glyph/i }).click()
+      const input = screen.getByRole('textbox')
+      await input.fill('${runId}')
+      await expect
+        .element(screen.getByTestId('current-value'))
+        .toHaveTextContent('${runId}')
+    })
+
+    it('enum field', async () => {
+      const screen = await renderWithProviders(<ControlledEnumField />)
+      await screen.getByRole('button', { name: /glyph/i }).click()
+      const input = screen.getByRole('textbox')
+      await input.fill('${expver}')
+      await expect
+        .element(screen.getByTestId('current-value'))
+        .toHaveTextContent('${expver}')
+    })
+
+    it('date field', async () => {
+      const screen = await renderWithProviders(<ControlledDateField />)
+      await screen.getByRole('button', { name: /glyph/i }).click()
+      const input = screen.getByRole('textbox')
+      await input.fill('${forecastDate}')
+      await expect
+        .element(screen.getByTestId('current-value'))
+        .toHaveTextContent('${forecastDate}')
+    })
+  })
+})


### PR DESCRIPTION

### Description

- Include a backend sync for local glyphs and a broader UX overhaul: glyphs (`${variable}`) can now be used in every field type in the Fable Builder.
- Centralized notifications panel 

  ### Activity monitor
  - Centralized notifications panel for long-running tasks (plugin installs, job submissions, execution progress)
  - `ActivityMonitor` component in the authenticated header
  - `activityStore` + `useActivityCollector` hook for tracking in-flight operations across the app
  - Integrated with plugin install, job submit, and execution detail flows

  ### Local glyphs support 
  - Add `local_glyphs` to `FableBuilderV1Schema` with store CRUD actions (`setLocalGlyph`, `removeLocalGlyph`)
  - New "Local" section in the `GlyphReferencePanel` with inline add/edit/delete — no dialog needed
  - Extended autocomplete dropdown to show local glyphs as a third group
  - Updated precedence help text: Intrinsic → Global → **Local** → Context
  - Handle 422 validation errors from `/blueprint/create` and `/blueprint/update` with structured error messages in the save toast
  - Fix API client to preserve structured `detail` objects instead of rendering `[object Object]`

  ### Universal glyph field support
  Introduce `GlyphFieldWrapper` — a dual-mode container using `InputGroup` that lets any field type switch between its specialized widget and a glyph-aware text input:

  - **Concrete mode** (default): the specialized widget renders normally (date picker, dropdown, number input)
  - **Glyph mode**: a `GlyphTextInput` replaces the widget with `${…}` autocomplete and a "resolves to" preview
  - **`{ }` toggle button** integrated into the `InputGroup` at `inline-start`, with active/inactive styling
  - **Auto-detect**: values containing `${…}` automatically render in glyph mode
  - **Auto-trigger**: clicking the toggle on an empty field inserts `${` and opens autocomplete in one click
  - **Blur-exit**: clearing the field and blurring returns to the concrete widget — no stuck "select an option" text input
  - **Prevents data loss**: toggle back to concrete is disabled while a glyph expression is set
  - **Graceful degradation**: toggle hidden entirely when no glyphs are available in context

  All four non-string field types (`DateTimeField`, `NumberField`, `EnumField`, `ListField`) and `StringField` itself are now wrapped consistently — the visual treatment is uniform across the builder. The `EnumField` uses `data-slot="input-group-control"` on the `SelectTrigger`
  so the dropdown composes correctly inside the `InputGroup`.

  ### Bug fixes
  - `containsGlyphs()` used a global-flag regex with `.test()`, which caused alternating true/false on consecutive calls
  - Dependencies bump (`package.json` / `package-lock.json`)

  ### Tests
  - Add 18 integration tests for `GlyphFieldWrapper` covering toggle visibility, mode switching, auto-detect, auto-trigger, blur-exit, resolved preview, back-switch prevention, and glyph entry across all field types
  - Export `GlyphContext` so tests can inject test glyphs without needing MSW or the full store

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 