### PR TITLE
[frontend] backend-resolved glyphs, validation UX, resizable sidebars

### DIFF
--- a/frontend/src/api/hooks/useFable.ts
+++ b/frontend/src/api/hooks/useFable.ts
@@ -9,7 +9,12 @@
  */
 
 import { useMemo } from 'react'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
 import type {
   BlockFactoryCatalogue,
   BlueprintDeleteRequest,
@@ -135,10 +140,16 @@ export function useFableValidation(
     enabled: enabled && hasBlocks,
     staleTime: 10 * 1000, // 10 seconds
     refetchOnWindowFocus: false,
-    // Retry server errors (503 during plugin reload) but not validation errors (4xx)
+    // Keep previous error state visible while a new validation is in flight.
+    // Prevents the right panel and graph nodes from flickering between
+    // "errors" and "clean" across keystrokes.
+    placeholderData: keepPreviousData,
+    // Only retry 503 (plugin reload). 4xx are validation errors (don't retry),
+    // and other 5xx (e.g. a backend crash in validate_expand) aren't transient —
+    // retrying just spams the server logs without changing the outcome.
     retry: (failureCount, error) => {
-      if (error instanceof ApiClientError && error.status && error.status < 500)
-        return false
+      if (!(error instanceof ApiClientError)) return false
+      if (error.status !== 503) return false
       return failureCount < QUERY_CONSTANTS.RETRY.ON_503
     },
     retryDelay: QUERY_CONSTANTS.RETRY_DELAY.ON_503,

--- a/frontend/src/api/types/fable.types.ts
+++ b/frontend/src/api/types/fable.types.ts
@@ -147,6 +147,10 @@ export const FableValidationExpansionSchema = z.object({
     z.string(),
     z.array(PluginBlockFactoryIdSchema),
   ),
+  resolved_configuration_options: z
+    .record(z.string(), z.record(z.string(), z.string()))
+    .optional()
+    .default({}),
 })
 
 export type FableValidationExpansion = z.infer<
@@ -249,6 +253,13 @@ export interface FableValidationState {
   globalErrors: Array<string>
   blockStates: Record<BlockInstanceId, BlockValidationState>
   possibleSources: Array<PluginBlockFactoryId>
+  /**
+   * Backend-resolved configuration values, keyed by BlockInstanceId then
+   * configuration key. Only contains entries whose original value contained
+   * glyph references (${...}). Sourced from /blueprint/expand — the frontend
+   * never resolves glyphs client-side.
+   */
+  resolvedConfigurationOptions: Record<BlockInstanceId, Record<string, string>>
 }
 
 export interface BlockKindMetadata {
@@ -559,5 +570,6 @@ export function toValidationState(
     globalErrors: expansion.global_errors,
     blockStates,
     possibleSources: expansion.possible_sources,
+    resolvedConfigurationOptions: expansion.resolved_configuration_options,
   }
 }

--- a/frontend/src/components/base/fields/FieldRenderer.tsx
+++ b/frontend/src/components/base/fields/FieldRenderer.tsx
@@ -21,6 +21,8 @@ import { cn } from '@/lib/utils'
 
 export interface FieldRendererProps {
   id: string
+  /** Configuration key for this field, used to look up server-resolved glyph values */
+  configKey: string
   valueType: string | undefined
   value: string
   onChange: (value: string) => void
@@ -34,6 +36,7 @@ export interface FieldRendererProps {
 
 export function FieldRenderer({
   id,
+  configKey,
   valueType,
   value,
   onChange,
@@ -49,6 +52,7 @@ export function FieldRenderer({
   const inputElement = renderField(
     parsedType,
     id,
+    configKey,
     value,
     onChange,
     placeholder,
@@ -74,6 +78,7 @@ export function FieldRenderer({
 function renderField(
   parsedType: ParsedValueType,
   id: string,
+  configKey: string,
   value: string,
   onChange: (value: string) => void,
   placeholder?: string,
@@ -86,6 +91,7 @@ function renderField(
       return (
         <StringField
           id={id}
+          configKey={configKey}
           value={value}
           onChange={onChange}
           placeholder={placeholder}
@@ -98,6 +104,7 @@ function renderField(
       return (
         <NumberField
           id={id}
+          configKey={configKey}
           value={value}
           onChange={onChange}
           isInteger={true}
@@ -111,6 +118,7 @@ function renderField(
       return (
         <NumberField
           id={id}
+          configKey={configKey}
           value={value}
           onChange={onChange}
           isInteger={false}
@@ -124,6 +132,7 @@ function renderField(
       return (
         <DateTimeField
           id={id}
+          configKey={configKey}
           value={value}
           onChange={onChange}
           isDateOnly={false}
@@ -137,6 +146,7 @@ function renderField(
       return (
         <DateTimeField
           id={id}
+          configKey={configKey}
           value={value}
           onChange={onChange}
           isDateOnly={true}
@@ -150,6 +160,7 @@ function renderField(
       return (
         <EnumField
           id={id}
+          configKey={configKey}
           value={value}
           onChange={onChange}
           options={parsedType.options}
@@ -163,6 +174,7 @@ function renderField(
       return (
         <ListField
           id={id}
+          configKey={configKey}
           value={value}
           onChange={onChange}
           placeholder={placeholder}
@@ -178,6 +190,7 @@ function renderField(
  */
 export interface InlineFieldRendererProps {
   id: string
+  configKey: string
   valueType: string | undefined
   value: string
   onChange: (value: string) => void
@@ -188,6 +201,7 @@ export interface InlineFieldRendererProps {
 
 export function InlineFieldRenderer({
   id,
+  configKey,
   valueType,
   value,
   onChange,
@@ -200,6 +214,7 @@ export function InlineFieldRenderer({
   return renderField(
     parsedType,
     id,
+    configKey,
     value,
     onChange,
     placeholder,

--- a/frontend/src/components/base/fields/fields/DateTimeField.tsx
+++ b/frontend/src/components/base/fields/fields/DateTimeField.tsx
@@ -13,6 +13,7 @@ import { InputGroupInput } from '@/components/ui/input-group'
 
 export interface DateTimeFieldProps {
   id: string
+  configKey: string
   value: string
   onChange: (value: string) => void
   isDateOnly?: boolean
@@ -23,6 +24,7 @@ export interface DateTimeFieldProps {
 
 export function DateTimeField({
   id,
+  configKey,
   value,
   onChange,
   isDateOnly = false,
@@ -33,6 +35,7 @@ export function DateTimeField({
   return (
     <GlyphFieldWrapper
       id={id}
+      configKey={configKey}
       value={value}
       onChange={onChange}
       placeholder={placeholder}

--- a/frontend/src/components/base/fields/fields/EnumField.tsx
+++ b/frontend/src/components/base/fields/fields/EnumField.tsx
@@ -16,9 +16,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { cn } from '@/lib/utils'
 
 export interface EnumFieldProps {
   id: string
+  configKey: string
   value: string
   onChange: (value: string) => void
   options: Array<string>
@@ -29,6 +31,7 @@ export interface EnumFieldProps {
 
 export function EnumField({
   id,
+  configKey,
   value,
   onChange,
   options,
@@ -39,22 +42,20 @@ export function EnumField({
   return (
     <GlyphFieldWrapper
       id={id}
+      configKey={configKey}
       value={value}
       onChange={onChange}
       placeholder={placeholder}
       disabled={disabled}
       className={className}
+      allowGlyphMode={false}
     >
       <Select
         value={value || null}
         onValueChange={(newValue) => onChange(newValue ?? '')}
         disabled={disabled}
       >
-        <SelectTrigger
-          id={id}
-          data-slot="input-group-control"
-          className="flex-1 border-0 shadow-none ring-0 focus-visible:ring-0"
-        >
+        <SelectTrigger id={id} className={cn('w-full', className)}>
           <SelectValue placeholder={placeholder} />
         </SelectTrigger>
         <SelectContent>

--- a/frontend/src/components/base/fields/fields/GlyphFieldWrapper.tsx
+++ b/frontend/src/components/base/fields/fields/GlyphFieldWrapper.tsx
@@ -38,19 +38,27 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { useGlyphContext } from '@/features/fable-builder/context/GlyphContext'
-import {
-  containsGlyphs,
-  resolveGlyphValue,
-} from '@/features/fable-builder/utils/glyph-display'
+import { useResolvedConfig } from '@/features/fable-builder/context/ResolvedConfigContext'
+import { useFieldErrors } from '@/features/fable-builder/context/FieldErrorsContext'
+import { containsGlyphs } from '@/features/fable-builder/utils/glyph-display'
 import { cn } from '@/lib/utils'
 
 export interface GlyphFieldWrapperProps {
   id: string
+  /** Configuration key under which the backend publishes the resolved value */
+  configKey: string
   value: string
   onChange: (value: string) => void
   placeholder?: string
   disabled?: boolean
   className?: string
+  /**
+   * When false, glyph mode is unavailable and the wrapper renders children
+   * directly with no toggle or InputGroup chrome. Used for field types
+   * where free-form glyph expressions don't make sense (e.g. enum dropdowns,
+   * whose values are constrained to a backend-declared set).
+   */
+  allowGlyphMode?: boolean
   /** The specialized widget (must use InputGroupInput or data-slot="input-group-control") */
   children: React.ReactNode
 }
@@ -59,11 +67,13 @@ type FieldMode = 'concrete' | 'glyph'
 
 export function GlyphFieldWrapper({
   id,
+  configKey,
   value,
   onChange,
   placeholder,
   disabled,
   className,
+  allowGlyphMode = true,
   children,
 }: GlyphFieldWrapperProps) {
   const { t } = useTranslation('glyphs')
@@ -82,8 +92,33 @@ export function GlyphFieldWrapper({
     }
   }, [value, mode])
 
-  // If no glyphs available, always render concrete mode without the wrapper
-  if (!hasGlyphs) {
+  // All hooks must be called before any conditional early return to satisfy
+  // Rules of Hooks — hasGlyphs / allowGlyphMode can toggle at runtime
+  // (glyphs load async), so the hook count must stay constant across renders.
+  const resolvedConfig = useResolvedConfig()
+  const fieldErrors = useFieldErrors()?.[configKey] ?? null
+  const hasFieldError = fieldErrors !== null && fieldErrors.length > 0
+  const errorMessage = hasFieldError
+    ? fieldErrors.length > 1
+      ? `${fieldErrors[0]} (+${fieldErrors.length - 1} more)`
+      : fieldErrors[0]
+    : null
+
+  // If no glyphs available or glyph mode is disallowed for this field type,
+  // render children directly with no InputGroup / toggle chrome. Field-level
+  // error styling still applies: wrap in a ring container when errored.
+  // Error text is absolutely positioned so it doesn't push sibling fields.
+  if (!hasGlyphs || !allowGlyphMode) {
+    if (hasFieldError) {
+      return (
+        <div className="relative">
+          <div className="rounded-md ring-1 ring-destructive">{children}</div>
+          <p className="pointer-events-none absolute top-full left-0 mt-0.5 truncate text-xs text-destructive">
+            {errorMessage}
+          </p>
+        </div>
+      )
+    }
     return <>{children}</>
   }
 
@@ -107,20 +142,24 @@ export function GlyphFieldWrapper({
         ? t('field.cannotSwitchBack')
         : t('field.switchToConcrete')
 
-  // Resolved preview — rendered below the InputGroup
+  // Resolved preview — backend is the sole source of truth. If the backend
+  // hasn't returned a resolved value for this config key (validation in-flight,
+  // block in error state, etc.) we simply don't render a preview. Also
+  // suppressed when a field-level error is active — the error takes priority
+  // for the below-field slot.
   const resolvedPreview =
-    mode === 'glyph' && valueHasGlyphs
-      ? resolveGlyphValue(
-          value,
-          Object.fromEntries(glyphs.map((g) => [g.name, g.valueExample])),
-        )
+    mode === 'glyph' && valueHasGlyphs && !hasFieldError
+      ? (resolvedConfig?.[configKey] ?? null)
       : null
 
   return (
-    <div>
+    <div className="relative">
       <InputGroup
         data-disabled={disabled || undefined}
-        className={cn(mode === 'glyph' && 'border-primary/30')}
+        className={cn(
+          mode === 'glyph' && 'border-primary/30',
+          hasFieldError && 'border-destructive',
+        )}
       >
         {mode === 'glyph' ? (
           <GlyphTextInput
@@ -166,6 +205,12 @@ export function GlyphFieldWrapper({
           <div className="h-5 w-px bg-border" />
         </InputGroupAddon>
       </InputGroup>
+
+      {errorMessage && (
+        <p className="pointer-events-none absolute top-full left-0 mt-0.5 truncate text-xs text-destructive">
+          {errorMessage}
+        </p>
+      )}
 
       {resolvedPreview && resolvedPreview !== value && (
         <Tooltip>

--- a/frontend/src/components/base/fields/fields/GlyphTextInput.tsx
+++ b/frontend/src/components/base/fields/fields/GlyphTextInput.tsx
@@ -20,20 +20,10 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { useTranslation } from 'react-i18next'
 import { Input } from '@/components/ui/input'
 import { InputGroupInput } from '@/components/ui/input-group'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
 import { useGlyphContext } from '@/features/fable-builder/context/GlyphContext'
 import { GlyphAutocomplete } from '@/features/fable-builder/components/shared/GlyphAutocomplete'
-import {
-  containsGlyphs,
-  resolveGlyphValue,
-} from '@/features/fable-builder/utils/glyph-display'
 
 export interface GlyphTextInputProps {
   id: string
@@ -79,7 +69,6 @@ export function GlyphTextInput({
   autoTrigger = false,
   onBlurEmpty,
 }: GlyphTextInputProps) {
-  const { t } = useTranslation('glyphs')
   const glyphs = useGlyphContext()
   const inputRef = useRef<HTMLInputElement>(null)
   const [autocompleteFilter, setAutocompleteFilter] = useState<string | null>(
@@ -176,15 +165,6 @@ export function GlyphTextInput({
     }, 150)
   }, [onBlurEmpty])
 
-  // Build resolved preview
-  const showPreview = hasGlyphs && containsGlyphs(value)
-  const resolvedPreview = showPreview
-    ? resolveGlyphValue(
-        value,
-        Object.fromEntries(glyphs.map((g) => [g.name, g.valueExample])),
-      )
-    : null
-
   const inputProps = {
     ref: inputRef,
     id,
@@ -211,24 +191,8 @@ export function GlyphTextInput({
     </div>
   )
 
-  const previewElement = resolvedPreview && resolvedPreview !== value && (
-    <Tooltip>
-      <TooltipTrigger
-        render={
-          <div className="mt-1 truncate text-sm text-muted-foreground italic" />
-        }
-      >
-        {t('panel.resolvesTo')}{' '}
-        <span className="font-mono">{resolvedPreview}</span>
-      </TooltipTrigger>
-      <TooltipContent side="bottom" className="max-w-96 font-mono break-all">
-        {resolvedPreview}
-      </TooltipContent>
-    </Tooltip>
-  )
-
   // When grouped (inside InputGroup), only render the input inline.
-  // The autocomplete and preview are rendered outside via the wrapper.
+  // The autocomplete and resolved preview are rendered outside via the wrapper.
   if (grouped) {
     return (
       <>
@@ -242,7 +206,6 @@ export function GlyphTextInput({
     <div className="relative">
       <Input {...inputProps} />
       {autocompleteDropdown}
-      {previewElement}
     </div>
   )
 }

--- a/frontend/src/components/base/fields/fields/ListField.tsx
+++ b/frontend/src/components/base/fields/fields/ListField.tsx
@@ -18,6 +18,7 @@ import { cn } from '@/lib/utils'
 
 export interface ListFieldProps {
   id: string
+  configKey: string
   value: string
   onChange: (value: string) => void
   placeholder?: string
@@ -45,6 +46,7 @@ function serializeListValue(items: Array<string>): string {
 
 export function ListField({
   id,
+  configKey,
   value,
   onChange,
   placeholder = 'Add item...',
@@ -54,6 +56,7 @@ export function ListField({
   return (
     <GlyphFieldWrapper
       id={id}
+      configKey={configKey}
       value={value}
       onChange={onChange}
       placeholder={placeholder}
@@ -78,7 +81,7 @@ function ListFieldConcrete({
   placeholder = 'Add item...',
   disabled,
   className,
-}: ListFieldProps) {
+}: Omit<ListFieldProps, 'configKey'>) {
   const [inputValue, setInputValue] = useState('')
   const items = parseListValue(value)
 

--- a/frontend/src/components/base/fields/fields/NumberField.tsx
+++ b/frontend/src/components/base/fields/fields/NumberField.tsx
@@ -13,6 +13,7 @@ import { InputGroupInput } from '@/components/ui/input-group'
 
 export interface NumberFieldProps {
   id: string
+  configKey: string
   value: string
   onChange: (value: string) => void
   isInteger?: boolean
@@ -23,6 +24,7 @@ export interface NumberFieldProps {
 
 export function NumberField({
   id,
+  configKey,
   value,
   onChange,
   isInteger = false,
@@ -33,6 +35,7 @@ export function NumberField({
   return (
     <GlyphFieldWrapper
       id={id}
+      configKey={configKey}
       value={value}
       onChange={onChange}
       placeholder={placeholder}

--- a/frontend/src/components/base/fields/fields/StringField.tsx
+++ b/frontend/src/components/base/fields/fields/StringField.tsx
@@ -13,6 +13,7 @@ import { InputGroupInput } from '@/components/ui/input-group'
 
 export interface StringFieldProps {
   id: string
+  configKey: string
   value: string
   onChange: (value: string) => void
   placeholder?: string
@@ -26,6 +27,7 @@ export interface StringFieldProps {
  */
 export function StringField({
   id,
+  configKey,
   value,
   onChange,
   placeholder,
@@ -35,6 +37,7 @@ export function StringField({
   return (
     <GlyphFieldWrapper
       id={id}
+      configKey={configKey}
       value={value}
       onChange={onChange}
       placeholder={placeholder}

--- a/frontend/src/features/fable-builder/components/FableBuilderPage.tsx
+++ b/frontend/src/features/fable-builder/components/FableBuilderPage.tsx
@@ -22,6 +22,11 @@ import { ReviewStep as ReviewStepComponent } from './review/ReviewStep'
 import type { PresetId } from '@/features/fable-builder/presets/presets'
 import type { BlockFactoryCatalogue } from '@/api/types/fable.types'
 import { useURLStateSync } from '@/features/fable-builder/hooks/useURLStateSync'
+import {
+  clearDraft,
+  readDraft,
+  useDraftPersistence,
+} from '@/features/fable-builder/hooks/useDraftPersistence'
 import { getPreset } from '@/features/fable-builder/presets/presets'
 import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
 import { useMedia } from '@/hooks/useMedia'
@@ -40,6 +45,7 @@ import { Button } from '@/components/ui/button'
 import { useAuth } from '@/features/auth/AuthContext'
 import { useUser } from '@/hooks/useUser'
 import { ApiClientError } from '@/api/client'
+import { showToast } from '@/lib/toast'
 
 /**
  * Extract a user-friendly error message from a validation error
@@ -98,6 +104,9 @@ export function FableBuilderPage({
 
   const initializedRef = useRef(false)
 
+  // Auto-persist drafts to localStorage + beforeunload guard
+  useDraftPersistence()
+
   useURLStateSync({
     encodedState: fableId ? undefined : encodedState,
     enabled: !fableId,
@@ -120,9 +129,40 @@ export function FableBuilderPage({
     error: validationError,
   } = useFableValidation(fable)
 
-  // Initialize fable state - only runs once per mount
+  // Initialize fable state - only runs once per mount.
+  // Checks for a stale draft in localStorage before loading from backend.
   useEffect(() => {
     if (initializedRef.current) return
+
+    // Check for a recoverable draft before normal initialization
+    const draft = readDraft()
+    if (draft) {
+      const draftMatchesRoute =
+        (fableId && draft.fableId === fableId) || (!fableId && !draft.fableId)
+
+      if (draftMatchesRoute && Object.keys(draft.fable.blocks).length > 0) {
+        const ago = Math.round((Date.now() - draft.savedAt) / 60_000)
+        const timeLabel = ago < 1 ? 'just now' : `${ago} min ago`
+
+        showToast.info(`Unsaved draft restored (${timeLabel})`, draft.fableName)
+        setFable(draft.fable, draft.fableId)
+        if (draft.fableName) setFableName(draft.fableName)
+        if (draft.fableVersion) {
+          useFableBuilderStore.setState({
+            fableVersion: draft.fableVersion,
+            isDirty: true,
+          })
+        } else {
+          useFableBuilderStore.setState({ isDirty: true })
+        }
+        clearDraft()
+        initializedRef.current = true
+        return
+      }
+
+      // Draft doesn't match current route — discard silently
+      clearDraft()
+    }
 
     if (fableId && existingFable) {
       setFable(existingFable, fableId)

--- a/frontend/src/features/fable-builder/components/form-mode/BlockInstanceCard.tsx
+++ b/frontend/src/features/fable-builder/components/form-mode/BlockInstanceCard.tsx
@@ -32,6 +32,9 @@ import {
 import { P } from '@/components/base/typography'
 import { Button } from '@/components/ui/button'
 import { FieldRenderer } from '@/components/base/fields/FieldRenderer'
+import { ResolvedConfigContext } from '@/features/fable-builder/context/ResolvedConfigContext'
+import { FieldErrorsContext } from '@/features/fable-builder/context/FieldErrorsContext'
+import { mapBlockErrorsToFields } from '@/features/fable-builder/utils/map-block-errors-to-fields'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import {
   ContextMenu,
@@ -104,6 +107,10 @@ export function BlockInstanceCard({
   )
   const connectBlocks = useFableBuilderStore((state) => state.connectBlocks)
   const disconnectBlock = useFableBuilderStore((state) => state.disconnectBlock)
+  const resolvedConfigForBlock = useFableBuilderStore(
+    (state) =>
+      state.validationState?.resolvedConfigurationOptions[instanceId] ?? null,
+  )
   const blockValidation = useBlockValidation(instanceId)
 
   const instance = fable.blocks[instanceId]
@@ -127,14 +134,19 @@ export function BlockInstanceCard({
       }))
   }, [fable.blocks, instanceId, catalogue])
 
+  const hasErrors = blockValidation?.hasErrors ?? false
+  const errors = blockValidation?.errors ?? []
+  const mappedErrors = useMemo(
+    () => mapBlockErrorsToFields(errors, instance.configuration_values),
+    [errors, instance.configuration_values],
+  )
+
   if (!factory) {
     return null
   }
 
   const metadata = BLOCK_KIND_METADATA[factory.kind]
   const IconComponent = getBlockKindIcon(factory.kind)
-  const hasErrors = blockValidation?.hasErrors ?? false
-  const errors = blockValidation?.errors ?? []
 
   return (
     <ContextMenu>
@@ -236,17 +248,6 @@ export function BlockInstanceCard({
 
           {isExpanded && (
             <CardContent className="border-t px-4 py-3">
-              {hasErrors && (
-                <div className="mb-4 rounded-md bg-destructive/10 p-3 text-destructive">
-                  <P className="mb-1 font-medium">Configuration Issues</P>
-                  <ul className="list-disc space-y-0.5 pl-4 text-sm">
-                    {errors.map((error, index) => (
-                      <li key={`${error}-${index}`}>{error}</li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-
               {factory.inputs.length > 0 && (
                 <div className="mb-4 border-b pb-4">
                   <P className="mb-3 font-medium">Input Connections</P>
@@ -313,23 +314,28 @@ export function BlockInstanceCard({
               )}
 
               {Object.keys(factory.configuration_options).length > 0 ? (
-                <div className="space-y-4">
-                  {Object.entries(factory.configuration_options).map(
-                    ([key, option]) => (
-                      <FieldRenderer
-                        key={key}
-                        id={`${instanceId}-${key}`}
-                        valueType={option.value_type}
-                        value={instance.configuration_values[key] ?? ''}
-                        onChange={(value) =>
-                          updateBlockConfig(instanceId, key, value)
-                        }
-                        label={option.title}
-                        description={option.description}
-                      />
-                    ),
-                  )}
-                </div>
+                <ResolvedConfigContext.Provider value={resolvedConfigForBlock}>
+                  <FieldErrorsContext.Provider value={mappedErrors.byConfigKey}>
+                    <div className="space-y-4">
+                      {Object.entries(factory.configuration_options).map(
+                        ([key, option]) => (
+                          <FieldRenderer
+                            key={key}
+                            id={`${instanceId}-${key}`}
+                            configKey={key}
+                            valueType={option.value_type}
+                            value={instance.configuration_values[key] ?? ''}
+                            onChange={(value) =>
+                              updateBlockConfig(instanceId, key, value)
+                            }
+                            label={option.title}
+                            description={option.description}
+                          />
+                        ),
+                      )}
+                    </div>
+                  </FieldErrorsContext.Provider>
+                </ResolvedConfigContext.Provider>
               ) : (
                 <P className="py-2 text-center text-muted-foreground">
                   No configuration options

--- a/frontend/src/features/fable-builder/components/graph-mode/AddNodeButton.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/AddNodeButton.tsx
@@ -37,6 +37,10 @@ interface AddNodeButtonProps {
   sourceBlockId: BlockInstanceId
   possibleExpansions: Array<PluginBlockFactoryId>
   catalogue: BlockFactoryCatalogue
+  /** When true, the button adopts the destructive color to signal errors on the parent node */
+  hasErrors?: boolean
+  /** When true, this block already has a downstream connection — hide the button */
+  hasDownstream?: boolean
 }
 
 const POSITION_CLASSES: Record<string, string> = {
@@ -57,6 +61,8 @@ export const AddNodeButton = memo(function ({
   sourceBlockId,
   possibleExpansions,
   catalogue,
+  hasErrors = false,
+  hasDownstream = false,
 }: AddNodeButtonProps) {
   const [open, setOpen] = useState(false)
   const [search, setSearch] = useState('')
@@ -65,9 +71,12 @@ export const AddNodeButton = memo(function ({
   const connectBlocks = useFableBuilderStore((state) => state.connectBlocks)
   const layoutDirection = useFableBuilderStore((state) => state.layoutDirection)
 
-  const availableFactories = useMemo(
-    () =>
-      possibleExpansions
+  // When the backend provides validated expansions, use them. Otherwise build
+  // a fallback from the full catalogue (all factories that accept inputs) so
+  // the user can always add blocks even when the parent node has errors.
+  const availableFactories = useMemo(() => {
+    if (possibleExpansions.length > 0) {
+      return possibleExpansions
         .map((id) => ({
           id,
           factory: getFactory(catalogue, id),
@@ -75,9 +84,28 @@ export const AddNodeButton = memo(function ({
         .filter(
           (item): item is { id: PluginBlockFactoryId; factory: BlockFactory } =>
             item.factory !== undefined,
-        ),
-    [possibleExpansions, catalogue],
-  )
+        )
+    }
+
+    // Fallback: all factories with at least one input (i.e. can be downstream)
+    const fallback: Array<{
+      id: PluginBlockFactoryId
+      factory: BlockFactory
+    }> = []
+    for (const [pluginKey, plugin] of Object.entries(catalogue)) {
+      for (const [factoryKey, factory] of Object.entries(plugin.factories)) {
+        if (factory.inputs.length > 0) {
+          // Reconstruct the PluginBlockFactoryId — pluginKey is "store/local"
+          const [store, local] = pluginKey.split('/')
+          fallback.push({
+            id: { plugin: { store, local }, factory: factoryKey },
+            factory,
+          })
+        }
+      }
+    }
+    return fallback
+  }, [possibleExpansions, catalogue])
 
   const filteredFactories = useMemo(() => {
     if (!search.trim()) return availableFactories
@@ -119,7 +147,9 @@ export const AddNodeButton = memo(function ({
     setSearch('')
   }
 
-  if (possibleExpansions.length === 0) {
+  // Once a downstream block is connected, the output Handle is enough —
+  // the plus button is only for adding the first downstream block.
+  if (hasDownstream) {
     return null
   }
 
@@ -133,8 +163,10 @@ export const AddNodeButton = memo(function ({
             className={cn(
               POSITION_CLASSES[layoutDirection],
               'h-7 w-7 rounded-full',
-              'border-2 bg-background shadow-md',
-              'hover:border-primary hover:bg-primary hover:text-primary-foreground',
+              'border-2 bg-background shadow-md hover:bg-background',
+              hasErrors
+                ? 'border-destructive text-destructive hover:border-destructive/70'
+                : 'hover:border-primary hover:text-primary',
               'nodrag nopan transition-all duration-200',
             )}
             onClick={(e) => e.stopPropagation()}

--- a/frontend/src/features/fable-builder/components/graph-mode/FableGraphCanvas.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/FableGraphCanvas.tsx
@@ -248,9 +248,9 @@ function FableGraphCanvasInner({ catalogue }: FableGraphCanvasProps) {
     [selectBlock],
   )
 
-  const onPaneClick = useCallback(() => {
-    selectBlock(null)
-  }, [selectBlock])
+  // Clicking empty canvas intentionally does NOT deselect the node (Blender
+  // pattern). The sidebar stays with the last-selected node's config. To
+  // deselect, use the X button in the ConfigPanel header.
 
   return (
     <div ref={containerRef} className="h-full w-full">
@@ -261,7 +261,6 @@ function FableGraphCanvasInner({ catalogue }: FableGraphCanvasProps) {
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}
         onNodeClick={onNodeClick}
-        onPaneClick={onPaneClick}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
         nodesDraggable={!nodesLocked}

--- a/frontend/src/features/fable-builder/components/graph-mode/nodes/BlockNode.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/nodes/BlockNode.tsx
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-import { memo, useState } from 'react'
+import { memo, useMemo, useState } from 'react'
 import { Handle, Position } from '@xyflow/react'
 import {
   AlertCircle,
@@ -47,11 +47,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
+import { Alert, AlertDescription } from '@/components/ui/alert'
 import { parseGlyphSegments } from '@/features/fable-builder/utils/glyph-display'
 import { cn } from '@/lib/utils'
 
@@ -99,11 +95,20 @@ export const BlockNode = memo(function ({
   const outputPosition = OUTPUT_POSITIONS[layoutDirection]
   const isHorizontalLayout = layoutDirection === 'LR'
 
+  const fable = useFableBuilderStore((state) => state.fable)
+
   const isSelected = selected || selectedBlockId === id
   const hasErrors = blockValidation?.hasErrors ?? false
   const errors = blockValidation?.errors ?? []
   const possibleExpansions =
     validationState?.blockStates[id]?.possibleExpansions ?? []
+  const hasDownstream = useMemo(
+    () =>
+      Object.values(fable.blocks).some((block) =>
+        Object.values(block.input_ids).includes(id),
+      ),
+    [fable.blocks, id],
+  )
 
   function handleClick(): void {
     selectBlock(id)
@@ -151,32 +156,20 @@ export const BlockNode = memo(function ({
       onKeyDown={(e) => e.key === 'Enter' && handleClick()}
       className={cn(
         'relative w-70 rounded-2xl border bg-card shadow-sm',
-        'cursor-pointer transition-all duration-300 hover:shadow-lg',
+        'cursor-pointer transition-all duration-200',
+        // Hover: subtle border hint (distinct from full selection)
+        !isSelected &&
+          !hasErrors &&
+          'hover:shadow-md hover:ring-1 hover:ring-primary/20',
+        // Selected: prominent blue ring + lifted scale
         isSelected &&
-          'shadow-[0_0_0_2px_rgba(18,69,222,1),0_15px_35px_-5px_rgba(18,69,222,0.15)]',
+          'scale-[1.02] shadow-[0_0_0_2.5px_rgba(18,69,222,1),0_20px_40px_-5px_rgba(18,69,222,0.2)]',
+        // Error (unselected): red ring
         hasErrors &&
           !isSelected &&
           'shadow-[0_0_0_2px_rgba(220,38,38,1),0_15px_35px_-5px_rgba(220,38,38,0.15)]',
       )}
     >
-      {hasErrors && (
-        <Tooltip>
-          <TooltipTrigger className="absolute -top-2 -right-2 z-10 flex h-5 w-5 cursor-pointer items-center justify-center rounded-full bg-destructive text-destructive-foreground">
-            <AlertCircle className="h-3 w-3" />
-          </TooltipTrigger>
-          <TooltipContent side="top" className="max-w-75">
-            <div className="space-y-1">
-              <P className="font-medium text-destructive">Validation Errors</P>
-              <ul className="list-disc space-y-0.5 pl-4 text-sm">
-                {errors.map((error, index) => (
-                  <li key={`${error}-${index}`}>{error}</li>
-                ))}
-              </ul>
-            </div>
-          </TooltipContent>
-        </Tooltip>
-      )}
-
       <div
         className={cn(
           'h-1.5 w-full rounded-t-2xl opacity-80',
@@ -330,10 +323,22 @@ export const BlockNode = memo(function ({
             )}
           </div>
         )}
+
+        {hasErrors && (
+          <Alert
+            variant="destructive"
+            className="nodrag mt-3 gap-1 px-2 py-1.5 text-xs"
+          >
+            <AlertCircle className="h-3 w-3" />
+            <AlertDescription className="line-clamp-2 text-xs">
+              {errors[0]}
+              {errors.length > 1 && ` (+${errors.length - 1} more)`}
+            </AlertDescription>
+          </Alert>
+        )}
       </div>
 
       {factory.inputs.map((inputName, index) => {
-        const isConnected = Boolean(instance.input_ids[inputName])
         const percent = ((index + 1) / (factory.inputs.length + 1)) * 100
 
         return (
@@ -348,9 +353,7 @@ export const BlockNode = memo(function ({
               isHorizontalLayout ? '-left-2.5!' : '-top-2.5!',
               inputPosition === Position.Right && '-right-2.5! left-auto!',
               inputPosition === Position.Bottom && 'top-auto! -bottom-2.5!',
-              isConnected
-                ? 'border-primary!'
-                : 'border-muted-foreground/30! hover:border-muted-foreground/50!',
+              'border-foreground/30!',
               'transition-all hover:scale-110',
             )}
             style={
@@ -371,7 +374,7 @@ export const BlockNode = memo(function ({
             title="Output"
             className={cn(
               'h-5! w-5! rounded-full! border-4! bg-card!',
-              metadata.handleColor,
+              'border-foreground/30!',
               isHorizontalLayout ? '-right-2.5!' : '-bottom-2.5!',
               outputPosition === Position.Left && 'right-auto! -left-2.5!',
               outputPosition === Position.Top && '-top-2.5! bottom-auto!',
@@ -386,6 +389,8 @@ export const BlockNode = memo(function ({
           <AddNodeButton
             sourceBlockId={id}
             possibleExpansions={possibleExpansions}
+            hasErrors={hasErrors}
+            hasDownstream={hasDownstream}
             catalogue={catalogue}
           />
         </>

--- a/frontend/src/features/fable-builder/components/graph-mode/nodes/InlineBlockNode.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/nodes/InlineBlockNode.tsx
@@ -15,6 +15,7 @@ import { AlertCircle, Trash2 } from 'lucide-react'
 import type { Node, NodeProps } from '@xyflow/react'
 import type { FableNodeData } from '@/features/fable-builder/utils/fable-to-graph'
 import type { BlockFactory, BlockInstance } from '@/api/types/fable.types'
+import { Alert, AlertDescription } from '@/components/ui/alert'
 import { AddNodeButton } from '@/features/fable-builder/components/graph-mode/AddNodeButton'
 import { useNodeDimensions } from '@/features/fable-builder/hooks/useNodeDimensions'
 import {
@@ -39,6 +40,9 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
 import { FieldRenderer } from '@/components/base/fields/FieldRenderer'
+import { ResolvedConfigContext } from '@/features/fable-builder/context/ResolvedConfigContext'
+import { FieldErrorsContext } from '@/features/fable-builder/context/FieldErrorsContext'
+import { mapBlockErrorsToFields } from '@/features/fable-builder/utils/map-block-errors-to-fields'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import {
@@ -49,11 +53,6 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Separator } from '@/components/ui/separator'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 
 export type FableNode = Node<FableNodeData>
@@ -87,6 +86,13 @@ export const InlineBlockNode = memo(function ({
   const errors = blockValidation?.errors ?? []
   const possibleExpansions =
     validationState?.blockStates[id]?.possibleExpansions ?? []
+  const hasDownstream = useMemo(
+    () =>
+      Object.values(fable.blocks).some((block) =>
+        Object.values(block.input_ids).includes(id),
+      ),
+    [fable.blocks, id],
+  )
 
   const availableSources = useMemo(() => {
     const sources: Array<{
@@ -120,6 +126,11 @@ export const InlineBlockNode = memo(function ({
   const configOptions = Object.entries(factory.configuration_options)
   const inputs = factory.inputs
 
+  const mappedErrors = useMemo(
+    () => mapBlockErrorsToFields(errors, instance.configuration_values),
+    [errors, instance.configuration_values],
+  )
+
   return (
     <div
       ref={containerRef}
@@ -129,32 +140,20 @@ export const InlineBlockNode = memo(function ({
       onKeyDown={(e) => e.key === 'Enter' && selectBlock(id)}
       className={cn(
         'relative w-[380px] rounded-2xl border bg-card shadow-sm',
-        'cursor-pointer transition-all duration-300 hover:shadow-lg',
+        'cursor-pointer transition-all duration-200',
+        // Hover: subtle border hint (distinct from full selection)
+        !isSelected &&
+          !hasErrors &&
+          'hover:shadow-md hover:ring-1 hover:ring-primary/20',
+        // Selected: prominent blue ring + lifted scale
         isSelected &&
-          'shadow-[0_0_0_2px_rgba(18,69,222,1),0_15px_35px_-5px_rgba(18,69,222,0.15)]',
+          'scale-[1.02] shadow-[0_0_0_2.5px_rgba(18,69,222,1),0_20px_40px_-5px_rgba(18,69,222,0.2)]',
+        // Error (unselected): red ring
         hasErrors &&
           !isSelected &&
           'shadow-[0_0_0_2px_rgba(220,38,38,1),0_15px_35px_-5px_rgba(220,38,38,0.15)]',
       )}
     >
-      {hasErrors && (
-        <Tooltip>
-          <TooltipTrigger className="absolute -top-2 -right-2 z-10 flex h-5 w-5 cursor-pointer items-center justify-center rounded-full bg-destructive text-destructive-foreground">
-            <AlertCircle className="h-3 w-3" />
-          </TooltipTrigger>
-          <TooltipContent side="top" className="max-w-75">
-            <div className="space-y-1">
-              <P className="font-medium text-destructive">Validation Errors</P>
-              <ul className="list-disc space-y-0.5 pl-4 text-sm">
-                {errors.map((error, index) => (
-                  <li key={`${error}-${index}`}>{error}</li>
-                ))}
-              </ul>
-            </div>
-          </TooltipContent>
-        </Tooltip>
-      )}
-
       <div
         className={cn(
           'h-1.5 w-full rounded-t-2xl opacity-80',
@@ -273,34 +272,53 @@ export const InlineBlockNode = memo(function ({
         )}
 
         {configOptions.length > 0 && (
-          <div className="space-y-3">
-            {inputs.length > 0 && <Separator />}
-            <div className="text-sm font-medium text-muted-foreground">
-              Configuration
-            </div>
-            {configOptions.map(([key, option]) => (
-              <div
-                key={key}
-                className="nodrag space-y-1"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <FieldRenderer
-                  id={`config-${id}-${key}`}
-                  valueType={option.value_type}
-                  value={instance.configuration_values[key] || ''}
-                  onChange={(value) => updateBlockConfig(id, key, value)}
-                  label={option.title || key}
-                  description={option.description}
-                  inputClassName="h-8 text-sm"
-                />
+          <ResolvedConfigContext.Provider
+            value={validationState?.resolvedConfigurationOptions[id] ?? null}
+          >
+            <FieldErrorsContext.Provider value={mappedErrors.byConfigKey}>
+              <div className="space-y-3">
+                {inputs.length > 0 && <Separator />}
+                <div className="text-sm font-medium text-muted-foreground">
+                  Configuration
+                </div>
+                {configOptions.map(([key, option]) => (
+                  <div
+                    key={key}
+                    className="nodrag space-y-1"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <FieldRenderer
+                      id={`config-${id}-${key}`}
+                      configKey={key}
+                      valueType={option.value_type}
+                      value={instance.configuration_values[key] || ''}
+                      onChange={(value) => updateBlockConfig(id, key, value)}
+                      label={option.title || key}
+                      description={option.description}
+                      inputClassName="h-8 text-sm"
+                    />
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
+            </FieldErrorsContext.Provider>
+          </ResolvedConfigContext.Provider>
+        )}
+
+        {hasErrors && (
+          <Alert
+            variant="destructive"
+            className="nodrag mt-3 gap-1 px-2 py-1.5 text-xs"
+          >
+            <AlertCircle className="h-3 w-3" />
+            <AlertDescription className="line-clamp-2 text-xs">
+              {errors[0]}
+              {errors.length > 1 && ` (+${errors.length - 1} more)`}
+            </AlertDescription>
+          </Alert>
         )}
       </div>
 
       {inputs.map((inputName, index) => {
-        const isConnected = Boolean(instance.input_ids[inputName])
         const topPercent = ((index + 1) / (inputs.length + 1)) * 100
 
         return (
@@ -312,9 +330,7 @@ export const InlineBlockNode = memo(function ({
             title={inputName}
             className={cn(
               '-left-2.5! h-5! w-5! rounded-full! border-4! bg-card!',
-              isConnected
-                ? 'border-primary!'
-                : 'border-muted-foreground/30! hover:border-muted-foreground/50!',
+              'border-foreground/30!',
               'transition-all hover:scale-110',
             )}
             style={{
@@ -333,7 +349,7 @@ export const InlineBlockNode = memo(function ({
           title="Output"
           className={cn(
             '-right-2.5! h-5! w-5! rounded-full! border-4! bg-card!',
-            metadata.handleColor,
+            'border-foreground/30!',
             'transition-all hover:scale-110',
           )}
           style={{
@@ -348,6 +364,8 @@ export const InlineBlockNode = memo(function ({
           sourceBlockId={id}
           possibleExpansions={possibleExpansions}
           catalogue={catalogue}
+          hasErrors={hasErrors}
+          hasDownstream={hasDownstream}
         />
       )}
     </div>

--- a/frontend/src/features/fable-builder/components/layout/ConfigPanel.tsx
+++ b/frontend/src/features/fable-builder/components/layout/ConfigPanel.tsx
@@ -42,6 +42,9 @@ import {
 } from '@/components/ui/alert-dialog'
 import { Badge } from '@/components/ui/badge'
 import { GlyphReferencePanel } from '@/features/fable-builder/components/shared/GlyphReferencePanel'
+import { ResolvedConfigContext } from '@/features/fable-builder/context/ResolvedConfigContext'
+import { FieldErrorsContext } from '@/features/fable-builder/context/FieldErrorsContext'
+import { mapBlockErrorsToFields } from '@/features/fable-builder/utils/map-block-errors-to-fields'
 import { cn } from '@/lib/utils'
 
 interface ConfigPanelProps {
@@ -52,6 +55,19 @@ export function ConfigPanel({ catalogue }: ConfigPanelProps): React.ReactNode {
   // Use individual selectors to avoid creating new objects on every render
   const selectedBlockId = useFableBuilderStore((state) => state.selectedBlockId)
   const fable = useFableBuilderStore((state) => state.fable)
+  const resolvedConfigForBlock = useFableBuilderStore((state) =>
+    state.selectedBlockId
+      ? (state.validationState?.resolvedConfigurationOptions[
+          state.selectedBlockId
+        ] ?? null)
+      : null,
+  )
+  const blockErrors = useFableBuilderStore((state) =>
+    state.selectedBlockId
+      ? (state.validationState?.blockStates[state.selectedBlockId]?.errors ??
+        null)
+      : null,
+  )
   const selectBlock = useFableBuilderStore((state) => state.selectBlock)
   const updateBlockConfig = useFableBuilderStore(
     (state) => state.updateBlockConfig,
@@ -102,6 +118,14 @@ export function ConfigPanel({ catalogue }: ConfigPanelProps): React.ReactNode {
     removeBlock(selectedBlockId)
     selectBlock(null)
   }
+
+  // Hook must be called unconditionally — guard inside rather than early-
+  // returning above it.
+  const configurationValues = selectedBlock?.configuration_values
+  const mappedErrors = useMemo(
+    () => mapBlockErrorsToFields(blockErrors ?? [], configurationValues ?? {}),
+    [blockErrors, configurationValues],
+  )
 
   if (!selectedBlock || !factory) {
     return (
@@ -174,24 +198,29 @@ export function ConfigPanel({ catalogue }: ConfigPanelProps): React.ReactNode {
         )}
 
         {configOptions.length > 0 && (
-          <div className="space-y-3">
-            <div className="text-sm font-medium">Configuration</div>
-            <div className="space-y-4">
-              {configOptions.map(([key, option]) => (
-                <FieldRenderer
-                  key={key}
-                  id={`config-${key}`}
-                  valueType={option.value_type}
-                  value={selectedBlock.configuration_values[key] || ''}
-                  onChange={(value) => handleConfigChange(key, value)}
-                  label={option.title || key}
-                  description={option.description}
-                  inputClassName="h-9"
-                />
-              ))}
-            </div>
-            <GlyphReferencePanel />
-          </div>
+          <ResolvedConfigContext.Provider value={resolvedConfigForBlock}>
+            <FieldErrorsContext.Provider value={mappedErrors.byConfigKey}>
+              <div className="space-y-3">
+                <div className="text-sm font-medium">Configuration</div>
+                <div className="space-y-4">
+                  {configOptions.map(([key, option]) => (
+                    <FieldRenderer
+                      key={key}
+                      id={`config-${key}`}
+                      configKey={key}
+                      valueType={option.value_type}
+                      value={selectedBlock.configuration_values[key] || ''}
+                      onChange={(value) => handleConfigChange(key, value)}
+                      label={option.title || key}
+                      description={option.description}
+                      inputClassName="h-9"
+                    />
+                  ))}
+                </div>
+                <GlyphReferencePanel />
+              </div>
+            </FieldErrorsContext.Provider>
+          </ResolvedConfigContext.Provider>
         )}
 
         {configOptions.length === 0 && inputs.length === 0 && (

--- a/frontend/src/features/fable-builder/components/layout/PanelToggleHandle.tsx
+++ b/frontend/src/features/fable-builder/components/layout/PanelToggleHandle.tsx
@@ -50,9 +50,10 @@ export function PanelToggleHandle({
           <Button
             variant="ghost"
             size="icon"
+            onPointerDown={(e) => e.stopPropagation()}
             onClick={onToggle}
             className={cn(
-              'absolute top-1/2 z-20 -translate-y-1/2',
+              'absolute top-1/2 z-30 -translate-y-1/2',
               'rounded-sm border border-border bg-muted/50 hover:bg-muted',
               'transition-all duration-150',
               // Size: larger when closed for better touch target

--- a/frontend/src/features/fable-builder/components/layout/ThreeColumnLayout.tsx
+++ b/frontend/src/features/fable-builder/components/layout/ThreeColumnLayout.tsx
@@ -8,15 +8,63 @@
  * does it submit to any jurisdiction.
  */
 
+import { useCallback, useRef } from 'react'
+import { RotateCcw } from 'lucide-react'
 import { PanelToggleHandle } from './PanelToggleHandle'
 import type { ReactNode } from 'react'
 import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
+import { useUiPreferencesStore } from '@/features/fable-builder/stores/uiPreferencesStore'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 
 interface ThreeColumnLayoutProps {
   leftSidebar: ReactNode
   canvas: ReactNode
   rightSidebar: ReactNode
+}
+
+/**
+ * Hook for pointer-based sidebar resizing. Returns an onPointerDown handler
+ * that tracks horizontal drag delta and calls the setter with the new width.
+ */
+function useResizeHandle(
+  getCurrentWidth: () => number,
+  setWidth: (width: number) => void,
+  direction: 'left' | 'right',
+) {
+  const startXRef = useRef(0)
+  const startWidthRef = useRef(0)
+
+  return useCallback(
+    (e: React.PointerEvent) => {
+      e.preventDefault()
+      startXRef.current = e.clientX
+      startWidthRef.current = getCurrentWidth()
+
+      const onMove = (ev: PointerEvent) => {
+        const delta = ev.clientX - startXRef.current
+        // Left sidebar: drag right = wider. Right sidebar: drag left = wider.
+        const newWidth =
+          direction === 'left'
+            ? startWidthRef.current + delta
+            : startWidthRef.current - delta
+        setWidth(newWidth)
+      }
+
+      const onUp = () => {
+        document.removeEventListener('pointermove', onMove)
+        document.removeEventListener('pointerup', onUp)
+      }
+
+      document.addEventListener('pointermove', onMove)
+      document.addEventListener('pointerup', onUp)
+    },
+    [getCurrentWidth, setWidth, direction],
+  )
 }
 
 export function ThreeColumnLayout({
@@ -28,6 +76,19 @@ export function ThreeColumnLayout({
   const isConfigPanelOpen = useFableBuilderStore((s) => s.isConfigPanelOpen)
   const togglePalette = useFableBuilderStore((s) => s.togglePalette)
   const toggleConfigPanel = useFableBuilderStore((s) => s.toggleConfigPanel)
+
+  const leftWidth = useUiPreferencesStore((s) => s.leftSidebarWidth)
+  const rightWidth = useUiPreferencesStore((s) => s.rightSidebarWidth)
+  const setLeftWidth = useUiPreferencesStore((s) => s.setLeftSidebarWidth)
+  const setRightWidth = useUiPreferencesStore((s) => s.setRightSidebarWidth)
+  const resetLeftWidth = useUiPreferencesStore((s) => s.resetLeftSidebarWidth)
+  const resetRightWidth = useUiPreferencesStore((s) => s.resetRightSidebarWidth)
+
+  const getLeftWidth = useCallback(() => leftWidth, [leftWidth])
+  const getRightWidth = useCallback(() => rightWidth, [rightWidth])
+
+  const onLeftResize = useResizeHandle(getLeftWidth, setLeftWidth, 'left')
+  const onRightResize = useResizeHandle(getRightWidth, setRightWidth, 'right')
 
   return (
     <div className="relative flex h-full min-h-0 w-full">
@@ -42,15 +103,41 @@ export function ThreeColumnLayout({
       {/* Left Panel */}
       <aside
         className={cn(
-          'z-10 shrink-0 overflow-hidden border-r border-border bg-card transition-all duration-200 ease-in-out',
-          isPaletteOpen ? 'w-64' : 'w-0',
+          'z-10 shrink-0 overflow-hidden border-r border-border bg-card transition-[width] duration-200 ease-in-out',
         )}
+        style={{ width: isPaletteOpen ? leftWidth : 0 }}
       >
-        <div className="h-full w-64 overflow-y-auto">{leftSidebar}</div>
+        <div className="h-full overflow-y-auto" style={{ width: leftWidth }}>
+          {leftSidebar}
+        </div>
       </aside>
 
-      {/* Left toggle handle - positioned at the border */}
+      {/* Left resize + toggle handle */}
       <div className="relative shrink-0">
+        {isPaletteOpen && (
+          <div
+            className="group/resize absolute inset-y-0 -left-1 z-20 w-3 cursor-col-resize hover:bg-primary/10 active:bg-primary/20"
+            onPointerDown={onLeftResize}
+          >
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    className="absolute top-2 left-1/2 z-30 flex h-5 w-5 -translate-x-1/2 items-center justify-center rounded-full border border-border bg-card opacity-0 shadow-sm transition-opacity group-hover/resize:opacity-100 hover:bg-muted"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      resetLeftWidth()
+                    }}
+                    aria-label="Reset sidebar width"
+                  />
+                }
+              >
+                <RotateCcw className="h-2.5 w-2.5 text-muted-foreground" />
+              </TooltipTrigger>
+              <TooltipContent side="right">Reset sidebar width</TooltipContent>
+            </Tooltip>
+          </div>
+        )}
         <PanelToggleHandle
           isOpen={isPaletteOpen}
           onToggle={togglePalette}
@@ -62,8 +149,32 @@ export function ThreeColumnLayout({
       {/* Canvas */}
       <main className="min-w-0 flex-1 overflow-hidden">{canvas}</main>
 
-      {/* Right toggle handle - positioned at the border */}
+      {/* Right resize + toggle handle */}
       <div className="relative shrink-0">
+        {isConfigPanelOpen && (
+          <div
+            className="group/resize absolute inset-y-0 -right-1 z-20 w-3 cursor-col-resize hover:bg-primary/10 active:bg-primary/20"
+            onPointerDown={onRightResize}
+          >
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    className="absolute top-2 left-1/2 z-30 flex h-5 w-5 -translate-x-1/2 items-center justify-center rounded-full border border-border bg-card opacity-0 shadow-sm transition-opacity group-hover/resize:opacity-100 hover:bg-muted"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      resetRightWidth()
+                    }}
+                    aria-label="Reset sidebar width"
+                  />
+                }
+              >
+                <RotateCcw className="h-2.5 w-2.5 text-muted-foreground" />
+              </TooltipTrigger>
+              <TooltipContent side="left">Reset sidebar width</TooltipContent>
+            </Tooltip>
+          </div>
+        )}
         <PanelToggleHandle
           isOpen={isConfigPanelOpen}
           onToggle={toggleConfigPanel}
@@ -75,11 +186,13 @@ export function ThreeColumnLayout({
       {/* Right Panel */}
       <aside
         className={cn(
-          'z-10 shrink-0 overflow-hidden border-l border-border bg-card transition-all duration-200 ease-in-out',
-          isConfigPanelOpen ? 'w-80' : 'w-0',
+          'z-10 shrink-0 overflow-hidden border-l border-border bg-card transition-[width] duration-200 ease-in-out',
         )}
+        style={{ width: isConfigPanelOpen ? rightWidth : 0 }}
       >
-        <div className="h-full w-80 overflow-y-auto">{rightSidebar}</div>
+        <div className="h-full overflow-y-auto" style={{ width: rightWidth }}>
+          {rightSidebar}
+        </div>
       </aside>
 
       {/* Right margin zone when sidebar closed */}

--- a/frontend/src/features/fable-builder/context/FieldErrorsContext.tsx
+++ b/frontend/src/features/fable-builder/context/FieldErrorsContext.tsx
@@ -1,0 +1,31 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Per-block field errors, keyed by configuration option key. Provided by
+ * the builder layout components (ConfigPanel, BlockInstanceCard,
+ * InlineBlockNode) and consumed by GlyphFieldWrapper to render red borders
+ * and inline error messages beneath individual fields.
+ *
+ * `null` means no field-level errors for this block — either the block is
+ * valid, or its errors could not be attributed to a specific field (those
+ * are surfaced at the block level instead).
+ */
+
+import { createContext, useContext } from 'react'
+
+export const FieldErrorsContext = createContext<Record<
+  string,
+  Array<string>
+> | null>(null)
+
+export function useFieldErrors(): Record<string, Array<string>> | null {
+  return useContext(FieldErrorsContext)
+}

--- a/frontend/src/features/fable-builder/context/ResolvedConfigContext.tsx
+++ b/frontend/src/features/fable-builder/context/ResolvedConfigContext.tsx
@@ -1,0 +1,28 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Exposes the backend-resolved configuration map for the currently-rendered
+ * block. Populated from `/blueprint/expand` via useFableValidation and
+ * consumed by GlyphFieldWrapper / GlyphTextInput to render authoritative
+ * "resolves to" previews. Backend is the sole source of truth — when a
+ * value is missing from this map, no preview is rendered.
+ */
+
+import { createContext, useContext } from 'react'
+
+export const ResolvedConfigContext = createContext<Record<
+  string,
+  string
+> | null>(null)
+
+export function useResolvedConfig(): Record<string, string> | null {
+  return useContext(ResolvedConfigContext)
+}

--- a/frontend/src/features/fable-builder/hooks/useDraftPersistence.ts
+++ b/frontend/src/features/fable-builder/hooks/useDraftPersistence.ts
@@ -1,0 +1,129 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Auto-persists fable drafts to localStorage so users don't lose unsaved
+ * work on accidental navigation or tab close.
+ *
+ * - Writes debounced (2 s) after every store change that sets isDirty.
+ * - Clears the draft on successful save (markSaved).
+ * - On mount, checks for a stale draft and returns it for recovery.
+ * - Registers a `beforeunload` guard when isDirty.
+ */
+
+import { useCallback, useEffect, useRef } from 'react'
+import type { FableBuilderV1 } from '@/api/types/fable.types'
+import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
+
+const DRAFT_KEY = 'fiab.fable.draft'
+const DEBOUNCE_MS = 2000
+
+export interface FableDraft {
+  fable: FableBuilderV1
+  fableId: string | null
+  fableName: string
+  fableVersion: number | null
+  savedAt: number // Date.now() when the draft was written
+}
+
+// ---------------------------------------------------------------------------
+// localStorage helpers
+// ---------------------------------------------------------------------------
+
+function writeDraft(draft: FableDraft): void {
+  try {
+    localStorage.setItem(DRAFT_KEY, JSON.stringify(draft))
+  } catch {
+    // localStorage full or unavailable — silently drop
+  }
+}
+
+export function readDraft(): FableDraft | null {
+  try {
+    const raw = localStorage.getItem(DRAFT_KEY)
+    if (!raw) return null
+    return JSON.parse(raw) as FableDraft
+  } catch {
+    return null
+  }
+}
+
+export function clearDraft(): void {
+  try {
+    localStorage.removeItem(DRAFT_KEY)
+  } catch {
+    // noop
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useDraftPersistence(): void {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Debounced write: subscribe to store changes
+  useEffect(() => {
+    const unsub = useFableBuilderStore.subscribe((state, prevState) => {
+      // Clear draft immediately on save
+      if (state.lastSavedAt !== prevState.lastSavedAt) {
+        clearDraft()
+        if (timerRef.current) {
+          clearTimeout(timerRef.current)
+          timerRef.current = null
+        }
+        return
+      }
+
+      // Only persist when dirty and fable data actually changed
+      if (!state.isDirty) return
+      if (
+        state.fable === prevState.fable &&
+        state.fableName === prevState.fableName
+      )
+        return
+
+      if (timerRef.current) clearTimeout(timerRef.current)
+      timerRef.current = setTimeout(() => {
+        writeDraft({
+          fable: state.fable,
+          fableId: state.fableId,
+          fableName: state.fableName,
+          fableVersion: state.fableVersion,
+          savedAt: Date.now(),
+        })
+        timerRef.current = null
+      }, DEBOUNCE_MS)
+    })
+
+    return () => {
+      unsub()
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [])
+
+  // beforeunload guard
+  const isDirty = useFableBuilderStore((s) => s.isDirty)
+
+  const handleBeforeUnload = useCallback(
+    (e: BeforeUnloadEvent) => {
+      if (isDirty) {
+        e.preventDefault()
+      }
+    },
+    [isDirty],
+  )
+
+  useEffect(() => {
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+  }, [handleBeforeUnload])
+}

--- a/frontend/src/features/fable-builder/stores/fableBuilderStore.ts
+++ b/frontend/src/features/fable-builder/stores/fableBuilderStore.ts
@@ -472,7 +472,10 @@ export const useFableBuilderStore = create<FableBuilderState>()(
         selectBlock: (blockId) =>
           set({
             selectedBlockId: blockId,
-            isConfigPanelOpen: blockId !== null,
+            // Sidebar stays open even on deselect (blockId === null) —
+            // it shows a "Select a block to configure" placeholder.
+            // User closes it explicitly via toggleConfigPanel.
+            isConfigPanelOpen: true,
           }),
 
         clearSelection: () => set({ selectedBlockId: null }),

--- a/frontend/src/features/fable-builder/stores/uiPreferencesStore.ts
+++ b/frontend/src/features/fable-builder/stores/uiPreferencesStore.ts
@@ -1,0 +1,63 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Persisted UI preferences for the fable builder. Stored in localStorage
+ * so they survive page reloads and browser restarts. Separate from the
+ * main fableBuilderStore to keep persistence scoped to visual preferences
+ * (not fable data or selection state).
+ */
+
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+const LEFT_MIN = 200
+const LEFT_MAX = 400
+const LEFT_DEFAULT = 256 // w-64
+const RIGHT_MIN = 280
+const RIGHT_MAX = 500
+const RIGHT_DEFAULT = 320 // w-80
+
+interface UiPreferencesState {
+  leftSidebarWidth: number
+  rightSidebarWidth: number
+  setLeftSidebarWidth: (width: number) => void
+  setRightSidebarWidth: (width: number) => void
+  resetLeftSidebarWidth: () => void
+  resetRightSidebarWidth: () => void
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+export const useUiPreferencesStore = create<UiPreferencesState>()(
+  persist(
+    (set) => ({
+      leftSidebarWidth: LEFT_DEFAULT,
+      rightSidebarWidth: RIGHT_DEFAULT,
+      setLeftSidebarWidth: (width) =>
+        set({ leftSidebarWidth: clamp(width, LEFT_MIN, LEFT_MAX) }),
+      setRightSidebarWidth: (width) =>
+        set({ rightSidebarWidth: clamp(width, RIGHT_MIN, RIGHT_MAX) }),
+      resetLeftSidebarWidth: () => set({ leftSidebarWidth: LEFT_DEFAULT }),
+      resetRightSidebarWidth: () => set({ rightSidebarWidth: RIGHT_DEFAULT }),
+    }),
+    {
+      name: 'fable-builder-ui-preferences',
+      partialize: (state) => ({
+        leftSidebarWidth: state.leftSidebarWidth,
+        rightSidebarWidth: state.rightSidebarWidth,
+      }),
+    },
+  ),
+)
+
+export { LEFT_MIN, LEFT_MAX, RIGHT_MIN, RIGHT_MAX }

--- a/frontend/src/features/fable-builder/utils/glyph-display.ts
+++ b/frontend/src/features/fable-builder/utils/glyph-display.ts
@@ -66,17 +66,3 @@ export function containsGlyphs(value: string): boolean {
 export function extractGlyphKey(ref: string): string {
   return ref.slice(2, -1)
 }
-
-/**
- * Resolve a config value by substituting glyph references with their values.
- * Unknown glyphs are left as-is.
- */
-export function resolveGlyphValue(
-  value: string,
-  glyphValues: Record<string, string>,
-): string {
-  return value.replace(GLYPH_PATTERN, (match) => {
-    const key = extractGlyphKey(match)
-    return glyphValues[key] ?? match
-  })
-}

--- a/frontend/src/features/fable-builder/utils/map-block-errors-to-fields.ts
+++ b/frontend/src/features/fable-builder/utils/map-block-errors-to-fields.ts
@@ -1,0 +1,153 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Best-effort mapping from backend block-level error strings to individual
+ * config keys. The backend currently returns block errors as flat strings
+ * (see backend/src/forecastbox/domain/blueprint/service.py), so the frontend
+ * parses known message shapes to provide per-field UI highlights.
+ */
+
+import {
+  containsGlyphs,
+  extractGlyphKey,
+} from '@/features/fable-builder/utils/glyph-display'
+
+export interface MappedBlockErrors {
+  /** Field-level errors keyed by configuration option key. */
+  byConfigKey: Record<string, Array<string>>
+  /** Errors that could not be attributed to a specific field. */
+  unmapped: Array<string>
+}
+
+const GLYPH_PATTERN = /\$\{(\w+)\}/g
+
+/**
+ * Parse a Python-style set-of-strings literal like `{'foo', 'bar'}` into
+ * a Set<string>. Returns null if parsing fails.
+ */
+function parsePythonStringSet(input: string): Set<string> | null {
+  const trimmed = input.trim()
+  if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) return null
+
+  const inner = trimmed.slice(1, -1).trim()
+  if (inner === '') return new Set()
+
+  const names = new Set<string>()
+  // Python repr uses single quotes by default; also accept double quotes.
+  const itemPattern = /['"]([^'"]*)['"]/g
+  let match: RegExpExecArray | null
+  while ((match = itemPattern.exec(inner)) !== null) {
+    names.add(match[1])
+  }
+  return names.size > 0 ? names : null
+}
+
+/**
+ * Return the set of glyph names referenced inside a config value
+ * (e.g. `${runId}-foo` → {"runId"}).
+ */
+function referencedGlyphs(value: string): Set<string> {
+  const names = new Set<string>()
+  if (!containsGlyphs(value)) return names
+  for (const match of value.matchAll(GLYPH_PATTERN)) {
+    names.add(extractGlyphKey(match[0]))
+  }
+  return names
+}
+
+function pushError(
+  out: Record<string, Array<string>>,
+  configKey: string,
+  message: string,
+): void {
+  const existing = (out as Record<string, Array<string> | undefined>)[configKey]
+  if (existing) {
+    existing.push(message)
+  } else {
+    out[configKey] = [message]
+  }
+}
+
+/**
+ * Map block-level backend errors onto specific configuration keys.
+ *
+ * Recognised message shapes:
+ * - "Unknown glyphs referenced: {'foo', 'bar'}" — each unknown glyph is
+ *   attached to every config key whose value references it.
+ * - "Block contains extra config: {'foo', 'bar'}" — attached as "Unknown
+ *   configuration key" to each listed key.
+ * - "Block contains missing config: {'foo', 'bar'}" — attached as
+ *   "Missing required value" to each listed key.
+ *
+ * Everything else is returned as `unmapped`.
+ */
+export function mapBlockErrorsToFields(
+  errors: ReadonlyArray<string>,
+  configurationValues: Record<string, string>,
+): MappedBlockErrors {
+  const byConfigKey: Record<string, Array<string>> = {}
+  const unmapped: Array<string> = []
+
+  for (const error of errors) {
+    const unknownGlyphs = error.match(/^Unknown glyphs referenced:\s*(.+)$/)
+    if (unknownGlyphs) {
+      const set = parsePythonStringSet(unknownGlyphs[1])
+      if (!set || set.size === 0) {
+        unmapped.push(error)
+        continue
+      }
+      let attributed = false
+      for (const [configKey, value] of Object.entries(configurationValues)) {
+        const refs = referencedGlyphs(value)
+        for (const name of refs) {
+          if (set.has(name)) {
+            pushError(byConfigKey, configKey, `Unknown glyph: \${${name}}`)
+            attributed = true
+          }
+        }
+      }
+      if (!attributed) {
+        unmapped.push(error)
+      }
+      continue
+    }
+
+    const extraConfig = error.match(/^Block contains extra config:\s*(.+)$/)
+    if (extraConfig) {
+      const set = parsePythonStringSet(extraConfig[1])
+      if (!set || set.size === 0) {
+        unmapped.push(error)
+        continue
+      }
+      for (const key of set) {
+        pushError(byConfigKey, key, 'Unknown configuration key')
+      }
+      continue
+    }
+
+    const missingConfig = error.match(/^Block contains missing config:\s*(.+)$/)
+    if (missingConfig) {
+      const set = parsePythonStringSet(missingConfig[1])
+      if (!set || set.size === 0) {
+        unmapped.push(error)
+        continue
+      }
+      for (const key of set) {
+        pushError(byConfigKey, key, 'Missing required value')
+      }
+      continue
+    }
+
+    unmapped.push(error)
+  }
+
+  return { byConfigKey, unmapped }
+}

--- a/frontend/tests/integration/components/fields/field-renderer.test.tsx
+++ b/frontend/tests/integration/components/fields/field-renderer.test.tsx
@@ -40,6 +40,7 @@ function ControlledFieldRenderer(props: {
     <div>
       <FieldRenderer
         id="test-field"
+        configKey="test-field"
         valueType={props.valueType}
         value={value}
         onChange={setValue}
@@ -259,6 +260,7 @@ describe('FieldRenderer Integration', () => {
       const screen = await renderWithProviders(
         <InlineFieldRenderer
           id="inline-test"
+          configKey="inline-test"
           valueType="str"
           value="hello"
           onChange={() => {}}

--- a/frontend/tests/integration/components/fields/glyph-field-wrapper.test.tsx
+++ b/frontend/tests/integration/components/fields/glyph-field-wrapper.test.tsx
@@ -30,6 +30,8 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { GlyphContext } from '@/features/fable-builder/context/GlyphContext'
+import { ResolvedConfigContext } from '@/features/fable-builder/context/ResolvedConfigContext'
+import { FieldErrorsContext } from '@/features/fable-builder/context/FieldErrorsContext'
 
 // ---------------------------------------------------------------------------
 // Test data
@@ -63,20 +65,42 @@ const TEST_GLYPHS: Array<GlyphInfo> = [
 function WithGlyphs({
   children,
   glyphs = TEST_GLYPHS,
+  resolvedConfig = null,
+  fieldErrors = null,
 }: {
   children: React.ReactNode
   glyphs?: Array<GlyphInfo>
+  resolvedConfig?: Record<string, string> | null
+  fieldErrors?: Record<string, Array<string>> | null
 }) {
   return (
-    <GlyphContext.Provider value={glyphs}>{children}</GlyphContext.Provider>
+    <GlyphContext.Provider value={glyphs}>
+      <ResolvedConfigContext.Provider value={resolvedConfig}>
+        <FieldErrorsContext.Provider value={fieldErrors}>
+          {children}
+        </FieldErrorsContext.Provider>
+      </ResolvedConfigContext.Provider>
+    </GlyphContext.Provider>
   )
 }
 
-function ControlledStringField(props: { initialValue?: string }) {
+function ControlledStringField(props: {
+  initialValue?: string
+  resolvedConfig?: Record<string, string> | null
+  fieldErrors?: Record<string, Array<string>> | null
+}) {
   const [value, setValue] = useState(props.initialValue ?? '')
   return (
-    <WithGlyphs>
-      <GlyphFieldWrapper id="test-field" value={value} onChange={setValue}>
+    <WithGlyphs
+      resolvedConfig={props.resolvedConfig ?? null}
+      fieldErrors={props.fieldErrors ?? null}
+    >
+      <GlyphFieldWrapper
+        id="test-field"
+        configKey="value"
+        value={value}
+        onChange={setValue}
+      >
         <InputGroupInput
           id="test-field"
           type="text"
@@ -93,7 +117,12 @@ function ControlledDateField(props: { initialValue?: string }) {
   const [value, setValue] = useState(props.initialValue ?? '')
   return (
     <WithGlyphs>
-      <GlyphFieldWrapper id="test-field" value={value} onChange={setValue}>
+      <GlyphFieldWrapper
+        id="test-field"
+        configKey="value"
+        value={value}
+        onChange={setValue}
+      >
         <InputGroupInput
           id="test-field"
           type="date"
@@ -110,7 +139,12 @@ function ControlledNumberField(props: { initialValue?: string }) {
   const [value, setValue] = useState(props.initialValue ?? '')
   return (
     <WithGlyphs>
-      <GlyphFieldWrapper id="test-field" value={value} onChange={setValue}>
+      <GlyphFieldWrapper
+        id="test-field"
+        configKey="value"
+        value={value}
+        onChange={setValue}
+      >
         <InputGroupInput
           id="test-field"
           type="number"
@@ -124,17 +158,22 @@ function ControlledNumberField(props: { initialValue?: string }) {
   )
 }
 
-function ControlledEnumField(props: { initialValue?: string }) {
+function ControlledEnumField(props: {
+  initialValue?: string
+  fieldErrors?: Record<string, Array<string>> | null
+}) {
   const [value, setValue] = useState(props.initialValue ?? '')
   return (
-    <WithGlyphs>
-      <GlyphFieldWrapper id="test-field" value={value} onChange={setValue}>
+    <WithGlyphs fieldErrors={props.fieldErrors ?? null}>
+      <GlyphFieldWrapper
+        id="test-field"
+        configKey="value"
+        value={value}
+        onChange={setValue}
+        allowGlyphMode={false}
+      >
         <Select value={value || null} onValueChange={(v) => setValue(v ?? '')}>
-          <SelectTrigger
-            id="test-field"
-            data-slot="input-group-control"
-            className="flex-1 border-0 shadow-none ring-0 focus-visible:ring-0"
-          >
+          <SelectTrigger id="test-field">
             <SelectValue placeholder="Select..." />
           </SelectTrigger>
           <SelectContent>
@@ -152,7 +191,12 @@ function NoGlyphsStringField() {
   const [value, setValue] = useState('')
   return (
     <WithGlyphs glyphs={[]}>
-      <GlyphFieldWrapper id="test-field" value={value} onChange={setValue}>
+      <GlyphFieldWrapper
+        id="test-field"
+        configKey="value"
+        value={value}
+        onChange={setValue}
+      >
         <InputGroupInput
           id="test-field"
           type="text"
@@ -198,11 +242,13 @@ describe('GlyphFieldWrapper Integration', () => {
         .toBeVisible()
     })
 
-    it('shows toggle on enum fields', async () => {
+    it('hides toggle on enum fields (allowGlyphMode=false)', async () => {
       const screen = await renderWithProviders(<ControlledEnumField />)
+      // Enum dropdowns opt out of glyph mode — no toggle, combobox only
+      await expect.element(screen.getByRole('combobox')).toBeVisible()
       await expect
         .element(screen.getByRole('button', { name: /glyph/i }))
-        .toBeVisible()
+        .not.toBeInTheDocument()
     })
   })
 
@@ -260,17 +306,49 @@ describe('GlyphFieldWrapper Integration', () => {
   })
 
   describe('Resolved preview', () => {
-    it('shows "resolves to" preview for glyph values', async () => {
+    it('shows "resolves to" preview using server-resolved value', async () => {
       const screen = await renderWithProviders(
-        <ControlledStringField initialValue="${expver}" />,
+        <ControlledStringField
+          initialValue="${expver}"
+          resolvedConfig={{ value: 'server-0042' }}
+        />,
       )
       await expect.element(screen.getByText(/resolves to/i)).toBeVisible()
-      await expect.element(screen.getByText('0001')).toBeVisible()
+      // Must show the backend value, not the glyph's valueExample ('0001')
+      await expect.element(screen.getByText('server-0042')).toBeVisible()
+    })
+
+    it('hides preview when backend has not resolved the value yet', async () => {
+      // Glyph value present, but resolvedConfig is null (in-flight / error)
+      const screen = await renderWithProviders(
+        <ControlledStringField
+          initialValue="${expver}"
+          resolvedConfig={null}
+        />,
+      )
+      await expect
+        .element(screen.getByText(/resolves to/i))
+        .not.toBeInTheDocument()
+    })
+
+    it('hides preview when backend map lacks this configKey', async () => {
+      const screen = await renderWithProviders(
+        <ControlledStringField
+          initialValue="${expver}"
+          resolvedConfig={{ other_key: 'whatever' }}
+        />,
+      )
+      await expect
+        .element(screen.getByText(/resolves to/i))
+        .not.toBeInTheDocument()
     })
 
     it('does not show preview when value has no glyphs', async () => {
       const screen = await renderWithProviders(
-        <ControlledStringField initialValue="plain text" />,
+        <ControlledStringField
+          initialValue="plain text"
+          resolvedConfig={{ value: 'anything' }}
+        />,
       )
       await expect
         .element(screen.getByText(/resolves to/i))
@@ -289,28 +367,6 @@ describe('GlyphFieldWrapper Integration', () => {
     })
   })
 
-  describe('Blur-exit from glyph mode', () => {
-    it('returns to concrete mode when toggling on enum field', async () => {
-      const screen = await renderWithProviders(
-        <ControlledEnumField initialValue="opt1" />,
-      )
-
-      // Start in concrete mode — combobox visible
-      await expect.element(screen.getByRole('combobox')).toBeVisible()
-
-      // Toggle to glyph mode
-      await screen.getByTestId('glyph-toggle').click()
-      await expect.element(screen.getByRole('textbox')).toBeVisible()
-
-      // Close autocomplete then toggle back
-      await userEvent.keyboard('{Escape}')
-      await screen.getByTestId('glyph-toggle').click()
-
-      // Combobox should be back
-      await expect.element(screen.getByRole('combobox')).toBeVisible()
-    })
-  })
-
   describe('Prevents switching back with glyph value', () => {
     it('disables toggle when value contains a glyph', async () => {
       const screen = await renderWithProviders(
@@ -321,7 +377,10 @@ describe('GlyphFieldWrapper Integration', () => {
     })
   })
 
-  describe('All field types support glyph entry', () => {
+  describe('Text-like field types support glyph entry', () => {
+    // Enum fields are excluded by design: their values are constrained by
+    // the backend, so free-form glyph expressions are not meaningful.
+
     it('string field', async () => {
       const screen = await renderWithProviders(<ControlledStringField />)
       await screen.getByRole('button', { name: /glyph/i }).click()
@@ -342,16 +401,6 @@ describe('GlyphFieldWrapper Integration', () => {
         .toHaveTextContent('${runId}')
     })
 
-    it('enum field', async () => {
-      const screen = await renderWithProviders(<ControlledEnumField />)
-      await screen.getByRole('button', { name: /glyph/i }).click()
-      const input = screen.getByRole('textbox')
-      await input.fill('${expver}')
-      await expect
-        .element(screen.getByTestId('current-value'))
-        .toHaveTextContent('${expver}')
-    })
-
     it('date field', async () => {
       const screen = await renderWithProviders(<ControlledDateField />)
       await screen.getByRole('button', { name: /glyph/i }).click()
@@ -360,6 +409,57 @@ describe('GlyphFieldWrapper Integration', () => {
       await expect
         .element(screen.getByTestId('current-value'))
         .toHaveTextContent('${forecastDate}')
+    })
+  })
+
+  describe('Field-level validation errors', () => {
+    it('renders inline error message for the field when FieldErrorsContext has entries', async () => {
+      const screen = await renderWithProviders(
+        <ControlledStringField
+          initialValue="${runtd}"
+          fieldErrors={{ value: ['Unknown glyph: ${runtd}'] }}
+        />,
+      )
+      await expect
+        .element(screen.getByText('Unknown glyph: ${runtd}'))
+        .toBeVisible()
+    })
+
+    it('does not render an error when FieldErrorsContext is null', async () => {
+      const screen = await renderWithProviders(
+        <ControlledStringField initialValue="${runtd}" />,
+      )
+      await expect
+        .element(screen.getByText(/Unknown glyph/))
+        .not.toBeInTheDocument()
+    })
+
+    it('collapses multiple errors into "(+N more)" suffix', async () => {
+      const screen = await renderWithProviders(
+        <ControlledStringField
+          initialValue="${runtd}-${ghost}"
+          fieldErrors={{
+            value: ['Unknown glyph: ${runtd}', 'Unknown glyph: ${ghost}'],
+          }}
+        />,
+      )
+      await expect
+        .element(screen.getByText('Unknown glyph: ${runtd} (+1 more)'))
+        .toBeVisible()
+    })
+
+    it('renders inline error on enum fields too (allowGlyphMode=false path)', async () => {
+      const screen = await renderWithProviders(
+        <ControlledEnumField
+          initialValue="opt1"
+          fieldErrors={{ value: ['Missing required value'] }}
+        />,
+      )
+      await expect
+        .element(screen.getByText('Missing required value'))
+        .toBeVisible()
+      // Combobox still rendered (no glyph toggle)
+      await expect.element(screen.getByRole('combobox')).toBeVisible()
     })
   })
 })

--- a/frontend/tests/integration/features/fable-builder/form-mode.test.tsx
+++ b/frontend/tests/integration/features/fable-builder/form-mode.test.tsx
@@ -201,9 +201,6 @@ describe('Fable Builder Form Mode', () => {
     // The "Has errors" badge should be visible on the card
     // Use .first() since ValidationStatusBadge in the header also shows "Has errors"
     await expect.element(screen.getByText('Has errors').first()).toBeVisible()
-
-    // The "Configuration Issues" section should be visible
-    await expect.element(screen.getByText('Configuration Issues')).toBeVisible()
   })
 
   it('shows existing blocks with pre-filled configuration values', async () => {

--- a/frontend/tests/unit/features/fable-builder/hooks/useDraftPersistence.test.ts
+++ b/frontend/tests/unit/features/fable-builder/hooks/useDraftPersistence.test.ts
@@ -1,0 +1,147 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act } from '@testing-library/react'
+import type { FableDraft } from '@/features/fable-builder/hooks/useDraftPersistence'
+import {
+  clearDraft,
+  readDraft,
+} from '@/features/fable-builder/hooks/useDraftPersistence'
+import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
+
+const DRAFT_KEY = 'fiab.fable.draft'
+
+function makeDraft(overrides: Partial<FableDraft> = {}): FableDraft {
+  return {
+    fable: {
+      blocks: {
+        block_1: {
+          factory_id: {
+            plugin: { store: 'ecmwf', local: 'base' },
+            factory: 'ekdSource',
+          },
+          configuration_values: { source: 'ecmwf-open-data' },
+          input_ids: {},
+        },
+      },
+    },
+    fableId: null,
+    fableName: 'Test Config',
+    fableVersion: null,
+    savedAt: Date.now(),
+    ...overrides,
+  }
+}
+
+describe('useDraftPersistence helpers', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  describe('readDraft', () => {
+    it('returns null when no draft exists', () => {
+      expect(readDraft()).toBeNull()
+    })
+
+    it('reads a valid draft from localStorage', () => {
+      const draft = makeDraft()
+      localStorage.setItem(DRAFT_KEY, JSON.stringify(draft))
+
+      const result = readDraft()
+      expect(result).toEqual(draft)
+    })
+
+    it('returns null for malformed JSON', () => {
+      localStorage.setItem(DRAFT_KEY, 'not-json')
+      expect(readDraft()).toBeNull()
+    })
+  })
+
+  describe('clearDraft', () => {
+    it('removes the draft from localStorage', () => {
+      localStorage.setItem(DRAFT_KEY, JSON.stringify(makeDraft()))
+      expect(localStorage.getItem(DRAFT_KEY)).not.toBeNull()
+
+      clearDraft()
+      expect(localStorage.getItem(DRAFT_KEY)).toBeNull()
+    })
+
+    it('does not throw when no draft exists', () => {
+      expect(() => clearDraft()).not.toThrow()
+    })
+  })
+})
+
+describe('draft persistence via store', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.useFakeTimers()
+    act(() => useFableBuilderStore.getState().newFable())
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    localStorage.clear()
+  })
+
+  it('writes a draft to localStorage after debounce when dirty', () => {
+    // The hook subscribes to the store — simulate what it does by
+    // directly testing the write/read cycle since the hook requires
+    // React rendering context. This tests the serialisation contract.
+    const draft = makeDraft({ savedAt: Date.now() })
+    localStorage.setItem(DRAFT_KEY, JSON.stringify(draft))
+
+    const result = readDraft()
+    expect(result).not.toBeNull()
+    expect(result!.fable.blocks).toHaveProperty('block_1')
+    expect(result!.fableName).toBe('Test Config')
+  })
+
+  it('clears draft when markSaved is called', () => {
+    localStorage.setItem(DRAFT_KEY, JSON.stringify(makeDraft()))
+    expect(readDraft()).not.toBeNull()
+
+    // Simulate what the hook does on lastSavedAt change
+    clearDraft()
+    expect(readDraft()).toBeNull()
+  })
+
+  it('draft contains all required fields', () => {
+    const draft = makeDraft({
+      fableId: 'bp-123',
+      fableVersion: 3,
+      fableName: 'My Pipeline',
+    })
+    localStorage.setItem(DRAFT_KEY, JSON.stringify(draft))
+
+    const result = readDraft()!
+    expect(result.fableId).toBe('bp-123')
+    expect(result.fableVersion).toBe(3)
+    expect(result.fableName).toBe('My Pipeline')
+    expect(result.savedAt).toBeTypeOf('number')
+    expect(result.fable).toBeDefined()
+  })
+
+  it('draft with empty blocks is still readable', () => {
+    const draft = makeDraft({
+      fable: { blocks: {} },
+    })
+    localStorage.setItem(DRAFT_KEY, JSON.stringify(draft))
+
+    const result = readDraft()
+    expect(result).not.toBeNull()
+    expect(Object.keys(result!.fable.blocks)).toHaveLength(0)
+  })
+})

--- a/frontend/tests/unit/features/fable-builder/stores/fableBuilderStore.test.ts
+++ b/frontend/tests/unit/features/fable-builder/stores/fableBuilderStore.test.ts
@@ -118,6 +118,7 @@ describe('useFableBuilderStore', () => {
           globalErrors: [],
           blockStates: {},
           possibleSources: [],
+          resolvedConfigurationOptions: {},
         }),
       )
       act(() => useFableBuilderStore.getState().setFable(mockFable))
@@ -630,10 +631,12 @@ describe('useFableBuilderStore', () => {
       expect(useFableBuilderStore.getState().isConfigPanelOpen).toBe(true)
     })
 
-    it('closes config panel when deselecting', () => {
+    it('keeps config panel open when deselecting (Blender pattern)', () => {
       act(() => useFableBuilderStore.getState().selectBlock('block-1'))
       act(() => useFableBuilderStore.getState().selectBlock(null))
-      expect(useFableBuilderStore.getState().isConfigPanelOpen).toBe(false)
+      // Sidebar stays visible with placeholder — user closes explicitly
+      expect(useFableBuilderStore.getState().isConfigPanelOpen).toBe(true)
+      expect(useFableBuilderStore.getState().selectedBlockId).toBeNull()
     })
   })
 
@@ -668,6 +671,7 @@ describe('useFableBuilderStore', () => {
         globalErrors: ['Missing required block'],
         blockStates: {},
         possibleSources: [],
+        resolvedConfigurationOptions: {},
       }
       act(() =>
         useFableBuilderStore.getState().setValidationState(validationState),
@@ -685,6 +689,7 @@ describe('useFableBuilderStore', () => {
           globalErrors: [],
           blockStates: {},
           possibleSources: [],
+          resolvedConfigurationOptions: {},
         }),
       )
       const after = Date.now()
@@ -775,6 +780,7 @@ describe('selector hooks', () => {
           globalErrors: [],
           blockStates: {},
           possibleSources: [],
+          resolvedConfigurationOptions: {},
         }),
       )
       const { result } = renderHook(() => useIsValid())
@@ -788,6 +794,7 @@ describe('selector hooks', () => {
           globalErrors: ['Error'],
           blockStates: {},
           possibleSources: [],
+          resolvedConfigurationOptions: {},
         }),
       )
       const { result } = renderHook(() => useIsValid())

--- a/frontend/tests/unit/features/fable-builder/utils/map-block-errors-to-fields.test.ts
+++ b/frontend/tests/unit/features/fable-builder/utils/map-block-errors-to-fields.test.ts
@@ -1,0 +1,123 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { mapBlockErrorsToFields } from '@/features/fable-builder/utils/map-block-errors-to-fields'
+
+describe('mapBlockErrorsToFields', () => {
+  it('returns empty result for empty errors', () => {
+    const result = mapBlockErrorsToFields([], { foo: 'bar' })
+    expect(result).toEqual({ byConfigKey: {}, unmapped: [] })
+  })
+
+  describe('Unknown glyphs referenced', () => {
+    it('attaches unknown glyph to matching config key', () => {
+      const result = mapBlockErrorsToFields(
+        ["Unknown glyphs referenced: {'runtd'}"],
+        { expver: '${runtd}', date: '2026-04-15' },
+      )
+      expect(result.byConfigKey).toEqual({
+        expver: ['Unknown glyph: ${runtd}'],
+      })
+      expect(result.unmapped).toEqual([])
+    })
+
+    it('attaches to every config key that references an unknown glyph', () => {
+      const result = mapBlockErrorsToFields(
+        ["Unknown glyphs referenced: {'foo'}"],
+        { a: 'prefix-${foo}', b: '${foo}-suffix', c: 'plain' },
+      )
+      expect(result.byConfigKey).toEqual({
+        a: ['Unknown glyph: ${foo}'],
+        b: ['Unknown glyph: ${foo}'],
+      })
+    })
+
+    it('handles multiple unknown glyphs in one error', () => {
+      const result = mapBlockErrorsToFields(
+        ["Unknown glyphs referenced: {'foo', 'bar'}"],
+        { a: '${foo}', b: '${bar}', c: '${foo}-${bar}' },
+      )
+      expect(result.byConfigKey).toEqual({
+        a: ['Unknown glyph: ${foo}'],
+        b: ['Unknown glyph: ${bar}'],
+        c: ['Unknown glyph: ${foo}', 'Unknown glyph: ${bar}'],
+      })
+    })
+
+    it('falls back to unmapped when no config value references the unknown glyph', () => {
+      const result = mapBlockErrorsToFields(
+        ["Unknown glyphs referenced: {'ghost'}"],
+        { expver: '${runId}' },
+      )
+      expect(result.byConfigKey).toEqual({})
+      expect(result.unmapped).toEqual(["Unknown glyphs referenced: {'ghost'}"])
+    })
+
+    it('falls back to unmapped when the set literal is malformed', () => {
+      const result = mapBlockErrorsToFields(
+        ['Unknown glyphs referenced: not-a-set'],
+        { expver: '${runtd}' },
+      )
+      expect(result.unmapped).toEqual(['Unknown glyphs referenced: not-a-set'])
+    })
+  })
+
+  describe('Block contains extra / missing config', () => {
+    it('attaches "Unknown configuration key" for extra config', () => {
+      const result = mapBlockErrorsToFields(
+        ["Block contains extra config: {'orphan'}"],
+        {},
+      )
+      expect(result.byConfigKey).toEqual({
+        orphan: ['Unknown configuration key'],
+      })
+    })
+
+    it('attaches "Missing required value" for missing config', () => {
+      const result = mapBlockErrorsToFields(
+        ["Block contains missing config: {'needed', 'also_needed'}"],
+        {},
+      )
+      expect(result.byConfigKey).toEqual({
+        needed: ['Missing required value'],
+        also_needed: ['Missing required value'],
+      })
+    })
+  })
+
+  it('passes through unrecognised errors as unmapped', () => {
+    const result = mapBlockErrorsToFields(
+      ['Plugin not found', 'BlockFactory not found in the catalogue'],
+      { expver: '${runId}' },
+    )
+    expect(result.byConfigKey).toEqual({})
+    expect(result.unmapped).toEqual([
+      'Plugin not found',
+      'BlockFactory not found in the catalogue',
+    ])
+  })
+
+  it('mixes mapped and unmapped in a single call', () => {
+    const result = mapBlockErrorsToFields(
+      [
+        "Unknown glyphs referenced: {'runtd'}",
+        'Plugin not found',
+        "Block contains missing config: {'date'}",
+      ],
+      { expver: '${runtd}' },
+    )
+    expect(result.byConfigKey).toEqual({
+      expver: ['Unknown glyph: ${runtd}'],
+      date: ['Missing required value'],
+    })
+    expect(result.unmapped).toEqual(['Plugin not found'])
+  })
+})


### PR DESCRIPTION
## Summary

Syncs the frontend with backend glyph resolution (#366, #372), overhauls
the validation error UX, adds resizable sidebars
with persistent preferences, and introduces draft auto-save to prevent data loss.

### Backend glyph resolution
- Consume `resolved_configuration_options` from `/blueprint/expand` as the sole
  source of truth for "resolves to" previews. Delete client-side
  `resolveGlyphValue()`. Schema uses `.optional().default({})` for rollout safety.
- New `ResolvedConfigContext` provided per-block at all three FieldRenderer sites.
- Thread `configKey` through FieldRenderer → field components → GlyphFieldWrapper.
- Disable glyph mode on enum fields (`allowGlyphMode={false}`) since dropdowns
  are constrained to backend-declared options.

### Validation error visibility
- Replace hover-only red-dot tooltips on graph nodes with persistent Alert
  ribbons showing truncated error text.
- Field-level errors: new `FieldErrorsContext` + `mapBlockErrorsToFields` parser
  maps backend error strings to individual config keys. Red border + inline error
  text on affected fields, absolutely positioned to avoid layout reflow.
- `keepPreviousData` on `useFableValidation` kills between-keystroke flicker.
- Retry policy narrowed to 503-only (no retries on 500 crashes).
- Fix pre-existing Rules-of-Hooks violation in GlyphFieldWrapper.

### Graph builder UX
- Add-node button always visible (fallback expansion list from catalogue when
  backend can't compute). Red tint when parent has errors. Hidden once a
  downstream block is connected (output Handle circle suffices).
- Sidebar stays open on canvas click. Deselect only via X.
- Clearer active node highlighting: thicker selection ring + scale lift,
  distinct hover state, snappier transitions.
- Handle circles use consistent neutral `foreground/30` border.

### Resizable sidebars
- Drag handles between each sidebar and canvas in ThreeColumnLayout.
- New `uiPreferencesStore` (Zustand + localStorage persist) for sidebar widths
  with min/max bounds and double-click/icon reset to defaults.
- Mobile: not affected (MobileLayout uses modal sheets, not ThreeColumnLayout).

### Draft auto-persistence
- `useDraftPersistence` hook: debounced (2s) write to localStorage when dirty,
  immediate clear on save, `beforeunload` guard.
- On mount, matching draft is auto-restored with an info toast. Mismatched
  drafts (wrong fableId) discarded silently.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 