### PR TITLE
ci: cancel in-progress runs on new push to same branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ on:
   # Trigger the workflow manually
   workflow_dispatch: ~
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 # TODO unify with a single matrix over platforms
 jobs:
   changes:


### PR DESCRIPTION
For next time when somebody starts accepting copilot PR suggestions one by one :) 

Add concurrency group keyed on workflow name + branch name so that pushing multiple commits in quick succession only runs CI for the latest one.  cancel-in-progress: true cancels any already-running workflow for the same branch; queued runs are deduplicated by the group key.

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 