### PR TITLE
[frontend] backend variable sync, Jinja autocomp, glyphterminology rename

### DIFF
--- a/frontend/mocks/handlers/fable.handlers.ts
+++ b/frontend/mocks/handlers/fable.handlers.ts
@@ -55,7 +55,8 @@ interface MockGlobalGlyph {
   key: string
   value: string
   public: boolean
-  created_by: string | null
+  overriddable: boolean | null
+  created_by: string
   created_at: string
   updated_at: string
 }
@@ -68,22 +69,26 @@ const mockIntrinsicGlyphs = [
     name: 'runId',
     display_name: 'Run ID',
     valueExample: '550e8400-e29b-41d4-a716-446655440000',
+    created_by: 'intrinsic',
   },
   {
     name: 'submitDatetime',
     display_name:
       'Submit Datetime (fixed at first submission, preserved on restart)',
     valueExample: '2026-04-10 12:00:00',
+    created_by: 'intrinsic',
   },
   {
     name: 'startDatetime',
     display_name: 'Start Datetime (updated on every restart)',
     valueExample: '2026-04-10 12:00:00',
+    created_by: 'intrinsic',
   },
   {
     name: 'attemptCount',
     display_name: 'Attempt Count (incremented on every restart)',
     valueExample: '1',
+    created_by: 'intrinsic',
   },
 ]
 
@@ -264,6 +269,55 @@ export const fableHandlers = [
     })
   }),
 
+  http.get(API_ENDPOINTS.fable.glyphsFunctions, async () => {
+    await delay(150)
+    return HttpResponse.json({
+      functions: [
+        {
+          name: 'add_days',
+          description: 'Add N days to a datetime: ${dt | add_days(7)}',
+          kind: 'filter',
+        },
+        {
+          name: 'sub_days',
+          description: 'Subtract N days from a datetime',
+          kind: 'filter',
+        },
+        {
+          name: 'add_hours',
+          description: 'Add N hours to a datetime',
+          kind: 'filter',
+        },
+        {
+          name: 'floor_day',
+          description: 'Truncate a datetime to the start of its day',
+          kind: 'filter',
+        },
+        {
+          name: 'floor_hour',
+          description: 'Truncate a datetime to the start of its hour',
+          kind: 'filter',
+        },
+        {
+          name: 'split',
+          description: 'Split a string by a separator: ${s | split(",")}',
+          kind: 'filter',
+        },
+        {
+          name: 'timedelta',
+          description:
+            'Construct a timedelta: ${dt + timedelta(days=1, hours=2)}',
+          kind: 'global',
+        },
+        {
+          name: 'datetime',
+          description: 'Construct a datetime literal',
+          kind: 'global',
+        },
+      ],
+    })
+  }),
+
   http.get(API_ENDPOINTS.fable.glyphsList, async ({ request }) => {
     await delay(200)
     const url = new URL(request.url)
@@ -288,6 +342,7 @@ export const fableHandlers = [
         name: g.key,
         display_name: g.key,
         valueExample: g.value,
+        created_by: g.created_by,
       })),
       total: mockGlobalGlyphs.length,
       page,
@@ -301,7 +356,10 @@ export const fableHandlers = [
       key: string
       value: string
       public?: boolean
+      overriddable?: boolean | null
     }
+    const isPublic = body.public ?? false
+    const overriddable = body.overriddable ?? null
 
     const intrinsicNames = new Set(mockIntrinsicGlyphs.map((g) => g.name))
     if (intrinsicNames.has(body.key)) {
@@ -312,12 +370,25 @@ export const fableHandlers = [
         { status: 422 },
       )
     }
+    if (isPublic && overriddable === null) {
+      return HttpResponse.json(
+        { detail: 'overriddable must be specified when public=True.' },
+        { status: 422 },
+      )
+    }
+    if (!isPublic && overriddable !== null) {
+      return HttpResponse.json(
+        { detail: 'overriddable must not be specified when public=False.' },
+        { status: 422 },
+      )
+    }
 
     const existing = mockGlobalGlyphs.find((g) => g.key === body.key)
     const now = new Date().toISOString()
     if (existing) {
       existing.value = body.value
-      existing.public = body.public ?? false
+      existing.public = isPublic
+      existing.overriddable = overriddable
       existing.updated_at = now
       return HttpResponse.json(existing)
     }
@@ -326,7 +397,8 @@ export const fableHandlers = [
       global_glyph_id: `glyph-${String(glyphIdCounter++).padStart(3, '0')}`,
       key: body.key,
       value: body.value,
-      public: body.public ?? false,
+      public: isPublic,
+      overriddable,
       created_by: 'mock-user-123',
       created_at: now,
       updated_at: now,

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -73,6 +73,8 @@ export const API_ENDPOINTS = {
     delete: `${API_PREFIX}/blueprint/delete`,
     /** GET - List available intrinsic glyphs for ${glyph} interpolation in block configs */
     glyphsList: `${API_PREFIX}/blueprint/glyphs/list`,
+    /** GET - List custom Jinja filters/globals available in glyph expressions */
+    glyphsFunctions: `${API_PREFIX}/blueprint/glyphs/functions`,
     /** POST - Create or update a global glyph */
     glyphsGlobalPost: `${API_PREFIX}/blueprint/glyphs/global/post`,
     /** GET - Get a global glyph by ID */

--- a/frontend/src/api/endpoints/fable.ts
+++ b/frontend/src/api/endpoints/fable.ts
@@ -27,6 +27,7 @@ import type {
   GlobalGlyphPostRequest,
   GlobalGlyphResponse,
   GlyphDetail,
+  GlyphFunctionsResponse,
   GlyphListResponse,
 } from '@/api/types/fable.types'
 import { apiClient } from '@/api/client'
@@ -38,6 +39,7 @@ import {
   FableUpsertResponseSchema,
   FableValidationExpansionSchema,
   GlobalGlyphResponseSchema,
+  GlyphFunctionsResponseSchema,
   GlyphListResponseSchema,
   normalizeCatalogueKeys,
 } from '@/api/types/fable.types'
@@ -151,6 +153,15 @@ export async function getAvailableGlyphs(): Promise<Array<GlyphDetail>> {
     },
   )
   return response.glyphs
+}
+
+/**
+ * List Jinja filters and globals available inside ${...} glyph expressions.
+ */
+export async function listGlyphFunctions(): Promise<GlyphFunctionsResponse> {
+  return apiClient.get(API_ENDPOINTS.fable.glyphsFunctions, {
+    schema: GlyphFunctionsResponseSchema,
+  })
 }
 
 /**

--- a/frontend/src/api/endpoints/job.ts
+++ b/frontend/src/api/endpoints/job.ts
@@ -118,6 +118,29 @@ export async function getJobResult(
   return { blob, contentType }
 }
 
+/**
+ * Probe the output's MIME type without fetching the full body. Starlette
+ * answers HEAD for every GET route automatically, so the response carries
+ * Content-Type with no payload — cheap for GRIB/NetCDF outputs that might
+ * otherwise be megabytes or gigabytes.
+ */
+export async function headJobResultContentType(
+  runId: string,
+  datasetId: string,
+): Promise<string | null> {
+  const url = buildFullUrl(API_ENDPOINTS.job.outputContent, {
+    run_id: runId,
+    dataset_id: datasetId,
+  })
+  const response = await fetch(url, {
+    method: 'HEAD',
+    credentials: 'include',
+    headers: buildHeaders(),
+  })
+  if (!response.ok) return null
+  return response.headers.get('content-type')
+}
+
 export async function downloadJobLogs(runId: string): Promise<Blob> {
   const url = buildFullUrl(API_ENDPOINTS.job.logs, {
     run_id: runId,

--- a/frontend/src/api/hooks/useFable.ts
+++ b/frontend/src/api/hooks/useFable.ts
@@ -26,6 +26,7 @@ import type {
   GlobalGlyphPostRequest,
   GlobalGlyphResponse,
   GlyphDetail,
+  GlyphFunctionsResponse,
   GlyphListResponse,
   PluginBlockFactoryId,
 } from '@/api/types/fable.types'
@@ -38,6 +39,7 @@ import {
   getGlobalGlyph,
   listBlueprints,
   listGlobalGlyphs,
+  listGlyphFunctions,
   retrieveFable,
   updateBlueprint,
   upsertFable,
@@ -55,6 +57,7 @@ export const fableKeys = {
   validation: (fable: FableBuilderV1) =>
     [...fableKeys.all, 'validation', JSON.stringify(fable)] as const,
   glyphs: () => [...fableKeys.all, 'glyphs'] as const,
+  glyphFunctions: () => [...fableKeys.all, 'glyphFunctions'] as const,
   globalGlyphsBase: () => [...fableKeys.all, 'globalGlyphs'] as const,
   globalGlyphs: (page?: number, pageSize?: number) =>
     [...fableKeys.all, 'globalGlyphs', page, pageSize] as const,
@@ -67,6 +70,10 @@ export function useBlockCatalogue(language?: string) {
     queryFn: () => getCatalogue(language),
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 30 * 60 * 1000, // Keep in cache for 30 minutes
+    // Always refetch on mount so a previously-cached error state
+    // (e.g. the backend was still loading plugins on first visit) doesn't
+    // silently persist until the user hits F5.
+    refetchOnMount: 'always',
     retry: (failureCount, error) => {
       // Retry more on 503 (plugins temporarily unavailable after install/update)
       if (error instanceof ApiClientError && error.status === 503) {
@@ -251,6 +258,19 @@ export function useAvailableGlyphs() {
     queryFn: getAvailableGlyphs,
     staleTime: 30 * 60 * 1000, // 30 minutes — intrinsic glyphs change rarely
     gcTime: 60 * 60 * 1000, // 1 hour
+  })
+}
+
+/**
+ * Fetch the list of custom Jinja filters/globals available in glyph expressions.
+ * Static for the lifetime of the backend process, so we cache aggressively.
+ */
+export function useGlyphFunctions() {
+  return useQuery<GlyphFunctionsResponse>({
+    queryKey: fableKeys.glyphFunctions(),
+    queryFn: listGlyphFunctions,
+    staleTime: 30 * 60 * 1000,
+    gcTime: 60 * 60 * 1000,
   })
 }
 

--- a/frontend/src/api/hooks/useJobs.ts
+++ b/frontend/src/api/hooks/useJobs.ts
@@ -28,6 +28,7 @@ import {
   getJobAvailable,
   getJobStatus,
   getJobsStatus,
+  headJobResultContentType,
   restartJob,
 } from '@/api/endpoints/job'
 import { upsertFable } from '@/api/endpoints/fable'
@@ -38,6 +39,8 @@ export const jobKeys = {
   list: (page: number, pageSize: number, status?: JobStatus) =>
     [...jobKeys.all, 'list', page, pageSize, status] as const,
   available: (jobId: string) => [...jobKeys.all, 'available', jobId] as const,
+  contentType: (jobId: string, datasetId: string) =>
+    [...jobKeys.all, 'contentType', jobId, datasetId] as const,
 }
 
 export function useJobStatus(jobId: string | undefined) {
@@ -82,6 +85,25 @@ export function useJobAvailable(
       return 5000
     },
     refetchOnWindowFocus: false,
+  })
+}
+
+/**
+ * Probe the MIME type of a single output via a HEAD request.
+ * Lightweight (no body transfer); cached so repeat mounts don't re-probe.
+ */
+export function useJobContentType(
+  jobId: string | undefined,
+  datasetId: string | undefined,
+) {
+  return useQuery<string | null>({
+    queryKey: jobKeys.contentType(jobId ?? '', datasetId ?? ''),
+    queryFn: () => headJobResultContentType(jobId!, datasetId!),
+    enabled: !!jobId && !!datasetId,
+    staleTime: 30 * 60 * 1000,
+    gcTime: 60 * 60 * 1000,
+    refetchOnWindowFocus: false,
+    retry: 1,
   })
 }
 

--- a/frontend/src/api/types/fable.types.ts
+++ b/frontend/src/api/types/fable.types.ts
@@ -105,6 +105,8 @@ export const GlyphDetailSchema = z.object({
   name: z.string(),
   display_name: z.string(),
   valueExample: z.string(),
+  /** "intrinsic" for intrinsic glyphs; owner id (or passthrough sentinel "user") otherwise. */
+  created_by: z.string(),
 })
 
 export type GlyphDetail = z.infer<typeof GlyphDetailSchema>
@@ -119,11 +121,18 @@ export const GlyphListResponseSchema = z.object({
 
 export type GlyphListResponse = z.infer<typeof GlyphListResponseSchema>
 
-/** POST /blueprint/glyphs/global/post — outbound request */
+/**
+ * POST /blueprint/glyphs/global/post — outbound request.
+ *
+ * `overriddable` must be omitted (or null) when `public=false` and set to a
+ * concrete boolean when `public=true`. Non-admins may not submit `public=true`;
+ * the server returns 403 in that case.
+ */
 export interface GlobalGlyphPostRequest {
   key: string
   value: string
   public?: boolean
+  overriddable?: boolean | null
 }
 
 /** Response from global glyph endpoints */
@@ -132,12 +141,31 @@ export const GlobalGlyphResponseSchema = z.object({
   key: z.string(),
   value: z.string(),
   public: z.boolean(),
-  created_by: z.string().nullable(),
+  overriddable: z.boolean().nullable(),
+  created_by: z.string(),
   created_at: z.string(),
   updated_at: z.string(),
 })
 
 export type GlobalGlyphResponse = z.infer<typeof GlobalGlyphResponseSchema>
+
+/** Single entry from GET /blueprint/glyphs/functions — a Jinja filter or global. */
+export const GlyphFunctionDetailSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  kind: z.enum(['filter', 'global']),
+})
+
+export type GlyphFunctionDetail = z.infer<typeof GlyphFunctionDetailSchema>
+
+/** Response from GET /blueprint/glyphs/functions */
+export const GlyphFunctionsResponseSchema = z.object({
+  functions: z.array(GlyphFunctionDetailSchema),
+})
+
+export type GlyphFunctionsResponse = z.infer<
+  typeof GlyphFunctionsResponseSchema
+>
 
 export const FableValidationExpansionSchema = z.object({
   global_errors: z.array(z.string()),

--- a/frontend/src/api/types/schedule.types.ts
+++ b/frontend/src/api/types/schedule.types.ts
@@ -31,7 +31,7 @@ export const ScheduleDefinitionResponseSchema = z.object({
   max_acceptable_delay_hours: z.number(),
   enabled: z.boolean(),
   created_at: z.string(),
-  created_by: z.string().nullable(),
+  created_by: z.string(),
   display_name: z.string().nullable(),
   display_description: z.string().nullable(),
   tags: z.array(z.string()).nullable(),
@@ -102,7 +102,4 @@ export interface ScheduleUpdate {
   cron_expr?: string
   max_acceptable_delay_hours?: number
   first_run_override?: string
-  display_name?: string
-  display_description?: string
-  tags?: Array<string>
 }

--- a/frontend/src/components/base/fields/fields/DateTimeField.tsx
+++ b/frontend/src/components/base/fields/fields/DateTimeField.tsx
@@ -41,6 +41,7 @@ export function DateTimeField({
       placeholder={placeholder}
       disabled={disabled}
       className={className}
+      isDateOnly={isDateOnly}
     >
       <InputGroupInput
         id={id}

--- a/frontend/src/components/base/fields/fields/GlyphFieldWrapper.tsx
+++ b/frontend/src/components/base/fields/fields/GlyphFieldWrapper.tsx
@@ -24,9 +24,10 @@
  */
 
 import { useEffect, useState } from 'react'
-import { Braces } from 'lucide-react'
+import { AlertCircle, Braces } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { GlyphTextInput } from './GlyphTextInput'
+import { Button } from '@/components/ui/button'
 import {
   InputGroup,
   InputGroupAddon,
@@ -41,6 +42,11 @@ import { useGlyphContext } from '@/features/fable-builder/context/GlyphContext'
 import { useResolvedConfig } from '@/features/fable-builder/context/ResolvedConfigContext'
 import { useFieldErrors } from '@/features/fable-builder/context/FieldErrorsContext'
 import { containsGlyphs } from '@/features/fable-builder/utils/glyph-display'
+import {
+  applyFloorDay,
+  canApplyFloorDay,
+  previewHasTimeComponent,
+} from '@/features/fable-builder/utils/date-preview-nudge'
 import { cn } from '@/lib/utils'
 
 export interface GlyphFieldWrapperProps {
@@ -59,6 +65,13 @@ export interface GlyphFieldWrapperProps {
    * whose values are constrained to a backend-declared set).
    */
   allowGlyphMode?: boolean
+  /**
+   * When true, the backend expects a calendar-date-only value
+   * (`YYYY-MM-DD`). If a glyph expression resolves to a datetime with a
+   * time component, the wrapper surfaces a nudge below the preview and
+   * offers a one-click `| floor_day` fix where applicable.
+   */
+  isDateOnly?: boolean
   /** The specialized widget (must use InputGroupInput or data-slot="input-group-control") */
   children: React.ReactNode
 }
@@ -74,6 +87,7 @@ export function GlyphFieldWrapper({
   disabled,
   className,
   allowGlyphMode = true,
+  isDateOnly = false,
   children,
 }: GlyphFieldWrapperProps) {
   const { t } = useTranslation('glyphs')
@@ -104,22 +118,18 @@ export function GlyphFieldWrapper({
       : fieldErrors[0]
     : null
 
-  // If no glyphs available or glyph mode is disallowed for this field type,
-  // render children directly with no InputGroup / toggle chrome. Field-level
-  // error styling still applies: wrap in a ring container when errored.
-  // Error text is absolutely positioned so it doesn't push sibling fields.
+  // No glyphs / glyph mode disabled → render children directly, only adding
+  // an error ring + absolute-positioned error text when the field is invalid.
   if (!hasGlyphs || !allowGlyphMode) {
-    if (hasFieldError) {
-      return (
-        <div className="relative">
-          <div className="rounded-md ring-1 ring-destructive">{children}</div>
-          <p className="pointer-events-none absolute top-full left-0 mt-0.5 truncate text-xs text-destructive">
-            {errorMessage}
-          </p>
-        </div>
-      )
-    }
-    return <>{children}</>
+    if (!hasFieldError) return <>{children}</>
+    return (
+      <div className="relative">
+        <div className="rounded-md ring-1 ring-destructive">{children}</div>
+        <p className="pointer-events-none absolute top-full left-0 mt-0.5 truncate text-xs text-destructive">
+          {errorMessage}
+        </p>
+      </div>
+    )
   }
 
   const valueHasGlyphs = containsGlyphs(value)
@@ -151,6 +161,20 @@ export function GlyphFieldWrapper({
     mode === 'glyph' && valueHasGlyphs && !hasFieldError
       ? (resolvedConfig?.[configKey] ?? null)
       : null
+
+  const showPreview = resolvedPreview !== null && resolvedPreview !== value
+
+  // Nudge when a date-typed field gets a datetime-resolving expression.
+  const dateNudgeVisible =
+    isDateOnly &&
+    resolvedPreview !== null &&
+    previewHasTimeComponent(resolvedPreview)
+  const dateNudgeFixAvailable = dateNudgeVisible && canApplyFloorDay(value)
+
+  function handleApplyFloorDay() {
+    const next = applyFloorDay(value)
+    if (next !== value) onChange(next)
+  }
 
   return (
     <div className="relative">
@@ -212,7 +236,10 @@ export function GlyphFieldWrapper({
         </p>
       )}
 
-      {resolvedPreview && resolvedPreview !== value && (
+      {/* In-flow so visual order reads Input → Preview → Nudge. Validation
+          is debounced 300 ms, so these appear/disappear at pause boundaries,
+          not per keystroke — an honest layout reaction, not flicker. */}
+      {showPreview && (
         <Tooltip>
           <TooltipTrigger
             render={
@@ -229,6 +256,35 @@ export function GlyphFieldWrapper({
             {resolvedPreview}
           </TooltipContent>
         </Tooltip>
+      )}
+
+      {dateNudgeVisible && (
+        <div className="mt-1 flex items-center gap-2 rounded-md border border-amber-500/40 bg-amber-500/5 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400">
+          <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+          <span className="min-w-0 flex-1 truncate">
+            {t('field.datePreview.hasTime')}
+          </span>
+          {dateNudgeFixAvailable && (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    className="h-6 border-amber-500/60 px-2 text-xs text-amber-700 hover:bg-amber-500/10 dark:text-amber-400"
+                    onClick={handleApplyFloorDay}
+                  />
+                }
+              >
+                {t('field.datePreview.floorDayAction')}
+              </TooltipTrigger>
+              <TooltipContent side="left" className="max-w-64">
+                {t('field.datePreview.floorDayTooltip')}
+              </TooltipContent>
+            </Tooltip>
+          )}
+        </div>
       )}
     </div>
   )

--- a/frontend/src/components/base/fields/fields/GlyphTextInput.tsx
+++ b/frontend/src/components/base/fields/fields/GlyphTextInput.tsx
@@ -11,19 +11,26 @@
 /**
  * GlyphTextInput — Reusable glyph-aware text input.
  *
- * Provides ${…} autocomplete triggered by typing `${`, a "resolves to" preview,
- * and keyboard navigation. Extracted from StringField so it can be reused by
- * GlyphFieldWrapper when any field type switches to glyph mode.
+ * Provides ${…} autocomplete for variable names, callable helper globals
+ * (e.g. `timedelta(...)`) and pipe-style helper filters (e.g.
+ * `${dt | add_days}`). The current candidate set is decided by
+ * `parseGlyphContext`, which classifies the cursor as `value`, `filter`, or
+ * `none` based on the surrounding `${...}` syntax.
  *
  * When `grouped` is true, renders an InputGroupInput (for use inside an
  * InputGroup) instead of a standalone Input.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { GlyphContext } from '@/features/fable-builder/utils/glyph-expression-context'
+import type { AutocompleteCandidate } from '@/features/fable-builder/components/shared/GlyphAutocomplete'
 import { Input } from '@/components/ui/input'
 import { InputGroupInput } from '@/components/ui/input-group'
 import { useGlyphContext } from '@/features/fable-builder/context/GlyphContext'
+import { useGlyphFunctions } from '@/api/hooks/useFable'
 import { GlyphAutocomplete } from '@/features/fable-builder/components/shared/GlyphAutocomplete'
+import { buildAutocompleteInsertion } from '@/features/fable-builder/utils/build-autocomplete-insertion'
+import { parseGlyphContext } from '@/features/fable-builder/utils/glyph-expression-context'
 
 export interface GlyphTextInputProps {
   id: string
@@ -40,24 +47,6 @@ export interface GlyphTextInputProps {
   onBlurEmpty?: () => void
 }
 
-/**
- * Detects an open ${ pattern before the cursor position and returns the
- * partial filter text, or null if autocomplete should not trigger.
- */
-function detectGlyphTrigger(value: string, cursorPos: number): string | null {
-  const before = value.slice(0, cursorPos)
-  const triggerIndex = before.lastIndexOf('${')
-  if (triggerIndex === -1) return null
-
-  const afterTrigger = before.slice(triggerIndex + 2)
-  // Only trigger if we haven't closed the brace yet
-  if (afterTrigger.includes('}')) return null
-  // Only allow word characters in the partial
-  if (!/^\w*$/.test(afterTrigger)) return null
-
-  return afterTrigger
-}
-
 export function GlyphTextInput({
   id,
   value,
@@ -69,23 +58,22 @@ export function GlyphTextInput({
   autoTrigger = false,
   onBlurEmpty,
 }: GlyphTextInputProps) {
-  const glyphs = useGlyphContext()
-  const inputRef = useRef<HTMLInputElement>(null)
-  const [autocompleteFilter, setAutocompleteFilter] = useState<string | null>(
-    null,
-  )
-  const [cursorPos, setCursorPos] = useState(0)
+  const variables = useGlyphContext()
+  const { data: helperFunctionsResponse } = useGlyphFunctions()
+  const helperFunctions = helperFunctionsResponse?.functions ?? []
 
-  const hasGlyphs = glyphs.length > 0
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [context, setContext] = useState<GlyphContext | null>(null)
+
+  const hasAnyCandidates = variables.length > 0 || helperFunctions.length > 0
 
   // Auto-insert ${ and open autocomplete when entering glyph mode on an empty field
   const didAutoTrigger = useRef(false)
   useEffect(() => {
-    if (autoTrigger && hasGlyphs && !value && !didAutoTrigger.current) {
+    if (autoTrigger && hasAnyCandidates && !value && !didAutoTrigger.current) {
       didAutoTrigger.current = true
       onChange('${')
-      setCursorPos(2)
-      setAutocompleteFilter('')
+      setContext(parseGlyphContext('${', 2))
       requestAnimationFrame(() => {
         const input = inputRef.current
         if (input) {
@@ -94,70 +82,111 @@ export function GlyphTextInput({
         }
       })
     }
-  }, [autoTrigger, hasGlyphs, value, onChange])
+  }, [autoTrigger, hasAnyCandidates, value, onChange])
+
+  const recomputeContext = useCallback(
+    (text: string, pos: number) => {
+      if (!hasAnyCandidates) {
+        setContext(null)
+        return
+      }
+      const next = parseGlyphContext(text, pos)
+      setContext(next.kind === 'none' ? null : next)
+    },
+    [hasAnyCandidates],
+  )
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const newValue = e.target.value
       const pos = e.target.selectionStart ?? newValue.length
-      setCursorPos(pos)
       onChange(newValue)
-
-      if (hasGlyphs) {
-        setAutocompleteFilter(detectGlyphTrigger(newValue, pos))
-      }
+      recomputeContext(newValue, pos)
     },
-    [onChange, hasGlyphs],
+    [onChange, recomputeContext],
   )
 
   const handleKeyUp = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       const pos = e.currentTarget.selectionStart ?? value.length
-      setCursorPos(pos)
-      if (hasGlyphs) {
-        setAutocompleteFilter(detectGlyphTrigger(value, pos))
-      }
+      recomputeContext(value, pos)
     },
-    [value, hasGlyphs],
+    [value, recomputeContext],
   )
 
+  // Build the candidate set for the current context kind. Variables and
+  // helper-globals share the `value` slot; helper-filters fill the `filter`
+  // slot. Computed from the raw lists (not from `filter`) — `GlyphAutocomplete`
+  // does the prefix-matching itself.
+  const candidates = useMemo<Array<AutocompleteCandidate>>(() => {
+    if (!context) return []
+    if (context.kind === 'value') {
+      const fromVariables: Array<AutocompleteCandidate> = variables.map(
+        (g) => ({
+          name: g.name,
+          displayName: g.displayName,
+          meta: g.type === 'intrinsic' ? g.displayName : g.valueExample,
+          source: g.type, // 'local' | 'global' | 'intrinsic'
+        }),
+      )
+      const fromGlobals: Array<AutocompleteCandidate> = helperFunctions
+        .filter((f) => f.kind === 'global')
+        .map((f) => ({
+          name: f.name,
+          displayName: f.name,
+          meta: f.description,
+          source: 'helperGlobal' as const,
+        }))
+      return [...fromVariables, ...fromGlobals]
+    }
+    // context.kind === 'filter'
+    return helperFunctions
+      .filter((f) => f.kind === 'filter')
+      .map((f) => ({
+        name: f.name,
+        displayName: f.name,
+        meta: f.description,
+        source: 'filter' as const,
+      }))
+  }, [context, variables, helperFunctions])
+
   const handleSelect = useCallback(
-    (glyphName: string) => {
-      // Find the ${ trigger position before cursor
-      const before = value.slice(0, cursorPos)
-      const triggerIndex = before.lastIndexOf('${')
-      if (triggerIndex === -1) return
-
+    (candidate: AutocompleteCandidate) => {
+      if (!context) return
+      const { replaceStart, replaceEnd } = context
+      const insertion = buildAutocompleteInsertion(
+        {
+          name: candidate.name,
+          source: candidate.source,
+          description: candidate.meta,
+        },
+        value.slice(replaceEnd),
+      )
       const newValue =
-        value.slice(0, triggerIndex) +
-        '${' +
-        glyphName +
-        '}' +
-        value.slice(cursorPos)
+        value.slice(0, replaceStart) + insertion.text + value.slice(replaceEnd)
       onChange(newValue)
-      setAutocompleteFilter(null)
+      setContext(null)
 
-      // Restore focus and move cursor after the inserted glyph
       requestAnimationFrame(() => {
         const input = inputRef.current
         if (input) {
           input.focus()
-          const newPos = triggerIndex + glyphName.length + 3 // ${ + name + }
-          input.setSelectionRange(newPos, newPos)
+          const newCursor = replaceStart + insertion.cursorOffset
+          input.setSelectionRange(newCursor, newCursor)
         }
       })
     },
-    [value, cursorPos, onChange],
+    [context, value, onChange],
   )
 
   const handleClose = useCallback(() => {
-    setAutocompleteFilter(null)
+    setContext(null)
   }, [])
 
   const handleBlur = useCallback(() => {
     // Delay close to allow mousedown on autocomplete items
     setTimeout(() => {
-      setAutocompleteFilter(null)
+      setContext(null)
       // If the field is empty on blur, signal the wrapper to exit glyph mode
       if (onBlurEmpty && !inputRef.current?.value) {
         onBlurEmpty()
@@ -175,16 +204,17 @@ export function GlyphTextInput({
     onBlur: handleBlur,
     placeholder,
     disabled,
-    spellCheck: hasGlyphs ? false : undefined,
+    spellCheck: hasAnyCandidates ? false : undefined,
     autoComplete: 'off' as const,
     className,
   }
 
-  const autocompleteDropdown = autocompleteFilter !== null && (
+  const autocompleteDropdown = context !== null && (
     <div className="absolute top-full right-0 left-0 z-50 mt-1">
       <GlyphAutocomplete
-        glyphs={glyphs}
-        filter={autocompleteFilter}
+        candidates={candidates}
+        filter={context.prefix}
+        contextKind={context.kind === 'filter' ? 'filter' : 'value'}
         onSelect={handleSelect}
         onClose={handleClose}
       />

--- a/frontend/src/features/executions/components/OutputCard.tsx
+++ b/frontend/src/features/executions/components/OutputCard.tsx
@@ -19,6 +19,7 @@ import { Binary, Download, FileDown, Globe, Map, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import type { LucideIcon } from 'lucide-react'
 import { getJobResult } from '@/api/endpoints/job'
+import { useJobContentType } from '@/api/hooks/useJobs'
 import { Button } from '@/components/ui/button'
 import { P } from '@/components/base/typography'
 import { createLogger } from '@/lib/logger'
@@ -30,56 +31,51 @@ interface OutputCardProps {
   jobId: string
   taskId: string
   productName: string
-  contentType: string | null
 }
 
-const MIME_ICONS: Record<string, LucideIcon> = {
-  'image/png': Map,
-  'application/grib': FileDown,
-  'application/netcdf': Globe,
-  'application/numpy': Binary,
+interface MimeMeta {
+  icon: LucideIcon
+  label: string
+  ext: string
 }
 
-function getMimeIcon(contentType: string | null): LucideIcon {
-  if (!contentType) return FileDown
-  return MIME_ICONS[contentType] ?? FileDown
+const MIME_META: Record<string, MimeMeta> = {
+  'image/png': { icon: Map, label: 'PNG Image', ext: 'png' },
+  'application/grib': { icon: FileDown, label: 'GRIB', ext: 'grib' },
+  'application/netcdf': { icon: Globe, label: 'NetCDF', ext: 'nc' },
+  'application/numpy': { icon: Binary, label: 'NumPy', ext: 'npy' },
 }
 
-function getMimeLabel(contentType: string | null): string {
-  if (!contentType) return 'Unknown'
-  const labels: Record<string, string> = {
-    'image/png': 'PNG Image',
-    'application/grib': 'GRIB',
-    'application/netcdf': 'NetCDF',
-    'application/numpy': 'NumPy',
-  }
-  return labels[contentType] ?? contentType
+const UNKNOWN_META: MimeMeta = {
+  icon: FileDown,
+  label: 'Unknown',
+  ext: 'bin',
 }
 
-function getFileExtension(contentType: string | null): string {
-  if (!contentType) return 'bin'
-  const extensions: Record<string, string> = {
-    'image/png': 'png',
-    'application/grib': 'grib',
-    'application/netcdf': 'nc',
-    'application/numpy': 'npy',
-  }
-  return extensions[contentType] ?? 'bin'
+function getMimeMeta(contentType: string | null): MimeMeta {
+  if (!contentType) return UNKNOWN_META
+  // Without `noUncheckedIndexedAccess` the record lookup is typed as
+  // `MimeMeta` (not `MimeMeta | undefined`), but at runtime it can be
+  // missing — the cast keeps the fallback reachable.
+  const known = MIME_META[contentType] as MimeMeta | undefined
+  if (known) return known
+  return { ...UNKNOWN_META, label: contentType }
 }
 
-export function OutputCard({
-  jobId,
-  taskId,
-  productName,
-  contentType,
-}: OutputCardProps) {
+export function OutputCard({ jobId, taskId, productName }: OutputCardProps) {
   const { t } = useTranslation('executions')
+  // Probe the MIME type with a HEAD request so we can render the correct
+  // icon / inline preview without forcing a full download of every output.
+  const { data: contentType = null } = useJobContentType(jobId, taskId)
   const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
   const [lightboxOpen, setLightboxOpen] = useState(false)
 
-  const Icon = getMimeIcon(contentType)
-  const contentTypeLabel = getMimeLabel(contentType)
+  const {
+    icon: Icon,
+    label: contentTypeLabel,
+    ext: fileExt,
+  } = getMimeMeta(contentType)
   const isPng = contentType === 'image/png'
 
   useEffect(() => {
@@ -117,7 +113,7 @@ export function OutputCard({
       const url = URL.createObjectURL(blob)
       const a = document.createElement('a')
       a.href = url
-      a.download = `${productName}.${getFileExtension(contentType)}`
+      a.download = `${productName}.${fileExt}`
       document.body.appendChild(a)
       a.click()
       document.body.removeChild(a)
@@ -126,7 +122,7 @@ export function OutputCard({
       log.error('Failed to download output', { jobId, taskId, error: err })
       showToast.error(err instanceof Error ? err.message : String(err))
     }
-  }, [jobId, taskId, productName, contentType])
+  }, [jobId, taskId, productName, fileExt])
 
   const handleView = () => setLightboxOpen(true)
 

--- a/frontend/src/features/executions/components/OutputsPanel.tsx
+++ b/frontend/src/features/executions/components/OutputsPanel.tsx
@@ -8,11 +8,13 @@
  * does it submit to any jurisdiction.
  */
 
+import { useEffect, useRef } from 'react'
 import { Package } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { useQueryClient } from '@tanstack/react-query'
 import type { JobStatus } from '@/api/types/job.types'
 import { isTerminalStatus } from '@/api/types/job.types'
-import { useJobAvailable } from '@/api/hooks/useJobs'
+import { jobKeys, useJobAvailable } from '@/api/hooks/useJobs'
 import { OutputCard } from '@/features/executions/components/OutputCard'
 import { P } from '@/components/base/typography'
 import { Card } from '@/components/ui/card'
@@ -25,6 +27,21 @@ interface OutputsPanelProps {
 export function OutputsPanel({ jobId, status }: OutputsPanelProps) {
   const { t } = useTranslation('executions')
   const { data: availableIds } = useJobAvailable(jobId, status)
+  const queryClient = useQueryClient()
+
+  // The polling loop stops the moment status turns terminal, so the last
+  // poll can still be an empty list if outputs hadn't been published yet.
+  // Force a final refetch on the transition so the user doesn't need to
+  // reload the page to see completed outputs.
+  const prevStatusRef = useRef(status)
+  useEffect(() => {
+    const wasNonTerminal = !isTerminalStatus(prevStatusRef.current)
+    const nowTerminal = isTerminalStatus(status)
+    if (wasNonTerminal && nowTerminal) {
+      queryClient.invalidateQueries({ queryKey: jobKeys.available(jobId) })
+    }
+    prevStatusRef.current = status
+  }, [status, jobId, queryClient])
 
   const hasResults = availableIds && availableIds.length > 0
   const isRunning = !isTerminalStatus(status)
@@ -60,7 +77,6 @@ export function OutputsPanel({ jobId, status }: OutputsPanelProps) {
               jobId={jobId}
               taskId={taskId}
               productName={taskId}
-              contentType={null}
             />
           ))}
         </div>

--- a/frontend/src/features/fable-builder/components/DraftStatus.tsx
+++ b/frontend/src/features/fable-builder/components/DraftStatus.tsx
@@ -1,0 +1,54 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Figma-style subtle status line reporting on the LOCAL draft autosave only.
+ *
+ *   - isDirty && draftWritePending → "Saving draft…"
+ *   - isDirty && !draftWritePending → "Draft saved"
+ *   - !isDirty                     → nothing
+ *
+ * Backend-save state lives on the Save Config button variant (primary when
+ * dirty, outline when clean). Keeping the two concerns visually separate
+ * avoids the "Saving draft… → Unsaved" flip we had when one indicator tried
+ * to express both.
+ */
+
+import { Check, Loader2 } from 'lucide-react'
+import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
+import { cn } from '@/lib/utils'
+
+export function DraftStatus({ className }: { className?: string }) {
+  const isDirty = useFableBuilderStore((s) => s.isDirty)
+  const draftWritePending = useFableBuilderStore((s) => s.draftWritePending)
+
+  if (!isDirty) return null
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 text-xs text-muted-foreground',
+        className,
+      )}
+    >
+      {draftWritePending ? (
+        <>
+          <Loader2 className="h-3 w-3 animate-spin" />
+          Saving draft…
+        </>
+      ) : (
+        <>
+          <Check className="h-3 w-3" />
+          Draft saved
+        </>
+      )}
+    </span>
+  )
+}

--- a/frontend/src/features/fable-builder/components/FableBuilderHeader.tsx
+++ b/frontend/src/features/fable-builder/components/FableBuilderHeader.tsx
@@ -22,6 +22,7 @@ import {
 } from 'lucide-react'
 import { Link } from '@tanstack/react-router'
 import { ValidationStatusBadge } from './shared/ValidationStatus'
+import { DraftStatus } from './DraftStatus'
 import { GraphOptionsDropdown } from './graph-mode/GraphOptionsDropdown'
 import { SaveConfigPopover } from './SaveConfigPopover'
 import type {
@@ -32,7 +33,6 @@ import { getBlocksByKind } from '@/api/types/fable.types'
 import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
 import { Button } from '@/components/ui/button'
 import { ButtonGroup } from '@/components/ui/button-group'
-import { Badge } from '@/components/ui/badge'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -68,7 +68,6 @@ export function FableBuilderHeader({
   const step = useFableBuilderStore((s) => s.step)
   const fableName = useFableBuilderStore((s) => s.fableName)
   const fable = useFableBuilderStore((s) => s.fable)
-  const isDirty = useFableBuilderStore((s) => s.isDirty)
   const validationState = useFableBuilderStore((s) => s.validationState)
   const storeFableId = useFableBuilderStore((s) => s.fableId)
 
@@ -213,20 +212,13 @@ export function FableBuilderHeader({
                 <H1 className="min-w-0 truncate text-lg font-semibold">
                   {fableName}
                 </H1>
-                {isDirty && (
-                  <Badge
-                    variant="outline"
-                    className="hidden shrink-0 text-sm sm:inline-flex"
-                  >
-                    Unsaved
-                  </Badge>
-                )}
               </div>
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <span>
                   {blockCount} {blockCount === 1 ? 'block' : 'blocks'}
                 </span>
                 {hasBlocks && <ValidationStatusBadge />}
+                <DraftStatus className="hidden sm:inline-flex" />
               </div>
             </div>
           </div>

--- a/frontend/src/features/fable-builder/components/FableBuilderPage.tsx
+++ b/frontend/src/features/fable-builder/components/FableBuilderPage.tsx
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useMemo, useRef } from 'react'
 import { Link } from '@tanstack/react-router'
 import { AlertCircle, Package } from 'lucide-react'
 import { FableBuilderHeader } from './FableBuilderHeader'
@@ -29,6 +29,8 @@ import {
 } from '@/features/fable-builder/hooks/useDraftPersistence'
 import { getPreset } from '@/features/fable-builder/presets/presets'
 import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
+import { hasUnterminatedGlyph } from '@/features/fable-builder/utils/glyph-display'
+import { useDebounce } from '@/hooks/useDebounce'
 import { useMedia } from '@/hooks/useMedia'
 import { GlyphProvider } from '@/features/fable-builder/context/GlyphContext'
 import { LoadingSpinner } from '@/components/common/LoadingSpinner'
@@ -114,7 +116,11 @@ export function FableBuilderPage({
 
   const isDesktop = useMedia('(min-width: 768px)')
 
-  const { data: catalogue, isLoading: catalogueLoading } = useBlockCatalogue()
+  const {
+    data: catalogue,
+    isLoading: catalogueLoading,
+    refetch: refetchCatalogue,
+  } = useBlockCatalogue()
   const {
     data: existingFable,
     isLoading: fableLoading,
@@ -122,12 +128,30 @@ export function FableBuilderPage({
   } = useFable(fableId ?? null)
   const { data: fableRetrieveData } = useFableRetrieve(fableId ?? null)
 
+  // Coalesce keystrokes: toValidationState rebuilds nested objects, so a
+  // per-keystroke validation would re-render every canvas node.
+  const debouncedFable = useDebounce(fable, 300)
+
+  // Skip validation while any `${` is unterminated — backend 500s on Jinja
+  // parse errors; keepPreviousData retains the last successful resolution.
+  const fableHasOpenGlyph = useMemo(() => {
+    for (const block of Object.values(debouncedFable.blocks)) {
+      for (const val of Object.values(block.configuration_values)) {
+        if (hasUnterminatedGlyph(val)) return true
+      }
+    }
+    for (const val of Object.values(debouncedFable.local_glyphs ?? {})) {
+      if (hasUnterminatedGlyph(val)) return true
+    }
+    return false
+  }, [debouncedFable])
+
   const {
     data: validationResult,
     isLoading: isValidating,
     isFetching: isRevalidating,
     error: validationError,
-  } = useFableValidation(fable)
+  } = useFableValidation(debouncedFable, !fableHasOpenGlyph)
 
   // Initialize fable state - only runs once per mount.
   // Checks for a stale draft in localStorage before loading from backend.
@@ -244,6 +268,9 @@ export function FableBuilderPage({
     return (
       <div className="flex min-h-100 flex-col items-center justify-center gap-4">
         <P className="text-destructive">Failed to load block catalogue</P>
+        <Button variant="outline" onClick={() => refetchCatalogue()}>
+          Retry
+        </Button>
       </div>
     )
   }
@@ -256,17 +283,21 @@ export function FableBuilderPage({
       >
         <FableBuilderHeader fableId={fableId} catalogue={catalogue} />
 
-        {validationError && (
-          <Alert variant="destructive" className="mx-4 mt-2">
-            <AlertCircle className="h-4 w-4" />
-            <AlertTitle>Validation Error</AlertTitle>
-            <AlertDescription>
-              {getValidationErrorMessage(validationError)}
-            </AlertDescription>
-          </Alert>
-        )}
-
-        <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
+        {/* Absolute so toggling the banner doesn't shift the canvas — closed
+            but semantically broken expressions still 500. */}
+        <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden">
+          {validationError && (
+            <Alert
+              variant="destructive"
+              className="absolute top-2 right-4 left-4 z-10 shadow-lg"
+            >
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>Validation Error</AlertTitle>
+              <AlertDescription>
+                {getValidationErrorMessage(validationError)}
+              </AlertDescription>
+            </Alert>
+          )}
           {step === 'edit' ? (
             <EditStep catalogue={catalogue} isDesktop={isDesktop} mode={mode} />
           ) : (

--- a/frontend/src/features/fable-builder/components/graph-mode/FableGraphCanvas.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/FableGraphCanvas.tsx
@@ -83,6 +83,11 @@ function FableGraphCanvasInner({ catalogue }: FableGraphCanvasProps) {
   const prevLayoutDirectionRef = useRef(layoutDirection)
   const hasInitializedViewportRef = useRef<boolean>(false)
   const lastBlockCountRef = useRef<number>(0)
+  // Nodes whose dimensions have been measured at least once. Used to skip
+  // auto-relayout on subsequent content-driven resizes (e.g. config badges
+  // growing/shrinking while the user types), which would otherwise jostle
+  // the whole graph.
+  const measuredNodesRef = useRef<Set<string>>(new Set())
 
   // Debounced re-layout function that uses measured node dimensions
   const debouncedRelayout = useDebouncedCallback(() => {
@@ -107,17 +112,27 @@ function FableGraphCanvasInner({ catalogue }: FableGraphCanvasProps) {
     setNodes(layouted)
   }, 300)
 
-  // Wrap onNodesChange to detect dimension changes and trigger re-layout
+  // Trigger re-layout only on a node's FIRST measured dimension (freshly
+  // inserted or after layout direction change). Later resizes — e.g. a
+  // config badge wrap changing rows while the user types — are ignored
+  // so the graph doesn't jostle with every keystroke.
   const onNodesChange = useCallback(
     (changes: Array<NodeChange<FableNode>>) => {
       onNodesChangeInternal(changes)
 
-      // Check for dimension changes
-      const hasDimensionChange = changes.some(
-        (c) => c.type === 'dimensions' && c.dimensions,
-      )
+      let hasFirstMeasurement = false
+      for (const change of changes) {
+        if (change.type === 'remove') {
+          measuredNodesRef.current.delete(change.id)
+          continue
+        }
+        if (change.type !== 'dimensions' || !change.dimensions) continue
+        if (measuredNodesRef.current.has(change.id)) continue
+        measuredNodesRef.current.add(change.id)
+        hasFirstMeasurement = true
+      }
 
-      if (hasDimensionChange && autoLayout) {
+      if (hasFirstMeasurement && autoLayout) {
         debouncedRelayout()
       }
     },

--- a/frontend/src/features/fable-builder/components/graph-mode/nodes/BlockErrorOverlay.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/nodes/BlockErrorOverlay.tsx
@@ -1,0 +1,38 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Floating validation-error banner shown below a graph-node card. Absolute
+ * so toggling errors doesn't resize the node and trigger a React Flow
+ * relayout; shared between BlockNode and InlineBlockNode.
+ */
+
+import { AlertCircle } from 'lucide-react'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+
+export function BlockErrorOverlay({
+  errors,
+}: {
+  errors: ReadonlyArray<string>
+}) {
+  if (errors.length === 0) return null
+  return (
+    <Alert
+      variant="destructive"
+      className="nodrag absolute top-full right-0 left-0 z-10 mt-1 gap-1 px-2 py-1.5 text-xs shadow-md"
+    >
+      <AlertCircle className="h-3 w-3" />
+      <AlertDescription className="line-clamp-2 text-xs">
+        {errors[0]}
+        {errors.length > 1 && ` (+${errors.length - 1} more)`}
+      </AlertDescription>
+    </Alert>
+  )
+}

--- a/frontend/src/features/fable-builder/components/graph-mode/nodes/BlockNode.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/nodes/BlockNode.tsx
@@ -11,7 +11,6 @@
 import { memo, useMemo, useState } from 'react'
 import { Handle, Position } from '@xyflow/react'
 import {
-  AlertCircle,
   Bookmark,
   Copy,
   CopyPlus,
@@ -47,7 +46,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover'
-import { Alert, AlertDescription } from '@/components/ui/alert'
+import { BlockErrorOverlay } from '@/features/fable-builder/components/graph-mode/nodes/BlockErrorOverlay'
 import { parseGlyphSegments } from '@/features/fable-builder/utils/glyph-display'
 import { cn } from '@/lib/utils'
 
@@ -323,20 +322,8 @@ export const BlockNode = memo(function ({
             )}
           </div>
         )}
-
-        {hasErrors && (
-          <Alert
-            variant="destructive"
-            className="nodrag mt-3 gap-1 px-2 py-1.5 text-xs"
-          >
-            <AlertCircle className="h-3 w-3" />
-            <AlertDescription className="line-clamp-2 text-xs">
-              {errors[0]}
-              {errors.length > 1 && ` (+${errors.length - 1} more)`}
-            </AlertDescription>
-          </Alert>
-        )}
       </div>
+      <BlockErrorOverlay errors={errors} />
 
       {factory.inputs.map((inputName, index) => {
         const percent = ((index + 1) / (factory.inputs.length + 1)) * 100

--- a/frontend/src/features/fable-builder/components/graph-mode/nodes/InlineBlockNode.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/nodes/InlineBlockNode.tsx
@@ -10,12 +10,12 @@
 
 import { memo, useMemo } from 'react'
 import { Handle, Position } from '@xyflow/react'
-import { AlertCircle, Trash2 } from 'lucide-react'
+import { Trash2 } from 'lucide-react'
 
 import type { Node, NodeProps } from '@xyflow/react'
 import type { FableNodeData } from '@/features/fable-builder/utils/fable-to-graph'
 import type { BlockFactory, BlockInstance } from '@/api/types/fable.types'
-import { Alert, AlertDescription } from '@/components/ui/alert'
+import { BlockErrorOverlay } from '@/features/fable-builder/components/graph-mode/nodes/BlockErrorOverlay'
 import { AddNodeButton } from '@/features/fable-builder/components/graph-mode/AddNodeButton'
 import { useNodeDimensions } from '@/features/fable-builder/hooks/useNodeDimensions'
 import {
@@ -303,20 +303,8 @@ export const InlineBlockNode = memo(function ({
             </FieldErrorsContext.Provider>
           </ResolvedConfigContext.Provider>
         )}
-
-        {hasErrors && (
-          <Alert
-            variant="destructive"
-            className="nodrag mt-3 gap-1 px-2 py-1.5 text-xs"
-          >
-            <AlertCircle className="h-3 w-3" />
-            <AlertDescription className="line-clamp-2 text-xs">
-              {errors[0]}
-              {errors.length > 1 && ` (+${errors.length - 1} more)`}
-            </AlertDescription>
-          </Alert>
-        )}
       </div>
+      <BlockErrorOverlay errors={errors} />
 
       {inputs.map((inputName, index) => {
         const topPercent = ((index + 1) / (inputs.length + 1)) * 100

--- a/frontend/src/features/fable-builder/components/layout/ConfigPanel.tsx
+++ b/frontend/src/features/fable-builder/components/layout/ConfigPanel.tsx
@@ -217,7 +217,10 @@ export function ConfigPanel({ catalogue }: ConfigPanelProps): React.ReactNode {
                     />
                   ))}
                 </div>
-                <GlyphReferencePanel />
+                {/* mt-10 reserves clearance for the last field's absolute
+                    preview/nudge/error stack so they don't overlap the
+                    reference panel. */}
+                <GlyphReferencePanel className="mt-10" />
               </div>
             </FieldErrorsContext.Provider>
           </ResolvedConfigContext.Provider>

--- a/frontend/src/features/fable-builder/components/shared/GlyphAutocomplete.tsx
+++ b/frontend/src/features/fable-builder/components/shared/GlyphAutocomplete.tsx
@@ -11,26 +11,57 @@
 /**
  * GlyphAutocomplete Component
  *
- * Dropdown list of available glyphs, triggered when user types ${ in a config field.
- * Supports keyboard navigation (arrow keys + Enter) and filtering by partial input.
+ * Dropdown of candidates for the current cursor position inside a `${...}`
+ * expression. Driven by `parseGlyphContext`: shows variables + callable
+ * helpers in `value` position, and pipe-style helper filters in `filter`
+ * position. Supports keyboard navigation (arrow keys + Enter / Escape).
  */
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import type { GlyphInfo } from '@/features/fable-builder/hooks/useAllGlyphs'
 import { P } from '@/components/base/typography'
 import { cn } from '@/lib/utils'
 
+export type AutocompleteSource =
+  | 'local'
+  | 'global'
+  | 'intrinsic'
+  | 'filter'
+  | 'helperGlobal'
+
+export interface AutocompleteCandidate {
+  /** Identifier inserted on selection. */
+  name: string
+  /** Display label; for intrinsics this is friendlier than `name`. */
+  displayName: string
+  /** Right-aligned meta text (value example or backend description). */
+  meta: string
+  /** Drives section header, ordering, and badge. */
+  source: AutocompleteSource
+}
+
+export type AutocompleteContextKind = 'value' | 'filter'
+
 interface GlyphAutocompleteProps {
-  glyphs: Array<GlyphInfo>
+  candidates: Array<AutocompleteCandidate>
   filter: string
-  onSelect: (glyphName: string) => void
+  contextKind: AutocompleteContextKind
+  onSelect: (candidate: AutocompleteCandidate) => void
   onClose: () => void
 }
 
+const VALUE_SECTION_ORDER: ReadonlyArray<AutocompleteSource> = [
+  'local',
+  'global',
+  'intrinsic',
+  'helperGlobal',
+]
+const FILTER_SECTION_ORDER: ReadonlyArray<AutocompleteSource> = ['filter']
+
 export function GlyphAutocomplete({
-  glyphs,
+  candidates,
   filter,
+  contextKind,
   onSelect,
   onClose,
 }: GlyphAutocompleteProps) {
@@ -38,21 +69,37 @@ export function GlyphAutocomplete({
   const [activeIndex, setActiveIndex] = useState(0)
   const listRef = useRef<HTMLDivElement>(null)
 
-  const query = filter.toLowerCase()
-  const filtered = glyphs.filter(
-    (g) =>
-      g.name.toLowerCase().includes(query) ||
-      g.displayName.toLowerCase().includes(query),
-  )
+  const filtered = useMemo(() => {
+    const query = filter.toLowerCase()
+    return candidates.filter(
+      (c) =>
+        c.name.toLowerCase().includes(query) ||
+        c.displayName.toLowerCase().includes(query),
+    )
+  }, [candidates, filter])
 
-  const intrinsic = filtered.filter((g) => g.type === 'intrinsic')
-  const global = filtered.filter((g) => g.type === 'global')
-  const local = filtered.filter((g) => g.type === 'local')
-  const allItems = [...local, ...global, ...intrinsic]
+  const sectionOrder =
+    contextKind === 'filter' ? FILTER_SECTION_ORDER : VALUE_SECTION_ORDER
+
+  // Group filtered candidates by source, preserving the section order so the
+  // flat `allItems` index aligns with what the user sees vertically.
+  const grouped = useMemo(() => {
+    const bySource = new Map<AutocompleteSource, Array<AutocompleteCandidate>>()
+    for (const c of filtered) {
+      const arr = bySource.get(c.source) ?? []
+      arr.push(c)
+      bySource.set(c.source, arr)
+    }
+    return sectionOrder
+      .map((source) => ({ source, items: bySource.get(source) ?? [] }))
+      .filter((g) => g.items.length > 0)
+  }, [filtered, sectionOrder])
+
+  const allItems = useMemo(() => grouped.flatMap((g) => g.items), [grouped])
 
   useEffect(() => {
     setActiveIndex(0)
-  }, [filter])
+  }, [filter, contextKind])
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -64,7 +111,7 @@ export function GlyphAutocomplete({
         setActiveIndex((i) => Math.max(i - 1, 0))
       } else if (e.key === 'Enter' && allItems.length > 0) {
         e.preventDefault()
-        onSelect(allItems[activeIndex].name)
+        onSelect(allItems[activeIndex])
       } else if (e.key === 'Escape') {
         e.preventDefault()
         onClose()
@@ -90,90 +137,67 @@ export function GlyphAutocomplete({
   return (
     <div
       ref={listRef}
-      className="max-h-48 overflow-y-auto rounded-md border border-border bg-popover p-1 shadow-md"
+      className="max-h-60 overflow-y-auto rounded-md border border-border bg-popover p-1 shadow-md"
     >
-      {local.length > 0 && (
-        <>
-          <P className="px-2 py-1 text-sm font-medium text-muted-foreground">
-            {t('panel.local')}
-          </P>
-          {local.map((g) => {
-            const idx = itemIndex++
-            return (
-              <AutocompleteItem
-                key={g.name}
-                glyph={g}
-                active={idx === activeIndex}
-                onSelect={() => onSelect(g.name)}
-                onHover={() => setActiveIndex(idx)}
-              />
-            )
-          })}
-        </>
-      )}
-      {global.length > 0 && (
-        <>
-          {local.length > 0 && <div className="my-1 border-t border-border" />}
-          <P className="px-2 py-1 text-sm font-medium text-muted-foreground">
-            {t('panel.global')}
-          </P>
-          {global.map((g) => {
-            const idx = itemIndex++
-            return (
-              <AutocompleteItem
-                key={g.name}
-                glyph={g}
-                active={idx === activeIndex}
-                onSelect={() => onSelect(g.name)}
-                onHover={() => setActiveIndex(idx)}
-              />
-            )
-          })}
-        </>
-      )}
-      {intrinsic.length > 0 && (
-        <>
-          {(local.length > 0 || global.length > 0) && (
-            <div className="my-1 border-t border-border" />
-          )}
-          <P className="px-2 py-1 text-sm font-medium text-muted-foreground">
-            {t('panel.intrinsic')}
-          </P>
-          {intrinsic.map((g) => {
-            const idx = itemIndex++
-            return (
-              <AutocompleteItem
-                key={g.name}
-                glyph={g}
-                active={idx === activeIndex}
-                onSelect={() => onSelect(g.name)}
-                onHover={() => setActiveIndex(idx)}
-              />
-            )
-          })}
-        </>
-      )}
+      {grouped.map((group, groupIdx) => {
+        const label =
+          group.source === 'local'
+            ? t('panel.local')
+            : group.source === 'global'
+              ? t('panel.global')
+              : group.source === 'intrinsic'
+                ? t('panel.intrinsic')
+                : t('panel.helpers.title')
+        return (
+          <div key={group.source}>
+            {groupIdx > 0 && <div className="my-1 border-t border-border" />}
+            <P className="px-2 py-1 text-sm font-medium text-muted-foreground">
+              {label}
+            </P>
+            {group.items.map((c) => {
+              const idx = itemIndex++
+              return (
+                <AutocompleteItem
+                  key={`${c.source}:${c.name}`}
+                  candidate={c}
+                  active={idx === activeIndex}
+                  onSelect={() => onSelect(c)}
+                  onHover={() => setActiveIndex(idx)}
+                />
+              )
+            })}
+          </div>
+        )
+      })}
     </div>
   )
 }
 
 function AutocompleteItem({
-  glyph,
+  candidate,
   active,
   onSelect,
   onHover,
 }: {
-  glyph: GlyphInfo
+  candidate: AutocompleteCandidate
   active: boolean
   onSelect: () => void
   onHover: () => void
 }) {
+  const { t } = useTranslation('glyphs')
+  const badge =
+    candidate.source === 'filter'
+      ? t('panel.helpers.filterBadge')
+      : candidate.source === 'helperGlobal'
+        ? t('panel.helpers.globalBadge')
+        : null
+
   return (
     <button
       type="button"
       data-active={active}
       onMouseDown={(e) => {
-        e.preventDefault() // Prevent input blur
+        e.preventDefault() // prevent input blur
         onSelect()
       }}
       onMouseEnter={onHover}
@@ -183,10 +207,22 @@ function AutocompleteItem({
       )}
     >
       <code className="shrink-0 font-mono text-sm font-medium">
-        {glyph.name}
+        {candidate.name}
       </code>
+      {badge && (
+        <span
+          className={cn(
+            'shrink-0 rounded px-1 py-0.5 text-[10px] font-medium uppercase',
+            candidate.source === 'filter'
+              ? 'bg-blue-500/10 text-blue-600 dark:text-blue-400'
+              : 'bg-purple-500/10 text-purple-600 dark:text-purple-400',
+          )}
+        >
+          {badge}
+        </span>
+      )}
       <span className="min-w-0 truncate text-muted-foreground">
-        {glyph.type === 'intrinsic' ? glyph.displayName : glyph.valueExample}
+        {candidate.meta}
       </span>
     </button>
   )

--- a/frontend/src/features/fable-builder/components/shared/GlyphReferencePanel.tsx
+++ b/frontend/src/features/fable-builder/components/shared/GlyphReferencePanel.tsx
@@ -28,13 +28,17 @@ import {
   Pencil,
   Plus,
   Trash2,
+  Wand2,
   X,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Link } from '@tanstack/react-router'
+import type { GlyphFunctionDetail } from '@/api/types/fable.types'
 import type { GlyphInfo } from '@/features/fable-builder/hooks/useAllGlyphs'
+import { useGlyphFunctions } from '@/api/hooks/useFable'
 import { useAllGlyphs } from '@/features/fable-builder/hooks/useAllGlyphs'
 import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
+import { GlyphFormDialog } from '@/features/glyphs/components/GlyphFormDialog'
 import { showToast } from '@/lib/toast'
 import { P } from '@/components/base/typography'
 import {
@@ -46,14 +50,18 @@ import { cn } from '@/lib/utils'
 
 const EMPTY_GLYPHS: Record<string, string> = {}
 
-export function GlyphReferencePanel() {
+export function GlyphReferencePanel({ className }: { className?: string }) {
   const { t } = useTranslation('glyphs')
   const localGlyphs =
     useFableBuilderStore((state) => state.fable.local_glyphs) ?? EMPTY_GLYPHS
   const { glyphs, isLoading } = useAllGlyphs(localGlyphs)
+  const { data: functionsResponse } = useGlyphFunctions()
+  const helperFunctions = functionsResponse?.functions ?? []
   const [intrinsicOpen, setIntrinsicOpen] = useState(false)
   const [globalOpen, setGlobalOpen] = useState(true)
   const [localOpen, setLocalOpen] = useState(true)
+  const [helpersOpen, setHelpersOpen] = useState(false)
+  const [createGlobalOpen, setCreateGlobalOpen] = useState(false)
 
   if (isLoading) return null
 
@@ -67,39 +75,79 @@ export function GlyphReferencePanel() {
     showToast.success(t('panel.copied'), ref)
   }
 
+  function handleCopyHelper(fn: GlyphFunctionDetail) {
+    const snippet = fn.kind === 'filter' ? `| ${fn.name}` : `${fn.name}()`
+    navigator.clipboard.writeText(snippet)
+    showToast.success(t('panel.copied'), snippet)
+  }
+
   return (
-    <div className="rounded-md border border-dashed border-border bg-muted/30">
-      {/* Header */}
-      <div className="flex items-center justify-between p-3 pb-0">
-        <div className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground">
-          <Braces className="h-3.5 w-3.5" />
+    <div
+      className={cn(
+        'rounded-md border border-dashed border-border bg-muted/30',
+        className,
+      )}
+    >
+      {/* Header — icon-only actions so the row stays readable in a
+          narrow sidebar. Labels are preserved via tooltips. */}
+      <div className="flex items-center gap-1.5 p-3 pb-0">
+        <Braces className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        <span className="truncate text-sm font-medium text-muted-foreground">
           {t('panel.title')}
+        </span>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                className="shrink-0 text-muted-foreground/60 hover:text-muted-foreground"
+              />
+            }
+          >
+            <HelpCircle className="h-3.5 w-3.5" />
+          </TooltipTrigger>
+          <TooltipContent
+            side="bottom"
+            className="max-w-80 whitespace-pre-line"
+          >
+            {t('panel.help')}
+          </TooltipContent>
+        </Tooltip>
+        <div className="ml-auto flex items-center gap-0.5">
           <Tooltip>
             <TooltipTrigger
               render={
                 <button
                   type="button"
-                  className="text-muted-foreground/60 hover:text-muted-foreground"
+                  aria-label={t('panel.addGlobal')}
+                  onClick={() => setCreateGlobalOpen(true)}
+                  className="shrink-0 rounded p-1 text-primary hover:bg-primary/10"
                 />
               }
             >
-              <HelpCircle className="h-3.5 w-3.5" />
+              <Plus className="h-3.5 w-3.5" />
             </TooltipTrigger>
-            <TooltipContent
-              side="bottom"
-              className="max-w-80 whitespace-pre-line"
+            <TooltipContent side="bottom">
+              {t('panel.addGlobal')}
+            </TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Link
+                  to="/admin/variables"
+                  aria-label={t('panel.manageAll')}
+                  className="shrink-0 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                />
+              }
             >
-              {t('panel.help')}
+              <ExternalLink className="h-3.5 w-3.5" />
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {t('panel.manageAll')}
             </TooltipContent>
           </Tooltip>
         </div>
-        <Link
-          to="/admin/glyphs"
-          className="flex items-center gap-1 text-sm text-primary hover:underline"
-        >
-          {t('panel.manage')}
-          <ExternalLink className="h-3 w-3" />
-        </Link>
       </div>
 
       {/* Local section */}
@@ -131,9 +179,13 @@ export function GlyphReferencePanel() {
         ) : (
           <div className="px-3 pb-2 text-sm text-muted-foreground">
             {t('panel.noGlobal')}{' '}
-            <Link to="/admin/glyphs" className="text-primary hover:underline">
+            <button
+              type="button"
+              onClick={() => setCreateGlobalOpen(true)}
+              className="text-primary hover:underline"
+            >
               {t('panel.createOne')}
-            </Link>
+            </button>
           </div>
         )}
       </GlyphSection>
@@ -153,7 +205,147 @@ export function GlyphReferencePanel() {
           />
         ))}
       </GlyphSection>
+
+      {/* Helpers section — Jinja filters/globals from /blueprint/glyphs/functions */}
+      <HelperSection
+        open={helpersOpen}
+        onToggle={() => setHelpersOpen(!helpersOpen)}
+        helpers={helperFunctions}
+        onCopy={handleCopyHelper}
+      />
+
+      {/* Inline create-variable dialog: stays on the canvas; mutation invalidates
+          fableKeys.globalGlyphsBase so the panel refetches automatically. */}
+      <GlyphFormDialog
+        open={createGlobalOpen}
+        onOpenChange={setCreateGlobalOpen}
+      />
     </div>
+  )
+}
+
+function HelperSection({
+  open,
+  onToggle,
+  helpers,
+  onCopy,
+}: {
+  open: boolean
+  onToggle: () => void
+  helpers: Array<GlyphFunctionDetail>
+  onCopy: (fn: GlyphFunctionDetail) => void
+}) {
+  const { t } = useTranslation('glyphs')
+
+  return (
+    <div className="border-t border-border/50">
+      <div className="flex w-full items-center gap-1.5 px-3 py-2">
+        <button
+          type="button"
+          onClick={onToggle}
+          className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground"
+        >
+          {open ? (
+            <ChevronDown className="h-3.5 w-3.5" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5" />
+          )}
+          <Wand2 className="h-3.5 w-3.5" />
+          {t('panel.helpers.title')}
+        </button>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                className="text-muted-foreground/60 hover:text-muted-foreground"
+              />
+            }
+          >
+            <HelpCircle className="h-3 w-3" />
+          </TooltipTrigger>
+          <TooltipContent side="bottom" className="max-w-64">
+            {t('panel.helpers.tooltip')}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+      {open && (
+        <div className="space-y-0.5 pb-2">
+          {helpers.length === 0 ? (
+            <div className="px-3 pb-1 text-sm text-muted-foreground">
+              {t('panel.helpers.empty')}
+            </div>
+          ) : (
+            helpers.map((fn) => (
+              <HelperRow
+                key={`${fn.kind}:${fn.name}`}
+                fn={fn}
+                onCopy={onCopy}
+              />
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function HelperRow({
+  fn,
+  onCopy,
+}: {
+  fn: GlyphFunctionDetail
+  onCopy: (fn: GlyphFunctionDetail) => void
+}) {
+  const { t } = useTranslation('glyphs')
+  const snippet = fn.kind === 'filter' ? `| ${fn.name}` : `${fn.name}()`
+  const hint =
+    fn.kind === 'filter'
+      ? t('panel.helpers.copyHintFilter', { name: fn.name })
+      : t('panel.helpers.copyHintGlobal', { name: fn.name })
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <button
+            type="button"
+            onClick={() => onCopy(fn)}
+            className={cn(
+              'group flex w-full items-center gap-2 rounded px-3 py-1 text-left text-sm',
+              'transition-colors hover:bg-muted/80',
+            )}
+          />
+        }
+      >
+        <code className="shrink-0 rounded bg-muted px-1.5 py-0.5 font-mono text-xs">
+          {snippet}
+        </code>
+        <span
+          className={cn(
+            'shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium uppercase',
+            fn.kind === 'filter'
+              ? 'bg-blue-500/10 text-blue-600 dark:text-blue-400'
+              : 'bg-purple-500/10 text-purple-600 dark:text-purple-400',
+          )}
+        >
+          {fn.kind === 'filter'
+            ? t('panel.helpers.filterBadge')
+            : t('panel.helpers.globalBadge')}
+        </span>
+        <P className="min-w-0 truncate text-xs text-muted-foreground">
+          {fn.description}
+        </P>
+        <Copy className="ml-auto h-3 w-3 shrink-0 text-muted-foreground/0 transition-colors group-hover:text-muted-foreground" />
+      </TooltipTrigger>
+      <TooltipContent side="left" className="max-w-72">
+        <div className="space-y-1">
+          <div className="font-medium">{fn.name}</div>
+          <div className="text-muted-foreground">{fn.description}</div>
+          <div className="text-[10px] text-muted-foreground">{hint}</div>
+        </div>
+      </TooltipContent>
+    </Tooltip>
   )
 }
 

--- a/frontend/src/features/fable-builder/hooks/useDraftPersistence.ts
+++ b/frontend/src/features/fable-builder/hooks/useDraftPersistence.ts
@@ -14,11 +14,15 @@
  *
  * - Writes debounced (2 s) after every store change that sets isDirty.
  * - Clears the draft on successful save (markSaved).
- * - On mount, checks for a stale draft and returns it for recovery.
- * - Registers a `beforeunload` guard when isDirty.
+ * - On mount, restoration is handled by FableBuilderPage via readDraft().
+ *
+ * No `beforeunload` guard — the localStorage draft is the safety net, and
+ * the header already shows an "Unsaved" badge when the state is dirty. The
+ * native "Leave site?" prompt is intrusive and inconsistent with modern
+ * autosave UX (Figma / Google Docs / Airtable).
  */
 
-import { useCallback, useEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import type { FableBuilderV1 } from '@/api/types/fable.types'
 import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
 
@@ -80,6 +84,7 @@ export function useDraftPersistence(): void {
           clearTimeout(timerRef.current)
           timerRef.current = null
         }
+        useFableBuilderStore.setState({ draftWritePending: false })
         return
       }
 
@@ -92,6 +97,7 @@ export function useDraftPersistence(): void {
         return
 
       if (timerRef.current) clearTimeout(timerRef.current)
+      useFableBuilderStore.setState({ draftWritePending: true })
       timerRef.current = setTimeout(() => {
         writeDraft({
           fable: state.fable,
@@ -101,6 +107,7 @@ export function useDraftPersistence(): void {
           savedAt: Date.now(),
         })
         timerRef.current = null
+        useFableBuilderStore.setState({ draftWritePending: false })
       }, DEBOUNCE_MS)
     })
 
@@ -109,21 +116,4 @@ export function useDraftPersistence(): void {
       if (timerRef.current) clearTimeout(timerRef.current)
     }
   }, [])
-
-  // beforeunload guard
-  const isDirty = useFableBuilderStore((s) => s.isDirty)
-
-  const handleBeforeUnload = useCallback(
-    (e: BeforeUnloadEvent) => {
-      if (isDirty) {
-        e.preventDefault()
-      }
-    },
-    [isDirty],
-  )
-
-  useEffect(() => {
-    window.addEventListener('beforeunload', handleBeforeUnload)
-    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
-  }, [handleBeforeUnload])
 }

--- a/frontend/src/features/fable-builder/stores/fableBuilderStore.ts
+++ b/frontend/src/features/fable-builder/stores/fableBuilderStore.ts
@@ -64,6 +64,9 @@ interface FableBuilderState {
   lastValidatedAt: number | null
   isDirty: boolean
   lastSavedAt: number | null
+  /** True while the 2 s localStorage draft debounce is pending. Set by
+   *  `useDraftPersistence`; read by the DraftStatus indicator. */
+  draftWritePending: boolean
   submitDialogOpen: boolean
 
   setFable: (fable: FableBuilderV1, id?: string | null) => void
@@ -145,6 +148,7 @@ const initialState = {
   lastValidatedAt: null,
   isDirty: false,
   lastSavedAt: null,
+  draftWritePending: false,
   submitDialogOpen: false,
 }
 

--- a/frontend/src/features/fable-builder/utils/build-autocomplete-insertion.ts
+++ b/frontend/src/features/fable-builder/utils/build-autocomplete-insertion.ts
@@ -1,0 +1,77 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Smart-insert payload builder for autocomplete picks.
+ *
+ * Decides what to drop into the input when the user picks a candidate from
+ * `GlyphAutocomplete`, and where to land the cursor afterwards. Lives as a
+ * pure function so it can be unit-tested without rendering.
+ */
+
+import type { AutocompleteSource } from '@/features/fable-builder/components/shared/GlyphAutocomplete'
+
+export interface AutocompleteInsertion {
+  /** Replacement text to splice in for the parser's [replaceStart, replaceEnd) range. */
+  text: string
+  /** Cursor position after insertion, expressed as an offset from `replaceStart`. */
+  cursorOffset: number
+}
+
+interface CandidateInfo {
+  name: string
+  source: AutocompleteSource
+  /** Backend description for helpers; used to detect whether the helper takes arguments. */
+  description?: string
+}
+
+const isHelperSource = (source: AutocompleteSource): boolean =>
+  source === 'filter' || source === 'helperGlobal'
+
+/**
+ * The backend doesn't ship signatures, but every helper that takes arguments
+ * mentions `name(` somewhere in its description (e.g. `${dt | add_days(n)}`).
+ * Helpers without arguments (`floor_day`, `floor_hour`) reference themselves
+ * without parentheses. This heuristic stays good as long as backend authors
+ * keep that convention.
+ */
+function helperTakesArgs(name: string, description: string): boolean {
+  return description.includes(`${name}(`)
+}
+
+export function buildAutocompleteInsertion(
+  candidate: CandidateInfo,
+  textAfterReplaceEnd: string,
+): AutocompleteInsertion {
+  const isHelperWithArgs =
+    isHelperSource(candidate.source) &&
+    helperTakesArgs(candidate.name, candidate.description ?? '')
+
+  if (isHelperWithArgs) {
+    // Insert `name()` and drop the cursor between the parens so the user can
+    // start typing arguments straight away. Don't auto-close `}` here — they
+    // still need to finish the call.
+    return {
+      text: `${candidate.name}()`,
+      cursorOffset: candidate.name.length + 1,
+    }
+  }
+
+  // Variable, or a parameterless helper. Replace with the bare name and add
+  // a closing `}` only if the surrounding substitution wasn't already closed.
+  // Cursor always lands right after the name (i.e. *before* the `}`) so the
+  // user can keep typing `| filter` to chain filters; pressing Right-arrow
+  // skips past the brace when they're done.
+  const needsClosingBrace = !textAfterReplaceEnd.includes('}')
+  return {
+    text: candidate.name + (needsClosingBrace ? '}' : ''),
+    cursorOffset: candidate.name.length,
+  }
+}

--- a/frontend/src/features/fable-builder/utils/date-preview-nudge.ts
+++ b/frontend/src/features/fable-builder/utils/date-preview-nudge.ts
@@ -1,0 +1,75 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Helpers for the "this is a date field but your expression resolves to a
+ * datetime" nudge shown under a glyph-backed field preview.
+ *
+ * Kept as pure utilities so they're easy to unit-test without rendering the
+ * wrapper component or mocking i18n.
+ */
+
+import { findGlyphSpans } from '@/features/fable-builder/utils/glyph-display'
+
+/** Match `YYYY-MM-DD HH:MM` or `YYYY-MM-DDTHH:MM`; seconds optional. */
+const DATETIME_RE = /\b\d{4}-\d{2}-\d{2}[ T](\d{2}):(\d{2})(?::(\d{2}))?/
+
+/**
+ * Return true if `preview` looks like a datetime with a NON-ZERO time
+ * component. Plain `YYYY-MM-DD` and any form where the time is exactly
+ * midnight (`00:00`, `00:00:00`) return false — those are considered
+ * date-equivalent so the nudge doesn't linger after the user applies the
+ * `| floor_day` fix.
+ */
+export function previewHasTimeComponent(preview: string): boolean {
+  const match = DATETIME_RE.exec(preview)
+  if (!match) return false
+  const hh = match[1]
+  const mm = match[2]
+  // `match[3]` is typed as string but is actually optional (the `(\d{2})?`
+  // group in the regex). Cast so the undefined-check isn't flagged as dead.
+  const ss = match[3] as string | undefined
+  if (hh === '00' && mm === '00' && (ss === undefined || ss === '00')) {
+    return false
+  }
+  return true
+}
+
+/**
+ * Return true if the value contains exactly one `${...}` span that spans the
+ * whole string. That's the only shape where we can safely apply the fix
+ * without guessing which substitution is the "date-producing" one.
+ */
+export function canApplyFloorDay(value: string): boolean {
+  const spans = findGlyphSpans(value)
+  if (spans.length !== 1) return false
+  const [span] = spans
+  if (span.start !== 0 || span.end !== value.length) return false
+  if (alreadyHasFloorDay(value)) return false
+  return true
+}
+
+/**
+ * Append `| floor_day` to the single `${...}` substitution in `value`. Leaves
+ * any trailing filters on top of their existing chain
+ * (`${dt | sub_days(2)}` → `${dt | sub_days(2) | floor_day}`) so the final
+ * result is truncated to midnight regardless of what precedes.
+ *
+ * Idempotent: does nothing if `canApplyFloorDay(value)` is false.
+ */
+export function applyFloorDay(value: string): string {
+  if (!canApplyFloorDay(value)) return value
+  const body = value.slice(2, -1) // content between `${` and `}`
+  return `\${${body} | floor_day}`
+}
+
+function alreadyHasFloorDay(value: string): boolean {
+  return /\|\s*floor_day\b/.test(value)
+}

--- a/frontend/src/features/fable-builder/utils/glyph-display.ts
+++ b/frontend/src/features/fable-builder/utils/glyph-display.ts
@@ -9,7 +9,12 @@
  */
 
 /**
- * Glyph display utilities for parsing and rendering ${...} references.
+ * Glyph display utilities for parsing and rendering ${...} expressions.
+ *
+ * The substitution body can contain pipe-style filters, function calls and
+ * string literals (e.g. `${func("a}b") | filter(2)}`), so a regex isn't
+ * enough — we run a small scanner that tracks string-literal state and
+ * matches `}` only outside of quoted segments.
  */
 
 export interface GlyphSegment {
@@ -17,7 +22,76 @@ export interface GlyphSegment {
   isGlyph: boolean
 }
 
-const GLYPH_PATTERN = /(\$\{\w+\})/g
+export interface GlyphSpan {
+  /** Index of `$` in the original string. */
+  start: number
+  /** Exclusive end — one past the closing `}`. */
+  end: number
+}
+
+/**
+ * Walk `text` collecting every closed `${...}` span, honouring string
+ * literals inside the body (single/double quotes with backslash escapes).
+ *
+ * Stops at the first unterminated `${` and sets `terminated: false`. Closed
+ * spans already found before that point are still returned.
+ */
+function scanGlyphSpans(text: string): {
+  spans: Array<GlyphSpan>
+  terminated: boolean
+} {
+  const spans: Array<GlyphSpan> = []
+  let i = 0
+  while (i < text.length) {
+    if (text[i] !== '$' || text[i + 1] !== '{') {
+      i++
+      continue
+    }
+    const start = i
+    let j = i + 2
+    let inString: '"' | "'" | null = null
+    let closed = false
+    while (j < text.length) {
+      const c = text[j]
+      if (inString) {
+        if (c === '\\' && j + 1 < text.length) {
+          j += 2
+          continue
+        }
+        if (c === inString) inString = null
+        j++
+        continue
+      }
+      if (c === '"' || c === "'") {
+        inString = c
+        j++
+        continue
+      }
+      if (c === '}') {
+        closed = true
+        break
+      }
+      j++
+    }
+    if (!closed) return { spans, terminated: false }
+    spans.push({ start, end: j + 1 })
+    i = j + 1
+  }
+  return { spans, terminated: true }
+}
+
+/**
+ * All closed `${...}` spans in `text`. Unterminated substitutions are
+ * skipped; see {@link hasUnterminatedGlyph} to detect them explicitly.
+ */
+export function findGlyphSpans(text: string): Array<GlyphSpan> {
+  return scanGlyphSpans(text).spans
+}
+
+/** True if `text` contains a `${` with no matching `}` (string literals honoured). */
+export function hasUnterminatedGlyph(text: string): boolean {
+  return !scanGlyphSpans(text).terminated
+}
 
 /**
  * Split a config value into segments of plain text and glyph references.
@@ -31,37 +105,33 @@ const GLYPH_PATTERN = /(\$\{\w+\})/g
 export function parseGlyphSegments(value: string): Array<GlyphSegment> {
   const segments: Array<GlyphSegment> = []
   let lastIndex = 0
-
-  for (const match of value.matchAll(GLYPH_PATTERN)) {
-    const matchIndex = match.index
-    if (matchIndex > lastIndex) {
+  for (const span of findGlyphSpans(value)) {
+    if (span.start > lastIndex) {
       segments.push({
-        text: value.slice(lastIndex, matchIndex),
+        text: value.slice(lastIndex, span.start),
         isGlyph: false,
       })
     }
-    segments.push({ text: match[0], isGlyph: true })
-    lastIndex = matchIndex + match[0].length
+    segments.push({ text: value.slice(span.start, span.end), isGlyph: true })
+    lastIndex = span.end
   }
-
   if (lastIndex < value.length) {
     segments.push({ text: value.slice(lastIndex), isGlyph: false })
   }
-
   return segments
 }
 
-/**
- * Check if a value contains any glyph references.
- */
+/** Check if a value contains any glyph references. */
 export function containsGlyphs(value: string): boolean {
-  // Use a fresh regex — GLYPH_PATTERN has the `g` flag which makes .test()
-  // stateful (advances lastIndex), causing alternating true/false results.
-  return /\$\{\w+\}/.test(value)
+  return findGlyphSpans(value).length > 0
 }
 
 /**
- * Extract the glyph key from a reference like "${runId}" → "runId"
+ * Extract the inner expression from a `${...}` reference.
+ *
+ * For a plain reference like `${runId}` this is the variable name; for a
+ * Jinja expression like `${var | sub_days(2)}` it's the full body. Callers
+ * that need just the leading variable name should parse further.
  */
 export function extractGlyphKey(ref: string): string {
   return ref.slice(2, -1)

--- a/frontend/src/features/fable-builder/utils/glyph-expression-context.ts
+++ b/frontend/src/features/fable-builder/utils/glyph-expression-context.ts
@@ -1,0 +1,185 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Glyph-expression cursor classifier.
+ *
+ * Given the text of a field and a cursor offset, decides whether the user is
+ * positioned to receive autocomplete suggestions inside a `${...}` Jinja
+ * expression and — if so — which kind of candidate list to show:
+ *
+ *   - `value`: variable names and callable globals (e.g. `timedelta(...)`)
+ *   - `filter`: pipe-style filters (e.g. `${dt | add_days}`)
+ *   - `none`:  not inside an open `${...}`, inside a string literal, in a
+ *              nested `${...}` (unsupported by Jinja), or right after a
+ *              completed value with no separator.
+ *
+ * The classifier tokenises only enough of the expression to follow paren
+ * depth, pipe boundaries, and string literals; it does NOT evaluate or fully
+ * parse Jinja syntax.
+ */
+
+export type GlyphContextKind = 'value' | 'filter' | 'none'
+
+export interface GlyphContext {
+  kind: GlyphContextKind
+  /** Identifier already typed at the cursor; used to filter the candidate list. */
+  prefix: string
+  /** Inclusive start of the range a picked candidate should replace. */
+  replaceStart: number
+  /** Exclusive end of that range (always the cursor offset). */
+  replaceEnd: number
+}
+
+const NONE: GlyphContext = {
+  kind: 'none',
+  prefix: '',
+  replaceStart: 0,
+  replaceEnd: 0,
+}
+
+const isWordStart = (c: string): boolean => /[a-zA-Z_]/.test(c)
+const isWordChar = (c: string): boolean => /[a-zA-Z0-9_]/.test(c)
+const isOperator = (c: string): boolean => '+-*/=<>'.includes(c)
+
+/**
+ * Find the innermost open `${` whose matching `}` lies at or beyond the cursor.
+ * Returns -1 if the cursor is not inside any `${...}`, or -2 if a nested `${`
+ * is detected (we don't try to autocomplete inside nested substitutions —
+ * Jinja expressions can't actually nest the `${...}` delimiter anyway).
+ */
+function findOpenSubstitution(text: string, cursor: number): number {
+  let openIdx = -1
+  let i = 0
+  while (i < cursor) {
+    if (text[i] === '$' && text[i + 1] === '{') {
+      if (openIdx !== -1) return -2
+      openIdx = i + 2
+      i += 2
+      continue
+    }
+    if (text[i] === '}' && openIdx !== -1) {
+      openIdx = -1
+    }
+    i++
+  }
+  return openIdx
+}
+
+/**
+ * `'closed'` is an internal state meaning "we just consumed a complete value
+ * or filter and have not seen a separator that would re-open autocomplete";
+ * it never escapes — it maps to `'none'` at the public boundary.
+ */
+type FrameKind = 'value' | 'filter' | 'closed'
+
+export function parseGlyphContext(text: string, cursor: number): GlyphContext {
+  const openIdx = findOpenSubstitution(text, cursor)
+  if (openIdx < 0) return NONE
+
+  // Stack of paren frames. Each frame's `kind` tracks what's currently
+  // expected at that paren depth. `value` at depth 0 is the initial state of
+  // a fresh `${` expression.
+  const stack: Array<{ kind: FrameKind }> = [{ kind: 'value' }]
+  const top = (): { kind: FrameKind } => stack[stack.length - 1]
+
+  let identifier = ''
+  let identifierStart = openIdx
+  // Frame kind captured the moment the current identifier started, so we can
+  // still report `value`/`filter` even though `top().kind` is set to `closed`
+  // immediately after the identifier ends.
+  let kindBeforeIdentifier: FrameKind = 'value'
+
+  let i = openIdx
+  while (i < cursor) {
+    const c = text[i]
+
+    // Mid-identifier: keep accumulating until a non-word char appears.
+    if (identifier !== '') {
+      if (isWordChar(c)) {
+        identifier += c
+        i++
+        continue
+      }
+      // Identifier just terminated. Mark frame as closed and fall through
+      // to the separator-handling switch below WITHOUT advancing `i`.
+      identifier = ''
+      top().kind = 'closed'
+    }
+
+    if (c === "'" || c === '"') {
+      const quote = c
+      i++ // skip opening quote
+      while (i < cursor && text[i] !== quote) {
+        if (text[i] === '\\' && i + 1 < cursor) i++ // escape
+        i++
+      }
+      if (i >= cursor) return NONE // cursor sits inside an unterminated string
+      i++ // skip closing quote
+      top().kind = 'closed'
+      continue
+    }
+
+    if (isWordStart(c)) {
+      // Refuse to start a new identifier when the frame is already closed
+      // (e.g. `${a b` — two adjacent identifiers separated by whitespace).
+      if (top().kind === 'closed') return NONE
+      identifier = c
+      identifierStart = i
+      kindBeforeIdentifier = top().kind
+      i++
+      continue
+    }
+
+    if (c === '$' && text[i + 1] === '{') return NONE
+
+    if (c === '|') {
+      top().kind = 'filter'
+      i++
+    } else if (c === '(') {
+      stack.push({ kind: 'value' })
+      i++
+    } else if (c === ')') {
+      if (stack.length > 1) stack.pop()
+      top().kind = 'closed'
+      i++
+    } else if (c === ',') {
+      top().kind = 'value'
+      i++
+    } else if (isOperator(c)) {
+      top().kind = 'value'
+      i++
+    } else if (c === ' ' || c === '\t') {
+      i++
+    } else {
+      // Unknown / unsupported char — bail out.
+      return NONE
+    }
+  }
+
+  if (identifier !== '') {
+    if (kindBeforeIdentifier === 'closed') return NONE
+    return {
+      kind: kindBeforeIdentifier,
+      prefix: identifier,
+      replaceStart: identifierStart,
+      replaceEnd: cursor,
+    }
+  }
+
+  const finalKind = top().kind
+  if (finalKind === 'closed') return NONE
+  return {
+    kind: finalKind,
+    prefix: '',
+    replaceStart: cursor,
+    replaceEnd: cursor,
+  }
+}

--- a/frontend/src/features/glyphs/components/GlyphFormDialog.tsx
+++ b/frontend/src/features/glyphs/components/GlyphFormDialog.tsx
@@ -15,10 +15,12 @@
  */
 
 import { useState } from 'react'
-import { AlertCircle, Loader2 } from 'lucide-react'
+import { AlertCircle, HelpCircle, Loader2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import type { GlyphDetail } from '@/api/types/fable.types'
 import { useCreateGlobalGlyph } from '@/api/hooks/useFable'
+import { useAuth } from '@/features/auth/AuthContext'
+import { useUser } from '@/hooks/useUser'
 import { showToast } from '@/lib/toast'
 import {
   Dialog,
@@ -33,6 +35,12 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { P } from '@/components/base/typography'
 
 interface GlyphFormDialogProps {
@@ -47,11 +55,17 @@ export function GlyphFormDialog({
   editGlyph,
 }: GlyphFormDialogProps) {
   const { t } = useTranslation('glyphs')
+  const { authType } = useAuth()
+  const { data: user } = useUser()
+  // Passthrough mode treats every caller as admin (matches backend AuthContext).
+  const isAdmin = authType === 'anonymous' || (user?.is_superuser ?? false)
   const isEditing = !!editGlyph
 
   const [key, setKey] = useState(editGlyph?.name ?? '')
   const [value, setValue] = useState(editGlyph?.valueExample ?? '')
   const [isPublic, setIsPublic] = useState(false)
+  // null when public is off; concrete boolean when public is on (backend rule).
+  const [overriddable, setOverriddable] = useState<boolean | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   const createGlyph = useCreateGlobalGlyph()
@@ -61,9 +75,18 @@ export function GlyphFormDialog({
       setKey('')
       setValue('')
       setIsPublic(false)
+      setOverriddable(null)
       setError(null)
     }
     onOpenChange(nextOpen)
+  }
+
+  function handlePublicChange(next: boolean) {
+    setIsPublic(next)
+    // Default to "pinned" (overriddable=false) — the safer choice when an admin
+    // explicitly publishes a value. Reset to null when going private so the
+    // submit body satisfies the backend's public/overriddable invariant.
+    setOverriddable(next ? false : null)
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -80,6 +103,7 @@ export function GlyphFormDialog({
         key: trimmedKey,
         value: trimmedValue,
         public: isPublic,
+        overriddable,
       })
       showToast.success(
         isEditing ? t('actions.updateSuccess') : t('actions.createSuccess'),
@@ -133,19 +157,59 @@ export function GlyphFormDialog({
             />
           </div>
 
-          <div className="flex items-center justify-between">
-            <div className="space-y-0.5">
-              <Label htmlFor="glyph-public">{t('form.public')}</Label>
-              <P className="text-sm text-muted-foreground">
-                {t('form.publicHelp')}
-              </P>
+          {isAdmin && (
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <Label htmlFor="glyph-public">{t('form.public')}</Label>
+                <P className="text-sm text-muted-foreground">
+                  {t('form.publicHelp')}
+                </P>
+              </div>
+              <Switch
+                id="glyph-public"
+                checked={isPublic}
+                onCheckedChange={handlePublicChange}
+              />
             </div>
-            <Switch
-              id="glyph-public"
-              checked={isPublic}
-              onCheckedChange={setIsPublic}
-            />
-          </div>
+          )}
+
+          {isAdmin && isPublic && (
+            <div className="flex items-center justify-between rounded-md border border-dashed border-border/60 bg-muted/30 p-3">
+              <div className="space-y-0.5">
+                <div className="flex items-center gap-1.5">
+                  <Label htmlFor="glyph-overriddable">
+                    {t('form.overriddable')}
+                  </Label>
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <button
+                            type="button"
+                            aria-label={t('form.overriddableTooltip')}
+                            className="text-muted-foreground hover:text-foreground"
+                          />
+                        }
+                      >
+                        <HelpCircle className="h-3.5 w-3.5" />
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {t('form.overriddableTooltip')}
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                </div>
+                <P className="text-sm text-muted-foreground">
+                  {t('form.overriddableHelp')}
+                </P>
+              </div>
+              <Switch
+                id="glyph-overriddable"
+                checked={overriddable === true}
+                onCheckedChange={(next) => setOverriddable(next)}
+              />
+            </div>
+          )}
 
           <DialogFooter>
             <Button

--- a/frontend/src/features/glyphs/components/GlyphListItem.tsx
+++ b/frontend/src/features/glyphs/components/GlyphListItem.tsx
@@ -19,14 +19,29 @@ import { useTranslation } from 'react-i18next'
 import type { GlyphDetail } from '@/api/types/fable.types'
 import { Button } from '@/components/ui/button'
 import { P } from '@/components/base/typography'
+import { useUser } from '@/hooks/useUser'
 
 interface GlyphListItemProps {
   glyph: GlyphDetail
   onEdit: (glyph: GlyphDetail) => void
 }
 
+const PASSTHROUGH_USER_ID = 'user'
+
 export function GlyphListItem({ glyph, onEdit }: GlyphListItemProps) {
   const { t } = useTranslation('glyphs')
+  const { data: user } = useUser()
+
+  let creatorLabel: string
+  if (glyph.created_by === 'intrinsic') {
+    creatorLabel = t('creator.intrinsic')
+  } else if (glyph.created_by === PASSTHROUGH_USER_ID) {
+    creatorLabel = t('creator.passthrough')
+  } else if (user?.id && glyph.created_by === user.id) {
+    creatorLabel = t('creator.you')
+  } else {
+    creatorLabel = glyph.created_by
+  }
 
   return (
     <div className="p-6 transition-colors hover:bg-muted/50">
@@ -36,10 +51,13 @@ export function GlyphListItem({ glyph, onEdit }: GlyphListItemProps) {
         </div>
 
         <div className="grow">
-          <div className="mb-1">
+          <div className="mb-1 flex items-center gap-2">
             <code className="rounded bg-muted px-2 py-0.5 font-mono text-sm font-medium">
               {'${' + glyph.name + '}'}
             </code>
+            <span className="truncate text-xs text-muted-foreground italic">
+              {t('creator.label')} {creatorLabel}
+            </span>
           </div>
           <P className="line-clamp-1 text-muted-foreground">
             {glyph.valueExample}

--- a/frontend/src/features/glyphs/components/GlyphsPage.tsx
+++ b/frontend/src/features/glyphs/components/GlyphsPage.tsx
@@ -144,7 +144,7 @@ export function GlyphsPage() {
           {filteredGlyphs.length > 0 ? (
             filteredGlyphs.map((glyph) => (
               <GlyphListItem
-                key={glyph.name}
+                key={`${glyph.created_by}:${glyph.name}`}
                 glyph={glyph}
                 onEdit={handleEdit}
               />

--- a/frontend/src/features/schedules/components/ScheduleDetailPage.tsx
+++ b/frontend/src/features/schedules/components/ScheduleDetailPage.tsx
@@ -281,17 +281,13 @@ export function ScheduleDetailPage() {
             </span>
           }
         />
-        {schedule.created_by && (
-          <StatCard
-            label={t('detail.createdBy')}
-            icon={<User className="h-4 w-4" />}
-            value={
-              <span className="text-lg font-semibold">
-                {schedule.created_by}
-              </span>
-            }
-          />
-        )}
+        <StatCard
+          label={t('detail.createdBy')}
+          icon={<User className="h-4 w-4" />}
+          value={
+            <span className="text-lg font-semibold">{schedule.created_by}</span>
+          }
+        />
       </div>
 
       {/* Configuration overview */}

--- a/frontend/src/locales/en/glyphs.json
+++ b/frontend/src/locales/en/glyphs.json
@@ -1,41 +1,50 @@
 {
   "page": {
-    "title": "Global Glyphs",
-    "description": "Manage global glyph definitions used in fable configuration interpolation."
+    "title": "Global Variables",
+    "description": "Manage global variable definitions used in fable configuration interpolation."
   },
   "list": {
-    "loading": "Loading glyphs..."
+    "loading": "Loading variables..."
   },
   "filter": {
     "searchPlaceholder": "Search by key or value..."
   },
   "empty": {
-    "title": "No global glyphs",
-    "description": "Create a global glyph to use ${glyph} interpolation across all fable configurations."
+    "title": "No global variables",
+    "description": "Create a global variable to use ${variable} interpolation across all fable configurations."
   },
   "table": {
     "key": "Key",
     "value": "Value"
   },
+  "creator": {
+    "intrinsic": "intrinsic",
+    "you": "you",
+    "passthrough": "local",
+    "label": "by"
+  },
   "actions": {
-    "create": "Create Glyph",
+    "create": "Create Variable",
     "edit": "Edit",
     "save": "Save",
     "saving": "Saving...",
     "cancel": "Cancel",
-    "createSuccess": "Glyph created",
-    "updateSuccess": "Glyph updated"
+    "createSuccess": "Variable created",
+    "updateSuccess": "Variable updated"
   },
   "form": {
-    "title": "Create Global Glyph",
-    "editTitle": "Edit Global Glyph",
+    "title": "Create Global Variable",
+    "editTitle": "Edit Global Variable",
     "key": "Key",
     "keyPlaceholder": "e.g. myVariable",
     "keyHelp": "Used as ${key} in fable configurations",
     "value": "Value",
     "valuePlaceholder": "The value to interpolate",
     "public": "Public",
-    "publicHelp": "Public glyphs are visible to all users (admin only)"
+    "publicHelp": "Public variables are visible to all users (admin only)",
+    "overriddable": "Overriddable",
+    "overriddableHelp": "Allow users to shadow this variable with their own value of the same name",
+    "overriddableTooltip": "Overriddable: a user can define a private variable with the same name and it will win during resolution. Pinned (off): the public value always wins, even if a user defines their own."
   },
   "pagination": {
     "previous": "Previous",
@@ -43,17 +52,28 @@
     "page": "Page {{current}} of {{total}}"
   },
   "panel": {
-    "title": "Available Glyphs",
+    "title": "Variables",
     "manage": "Manage",
-    "help": "Use ${name} syntax in block configuration values to reference dynamic glyphs.\n\nIntrinsic — system-provided, always available (e.g., runId, submitDatetime). startDatetime and attemptCount update on each retry.\n\nGlobal — user-defined key-value pairs shared across fables. Manage them via the admin page.\n\nLocal — scoped to this blueprint only. Override global glyphs of the same name.\n\nContext — injected automatically per-execution (e.g., by the scheduler). Not shown here.\n\nPrecedence: Intrinsic → Global → Local → Context.\nPinned glyphs (startDatetime, attemptCount) always use the intrinsic value.",
+    "helpers": {
+      "title": "Helpers",
+      "tooltip": "Custom filters and globals you can use inside ${...} expressions.",
+      "empty": "No helpers available.",
+      "filterBadge": "filter",
+      "globalBadge": "global",
+      "copyHintFilter": "Copies | {{name}} — append after a value",
+      "copyHintGlobal": "Copies {{name}}() — call directly"
+    },
+    "help": "Use ${name} syntax in block configuration values to reference dynamic variables.\n\nIntrinsic — system-provided, always available (e.g., runId, submitDatetime). startDatetime and attemptCount update on each retry.\n\nGlobal — user-defined key-value pairs shared across fables. Manage them via the admin page.\n\nLocal — scoped to this blueprint only. Override global variables of the same name.\n\nContext — injected automatically per-execution (e.g., by the scheduler). Not shown here.\n\nPrecedence: Intrinsic → Global → Local → Context.\nPinned variables (startDatetime, attemptCount) always use the intrinsic value.",
     "intrinsic": "Intrinsic",
     "global": "Global",
     "local": "Local",
-    "localTooltip": "Glyphs scoped to this blueprint. Override global glyphs of the same name.",
-    "noGlobal": "No global glyphs yet.",
-    "noLocal": "No local glyphs.",
+    "localTooltip": "Variables scoped to this blueprint. Override global variables of the same name.",
+    "noGlobal": "No global variables yet.",
+    "noLocal": "No local variables.",
     "addLocalHint": "Add one to override a global value for this blueprint only.",
     "createOne": "Create one",
+    "addGlobal": "Add global variable",
+    "manageAll": "Manage all",
     "addLocal": "Add",
     "localKeyPlaceholder": "key",
     "localValuePlaceholder": "value",
@@ -62,12 +82,17 @@
     "resolvesTo": "resolves to"
   },
   "autocomplete": {
-    "filter": "Filter glyphs..."
+    "filter": "Filter variables..."
   },
   "field": {
-    "switchToGlyph": "Use a glyph expression",
+    "switchToGlyph": "Use a variable expression",
     "switchToConcrete": "Use the value picker",
-    "cannotSwitchBack": "Clear the glyph expression to switch back",
-    "glyphPlaceholder": "e.g. $\\{glyphName}"
+    "cannotSwitchBack": "Clear the variable expression to switch back",
+    "glyphPlaceholder": "e.g. ${variableName}",
+    "datePreview": {
+      "hasTime": "Date field — the value carries a time component",
+      "floorDayAction": "Truncate to date",
+      "floorDayTooltip": "Appends `| floor_day` to truncate the expression to midnight"
+    }
   }
 }

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -22,11 +22,11 @@ import { Route as AuthenticatedAdminIndexRouteImport } from './routes/_authentic
 import { Route as AuthenticatedSchedulesScheduleIdRouteImport } from './routes/_authenticated/schedules.$scheduleId'
 import { Route as AuthenticatedExecutionsJobIdRouteImport } from './routes/_authenticated/executions.$jobId'
 import { Route as AuthenticatedConfigureFableIdRouteImport } from './routes/_authenticated/configure.$fableId'
+import { Route as AuthenticatedAdminVariablesRouteImport } from './routes/_authenticated/admin/variables'
 import { Route as AuthenticatedAdminPluginsRouteImport } from './routes/_authenticated/admin/plugins'
-import { Route as AuthenticatedAdminGlyphsRouteImport } from './routes/_authenticated/admin/glyphs'
 import { Route as AuthenticatedAdminArtifactsRouteImport } from './routes/_authenticated/admin/artifacts'
+import { Route as AuthenticatedAdminVariablesIndexRouteImport } from './routes/_authenticated/admin/variables.index'
 import { Route as AuthenticatedAdminPluginsIndexRouteImport } from './routes/_authenticated/admin/plugins.index'
-import { Route as AuthenticatedAdminGlyphsIndexRouteImport } from './routes/_authenticated/admin/glyphs.index'
 import { Route as AuthenticatedAdminArtifactsIndexRouteImport } from './routes/_authenticated/admin/artifacts.index'
 import { Route as AuthenticatedAdminPluginsPluginIdRouteImport } from './routes/_authenticated/admin/plugins.$pluginId'
 import { Route as AuthenticatedAdminArtifactsArtifactIdRouteImport } from './routes/_authenticated/admin/artifacts.$artifactId'
@@ -100,16 +100,16 @@ const AuthenticatedConfigureFableIdRoute =
     path: '/$fableId',
     getParentRoute: () => AuthenticatedConfigureRoute,
   } as any)
+const AuthenticatedAdminVariablesRoute =
+  AuthenticatedAdminVariablesRouteImport.update({
+    id: '/variables',
+    path: '/variables',
+    getParentRoute: () => AuthenticatedAdminRoute,
+  } as any)
 const AuthenticatedAdminPluginsRoute =
   AuthenticatedAdminPluginsRouteImport.update({
     id: '/plugins',
     path: '/plugins',
-    getParentRoute: () => AuthenticatedAdminRoute,
-  } as any)
-const AuthenticatedAdminGlyphsRoute =
-  AuthenticatedAdminGlyphsRouteImport.update({
-    id: '/glyphs',
-    path: '/glyphs',
     getParentRoute: () => AuthenticatedAdminRoute,
   } as any)
 const AuthenticatedAdminArtifactsRoute =
@@ -118,17 +118,17 @@ const AuthenticatedAdminArtifactsRoute =
     path: '/artifacts',
     getParentRoute: () => AuthenticatedAdminRoute,
   } as any)
+const AuthenticatedAdminVariablesIndexRoute =
+  AuthenticatedAdminVariablesIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedAdminVariablesRoute,
+  } as any)
 const AuthenticatedAdminPluginsIndexRoute =
   AuthenticatedAdminPluginsIndexRouteImport.update({
     id: '/',
     path: '/',
     getParentRoute: () => AuthenticatedAdminPluginsRoute,
-  } as any)
-const AuthenticatedAdminGlyphsIndexRoute =
-  AuthenticatedAdminGlyphsIndexRouteImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () => AuthenticatedAdminGlyphsRoute,
   } as any)
 const AuthenticatedAdminArtifactsIndexRoute =
   AuthenticatedAdminArtifactsIndexRouteImport.update({
@@ -157,8 +157,8 @@ export interface FileRoutesByFullPath {
   '/dashboard': typeof AuthenticatedDashboardRoute
   '/presets': typeof AuthenticatedPresetsRoute
   '/admin/artifacts': typeof AuthenticatedAdminArtifactsRouteWithChildren
-  '/admin/glyphs': typeof AuthenticatedAdminGlyphsRouteWithChildren
   '/admin/plugins': typeof AuthenticatedAdminPluginsRouteWithChildren
+  '/admin/variables': typeof AuthenticatedAdminVariablesRouteWithChildren
   '/configure/$fableId': typeof AuthenticatedConfigureFableIdRoute
   '/executions/$jobId': typeof AuthenticatedExecutionsJobIdRoute
   '/schedules/$scheduleId': typeof AuthenticatedSchedulesScheduleIdRoute
@@ -168,8 +168,8 @@ export interface FileRoutesByFullPath {
   '/admin/artifacts/$artifactId': typeof AuthenticatedAdminArtifactsArtifactIdRoute
   '/admin/plugins/$pluginId': typeof AuthenticatedAdminPluginsPluginIdRoute
   '/admin/artifacts/': typeof AuthenticatedAdminArtifactsIndexRoute
-  '/admin/glyphs/': typeof AuthenticatedAdminGlyphsIndexRoute
   '/admin/plugins/': typeof AuthenticatedAdminPluginsIndexRoute
+  '/admin/variables/': typeof AuthenticatedAdminVariablesIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -186,8 +186,8 @@ export interface FileRoutesByTo {
   '/admin/artifacts/$artifactId': typeof AuthenticatedAdminArtifactsArtifactIdRoute
   '/admin/plugins/$pluginId': typeof AuthenticatedAdminPluginsPluginIdRoute
   '/admin/artifacts': typeof AuthenticatedAdminArtifactsIndexRoute
-  '/admin/glyphs': typeof AuthenticatedAdminGlyphsIndexRoute
   '/admin/plugins': typeof AuthenticatedAdminPluginsIndexRoute
+  '/admin/variables': typeof AuthenticatedAdminVariablesIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -199,8 +199,8 @@ export interface FileRoutesById {
   '/_authenticated/dashboard': typeof AuthenticatedDashboardRoute
   '/_authenticated/presets': typeof AuthenticatedPresetsRoute
   '/_authenticated/admin/artifacts': typeof AuthenticatedAdminArtifactsRouteWithChildren
-  '/_authenticated/admin/glyphs': typeof AuthenticatedAdminGlyphsRouteWithChildren
   '/_authenticated/admin/plugins': typeof AuthenticatedAdminPluginsRouteWithChildren
+  '/_authenticated/admin/variables': typeof AuthenticatedAdminVariablesRouteWithChildren
   '/_authenticated/configure/$fableId': typeof AuthenticatedConfigureFableIdRoute
   '/_authenticated/executions/$jobId': typeof AuthenticatedExecutionsJobIdRoute
   '/_authenticated/schedules/$scheduleId': typeof AuthenticatedSchedulesScheduleIdRoute
@@ -210,8 +210,8 @@ export interface FileRoutesById {
   '/_authenticated/admin/artifacts/$artifactId': typeof AuthenticatedAdminArtifactsArtifactIdRoute
   '/_authenticated/admin/plugins/$pluginId': typeof AuthenticatedAdminPluginsPluginIdRoute
   '/_authenticated/admin/artifacts/': typeof AuthenticatedAdminArtifactsIndexRoute
-  '/_authenticated/admin/glyphs/': typeof AuthenticatedAdminGlyphsIndexRoute
   '/_authenticated/admin/plugins/': typeof AuthenticatedAdminPluginsIndexRoute
+  '/_authenticated/admin/variables/': typeof AuthenticatedAdminVariablesIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -223,8 +223,8 @@ export interface FileRouteTypes {
     | '/dashboard'
     | '/presets'
     | '/admin/artifacts'
-    | '/admin/glyphs'
     | '/admin/plugins'
+    | '/admin/variables'
     | '/configure/$fableId'
     | '/executions/$jobId'
     | '/schedules/$scheduleId'
@@ -234,8 +234,8 @@ export interface FileRouteTypes {
     | '/admin/artifacts/$artifactId'
     | '/admin/plugins/$pluginId'
     | '/admin/artifacts/'
-    | '/admin/glyphs/'
     | '/admin/plugins/'
+    | '/admin/variables/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -252,8 +252,8 @@ export interface FileRouteTypes {
     | '/admin/artifacts/$artifactId'
     | '/admin/plugins/$pluginId'
     | '/admin/artifacts'
-    | '/admin/glyphs'
     | '/admin/plugins'
+    | '/admin/variables'
   id:
     | '__root__'
     | '/'
@@ -264,8 +264,8 @@ export interface FileRouteTypes {
     | '/_authenticated/dashboard'
     | '/_authenticated/presets'
     | '/_authenticated/admin/artifacts'
-    | '/_authenticated/admin/glyphs'
     | '/_authenticated/admin/plugins'
+    | '/_authenticated/admin/variables'
     | '/_authenticated/configure/$fableId'
     | '/_authenticated/executions/$jobId'
     | '/_authenticated/schedules/$scheduleId'
@@ -275,8 +275,8 @@ export interface FileRouteTypes {
     | '/_authenticated/admin/artifacts/$artifactId'
     | '/_authenticated/admin/plugins/$pluginId'
     | '/_authenticated/admin/artifacts/'
-    | '/_authenticated/admin/glyphs/'
     | '/_authenticated/admin/plugins/'
+    | '/_authenticated/admin/variables/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -378,18 +378,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedConfigureFableIdRouteImport
       parentRoute: typeof AuthenticatedConfigureRoute
     }
+    '/_authenticated/admin/variables': {
+      id: '/_authenticated/admin/variables'
+      path: '/variables'
+      fullPath: '/admin/variables'
+      preLoaderRoute: typeof AuthenticatedAdminVariablesRouteImport
+      parentRoute: typeof AuthenticatedAdminRoute
+    }
     '/_authenticated/admin/plugins': {
       id: '/_authenticated/admin/plugins'
       path: '/plugins'
       fullPath: '/admin/plugins'
       preLoaderRoute: typeof AuthenticatedAdminPluginsRouteImport
-      parentRoute: typeof AuthenticatedAdminRoute
-    }
-    '/_authenticated/admin/glyphs': {
-      id: '/_authenticated/admin/glyphs'
-      path: '/glyphs'
-      fullPath: '/admin/glyphs'
-      preLoaderRoute: typeof AuthenticatedAdminGlyphsRouteImport
       parentRoute: typeof AuthenticatedAdminRoute
     }
     '/_authenticated/admin/artifacts': {
@@ -399,19 +399,19 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAdminArtifactsRouteImport
       parentRoute: typeof AuthenticatedAdminRoute
     }
+    '/_authenticated/admin/variables/': {
+      id: '/_authenticated/admin/variables/'
+      path: '/'
+      fullPath: '/admin/variables/'
+      preLoaderRoute: typeof AuthenticatedAdminVariablesIndexRouteImport
+      parentRoute: typeof AuthenticatedAdminVariablesRoute
+    }
     '/_authenticated/admin/plugins/': {
       id: '/_authenticated/admin/plugins/'
       path: '/'
       fullPath: '/admin/plugins/'
       preLoaderRoute: typeof AuthenticatedAdminPluginsIndexRouteImport
       parentRoute: typeof AuthenticatedAdminPluginsRoute
-    }
-    '/_authenticated/admin/glyphs/': {
-      id: '/_authenticated/admin/glyphs/'
-      path: '/'
-      fullPath: '/admin/glyphs/'
-      preLoaderRoute: typeof AuthenticatedAdminGlyphsIndexRouteImport
-      parentRoute: typeof AuthenticatedAdminGlyphsRoute
     }
     '/_authenticated/admin/artifacts/': {
       id: '/_authenticated/admin/artifacts/'
@@ -455,20 +455,6 @@ const AuthenticatedAdminArtifactsRouteWithChildren =
     AuthenticatedAdminArtifactsRouteChildren,
   )
 
-interface AuthenticatedAdminGlyphsRouteChildren {
-  AuthenticatedAdminGlyphsIndexRoute: typeof AuthenticatedAdminGlyphsIndexRoute
-}
-
-const AuthenticatedAdminGlyphsRouteChildren: AuthenticatedAdminGlyphsRouteChildren =
-  {
-    AuthenticatedAdminGlyphsIndexRoute: AuthenticatedAdminGlyphsIndexRoute,
-  }
-
-const AuthenticatedAdminGlyphsRouteWithChildren =
-  AuthenticatedAdminGlyphsRoute._addFileChildren(
-    AuthenticatedAdminGlyphsRouteChildren,
-  )
-
 interface AuthenticatedAdminPluginsRouteChildren {
   AuthenticatedAdminPluginsPluginIdRoute: typeof AuthenticatedAdminPluginsPluginIdRoute
   AuthenticatedAdminPluginsIndexRoute: typeof AuthenticatedAdminPluginsIndexRoute
@@ -486,18 +472,34 @@ const AuthenticatedAdminPluginsRouteWithChildren =
     AuthenticatedAdminPluginsRouteChildren,
   )
 
+interface AuthenticatedAdminVariablesRouteChildren {
+  AuthenticatedAdminVariablesIndexRoute: typeof AuthenticatedAdminVariablesIndexRoute
+}
+
+const AuthenticatedAdminVariablesRouteChildren: AuthenticatedAdminVariablesRouteChildren =
+  {
+    AuthenticatedAdminVariablesIndexRoute:
+      AuthenticatedAdminVariablesIndexRoute,
+  }
+
+const AuthenticatedAdminVariablesRouteWithChildren =
+  AuthenticatedAdminVariablesRoute._addFileChildren(
+    AuthenticatedAdminVariablesRouteChildren,
+  )
+
 interface AuthenticatedAdminRouteChildren {
   AuthenticatedAdminArtifactsRoute: typeof AuthenticatedAdminArtifactsRouteWithChildren
-  AuthenticatedAdminGlyphsRoute: typeof AuthenticatedAdminGlyphsRouteWithChildren
   AuthenticatedAdminPluginsRoute: typeof AuthenticatedAdminPluginsRouteWithChildren
+  AuthenticatedAdminVariablesRoute: typeof AuthenticatedAdminVariablesRouteWithChildren
   AuthenticatedAdminIndexRoute: typeof AuthenticatedAdminIndexRoute
 }
 
 const AuthenticatedAdminRouteChildren: AuthenticatedAdminRouteChildren = {
   AuthenticatedAdminArtifactsRoute:
     AuthenticatedAdminArtifactsRouteWithChildren,
-  AuthenticatedAdminGlyphsRoute: AuthenticatedAdminGlyphsRouteWithChildren,
   AuthenticatedAdminPluginsRoute: AuthenticatedAdminPluginsRouteWithChildren,
+  AuthenticatedAdminVariablesRoute:
+    AuthenticatedAdminVariablesRouteWithChildren,
   AuthenticatedAdminIndexRoute: AuthenticatedAdminIndexRoute,
 }
 

--- a/frontend/src/routes/_authenticated/admin/variables.index.tsx
+++ b/frontend/src/routes/_authenticated/admin/variables.index.tsx
@@ -9,17 +9,14 @@
  */
 
 /**
- * Glyphs Layout Route
+ * Variables List Page Route
  *
- * Layout wrapper for all glyph-related routes.
+ * Admin page for managing global variable definitions.
  */
 
-import { Outlet, createFileRoute } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
+import { GlyphsPage } from '@/features/glyphs/components/GlyphsPage'
 
-export const Route = createFileRoute('/_authenticated/admin/glyphs')({
-  component: GlyphsLayout,
+export const Route = createFileRoute('/_authenticated/admin/variables/')({
+  component: GlyphsPage,
 })
-
-function GlyphsLayout() {
-  return <Outlet />
-}

--- a/frontend/src/routes/_authenticated/admin/variables.tsx
+++ b/frontend/src/routes/_authenticated/admin/variables.tsx
@@ -9,14 +9,17 @@
  */
 
 /**
- * Glyphs List Page Route
+ * Variables Layout Route
  *
- * Admin page for managing global glyph definitions.
+ * Layout wrapper for all variable-related routes.
  */
 
-import { createFileRoute } from '@tanstack/react-router'
-import { GlyphsPage } from '@/features/glyphs/components/GlyphsPage'
+import { Outlet, createFileRoute } from '@tanstack/react-router'
 
-export const Route = createFileRoute('/_authenticated/admin/glyphs/')({
-  component: GlyphsPage,
+export const Route = createFileRoute('/_authenticated/admin/variables')({
+  component: VariablesLayout,
 })
+
+function VariablesLayout() {
+  return <Outlet />
+}

--- a/frontend/tests/e2e/configure-forecast.spec.ts
+++ b/frontend/tests/e2e/configure-forecast.spec.ts
@@ -217,7 +217,7 @@ test.describe('Fable Builder - Form Mode', () => {
       await page.waitForTimeout(1000)
 
       // Should show "Unsaved" badge in header
-      const unsavedBadge = page.getByText('Unsaved')
+      const unsavedBadge = page.getByText(/saving draft|draft saved/i)
       if (
         await unsavedBadge
           .first()
@@ -474,7 +474,7 @@ test.describe('Fable Builder - Save & Load', () => {
             await page.waitForTimeout(2000)
 
             // Unsaved badge should disappear
-            const unsavedBadge = page.getByText('Unsaved')
+            const unsavedBadge = page.getByText(/saving draft|draft saved/i)
             const isUnsavedVisible = await unsavedBadge
               .first()
               .isVisible({ timeout: 2000 })
@@ -523,7 +523,7 @@ test.describe('Fable Builder - Save & Load', () => {
         await page.waitForTimeout(1000)
 
         // Unsaved badge should reappear
-        const unsavedBadge = page.getByText('Unsaved')
+        const unsavedBadge = page.getByText(/saving draft|draft saved/i)
         if (
           await unsavedBadge
             .first()

--- a/frontend/tests/integration/components/fields/glyph-field-wrapper.test.tsx
+++ b/frontend/tests/integration/components/fields/glyph-field-wrapper.test.tsx
@@ -216,7 +216,7 @@ describe('GlyphFieldWrapper Integration', () => {
   describe('Toggle visibility', () => {
     it('shows glyph toggle when glyphs are available', async () => {
       const screen = await renderWithProviders(<ControlledStringField />)
-      const toggle = screen.getByRole('button', { name: /glyph/i })
+      const toggle = screen.getByRole('button', { name: /variable/i })
       await expect.element(toggle).toBeVisible()
     })
 
@@ -224,21 +224,21 @@ describe('GlyphFieldWrapper Integration', () => {
       const screen = await renderWithProviders(<NoGlyphsStringField />)
       await expect.element(screen.getByRole('textbox')).toBeVisible()
       await expect
-        .element(screen.getByRole('button', { name: /glyph/i }))
+        .element(screen.getByRole('button', { name: /variable/i }))
         .not.toBeInTheDocument()
     })
 
     it('shows toggle on date fields', async () => {
       const screen = await renderWithProviders(<ControlledDateField />)
       await expect
-        .element(screen.getByRole('button', { name: /glyph/i }))
+        .element(screen.getByRole('button', { name: /variable/i }))
         .toBeVisible()
     })
 
     it('shows toggle on number fields', async () => {
       const screen = await renderWithProviders(<ControlledNumberField />)
       await expect
-        .element(screen.getByRole('button', { name: /glyph/i }))
+        .element(screen.getByRole('button', { name: /variable/i }))
         .toBeVisible()
     })
 
@@ -247,7 +247,7 @@ describe('GlyphFieldWrapper Integration', () => {
       // Enum dropdowns opt out of glyph mode — no toggle, combobox only
       await expect.element(screen.getByRole('combobox')).toBeVisible()
       await expect
-        .element(screen.getByRole('button', { name: /glyph/i }))
+        .element(screen.getByRole('button', { name: /variable/i }))
         .not.toBeInTheDocument()
     })
   })
@@ -255,7 +255,7 @@ describe('GlyphFieldWrapper Integration', () => {
   describe('Mode switching', () => {
     it('switches date field to glyph mode on toggle click', async () => {
       const screen = await renderWithProviders(<ControlledDateField />)
-      await screen.getByRole('button', { name: /glyph/i }).click()
+      await screen.getByRole('button', { name: /variable/i }).click()
 
       // Text input should appear (glyph mode)
       const textInput = screen.getByRole('textbox')
@@ -359,7 +359,7 @@ describe('GlyphFieldWrapper Integration', () => {
   describe('Auto-trigger on empty field', () => {
     it('auto-inserts ${ when toggling on an empty field', async () => {
       const screen = await renderWithProviders(<ControlledDateField />)
-      await screen.getByRole('button', { name: /glyph/i }).click()
+      await screen.getByRole('button', { name: /variable/i }).click()
 
       await expect
         .element(screen.getByTestId('current-value'))
@@ -372,7 +372,7 @@ describe('GlyphFieldWrapper Integration', () => {
       const screen = await renderWithProviders(
         <ControlledDateField initialValue="${forecastDate}" />,
       )
-      const toggle = screen.getByRole('button', { name: /glyph/i })
+      const toggle = screen.getByRole('button', { name: /variable/i })
       await expect.element(toggle).toBeDisabled()
     })
   })
@@ -383,7 +383,7 @@ describe('GlyphFieldWrapper Integration', () => {
 
     it('string field', async () => {
       const screen = await renderWithProviders(<ControlledStringField />)
-      await screen.getByRole('button', { name: /glyph/i }).click()
+      await screen.getByRole('button', { name: /variable/i }).click()
       const input = screen.getByRole('textbox')
       await input.fill('${expver}')
       await expect
@@ -393,7 +393,7 @@ describe('GlyphFieldWrapper Integration', () => {
 
     it('number field', async () => {
       const screen = await renderWithProviders(<ControlledNumberField />)
-      await screen.getByRole('button', { name: /glyph/i }).click()
+      await screen.getByRole('button', { name: /variable/i }).click()
       const input = screen.getByRole('textbox')
       await input.fill('${runId}')
       await expect
@@ -403,7 +403,7 @@ describe('GlyphFieldWrapper Integration', () => {
 
     it('date field', async () => {
       const screen = await renderWithProviders(<ControlledDateField />)
-      await screen.getByRole('button', { name: /glyph/i }).click()
+      await screen.getByRole('button', { name: /variable/i }).click()
       const input = screen.getByRole('textbox')
       await input.fill('${forecastDate}')
       await expect

--- a/frontend/tests/integration/features/fable-builder/build-flow.test.tsx
+++ b/frontend/tests/integration/features/fable-builder/build-flow.test.tsx
@@ -123,8 +123,10 @@ describe('Fable Builder Integration', () => {
     // Fable should be marked as dirty
     expect(state.isDirty).toBe(true)
 
-    // The "Unsaved" badge should appear in the header
-    await expect.element(screen.getByText('Unsaved')).toBeVisible()
+    // The draft-status chip should appear in the header while dirty
+    await expect
+      .element(screen.getByText(/saving draft|draft saved/i))
+      .toBeVisible()
 
     // Block count should update to "1 block"
     await expect.element(screen.getByText('1 block')).toBeVisible()
@@ -209,8 +211,10 @@ describe('Fable Builder Integration', () => {
       .poll(() => useFableBuilderStore.getState().isDirty, { timeout: 2000 })
       .toBe(false)
 
-    // "Unsaved" badge should no longer be visible
-    await expect.element(screen.getByText('Unsaved')).not.toBeInTheDocument()
+    // Draft-status chip should no longer be visible after a successful save
+    await expect
+      .element(screen.getByText(/saving draft|draft saved/i))
+      .not.toBeInTheDocument()
 
     // Store should have fableId set after save
     expect(useFableBuilderStore.getState().fableId).toBeTruthy()

--- a/frontend/tests/integration/features/fable-builder/form-mode.test.tsx
+++ b/frontend/tests/integration/features/fable-builder/form-mode.test.tsx
@@ -115,8 +115,10 @@ describe('Fable Builder Form Mode', () => {
     // Fable should be marked as dirty
     expect(useFableBuilderStore.getState().isDirty).toBe(true)
 
-    // The "Unsaved" badge should appear in the header
-    await expect.element(screen.getByText('Unsaved')).toBeVisible()
+    // The draft-status chip should appear in the header while dirty
+    await expect
+      .element(screen.getByText(/saving draft|draft saved/i))
+      .toBeVisible()
 
     // Block count should update to "1 block"
     await expect.element(screen.getByText('1 block')).toBeVisible()

--- a/frontend/tests/integration/features/fable-builder/save-and-load.test.tsx
+++ b/frontend/tests/integration/features/fable-builder/save-and-load.test.tsx
@@ -108,8 +108,10 @@ describe('Fable Builder Save & Load', () => {
       // lastSavedAt should be set
       expect(useFableBuilderStore.getState().lastSavedAt).toBeTruthy()
 
-      // "Unsaved" badge should no longer be visible
-      await expect.element(screen.getByText('Unsaved')).not.toBeInTheDocument()
+      // Draft-status chip should no longer be visible after a successful save
+      await expect
+        .element(screen.getByText(/saving draft|draft saved/i))
+        .not.toBeInTheDocument()
     })
 
     it('updates an existing configuration when fableId is set', async () => {
@@ -296,8 +298,10 @@ describe('Fable Builder Save & Load', () => {
       // Should now be dirty
       expect(useFableBuilderStore.getState().isDirty).toBe(true)
 
-      // "Unsaved" badge should appear
-      await expect.element(screen.getByText('Unsaved')).toBeVisible()
+      // Draft-status chip should appear while dirty
+      await expect
+        .element(screen.getByText(/saving draft|draft saved/i))
+        .toBeVisible()
     })
   })
 

--- a/frontend/tests/unit/features/fable-builder/utils/build-autocomplete-insertion.test.ts
+++ b/frontend/tests/unit/features/fable-builder/utils/build-autocomplete-insertion.test.ts
@@ -1,0 +1,143 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { buildAutocompleteInsertion } from '@/features/fable-builder/utils/build-autocomplete-insertion'
+
+describe('buildAutocompleteInsertion', () => {
+  describe('variable picks (intrinsic / global / local)', () => {
+    it('inserts name, auto-closes `}`, and lands cursor BEFORE the brace for chaining', () => {
+      const result = buildAutocompleteInsertion(
+        { name: 'startDatetime', source: 'intrinsic' },
+        '', // nothing after replaceEnd → no `}` yet
+      )
+      expect(result).toEqual({
+        text: 'startDatetime}',
+        // Cursor between `e` and `}` so the user can immediately type ` | sub_days`.
+        cursorOffset: 'startDatetime'.length,
+      })
+    })
+
+    it('does not append `}` when one already follows; cursor still after name', () => {
+      const result = buildAutocompleteInsertion(
+        { name: 'myVar', source: 'global' },
+        '} suffix',
+      )
+      expect(result).toEqual({
+        text: 'myVar',
+        cursorOffset: 'myVar'.length,
+      })
+    })
+
+    it('handles local-source variables identically to globals', () => {
+      const result = buildAutocompleteInsertion(
+        { name: 'localKey', source: 'local' },
+        '',
+      )
+      expect(result.text).toBe('localKey}')
+      expect(result.cursorOffset).toBe('localKey'.length)
+    })
+  })
+
+  describe('helper picks with arguments (filter or global)', () => {
+    it('opens parens and lands cursor inside for an arg-taking filter', () => {
+      const result = buildAutocompleteInsertion(
+        {
+          name: 'add_days',
+          source: 'filter',
+          description: 'Add n days to a datetime: ${dt | add_days(n)}',
+        },
+        '',
+      )
+      expect(result.text).toBe('add_days()')
+      // Cursor should land between the parens.
+      expect(result.cursorOffset).toBe('add_days('.length)
+    })
+
+    it('opens parens for an arg-taking global helper', () => {
+      const result = buildAutocompleteInsertion(
+        {
+          name: 'timedelta',
+          source: 'helperGlobal',
+          description:
+            'Python timedelta constructor, for inline arithmetic: ${dt + timedelta(days=1)}',
+        },
+        '',
+      )
+      expect(result.text).toBe('timedelta()')
+      expect(result.cursorOffset).toBe('timedelta('.length)
+    })
+
+    it('does NOT auto-close `}` for arg-taking helpers (user still needs to finish)', () => {
+      const result = buildAutocompleteInsertion(
+        {
+          name: 'sub_days',
+          source: 'filter',
+          description: 'Subtract n days from a datetime: ${dt | sub_days(n)}',
+        },
+        '',
+      )
+      expect(result.text).not.toContain('}')
+    })
+  })
+
+  describe('helper picks without arguments', () => {
+    it('treats a no-arg filter like a variable (auto-close `}`, cursor before brace)', () => {
+      const result = buildAutocompleteInsertion(
+        {
+          name: 'floor_day',
+          source: 'filter',
+          description: 'Truncate a datetime to midnight: ${dt | floor_day}',
+        },
+        '',
+      )
+      expect(result.text).toBe('floor_day}')
+      // Cursor between `y` and `}` so chaining a second filter is one keystroke.
+      expect(result.cursorOffset).toBe('floor_day'.length)
+    })
+
+    it('does not auto-close `}` when one already exists, even for a no-arg filter', () => {
+      const result = buildAutocompleteInsertion(
+        {
+          name: 'floor_hour',
+          source: 'filter',
+          description:
+            'Truncate a datetime to the start of the hour: ${dt | floor_hour}',
+        },
+        '} more',
+      )
+      expect(result.text).toBe('floor_hour')
+      expect(result.cursorOffset).toBe('floor_hour'.length)
+    })
+  })
+
+  describe('robustness', () => {
+    it('treats a missing description as no-args', () => {
+      const result = buildAutocompleteInsertion(
+        { name: 'mystery', source: 'filter' },
+        '',
+      )
+      expect(result.text).toBe('mystery}')
+    })
+
+    it('does not confuse a different name appearing with parens in the description', () => {
+      // Description mentions `other(` but not `target(` — should treat as no-args.
+      const result = buildAutocompleteInsertion(
+        {
+          name: 'target',
+          source: 'filter',
+          description: 'See also other(args) for a similar effect.',
+        },
+        '',
+      )
+      expect(result.text).toBe('target}')
+    })
+  })
+})

--- a/frontend/tests/unit/features/fable-builder/utils/date-preview-nudge.test.ts
+++ b/frontend/tests/unit/features/fable-builder/utils/date-preview-nudge.test.ts
@@ -1,0 +1,110 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  applyFloorDay,
+  canApplyFloorDay,
+  previewHasTimeComponent,
+} from '@/features/fable-builder/utils/date-preview-nudge'
+
+describe('previewHasTimeComponent', () => {
+  it('returns true for YYYY-MM-DD HH:MM:SS with non-zero time', () => {
+    expect(previewHasTimeComponent('2026-04-20 10:49:06')).toBe(true)
+  })
+
+  it('returns true for YYYY-MM-DD HH:MM (no seconds, non-zero)', () => {
+    expect(previewHasTimeComponent('2026-04-20 10:49')).toBe(true)
+  })
+
+  it('returns true for the ISO T-separated form with non-zero time', () => {
+    expect(previewHasTimeComponent('2026-04-20T10:49:06')).toBe(true)
+  })
+
+  it('returns false when the time is exactly midnight (HH:MM:SS all zero)', () => {
+    expect(previewHasTimeComponent('2026-04-20 00:00:00')).toBe(false)
+  })
+
+  it('returns false when the time is midnight without seconds', () => {
+    expect(previewHasTimeComponent('2026-04-20 00:00')).toBe(false)
+  })
+
+  it('returns false for the ISO form at midnight', () => {
+    expect(previewHasTimeComponent('2026-04-20T00:00:00')).toBe(false)
+  })
+
+  it('returns true when only minutes are zero but hours are not', () => {
+    expect(previewHasTimeComponent('2026-04-20 10:00:00')).toBe(true)
+  })
+
+  it('returns true when only seconds are non-zero', () => {
+    expect(previewHasTimeComponent('2026-04-20 00:00:01')).toBe(true)
+  })
+
+  it('returns false for a bare date', () => {
+    expect(previewHasTimeComponent('2026-04-20')).toBe(false)
+  })
+
+  it('returns false for plain text', () => {
+    expect(previewHasTimeComponent('hello world')).toBe(false)
+  })
+})
+
+describe('canApplyFloorDay', () => {
+  it('is true when the value is a single `${...}` expression', () => {
+    expect(canApplyFloorDay('${submitDatetime}')).toBe(true)
+    expect(canApplyFloorDay('${submitDatetime | sub_days(2)}')).toBe(true)
+  })
+
+  it('is false when the expression already pipes through floor_day', () => {
+    expect(canApplyFloorDay('${submitDatetime | floor_day}')).toBe(false)
+    expect(
+      canApplyFloorDay('${submitDatetime | floor_day | sub_days(2)}'),
+    ).toBe(false)
+  })
+
+  it('is false when there is text around the expression', () => {
+    expect(canApplyFloorDay('prefix-${submitDatetime}')).toBe(false)
+    expect(canApplyFloorDay('${submitDatetime}-suffix')).toBe(false)
+  })
+
+  it('is false when there are multiple expressions', () => {
+    expect(canApplyFloorDay('${a} and ${b}')).toBe(false)
+  })
+
+  it('is false when the value has no expressions at all', () => {
+    expect(canApplyFloorDay('2026-04-20')).toBe(false)
+    expect(canApplyFloorDay('')).toBe(false)
+  })
+})
+
+describe('applyFloorDay', () => {
+  it('appends `| floor_day` to a plain variable', () => {
+    expect(applyFloorDay('${submitDatetime}')).toBe(
+      '${submitDatetime | floor_day}',
+    )
+  })
+
+  it('appends after any existing filter chain', () => {
+    expect(applyFloorDay('${submitDatetime | sub_days(2)}')).toBe(
+      '${submitDatetime | sub_days(2) | floor_day}',
+    )
+  })
+
+  it('is a no-op when the expression already uses floor_day', () => {
+    const value = '${submitDatetime | floor_day}'
+    expect(applyFloorDay(value)).toBe(value)
+  })
+
+  it('is a no-op when the value has surrounding text', () => {
+    const value = 'prefix-${submitDatetime}'
+    expect(applyFloorDay(value)).toBe(value)
+  })
+})

--- a/frontend/tests/unit/features/fable-builder/utils/glyph-display.test.ts
+++ b/frontend/tests/unit/features/fable-builder/utils/glyph-display.test.ts
@@ -1,0 +1,153 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  containsGlyphs,
+  extractGlyphKey,
+  findGlyphSpans,
+  hasUnterminatedGlyph,
+  parseGlyphSegments,
+} from '@/features/fable-builder/utils/glyph-display'
+
+describe('findGlyphSpans', () => {
+  it('finds a simple `${name}` substitution', () => {
+    expect(findGlyphSpans('${runId}')).toEqual([{ start: 0, end: 8 }])
+  })
+
+  it('returns no spans for plain text', () => {
+    expect(findGlyphSpans('plain text')).toEqual([])
+  })
+
+  it('finds substitutions with pipe filters', () => {
+    const text = '${var | sub_days(2)}'
+    expect(findGlyphSpans(text)).toEqual([{ start: 0, end: text.length }])
+  })
+
+  it('honours a `}` inside a double-quoted string literal', () => {
+    // Without string-awareness, the inner `}` would close the substitution
+    // prematurely, leaving `b")}` as plain text.
+    const text = '${func("a}b")}'
+    expect(findGlyphSpans(text)).toEqual([{ start: 0, end: text.length }])
+  })
+
+  it('honours a `}` inside a single-quoted string literal', () => {
+    const text = "${func('a}b')}"
+    expect(findGlyphSpans(text)).toEqual([{ start: 0, end: text.length }])
+  })
+
+  it('handles backslash-escaped quotes inside string literals', () => {
+    const text = '${func("a\\"b}c")}'
+    expect(findGlyphSpans(text)).toEqual([{ start: 0, end: text.length }])
+  })
+
+  it('finds multiple substitutions in one string', () => {
+    const text = 'x=${a}, y=${b | f}'
+    expect(findGlyphSpans(text)).toEqual([
+      { start: 2, end: 6 }, // ${a}
+      { start: 10, end: 18 }, // ${b | f}
+    ])
+  })
+
+  it('skips an unterminated `${`', () => {
+    expect(findGlyphSpans('${var | sub')).toEqual([])
+  })
+
+  it('returns earlier spans even if a later substitution is unterminated', () => {
+    const text = '${good} then ${bad'
+    expect(findGlyphSpans(text)).toEqual([{ start: 0, end: 7 }])
+  })
+})
+
+describe('containsGlyphs', () => {
+  it('returns true for a plain `${name}` reference', () => {
+    expect(containsGlyphs('${runId}')).toBe(true)
+  })
+
+  it('returns true for a Jinja expression with filters', () => {
+    expect(containsGlyphs('${submitDatetime | sub_days(2)}')).toBe(true)
+  })
+
+  it('returns true even when the body contains a `}` inside a string', () => {
+    expect(containsGlyphs('${func("a}b")}')).toBe(true)
+  })
+
+  it('returns false for plain text', () => {
+    expect(containsGlyphs('hello world')).toBe(false)
+  })
+
+  it('returns false for an unterminated `${`', () => {
+    expect(containsGlyphs('${var | sub')).toBe(false)
+  })
+})
+
+describe('parseGlyphSegments', () => {
+  it('treats a complete expression as a single glyph segment', () => {
+    expect(parseGlyphSegments('${var | sub_days(2)}')).toEqual([
+      { text: '${var | sub_days(2)}', isGlyph: true },
+    ])
+  })
+
+  it('splits text and glyph segments correctly', () => {
+    expect(parseGlyphSegments('/data/${runId}/output')).toEqual([
+      { text: '/data/', isGlyph: false },
+      { text: '${runId}', isGlyph: true },
+      { text: '/output', isGlyph: false },
+    ])
+  })
+
+  it('keeps `}` inside string literals as part of the glyph segment', () => {
+    expect(parseGlyphSegments('prefix ${func("a}b")} suffix')).toEqual([
+      { text: 'prefix ', isGlyph: false },
+      { text: '${func("a}b")}', isGlyph: true },
+      { text: ' suffix', isGlyph: false },
+    ])
+  })
+})
+
+describe('extractGlyphKey', () => {
+  it('returns the variable name for a plain reference', () => {
+    expect(extractGlyphKey('${runId}')).toBe('runId')
+  })
+
+  it('returns the full inner body for a Jinja expression', () => {
+    expect(extractGlyphKey('${var | sub_days(2)}')).toBe('var | sub_days(2)')
+  })
+})
+
+describe('hasUnterminatedGlyph', () => {
+  it('returns false for a balanced expression', () => {
+    expect(hasUnterminatedGlyph('${var}')).toBe(false)
+    expect(hasUnterminatedGlyph('${var | sub_days(2)}')).toBe(false)
+  })
+
+  it('returns true for the bare opener inserted by the glyph toggle', () => {
+    expect(hasUnterminatedGlyph('${')).toBe(true)
+  })
+
+  it('returns true for partial variable names still being typed', () => {
+    expect(hasUnterminatedGlyph('${sub')).toBe(true)
+    expect(hasUnterminatedGlyph('${var | sub_d')).toBe(true)
+  })
+
+  it('returns true when only one of two expressions is closed', () => {
+    expect(hasUnterminatedGlyph('${a} and ${b')).toBe(true)
+  })
+
+  it('does not mistake a `}` inside a string literal for a closer', () => {
+    expect(hasUnterminatedGlyph('${func("a}b"')).toBe(true)
+    expect(hasUnterminatedGlyph('${func("a}b")}')).toBe(false)
+  })
+
+  it('returns false for plain text without any substitution', () => {
+    expect(hasUnterminatedGlyph('2026-04-20')).toBe(false)
+    expect(hasUnterminatedGlyph('')).toBe(false)
+  })
+})

--- a/frontend/tests/unit/features/fable-builder/utils/glyph-expression-context.test.ts
+++ b/frontend/tests/unit/features/fable-builder/utils/glyph-expression-context.test.ts
@@ -1,0 +1,184 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { parseGlyphContext } from '@/features/fable-builder/utils/glyph-expression-context'
+
+/**
+ * Convenience: place the cursor at the `‸` (caret, U+2038) marker in the
+ * source string and call the parser. Avoids hand-counting offsets in every
+ * test case. The caret cannot appear in Jinja syntax so it never collides
+ * with a real `|`, `(`, etc.
+ */
+function ctx(source: string) {
+  const cursor = source.indexOf('‸')
+  if (cursor === -1) {
+    throw new Error('test input must contain a `‸` cursor marker')
+  }
+  const text = source.slice(0, cursor) + source.slice(cursor + 1)
+  return parseGlyphContext(text, cursor)
+}
+
+describe('parseGlyphContext', () => {
+  describe('outside a substitution', () => {
+    it('returns none for plain text', () => {
+      expect(ctx('hello ‸world')).toMatchObject({ kind: 'none' })
+    })
+
+    it('returns none after a closed substitution', () => {
+      expect(ctx('${var}‸')).toMatchObject({ kind: 'none' })
+    })
+
+    it('returns none for empty input', () => {
+      expect(ctx('‸')).toMatchObject({ kind: 'none' })
+    })
+  })
+
+  describe('value position (variables and globals)', () => {
+    it('classifies the cursor right after `${` as value', () => {
+      expect(ctx('${‸')).toMatchObject({ kind: 'value', prefix: '' })
+    })
+
+    it('captures a partial identifier as the prefix', () => {
+      const result = ctx('${star‸')
+      expect(result.kind).toBe('value')
+      expect(result.prefix).toBe('star')
+      expect(result.replaceStart).toBe(2) // right after ${
+      expect(result.replaceEnd).toBe(6) // cursor offset
+    })
+
+    it('skips whitespace immediately after `${`', () => {
+      expect(ctx('${ ‸')).toMatchObject({ kind: 'value', prefix: '' })
+    })
+
+    it('treats the second substitution as the active one', () => {
+      const result = ctx('${first} ${se‸')
+      expect(result.kind).toBe('value')
+      expect(result.prefix).toBe('se')
+    })
+  })
+
+  describe('filter position (single pipe)', () => {
+    it('classifies right after `|` as filter', () => {
+      expect(ctx('${var | ‸')).toMatchObject({ kind: 'filter', prefix: '' })
+    })
+
+    it('captures the partial filter name', () => {
+      const result = ctx('${startDatetime | sub_d‸')
+      expect(result.kind).toBe('filter')
+      expect(result.prefix).toBe('sub_d')
+    })
+
+    it('handles a pipe with no surrounding whitespace', () => {
+      expect(ctx('${var|f‸')).toMatchObject({ kind: 'filter', prefix: 'f' })
+    })
+  })
+
+  describe('chained filters', () => {
+    it('classifies the position after a second pipe as filter', () => {
+      expect(ctx('${var | f1 | ‸')).toMatchObject({
+        kind: 'filter',
+        prefix: '',
+      })
+    })
+
+    it('captures a partial second filter name', () => {
+      const result = ctx('${var | f1 | f2‸')
+      expect(result.kind).toBe('filter')
+      expect(result.prefix).toBe('f2')
+    })
+  })
+
+  describe('function-call argument position', () => {
+    it('classifies right after `(` as value', () => {
+      expect(ctx('${func(‸')).toMatchObject({ kind: 'value', prefix: '' })
+    })
+
+    it('classifies right after `,` as value', () => {
+      expect(ctx('${func(a, ‸')).toMatchObject({ kind: 'value', prefix: '' })
+    })
+
+    it('classifies a pipe inside a function arg as filter', () => {
+      const result = ctx('${func(x | f‸')
+      expect(result.kind).toBe('filter')
+      expect(result.prefix).toBe('f')
+    })
+
+    it('returns to outer-frame state after a closing `)`', () => {
+      // After `f(x)` the outer frame is "closed" (filter applied to a value);
+      // a following pipe re-opens filter context.
+      expect(ctx('${func(x) | ‸')).toMatchObject({
+        kind: 'filter',
+        prefix: '',
+      })
+    })
+  })
+
+  describe('string literals', () => {
+    it('returns none when the cursor sits inside a single-quoted string', () => {
+      expect(ctx('${func("hello, ‸')).toMatchObject({ kind: 'none' })
+    })
+
+    it('skips past a closed string literal and continues classifying', () => {
+      const result = ctx('${func("a", b‸')
+      expect(result.kind).toBe('value')
+      expect(result.prefix).toBe('b')
+    })
+
+    it('handles backslash-escaped quotes inside a string', () => {
+      const result = ctx('${func("a\\"b", c‸')
+      expect(result.kind).toBe('value')
+      expect(result.prefix).toBe('c')
+    })
+  })
+
+  describe('rejected positions', () => {
+    it('returns none in the middle of a closed substitution after the identifier', () => {
+      // `${var ` → after the identifier and a space, with no separator,
+      // there's no candidate set to suggest.
+      expect(ctx('${var ‸')).toMatchObject({ kind: 'none' })
+    })
+
+    it('returns none for nested substitutions', () => {
+      expect(ctx('${func(${inner‸')).toMatchObject({ kind: 'none' })
+    })
+
+    it('returns none for two adjacent identifiers separated by whitespace', () => {
+      // `${a b` is invalid Jinja and should not surface autocomplete.
+      expect(ctx('${a b‸')).toMatchObject({ kind: 'none' })
+    })
+
+    it('returns none for an unrecognised char like `.` after an identifier', () => {
+      expect(ctx('${var.field‸')).toMatchObject({ kind: 'none' })
+    })
+  })
+
+  describe('replace range', () => {
+    it('uses cursor for both ends when no prefix exists', () => {
+      const text = '${'
+      const result = parseGlyphContext(text, text.length)
+      expect(result).toMatchObject({
+        kind: 'value',
+        prefix: '',
+        replaceStart: 2,
+        replaceEnd: 2,
+      })
+    })
+
+    it('captures the full prefix range for filter completions', () => {
+      const text = '${dt | add_d'
+      const result = parseGlyphContext(text, text.length)
+      expect(result.replaceStart).toBe(text.indexOf('add_d'))
+      expect(result.replaceEnd).toBe(text.length)
+      expect(result.kind).toBe('filter')
+      expect(result.prefix).toBe('add_d')
+    })
+  })
+})


### PR DESCRIPTION
 ## Summary

  Frontend alignment with backend commits add Jinja autocomplete, glyph Terminology rename

  ### Backend API alignment

  - Zod schemas + form for user-glyphs (#387): `overriddable` field, required `created_by`, per-user `(created_by, key)` uniqueness.
  - Non-null `created_by` on `GlobalGlyphResponse` and `ScheduleDefinitionResponse` (#388).
  - Wire `GET /blueprint/glyphs/functions` (#365) as `useGlyphFunctions`.
  - MSW handlers mirror the new validation rules.

  ### Jinja autocomplete

  - `parseGlyphContext` classifies the cursor as `value` / `filter` /  `none` with string-literal + paren awareness. 25 tests.
  - Dropdown surfaces variables + callable globals at `value`, pipe filters at `filter`; helper rows carry a kind badge.
  - Smart insert: variables auto-close `}` with cursor before it (chain-friendly); arg-taking helpers insert `name()` with cursor inside.
  - Helpers reference section in the canvas panel.
  - `containsGlyphs` rewritten to handle `${func("a}b") | filter}`.
  - Date-typed fields with a non-midnight resolution show a one-click "Truncate to date" (`| floor_day`) nudge.

  ### Variable management in-canvas

  - Inline "Add variable" dialog from the reference panel — no more leaving the fable to manage globals.
  - Non-admins don't see the public toggle; list rows show creator    ("you" / "local" / "intrinsic" / owner id).

  ### Terminology rename (UI-only)

 - All user-facing strings `glyph` → `variable`; API keeps `glyph`.
 - Admin route `/admin/glyphs` → `/admin/variables`.

  ### Autosave UX

  - `DraftStatus` chip under the fable name     (`⟳ Saving draft…` → `✓ Draft saved`).
  - Drop the native "Leave site?" `beforeunload` prompt; the existing    localStorage draft covers refresh/close/crash.

  ### Layout / flicker fixes

  - Debounce validation (300 ms) and gate it on well-formed `${...}` —     backend 500s on bare `${` never reach the UI.
  - Float the header's validation banner; lift error alerts out of     `BlockNode` / `InlineBlockNode` 
  - `FableGraphCanvas` auto-relayouts only on a node's FIRST measured    size; content-driven resizes are ignored.
  - Compact variables panel header.

  ### Outputs panel

  - Auto-refresh on job completion.
  - Catalogue: `refetchOnMount: 'always'` + Retry button to recover from     first-visit errors.

  ### Code hygiene

  - Simplification pass: scanner consolidation, MIME table folding,   shared overlay, dead-state removal, hoisted regex.
### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
