### PR TITLE
[backend/blueprint] track invalidable blocks

### DIFF
--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -148,15 +148,21 @@ async def validate_expand(
     for key in sorted(colliding_keys):
         global_errors.append(f"Local glyph key {key!r} is reserved as an intrinsic glyph and cannot be overridden.")
 
+    invalidable: set[BlockInstanceId] = set()
+    visited: set[BlockInstanceId] = set()
+
     for blockId in topological_order(blueprint.blocks.items(), lambda block: block.input_ids.values()):
+        visited.add(blockId)
         blockInstance = blueprint.blocks[blockId]
         plugin = plugins.get(blockInstance.factory_id.plugin, None)
         if not plugin:
             block_errors[blockId] += ["Plugin not found"]
+            invalidable.add(blockId)
             continue
         blockFactory = plugin.catalogue.factories.get(blockInstance.factory_id.factory, None)
         if not blockFactory:
             block_errors[blockId] += ["BlockFactory not found in the catalogue"]
+            invalidable.add(blockId)
             continue
         extraConfig = blockInstance.configuration_values.keys() - blockFactory.configuration_options.keys()
         if extraConfig:
@@ -169,19 +175,26 @@ async def validate_expand(
         extract_result = glyph_resolution.extract_glyphs(blockInstance)
         if extract_result.e is not None:
             block_errors[blockId] += extract_result.e
+            invalidable.add(blockId)
             continue
         extracted = cast(ExtractedGlyphs, extract_result.t)
         unknown_glyphs = extracted.glyphs - available_glyphs
         if unknown_glyphs:
             block_errors[blockId] += [f"Unknown glyphs referenced: {unknown_glyphs}"]
+            invalidable.add(blockId)
             continue
         glyph_resolution.resolve_configurations(blockInstance, all_glyphs)
         resolved_configuration_options[blockId] = {k: blockInstance.configuration_values[k] for k in extracted.glyphed_options}
+
+        if any(source_id in invalidable for source_id in blockInstance.input_ids.values()):
+            invalidable.add(blockId)
+            continue
 
         inputs = {input_id: outputs[source_id] for input_id, source_id in blockInstance.input_ids.items()}
         output_or_error = plugin.validator(blockInstance, inputs)
         if output_or_error.t is None:
             block_errors[blockId] += [cast(str, output_or_error.e)]
+            invalidable.add(blockId)
             continue
         outputs[blockId] = output_or_error.t
 
@@ -191,6 +204,14 @@ async def validate_expand(
                 for any_plugin_id, any_plugin in plugins.items()
                 for block_factory_id in any_plugin.expander(output_or_error.t)
             ]
+
+    # the topological search *omits* nodes in cycles or with missing ancestors -- thus we need to report and detect them
+    for blockId, blockInstance in blueprint.blocks.items():
+        if blockId not in visited:
+            missing = [source_id for source_id in blockInstance.input_ids.values() if source_id not in blueprint.blocks]
+            if missing:
+                block_errors[blockId] += [f"References non-existent block(s): {missing}"]
+                invalidable.add(blockId)
 
     return BlueprintValidationExpansion(
         possible_sources=possible_sources,

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -475,3 +475,63 @@ def test_list_available_glyphs(backend_client_with_auth: httpx.Client) -> None:
         json={"key": "shouldBeRejected", "value": "v", "public": True},
     )
     assert public_resp.status_code == 403
+
+
+def test_blueprint_expand_failure_01(backend_client_with_auth: httpx.Client) -> None:
+    """Source has an invalid factory; transform referencing it must not generate its own error."""
+    bad_source = BlockInstance(
+        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory="nonexistent_factory"),
+        configuration_values={},
+        input_ids={},
+    )
+    good_transform = BlockInstance(
+        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory="transform_increment"),
+        configuration_values={"amount": "1"},
+        input_ids={"a": "bad_source"},
+    )
+    builder = BlueprintBuilder(blocks={"bad_source": bad_source, "good_transform": good_transform})
+    response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())
+    assert response.is_success, response.text
+    block_errors = response.json()["block_errors"]
+    assert "bad_source" in block_errors
+    assert "good_transform" not in block_errors
+
+
+def test_blueprint_expand_failure_02(backend_client_with_auth: httpx.Client) -> None:
+    """Transform declares an input id that does not exist in the blueprint; only the transform errors."""
+    source_42 = BlockInstance(
+        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory="source_42"),
+        configuration_values={},
+        input_ids={},
+    )
+    bad_transform = BlockInstance(
+        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory="transform_increment"),
+        configuration_values={"amount": "1"},
+        input_ids={"a": "nonexistent_block"},
+    )
+    builder = BlueprintBuilder(blocks={"source_42": source_42, "bad_transform": bad_transform})
+    response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())
+    assert response.is_success, response.text
+    block_errors = response.json()["block_errors"]
+    assert "source_42" not in block_errors
+    assert "bad_transform" in block_errors
+
+
+def test_blueprint_expand_failure_03(backend_client_with_auth: httpx.Client) -> None:
+    """Bad source and transform with a non-existent input id both report independent errors."""
+    bad_source = BlockInstance(
+        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory="nonexistent_factory"),
+        configuration_values={},
+        input_ids={},
+    )
+    bad_transform = BlockInstance(
+        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory="transform_increment"),
+        configuration_values={"amount": "1"},
+        input_ids={"a": "nonexistent_block"},
+    )
+    builder = BlueprintBuilder(blocks={"bad_source": bad_source, "bad_transform": bad_transform})
+    response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())
+    assert response.is_success, response.text
+    block_errors = response.json()["block_errors"]
+    assert "bad_source" in block_errors
+    assert "bad_transform" in block_errors


### PR DESCRIPTION
Fixes https://github.com/ecmwf/forecast-in-a-box/issues/370 and another error

Expands test suite

When a block fails validation it does not populate outputs, causing a KeyError when a downstream block tries to gather its inputs.

Fix:
- Introduce an `invalidable` set; add a block to it whenever validation cannot complete (i.e. at every existing `continue`).
- Before gathering inputs check whether any input source is in `invalidable`; if so, mark the current block as invalidable too and skip without emitting a spurious error.
- Introduce a `visited` set to track blocks that topological_order actually yields. Kahn's algorithm silently drops nodes whose parents are missing or form a cycle; a post-loop sweep over unvisited blocks detects and reports non-existent input references.

Tests: add test_blueprint_expand_failure_01/02/03 covering
- invalid source + valid transform (only source error reported)
- valid source + transform referencing a missing block (only transform)
- invalid source + transform referencing a missing block (both reported)

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 