### PR TITLE
Feat/replace null user

### DIFF
--- a/backend/src/forecastbox/domain/auth/users.py
+++ b/backend/src/forecastbox/domain/auth/users.py
@@ -134,6 +134,6 @@ async def get_auth_context(user: UserRead | None = Depends(current_active_user))
     if user is None:
         if not config.auth.passthrough:
             raise ValueError("Unauthenticated request in non-passthrough deployment")
-        return AuthContext(user_id=PASSTHROUGH_USER_ID, is_admin=False, is_passthrough=True)
+        return AuthContext(user_id=PASSTHROUGH_USER_ID, is_admin=True)
     else:
-        return AuthContext(user_id=str(user.id), is_admin=user.is_superuser, is_passthrough=False)
+        return AuthContext(user_id=str(user.id), is_admin=user.is_superuser)

--- a/backend/src/forecastbox/domain/auth/users.py
+++ b/backend/src/forecastbox/domain/auth/users.py
@@ -132,6 +132,8 @@ current_active_user = fastapi_users.current_user(active=True, optional=config.au
 async def get_auth_context(user: UserRead | None = Depends(current_active_user)) -> AuthContext:
     """Build an AuthContext from an optional authenticated user."""
     if user is None:
+        if not config.auth.passthrough:
+            raise ValueError("Unauthenticated request in non-passthrough deployment")
         return AuthContext(user_id=PASSTHROUGH_USER_ID, is_admin=False, is_passthrough=True)
     else:
         return AuthContext(user_id=str(user.id), is_admin=user.is_superuser, is_passthrough=False)

--- a/backend/src/forecastbox/domain/auth/users.py
+++ b/backend/src/forecastbox/domain/auth/users.py
@@ -21,7 +21,7 @@ from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from forecastbox.schemata.user import OAuthAccount, UserCreate, UserRead, UserTable, async_session_maker
-from forecastbox.utility.auth import AuthContext
+from forecastbox.utility.auth import PASSTHROUGH_USER_ID, AuthContext
 from forecastbox.utility.config import config
 
 SECRET = config.auth.jwt_secret.get_secret_value()
@@ -132,6 +132,6 @@ current_active_user = fastapi_users.current_user(active=True, optional=config.au
 async def get_auth_context(user: UserRead | None = Depends(current_active_user)) -> AuthContext:
     """Build an AuthContext from an optional authenticated user."""
     if user is None:
-        return AuthContext(user_id=None, is_admin=False)
+        return AuthContext(user_id=PASSTHROUGH_USER_ID, is_admin=False, is_passthrough=True)
     else:
-        return AuthContext(user_id=str(user.id), is_admin=user.is_superuser)
+        return AuthContext(user_id=str(user.id), is_admin=user.is_superuser, is_passthrough=False)

--- a/backend/src/forecastbox/domain/blueprint/db.py
+++ b/backend/src/forecastbox/domain/blueprint/db.py
@@ -34,7 +34,7 @@ async def upsert_blueprint(
     auth_context: AuthContext,
     blueprint_id: BlueprintId | None = None,
     source: BlueprintSource,
-    created_by: str | None,
+    created_by: str,
     builder: dict | None = None,
     display_name: str | None = None,
     display_description: str | None = None,
@@ -80,7 +80,7 @@ async def upsert_blueprint(
                 owner_result = await session.execute(owner_query)
                 row = owner_result.first()
                 if row is not None:
-                    owner: str | None = row[0]
+                    owner: str = row[0]
                     if not auth_context.allowed(owner):
                         raise BlueprintAccessDenied(f"User {auth_context.user_id!r} is not allowed to modify Blueprint {blueprint_id!r}.")
 
@@ -209,7 +209,7 @@ async def soft_delete_blueprint(blueprint_id: BlueprintId, *, expected_version: 
         raise BlueprintVersionConflict(
             f"Version conflict for Blueprint {blueprint_id!r}: expected version {expected_version}, current is {existing.version}."
         )
-    if not auth_context.allowed(cast(str | None, existing.created_by)):
+    if not auth_context.allowed(cast(str, existing.created_by)):
         raise BlueprintAccessDenied(f"User {auth_context.user_id!r} is not allowed to delete Blueprint {blueprint_id!r}.")
     stmt = update(Blueprint).where(Blueprint.blueprint_id == blueprint_id).values(is_deleted=True)
     await executeAndCommit(stmt, _jobs_module.async_session_maker)

--- a/backend/src/forecastbox/domain/experiment/db.py
+++ b/backend/src/forecastbox/domain/experiment/db.py
@@ -37,7 +37,7 @@ async def upsert_experiment_definition(
     blueprint_id: BlueprintId,
     blueprint_version: int,
     experiment_type: ExperimentType,
-    created_by: str | None,
+    created_by: str,
     experiment_definition: dict | None = None,
     display_name: str | None = None,
     display_description: str | None = None,
@@ -49,7 +49,7 @@ async def upsert_experiment_definition(
     For updates, checks that the caller is the owner or has admin access (via
     ``auth_context.allowed()``), raising ``ExperimentAccessDenied`` otherwise.
     Raises ``ExperimentNotFound`` if an ``experiment_definition_id`` is given but
-    does not exist.  ``created_by`` may be ``None`` in passthrough deployments.
+    does not exist.
     """
     id_provided = experiment_definition_id is not None
     experiment_id = experiment_definition_id if experiment_definition_id is not None else ExperimentDefinitionId(str(uuid.uuid4()))
@@ -77,7 +77,7 @@ async def upsert_experiment_definition(
                 owner_result = await session.execute(owner_query)
                 row = owner_result.first()
                 if row is not None:
-                    owner: str | None = row[0]
+                    owner: str = row[0]
                     if not auth_context.allowed(owner):
                         raise ExperimentAccessDenied(
                             f"User {auth_context.user_id!r} is not allowed to modify ExperimentDefinition {experiment_id!r}."
@@ -223,7 +223,7 @@ async def soft_delete_experiment_definition(experiment_id: ExperimentDefinitionI
     existing = await get_experiment_definition(experiment_id)
     if existing is None:
         raise ExperimentNotFound(f"No ExperimentDefinition with id={experiment_id!r}.")
-    if not auth_context.allowed(cast(str | None, existing.created_by)):
+    if not auth_context.allowed(cast(str, existing.created_by)):
         raise ExperimentAccessDenied(f"User {auth_context.user_id!r} is not allowed to delete ExperimentDefinition {experiment_id!r}.")
     stmt = update(ExperimentDefinition).where(ExperimentDefinition.experiment_definition_id == experiment_id).values(is_deleted=True)
     await executeAndCommit(stmt, _jobs_module.async_session_maker)

--- a/backend/src/forecastbox/domain/experiment/scheduling/background.py
+++ b/backend/src/forecastbox/domain/experiment/scheduling/background.py
@@ -100,8 +100,7 @@ class SchedulerThread(threading.Thread):
                             # NOTE we dont know the actual value of the is_admin flag, but its not important for this call
                             AuthContext(
                                 user_id=runnable.created_by,
-                                is_admin=False,
-                                is_passthrough=runnable.created_by == PASSTHROUGH_USER_ID,
+                                is_admin=runnable.created_by == PASSTHROUGH_USER_ID,
                             ),
                             experiment_id=experiment_id,
                             experiment_version=cast(int, exp_def.version),

--- a/backend/src/forecastbox/domain/experiment/scheduling/background.py
+++ b/backend/src/forecastbox/domain/experiment/scheduling/background.py
@@ -24,7 +24,7 @@ from forecastbox.domain.experiment.scheduling.dt_utils import calculate_next_run
 from forecastbox.domain.experiment.scheduling.job_utils import experiment2runnable
 from forecastbox.domain.experiment.types import ExperimentDefinitionId
 from forecastbox.domain.run.service import execute
-from forecastbox.utility.auth import AuthContext
+from forecastbox.utility.auth import PASSTHROUGH_USER_ID, AuthContext
 from forecastbox.utility.concurrent import timed_acquire
 from forecastbox.utility.config import config
 from forecastbox.utility.time import current_time
@@ -98,7 +98,11 @@ class SchedulerThread(threading.Thread):
                         execute(
                             runnable.blueprint,
                             # NOTE we dont know the actual value of the is_admin flag, but its not important for this call
-                            AuthContext(user_id=runnable.created_by, is_admin=False),
+                            AuthContext(
+                                user_id=runnable.created_by,
+                                is_admin=False,
+                                is_passthrough=runnable.created_by == PASSTHROUGH_USER_ID,
+                            ),
                             experiment_id=experiment_id,
                             experiment_version=cast(int, exp_def.version),
                             compiler_runtime_context=runnable.compiler_runtime_context,

--- a/backend/src/forecastbox/domain/experiment/scheduling/background.py
+++ b/backend/src/forecastbox/domain/experiment/scheduling/background.py
@@ -97,10 +97,10 @@ class SchedulerThread(threading.Thread):
                     exec_result = self._run_async(
                         execute(
                             runnable.blueprint,
-                            # NOTE we dont know the actual value of the is_admin flag, but its not important for this call
+                            # NOTE the is_admin may be True, but we dont know and its not important for this call
                             AuthContext(
                                 user_id=runnable.created_by,
-                                is_admin=runnable.created_by == PASSTHROUGH_USER_ID,
+                                is_admin=False,
                             ),
                             experiment_id=experiment_id,
                             experiment_version=cast(int, exp_def.version),

--- a/backend/src/forecastbox/domain/experiment/scheduling/background.py
+++ b/backend/src/forecastbox/domain/experiment/scheduling/background.py
@@ -97,6 +97,7 @@ class SchedulerThread(threading.Thread):
                     exec_result = self._run_async(
                         execute(
                             runnable.blueprint,
+                            # NOTE we dont know the actual value of the is_admin flag, but its not important for this call
                             AuthContext(user_id=runnable.created_by, is_admin=False),
                             experiment_id=experiment_id,
                             experiment_version=cast(int, exp_def.version),

--- a/backend/src/forecastbox/domain/experiment/scheduling/job_utils.py
+++ b/backend/src/forecastbox/domain/experiment/scheduling/job_utils.py
@@ -30,7 +30,7 @@ class RunnableExperiment:
     """Carries the Blueprint and all metadata needed to submit and track a scheduled run."""
 
     blueprint: Blueprint
-    created_by: str | None
+    created_by: str
     next_run_at: dt.datetime | None
     scheduled_at: dt.datetime
     experiment_id: ExperimentDefinitionId
@@ -63,7 +63,7 @@ async def experiment2runnable(experiment_id: ExperimentDefinitionId, exec_time: 
 
     rv = RunnableExperiment(
         blueprint=job_def,
-        created_by=cast(str | None, exp.created_by),
+        created_by=cast(str, exp.created_by),
         next_run_at=next_run_at,
         scheduled_at=exec_time,
         experiment_id=experiment_id,

--- a/backend/src/forecastbox/domain/experiment/service.py
+++ b/backend/src/forecastbox/domain/experiment/service.py
@@ -260,18 +260,17 @@ async def get_schedule_runs(
 
     Raises ExperimentNotFound if the schedule does not exist.
     Raises ValueError if page is out of range.
+    Will return empty if the user is not authenticated to see the resource.
     """
     exp_def = await experiment_db.get_experiment_definition(experiment_id)
     if exp_def is None or exp_def.experiment_type != "cron_schedule":
         raise ExperimentNotFound(f"Schedule {experiment_id} not found")
 
-    total = await run_db.count_runs_by_experiment(experiment_id, auth_context=AuthContext(user_id=None, is_admin=True))
+    total = await run_db.count_runs_by_experiment(experiment_id, auth_context=auth_context)
     start = pagination.start()
 
     if start >= total and total > 0:
         raise ValueError("Page number out of range.")
 
-    executions = await run_db.list_runs_by_experiment(
-        experiment_id, auth_context=AuthContext(user_id=None, is_admin=True), offset=start, limit=pagination.page_size
-    )
+    executions = await run_db.list_runs_by_experiment(experiment_id, auth_context=auth_context, offset=start, limit=pagination.page_size)
     return executions, total, pagination.total_pages(total)

--- a/backend/src/forecastbox/domain/experiment/service.py
+++ b/backend/src/forecastbox/domain/experiment/service.py
@@ -201,7 +201,7 @@ async def update_schedule(
             blueprint_id=BlueprintId(str(current.blueprint_id)),  # ty:ignore[invalid-argument-type]
             blueprint_version=cast(int, current.blueprint_version),
             experiment_type="cron_schedule",
-            created_by=cast(str | None, current.created_by),
+            created_by=cast(str, current.created_by),
             experiment_definition=new_experiment_definition,
             display_name=cast(str | None, current.display_name),
             display_description=cast(str | None, current.display_description),

--- a/backend/src/forecastbox/domain/glyphs/resolution.py
+++ b/backend/src/forecastbox/domain/glyphs/resolution.py
@@ -89,8 +89,10 @@ def merge_glyph_values(
     """Merge glyphs from all sources into a single resolution map.
 
     Resolution order (lowest to highest precedence):
-    intrinsic < public_overriddable < user_own < public_nonoverridable < local < context.
+    intrinsic < public_overriddable < user_own < local < public_nonoverridable < context.
 
+    ``public_nonoverridable`` beats local blueprint glyphs so that admin-mandated
+    values cannot be bypassed at the blueprint level.
     Intrinsic pinned keys (``startDatetime``, ``attemptCount``) always win regardless,
     so that each restart records its own actual values.
     """
@@ -98,8 +100,8 @@ def merge_glyph_values(
         **intrinsic_values,
         **public_overriddable_values,
         **user_values,
-        **public_nonoverridable_values,
         **local_values,
+        **public_nonoverridable_values,
         **context_values,
     }
     for pinned in PINNED_INTRINSIC_KEYS:

--- a/backend/src/forecastbox/domain/run/db.py
+++ b/backend/src/forecastbox/domain/run/db.py
@@ -51,7 +51,7 @@ async def upsert_run(
     run_id: RunId | None = None,
     blueprint_id: BlueprintId,
     blueprint_version: int,
-    created_by: str | None,
+    created_by: str,
     status: RunStatus,
     experiment_id: ExperimentDefinitionId | None = None,
     experiment_version: int | None = None,

--- a/backend/src/forecastbox/routes/blueprint.py
+++ b/backend/src/forecastbox/routes/blueprint.py
@@ -181,7 +181,7 @@ class GlobalGlyphResponse(BaseModel):
     value: str
     public: bool
     overriddable: bool | None = None
-    created_by: str | None = None
+    created_by: str
     created_at: str
     updated_at: str
 
@@ -427,7 +427,7 @@ async def list_available_glyphs(
                 name=str(row.key),
                 display_name=str(row.key),
                 valueExample=str(row.value),
-                created_by=str(row.created_by) if row.created_by is not None else "",
+                created_by=str(row.created_by),
             )
             for row in rows
         ]
@@ -486,7 +486,7 @@ async def post_global_glyph(
         value=str(row.value),
         public=bool(row.public),
         overriddable=bool(row.overriddable) if row.overriddable is not None else None,
-        created_by=str(row.created_by) if row.created_by is not None else None,
+        created_by=str(row.created_by),
         created_at=str(row.created_at),
         updated_at=str(row.updated_at),
     )
@@ -507,7 +507,7 @@ async def get_global_glyph(
         value=str(row.value),
         public=bool(row.public),
         overriddable=bool(row.overriddable) if row.overriddable is not None else None,
-        created_by=str(row.created_by) if row.created_by is not None else None,
+        created_by=str(row.created_by),
         created_at=str(row.created_at),
         updated_at=str(row.updated_at),
     )

--- a/backend/src/forecastbox/routes/experiment.py
+++ b/backend/src/forecastbox/routes/experiment.py
@@ -86,7 +86,7 @@ class ExperimentDetail(BaseModel):
     max_acceptable_delay_hours: int
     enabled: bool
     created_at: str
-    created_by: str | None
+    created_by: str
     display_name: str | None
     display_description: str | None
     tags: list[str] | None = None
@@ -151,7 +151,7 @@ def _experiment_to_detail(exp: ExperimentDefinition) -> ExperimentDetail:
         max_acceptable_delay_hours=int(exp_def.get("max_acceptable_delay_hours", 24)),
         enabled=bool(exp_def.get("enabled", True)),
         created_at=str(exp.created_at),
-        created_by=cast(str | None, exp.created_by),
+        created_by=cast(str, exp.created_by),
         display_name=cast(str | None, exp.display_name),
         display_description=cast(str | None, exp.display_description),
         tags=cast(list[str] | None, exp.tags),

--- a/backend/src/forecastbox/schemata/jobs.py
+++ b/backend/src/forecastbox/schemata/jobs.py
@@ -48,7 +48,7 @@ class Blueprint(Base):
 
     blueprint_id = Column(String(255), primary_key=True, nullable=False)
     version = Column(Integer, primary_key=True, nullable=False)
-    created_by = Column(String(255), nullable=True)
+    created_by = Column(String(255), nullable=False)
     created_at = Column(DateTime, nullable=False)
 
     # TODO later -- make sure entity validates this
@@ -86,7 +86,7 @@ class GlobalGlyph(Base):
     value = Column(String(1024), nullable=False)
     public = Column(Boolean, nullable=False, default=False)
     overriddable = Column(Boolean, nullable=True)
-    created_by = Column(String(255), nullable=True)
+    created_by = Column(String(255), nullable=False)
     created_at = Column(DateTime, nullable=False)
     updated_at = Column(DateTime, nullable=False)
 
@@ -111,7 +111,7 @@ class ExperimentDefinition(Base):
 
     experiment_definition_id = Column(String(255), primary_key=True, nullable=False)
     version = Column(Integer, primary_key=True, nullable=False)
-    created_by = Column(String(255), nullable=True)
+    created_by = Column(String(255), nullable=False)
     created_at = Column(DateTime, nullable=False)
 
     display_name = Column(String(255), nullable=True)
@@ -149,7 +149,7 @@ class Run(Base):
 
     run_id = Column(String(255), primary_key=True, nullable=False)
     attempt_count = Column(Integer, primary_key=True, nullable=False)
-    created_by = Column(String(255), nullable=True)
+    created_by = Column(String(255), nullable=False)
     created_at = Column(DateTime, nullable=False)
     updated_at = Column(DateTime, nullable=False)
 

--- a/backend/src/forecastbox/utility/auth.py
+++ b/backend/src/forecastbox/utility/auth.py
@@ -32,13 +32,15 @@ class AuthContext:
     is_admin: bool
 
     def has_admin(self) -> bool:
-        """Return True if the caller has unrestricted access (``is_admin=True``)."""
+        """Return True if the caller has unrestricted access (``is_admin=True``).
+        Note: this is a standalone function for historical reasons, when the condition
+        was more complicated -- stick to that, it may change in the future again."""
         return self.is_admin
 
     def allowed(self, resource_owner: str) -> bool:
         """Return True if the caller may mutate a resource owned by resource_owner.
 
-        Grants access when ``has_admin()`` is True (admins and passthrough) or
+        Grants access when ``has_admin()`` is True (true admins and passthrough) or
         when the caller's ``user_id`` matches the resource owner.
         """
         return self.has_admin() or self.user_id == resource_owner

--- a/backend/src/forecastbox/utility/auth.py
+++ b/backend/src/forecastbox/utility/auth.py
@@ -9,9 +9,10 @@
 
 """Cross-domain authentication context helpers."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
-from forecastbox.utility.config import config
+PASSTHROUGH_USER_ID = "anonymous"
+"""Sentinel user-id stored in all resources created under passthrough (auth-disabled) mode."""
 
 
 @dataclass(frozen=True, eq=True, slots=True)
@@ -21,25 +22,27 @@ class AuthContext:
     Two special regimes exist beyond ordinary authenticated users:
 
     - **Admin** (``is_admin=True``): sees and may mutate all resources.
-    - **Passthrough / anonymous** (``user_id=None``): used in single-user local
+    - **Passthrough** (``is_passthrough=True``): used in single-user local
       deployments where authentication is disabled.  Treated identically to an
       admin — ``has_admin()`` returns ``True`` and ``allowed()`` always grants
-      access.  ``user_id`` being ``None`` does *not* mean "unauthenticated
-      restricted user"; that state simply does not exist in this model.
+      access.  In this regime ``user_id`` is set to ``PASSTHROUGH_USER_ID``
+      ("anonymous") rather than ``None`` so that ``created_by`` columns are
+      always non-null.
     """
 
     user_id: str | None
     is_admin: bool
+    is_passthrough: bool = field(default=False)
 
     def has_admin(self) -> bool:
         """Return True if the caller has unrestricted access.
 
         True for explicit admins (``is_admin=True``) and for the passthrough
-        regime (``user_id=None``, auth disabled).
+        regime (``is_passthrough=True``, auth disabled).
         """
-        return self.is_admin or (self.user_id is None and config.auth.passthrough)
+        return self.is_admin or self.is_passthrough
 
-    def allowed(self, resource_owner: str | None) -> bool:
+    def allowed(self, resource_owner: str) -> bool:
         """Return True if the caller may mutate a resource owned by resource_owner.
 
         Grants access when ``has_admin()`` is True (admins and passthrough) or

--- a/backend/src/forecastbox/utility/auth.py
+++ b/backend/src/forecastbox/utility/auth.py
@@ -9,7 +9,7 @@
 
 """Cross-domain authentication context helpers."""
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 PASSTHROUGH_USER_ID = "user"
 """Sentinel user-id stored in all resources created under passthrough (auth-disabled) mode."""
@@ -22,25 +22,18 @@ class AuthContext:
     Two special regimes exist beyond ordinary authenticated users:
 
     - **Admin** (``is_admin=True``): sees and may mutate all resources.
-    - **Passthrough** (``is_passthrough=True``): used in single-user local
-      deployments where authentication is disabled.  Treated identically to an
-      admin — ``has_admin()`` returns ``True`` and ``allowed()`` always grants
-      access.  In this regime ``user_id`` is set to ``PASSTHROUGH_USER_ID``
-      ("anonymous") rather than ``None`` so that ``created_by`` columns are
-      always non-null.
+    - **Passthrough**: used in single-user local deployments where
+      authentication is disabled.  Created with ``is_admin=True`` and
+      ``user_id=PASSTHROUGH_USER_ID`` so that ``created_by`` columns are
+      always non-null and admin access is granted.
     """
 
     user_id: str
     is_admin: bool
-    is_passthrough: bool = field(default=False)
 
     def has_admin(self) -> bool:
-        """Return True if the caller has unrestricted access.
-
-        True for explicit admins (``is_admin=True``) and for the passthrough
-        regime (``is_passthrough=True``, auth disabled).
-        """
-        return self.is_admin or self.is_passthrough
+        """Return True if the caller has unrestricted access (``is_admin=True``)."""
+        return self.is_admin
 
     def allowed(self, resource_owner: str) -> bool:
         """Return True if the caller may mutate a resource owned by resource_owner.

--- a/backend/src/forecastbox/utility/auth.py
+++ b/backend/src/forecastbox/utility/auth.py
@@ -30,7 +30,7 @@ class AuthContext:
       always non-null.
     """
 
-    user_id: str | None
+    user_id: str
     is_admin: bool
     is_passthrough: bool = field(default=False)
 

--- a/backend/src/forecastbox/utility/auth.py
+++ b/backend/src/forecastbox/utility/auth.py
@@ -11,7 +11,7 @@
 
 from dataclasses import dataclass, field
 
-PASSTHROUGH_USER_ID = "anonymous"
+PASSTHROUGH_USER_ID = "user"
 """Sentinel user-id stored in all resources created under passthrough (auth-disabled) mode."""
 
 

--- a/backend/tests/unit/domain/run/test_compile.py
+++ b/backend/tests/unit/domain/run/test_compile.py
@@ -66,10 +66,16 @@ def test_merge_glyph_values_start_datetime_preserved_alongside_context() -> None
     assert result["globalKey"] == "gval"
 
 
-def test_merge_glyph_values_local_overrides_global() -> None:
-    """local_values take precedence over all global tiers for the same key."""
+def test_merge_glyph_values_local_overrides_overriddable_global() -> None:
+    """local_values take precedence over pub_overriddable and user_own tiers for the same key."""
     result = merge_glyph_values({}, {}, {"sharedKey": "globalVal"}, {}, {"sharedKey": "localVal"}, {})
     assert result == {"sharedKey": "localVal"}
+
+
+def test_merge_glyph_values_pub_nonoverridable_overrides_local() -> None:
+    """pub_nonoverridable_values take precedence over local_values, enforcing admin mandates."""
+    result = merge_glyph_values({}, {}, {}, {"sharedKey": "adminVal"}, {"sharedKey": "localVal"}, {})
+    assert result == {"sharedKey": "adminVal"}
 
 
 def test_merge_glyph_values_context_overrides_local() -> None:
@@ -92,10 +98,10 @@ def test_merge_glyph_values_local_not_overridable_for_pinned() -> None:
 
 
 def test_merge_glyph_values_resolution_order() -> None:
-    """Resolution order: pub_overriddable < user_own < pub_nonoverridable < local < context."""
+    """Resolution order: pub_overriddable < user_own < local < pub_nonoverridable < context."""
     key = "x"
     assert merge_glyph_values({}, {key: "a"}, {}, {}, {}, {})[key] == "a"
     assert merge_glyph_values({}, {key: "a"}, {key: "b"}, {}, {}, {})[key] == "b"
-    assert merge_glyph_values({}, {key: "a"}, {key: "b"}, {key: "c"}, {}, {})[key] == "c"
-    assert merge_glyph_values({}, {key: "a"}, {key: "b"}, {key: "c"}, {key: "d"}, {})[key] == "d"
-    assert merge_glyph_values({}, {key: "a"}, {key: "b"}, {key: "c"}, {key: "d"}, {key: "e"})[key] == "e"
+    assert merge_glyph_values({}, {key: "a"}, {key: "b"}, {}, {key: "c"}, {})[key] == "c"
+    assert merge_glyph_values({}, {key: "a"}, {key: "b"}, {key: "d"}, {key: "c"}, {})[key] == "d"
+    assert merge_glyph_values({}, {key: "a"}, {key: "b"}, {key: "d"}, {key: "c"}, {key: "e"})[key] == "e"

--- a/backend/tests/unit/test_jobs.py
+++ b/backend/tests/unit/test_jobs.py
@@ -37,7 +37,7 @@ from forecastbox.domain.run.db import CompilerRuntimeContext
 from forecastbox.domain.run.exceptions import RunAccessDenied, RunNotFound
 from forecastbox.domain.run.types import RunId
 from forecastbox.schemata.jobs import Base
-from forecastbox.utility.auth import AuthContext
+from forecastbox.utility.auth import PASSTHROUGH_USER_ID, AuthContext
 
 
 @pytest_asyncio.fixture
@@ -69,7 +69,7 @@ mem_session_maker_all = mem_session_maker_both
 _admin = AuthContext(user_id="admin", is_admin=True)
 _user1 = AuthContext(user_id="user1", is_admin=False)
 _user2 = AuthContext(user_id="user2", is_admin=False)
-_anon = AuthContext(user_id=None, is_admin=False)
+_anon = AuthContext(user_id=PASSTHROUGH_USER_ID, is_admin=False, is_passthrough=True)
 
 
 # ---------------------------------------------------------------------------
@@ -275,19 +275,19 @@ async def test_jobs_experiment_definition_soft_delete(mem_session_maker_both: as
 
 @pytest.mark.asyncio
 async def test_experiment_create_anon_allowed(mem_session_maker_both: async_sessionmaker[AsyncSession]) -> None:
-    """Passthrough (user_id=None) callers may create experiments; created_by is stored as None."""
+    """Passthrough callers may create experiments; created_by is stored as the passthrough sentinel."""
     job_id, job_v = await blueprint_db.upsert_blueprint(auth_context=_user1, source="user_defined", created_by="user1")
     exp_id, v1 = await experiment_db.upsert_experiment_definition(
         auth_context=_anon,
         blueprint_id=job_id,
         blueprint_version=job_v,
         experiment_type="cron_schedule",
-        created_by=None,
+        created_by=PASSTHROUGH_USER_ID,
     )
     assert v1 == 1
     result = await experiment_db.get_experiment_definition(exp_id)
     assert result is not None
-    assert result.created_by is None
+    assert result.created_by == PASSTHROUGH_USER_ID
 
 
 @pytest.mark.asyncio
@@ -400,7 +400,7 @@ async def test_anon_update_blueprint_bypasses_ownership(mem_session_maker_both: 
         auth_context=_anon,
         blueprint_id=job_id,
         source="user_defined",
-        created_by=None,
+        created_by=PASSTHROUGH_USER_ID,
     )
     assert v2 == 2
 
@@ -444,7 +444,7 @@ async def test_anon_update_experiment_bypasses_ownership(mem_session_maker_both:
         blueprint_id=job_id,
         blueprint_version=job_v,
         experiment_type="cron_schedule",
-        created_by=None,
+        created_by=PASSTHROUGH_USER_ID,
     )
     assert v2 == 2
 

--- a/backend/tests/unit/test_jobs.py
+++ b/backend/tests/unit/test_jobs.py
@@ -69,7 +69,7 @@ mem_session_maker_all = mem_session_maker_both
 _admin = AuthContext(user_id="admin", is_admin=True)
 _user1 = AuthContext(user_id="user1", is_admin=False)
 _user2 = AuthContext(user_id="user2", is_admin=False)
-_anon = AuthContext(user_id=PASSTHROUGH_USER_ID, is_admin=False, is_passthrough=True)
+_anon = AuthContext(user_id=PASSTHROUGH_USER_ID, is_admin=True)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Internal change -- we cease to save `created_by=None` in the passthrough/anonymous mode, and instead use the hardcoded value `user`. This is motivated by issues with None on sql level in constraints etc

No behavioral change, except that now, the `created_by` field will not be None but "user" in all the respective get/list Responses. No change on how we authorize or the Request level -- cc @liefra 