### PR TITLE
refactor: introduce FiabCoreBaseModel and FiabBaseModel with extra=fo…

### DIFF
--- a/backend/development.md
+++ b/backend/development.md
@@ -13,7 +13,8 @@
   * when working with a package with insufficient typing coverage like sqlalchemy, use `ty:ignore` comment
   * when `ty` is not powerful enough, use `ty:ignore `
   * use `typing.cast` when the code logic is implicitly erasing the type information
-* prioritize using pydantic.BaseModel or dataclasses.dataclass object for capturing contracts and interfaces.
+* prioritize using pydantic BaseModel or dataclasses.dataclass object for capturing contracts and interfaces.
+  * when using pydantic, use `FiabBaseModel` from `forecastbox.utility.pydantic` (or `FiabCoreBaseModel` from `fiab_core.pydantic_utils` in fiab-core) instead of `pydantic.BaseModel` directly, unless the model requires dynamic field handling (e.g., `extra="allow"` for JSON Schema types). These base models set `extra="forbid"` to catch misconfigured constructors early. If you need the dynamic model handling, mark it clearly with a comment.
   * ideally keep them plain, stateless, frozen, without functions -- we end up serializing those objects often over to other python processes or different languages
     * having a few methods that provide convenience views, ser/de, validation, conversion does not necessarilly hurt -- its primarily about keeping the codebase generally functional and data-oriented rather than object-oriented.
   * for simple immutable data transfer objects, use `@dataclass(frozen=True, eq=True, slots=True)` directly for best type checker support -- provides immutability, hashability, and memory efficiency via slots. We set `eq=True` explicitly, despite being a default, for clarity.

--- a/backend/packages/fiab-core/src/fiab_core/artifacts.py
+++ b/backend/packages/fiab-core/src/fiab_core/artifacts.py
@@ -16,7 +16,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, NewType
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from fiab_core.pydantic_utils import FiabCoreBaseModel
 
 # NOTE we may eventually fine-grain this with like cuda versions or architecture etc, form a hierarchy, etc. Or maybe not and this will be enough.
 Platform = Literal["macos", "linux"]
@@ -33,7 +35,7 @@ class CompositeArtifactId:
     ml_model_checkpoint_id: MlModelCheckpointId
 
 
-class MlModelCheckpoint(BaseModel):
+class MlModelCheckpoint(FiabCoreBaseModel):
     url: str = Field(
         description="Location such as anemoi catalogue or hugging face registry url. Represents the source url, not an url of a local copy"
     )

--- a/backend/packages/fiab-core/src/fiab_core/fable.py
+++ b/backend/packages/fiab-core/src/fiab_core/fable.py
@@ -14,11 +14,13 @@ Types pertaining to Forecast As BLock Expression (Fable): blocks
 from typing import Literal, NewType
 
 from earthkit.workflows.fluent import Action
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
 from typing_extensions import Self
 
+from fiab_core.pydantic_utils import FiabCoreBaseModel
 
-class BlockConfigurationOption(BaseModel):
+
+class BlockConfigurationOption(FiabCoreBaseModel):
     title: str
     """Brief string to display in the BlockFactory detail"""
     description: str
@@ -31,7 +33,7 @@ class BlockConfigurationOption(BaseModel):
 BlockKind = Literal["source", "transform", "product", "sink"]
 
 
-class BlockFactory(BaseModel):
+class BlockFactory(FiabCoreBaseModel):
     """When building a fable, user selects from an available catalogue of BlockFactories which
     have description of what they do and specification of configuration options they offer"""
 
@@ -53,7 +55,7 @@ PluginId = NewType("PluginId", str)
 PluginStoreId = NewType("PluginStoreId", str)
 
 
-class PluginCompositeId(BaseModel):
+class PluginCompositeId(FiabCoreBaseModel):
     model_config = ConfigDict(frozen=True)
     store: PluginStoreId
     local: PluginId
@@ -70,7 +72,7 @@ class PluginCompositeId(BaseModel):
         return f"{k.store}:{k.local}"
 
 
-class PluginBlockFactoryId(BaseModel):
+class PluginBlockFactoryId(FiabCoreBaseModel):
     """Note to plugin authors: This is a routing class. When you implement your BlockFactories for the catalogue,
     you dont use this, you only need to declare a BlockFactoryId unique inside your plugin. Similarly, when you
     return which BlockFactories are possible in the expand method, you only return your BlockFactoryIds. This
@@ -81,11 +83,11 @@ class PluginBlockFactoryId(BaseModel):
     factory: BlockFactoryId
 
 
-class BlockFactoryCatalogue(BaseModel):
+class BlockFactoryCatalogue(FiabCoreBaseModel):
     factories: dict[BlockFactoryId, BlockFactory]
 
 
-class BlockInstance(BaseModel):
+class BlockInstance(FiabCoreBaseModel):
     """As produced by BlockFactory *by the client* -- basically the configuration/inputs values"""
 
     factory_id: PluginBlockFactoryId
@@ -95,16 +97,16 @@ class BlockInstance(BaseModel):
     """Keys come from factory's `inputs`, values are other blocks in the (partial) fable"""
 
 
-class XarrayOutput(BaseModel):  # NOTE eventually Qubed
+class XarrayOutput(FiabCoreBaseModel):  # NOTE eventually Qubed
     variables: list[str]
     coords: list[str]
 
 
-class RawOutput(BaseModel):
+class RawOutput(FiabCoreBaseModel):
     type_fqn: str  # most likely you want Any here
 
 
-class NoOutput(BaseModel):
+class NoOutput(FiabCoreBaseModel):
     pass
 
 

--- a/backend/packages/fiab-core/src/fiab_core/pydantic_utils.py
+++ b/backend/packages/fiab-core/src/fiab_core/pydantic_utils.py
@@ -1,0 +1,21 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Pydantic base model for fiab-core.
+
+Prefer FiabCoreBaseModel over pydantic.BaseModel unless the model requires dynamic field handling.
+"""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class FiabCoreBaseModel(BaseModel):
+    """Base pydantic model for fiab-core. Forbids extra fields to catch misconfigured constructors early."""
+
+    model_config = ConfigDict(extra="forbid")

--- a/backend/src/forecastbox/domain/blueprint/cascade.py
+++ b/backend/src/forecastbox/domain/blueprint/cascade.py
@@ -10,10 +10,12 @@
 """Cascade execution data models: environment specification."""
 
 from fiab_core.artifacts import CompositeArtifactId
-from pydantic import BaseModel, Field, PositiveInt
+from pydantic import Field, PositiveInt
+
+from forecastbox.utility.pydantic import FiabBaseModel
 
 
-class EnvironmentSpecification(BaseModel):
+class EnvironmentSpecification(FiabBaseModel):
     # NOTE warning -- this class is used by the web api. Be careful about changes here
     hosts: PositiveInt | None = Field(default=None)
     workers_per_host: PositiveInt | None = Field(default=None)

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -32,7 +32,6 @@ from fiab_core.fable import (
     BlockKind,
     PluginBlockFactoryId,
 )
-from pydantic import BaseModel
 
 from forecastbox.domain.blueprint import db
 from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
@@ -46,25 +45,26 @@ from forecastbox.domain.glyphs.resolution import ExtractedGlyphs, expand_glyph_v
 from forecastbox.domain.plugin.manager import PluginManager
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.graph import topological_order
+from forecastbox.utility.pydantic import FiabBaseModel
 
 logger = logging.getLogger(__name__)
 
 
-class BlueprintBuilder(BaseModel):
+class BlueprintBuilder(FiabBaseModel):
     # NOTE warning -- this class is used by the web api. Be careful about changes here
     blocks: dict[BlockInstanceId, BlockInstance]
     environment: EnvironmentSpecification | None = None
     local_glyphs: dict[str, str] = {}
 
 
-class BlueprintSaveResult(BaseModel):
+class BlueprintSaveResult(FiabBaseModel):
     """Returned by save_builder; contains the stable id and the new version number."""
 
     blueprint_id: BlueprintId
     blueprint_version: int
 
 
-class BlueprintRetrieveResult(BaseModel):
+class BlueprintRetrieveResult(FiabBaseModel):
     """Full payload returned by load_builder."""
 
     blueprint_id: BlueprintId
@@ -76,7 +76,7 @@ class BlueprintRetrieveResult(BaseModel):
     parent_id: str | None = None
 
 
-class BlueprintValidationExpansion(BaseModel):
+class BlueprintValidationExpansion(FiabBaseModel):
     """Structured validation result and completion options for a BlueprintBuilder."""
 
     global_errors: list[str]
@@ -86,7 +86,7 @@ class BlueprintValidationExpansion(BaseModel):
     resolved_configuration_options: dict[BlockInstanceId, dict[str, str]] = {}
 
 
-class BlueprintSaveCommand(BaseModel):
+class BlueprintSaveCommand(FiabBaseModel):
     """Command payload for saving a blueprint builder."""
 
     builder: BlueprintBuilder

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -40,12 +40,12 @@ from typing import Iterator, Literal
 from cascade.low.func import assert_never
 from fiab_core.fable import BlockFactoryCatalogue, PluginCompositeId
 from fiab_core.plugin import Plugin
-from pydantic import BaseModel
 from pyrsistent import pmap
 from pyrsistent.typing import PMap
 
 from forecastbox.utility.concurrent import delayed_thread, timed_acquire
 from forecastbox.utility.config import PluginSettings, PluginsSettings, config, config_edit_lock
+from forecastbox.utility.pydantic import FiabBaseModel
 
 logger = logging.getLogger(__name__)
 
@@ -226,7 +226,7 @@ def submit_load_plugins(start_after: Future[None]) -> None:
             PluginManager.updater.start()
 
 
-class PluginsStatus(BaseModel):
+class PluginsStatus(FiabBaseModel):
     # TODO: Change these fields to use pyrsistent types (PMap) instead of dict once we solve pydantic serialization
     updater_status: Literal["ok", "running", "retrieving"] | str
     plugin_errors: dict[PluginCompositeId, str]

--- a/backend/src/forecastbox/domain/plugin/store.py
+++ b/backend/src/forecastbox/domain/plugin/store.py
@@ -17,7 +17,6 @@ import httpx
 import orjson
 from cascade.low.func import assert_never
 from fiab_core.fable import PluginCompositeId, PluginId
-from pydantic import BaseModel
 from pyrsistent import pmap
 from pyrsistent.typing import PMap
 from typing_extensions import Self
@@ -26,11 +25,12 @@ from forecastbox.domain.plugin.manager import submit_update_single
 from forecastbox.utility.concurrent import timed_acquire
 from forecastbox.utility.config import PluginSettings, PluginStoreConfig, PluginStoreId, PluginStoresConfig, config, config_edit_lock
 from forecastbox.utility.httpx import fetch_content
+from forecastbox.utility.pydantic import FiabBaseModel
 
 logger = logging.getLogger(__name__)
 
 
-class PluginStoreEntry(BaseModel):
+class PluginStoreEntry(FiabBaseModel):
     pip_source: str
     """Name of the package if assuming PyPI, or a local path, git repo, ... Anything that pip accepts"""
     module_name: str
@@ -45,7 +45,7 @@ class PluginStoreEntry(BaseModel):
     """Any comment or clarification to developers or maintainers. Not propagated to the frontend"""
 
 
-class PluginRemoteInfo(BaseModel):
+class PluginRemoteInfo(FiabBaseModel):
     """Data from eg PyPI such as the most recent version"""
 
     version: str
@@ -64,7 +64,7 @@ def get_latest_version(package_name: str, client: httpx.Client) -> str:
     return "unknown"
 
 
-class PluginStore(BaseModel):
+class PluginStore(FiabBaseModel):
     display_name: str
     plugins: dict[PluginId, PluginStoreEntry] = {}
     remote: dict[PluginId, PluginRemoteInfo] = {}

--- a/backend/src/forecastbox/domain/run/cascade.py
+++ b/backend/src/forecastbox/domain/run/cascade.py
@@ -21,21 +21,22 @@ from cascade.gateway.api import JobSpec, ResultRetrievalResponse, SubmitJobReque
 from cascade.gateway.client import request_response
 from cascade.low import views
 from cascade.low.core import JobInstance, JobInstanceRich
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from forecastbox.domain.artifact.manager import ArtifactManager, submit_artifact_download
 from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
 from forecastbox.utility.config import config
+from forecastbox.utility.pydantic import FiabBaseModel
 
 logger = logging.getLogger(__name__)
 
 
-class RawCascadeJob(BaseModel):
+class RawCascadeJob(FiabBaseModel):
     job_type: Literal["raw_cascade_job"]
     job_instance: JobInstance
 
 
-class ExecutionSpecification(BaseModel):
+class ExecutionSpecification(FiabBaseModel):
     job: RawCascadeJob  # = Field(discriminator="job_type")
     environment: EnvironmentSpecification
     shared: bool = Field(default=False)
@@ -82,7 +83,7 @@ def encode_result(result: ResultRetrievalResponse) -> tuple[bytes, str]:
     return cloudpickle.dumps(obj), "application/clpkl"
 
 
-class ProductToOutputId(BaseModel):
+class ProductToOutputId(FiabBaseModel):
     product_name: str
     product_spec: dict[str, Any]
     output_ids: Sequence[str]

--- a/backend/src/forecastbox/domain/run/db.py
+++ b/backend/src/forecastbox/domain/run/db.py
@@ -22,7 +22,7 @@ import datetime as dt
 import uuid
 from collections.abc import Iterable
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 from sqlalchemy import func, select, update
 
 import forecastbox.schemata.jobs as _jobs_module
@@ -33,9 +33,10 @@ from forecastbox.domain.run.types import RunId
 from forecastbox.schemata.jobs import Run, RunStatus
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.db import dbRetry, executeAndCommit, querySingle
+from forecastbox.utility.pydantic import FiabBaseModel
 
 
-class CompilerRuntimeContext(BaseModel):
+class CompilerRuntimeContext(FiabBaseModel):
     """Per-execution dynamic values that override compiled ExecutionSpecification fields.
 
     Merged via deep_union into the compiled spec before job submission; only the fields

--- a/backend/src/forecastbox/domain/run/service.py
+++ b/backend/src/forecastbox/domain/run/service.py
@@ -30,7 +30,6 @@ from typing import cast
 
 from cascade.gateway import api, client
 from cascade.low.func import Either
-from pydantic import BaseModel
 
 import forecastbox.domain.blueprint.db as blueprint_db
 import forecastbox.domain.run.db as run_db
@@ -43,11 +42,12 @@ from forecastbox.domain.run.types import RunId
 from forecastbox.schemata.jobs import Blueprint, Run
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.config import config
+from forecastbox.utility.pydantic import FiabBaseModel
 
 logger = logging.getLogger(__name__)
 
 
-class RunDetail(BaseModel):
+class RunDetail(FiabBaseModel):
     """Detail of a single job execution attempt."""
 
     run_id: RunId
@@ -62,7 +62,7 @@ class RunDetail(BaseModel):
     cascade_job_id: str | None = None
 
 
-class ExecuteResult(BaseModel):
+class ExecuteResult(FiabBaseModel):
     """Result of a job execution submission."""
 
     run_id: RunId

--- a/backend/src/forecastbox/routes/admin.py
+++ b/backend/src/forecastbox/routes/admin.py
@@ -20,12 +20,13 @@ from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import HTMLResponse
-from pydantic import UUID4, BaseModel
+from pydantic import UUID4
 
 from forecastbox.domain.admin import Release, get_local_release, get_most_recent_release, get_pylock, mark_release, save_pylock
 from forecastbox.domain.auth.db import delete_user_by_id, get_user_by_id, list_users, patch_user_by_id, update_user_by_id
 from forecastbox.domain.auth.users import UserRead, UserUpdate, current_active_user
 from forecastbox.utility.config import BackendAPISettings, CascadeSettings, ProductSettings, config
+from forecastbox.utility.pydantic import FiabBaseModel
 from forecastbox.utility.rsjf import ExportedSchemas, FormDefinition, from_pydantic
 
 PREFIX = "/api/v1/admin"
@@ -48,7 +49,7 @@ router = APIRouter(
 )
 
 
-class ExposedSettings(BaseModel):
+class ExposedSettings(FiabBaseModel):
     """Exposed settings for modification"""
 
     product: ProductSettings = config.product
@@ -67,13 +68,13 @@ class ExposedSettings(BaseModel):
         )
 
 
-class GetReleaseStatusResponse(BaseModel):
+class GetReleaseStatusResponse(FiabBaseModel):
     local_release: Release
     local_release_age_days: int
     newest_available_release: Release
 
 
-class UpdateReleaseResponse(BaseModel):
+class UpdateReleaseResponse(FiabBaseModel):
     release: Release
 
 
@@ -120,7 +121,7 @@ async def get_settings(admin: UserRead | None = Depends(get_admin_user)) -> Expo
 async def update_settings(settings: ExposedSettings, admin: UserRead | None = Depends(get_admin_user)) -> HTMLResponse:
     """Update settings"""
 
-    def update(old: BaseModel, new: BaseModel) -> None:
+    def update(old: FiabBaseModel, new: FiabBaseModel) -> None:
         for key, val in new.model_dump().items():
             setattr(old, key, val)
 

--- a/backend/src/forecastbox/routes/blueprint.py
+++ b/backend/src/forecastbox/routes/blueprint.py
@@ -31,7 +31,6 @@ from cascade.low.func import assert_never
 from fastapi import APIRouter, Depends, status
 from fastapi.exceptions import HTTPException
 from fiab_core.fable import BlockFactoryCatalogue, BlockInstanceId, PluginBlockFactoryId, PluginCompositeId
-from pydantic import BaseModel
 
 from forecastbox.domain.auth.users import get_auth_context
 from forecastbox.domain.blueprint import db, service
@@ -49,6 +48,7 @@ from forecastbox.domain.glyphs.types import GlobalGlyphId
 from forecastbox.domain.plugin.manager import catalogue_view, plugins_ready
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.pagination import PaginationSpec
+from forecastbox.utility.pydantic import FiabBaseModel
 
 PREFIX = "/api/v1/blueprint"
 
@@ -63,7 +63,7 @@ router = APIRouter(
 # ---------------------------------------------------------------------------
 
 
-class BlueprintLookup(BaseModel):
+class BlueprintLookup(FiabBaseModel):
     """Identifies a blueprint, optionally pinning a specific version.
 
     Used as a Depends()-based query-param group on GET endpoints, and as a
@@ -74,7 +74,7 @@ class BlueprintLookup(BaseModel):
     version: int | None = None
 
 
-class BlueprintCreateRequest(BaseModel):
+class BlueprintCreateRequest(FiabBaseModel):
     builder: BlueprintBuilder
     display_name: str | None = None
     display_description: str | None = None
@@ -82,12 +82,12 @@ class BlueprintCreateRequest(BaseModel):
     parent_id: str | None = None
 
 
-class BlueprintCreateResponse(BaseModel):
+class BlueprintCreateResponse(FiabBaseModel):
     blueprint_id: BlueprintId
     version: int
 
 
-class BlueprintGetResponse(BaseModel):
+class BlueprintGetResponse(FiabBaseModel):
     blueprint_id: BlueprintId
     version: int
     builder: BlueprintBuilder
@@ -97,7 +97,7 @@ class BlueprintGetResponse(BaseModel):
     parent_id: str | None = None
 
 
-class BlueprintListItem(BaseModel):
+class BlueprintListItem(FiabBaseModel):
     blueprint_id: BlueprintId
     version: int
     display_name: str | None = None
@@ -107,14 +107,14 @@ class BlueprintListItem(BaseModel):
     created_by: str | None = None
 
 
-class BlueprintListResponse(BaseModel):
+class BlueprintListResponse(FiabBaseModel):
     blueprints: list[BlueprintListItem]
     total: int
     page: int
     page_size: int
 
 
-class BlueprintUpdateRequest(BaseModel):
+class BlueprintUpdateRequest(FiabBaseModel):
     blueprint_id: BlueprintId
     version: int
     builder: BlueprintBuilder
@@ -124,17 +124,17 @@ class BlueprintUpdateRequest(BaseModel):
     parent_id: str | None = None
 
 
-class BlueprintUpdateResponse(BaseModel):
+class BlueprintUpdateResponse(FiabBaseModel):
     blueprint_id: BlueprintId
     version: int
 
 
-class BlueprintDeleteRequest(BaseModel):
+class BlueprintDeleteRequest(FiabBaseModel):
     blueprint_id: BlueprintId
     version: int
 
 
-class BlueprintValidationExpansionResponse(BaseModel):
+class BlueprintValidationExpansionResponse(FiabBaseModel):
     """HTTP response for blueprint expand — mirrors BlueprintValidationExpansion from the service layer."""
 
     global_errors: list[str]
@@ -144,14 +144,14 @@ class BlueprintValidationExpansionResponse(BaseModel):
     resolved_configuration_options: dict[BlockInstanceId, dict[str, str]]
 
 
-class GlyphDetail(BaseModel):
+class GlyphDetail(FiabBaseModel):
     name: str
     display_name: str
     valueExample: str
     created_by: str
 
 
-class GlyphListResponse(BaseModel):
+class GlyphListResponse(FiabBaseModel):
     """Paginated list of glyphs, for both intrinsic and global types."""
 
     glyphs: list[GlyphDetail]
@@ -160,7 +160,7 @@ class GlyphListResponse(BaseModel):
     page_size: int
 
 
-class GlobalGlyphPostRequest(BaseModel):
+class GlobalGlyphPostRequest(FiabBaseModel):
     """Request body for creating or updating a global glyph.
 
     ``overriddable`` must be omitted (or ``None``) when ``public=False`` and must
@@ -173,7 +173,7 @@ class GlobalGlyphPostRequest(BaseModel):
     overriddable: bool | None = None
 
 
-class GlobalGlyphResponse(BaseModel):
+class GlobalGlyphResponse(FiabBaseModel):
     """Detail of a single global glyph, returned by get and post endpoints."""
 
     global_glyph_id: GlobalGlyphId
@@ -186,13 +186,13 @@ class GlobalGlyphResponse(BaseModel):
     updated_at: str
 
 
-class GlobalGlyphLookup(BaseModel):
+class GlobalGlyphLookup(FiabBaseModel):
     """Identifies a global glyph by its stable id."""
 
     global_glyph_id: GlobalGlyphId
 
 
-class GlyphFunctionDetail(BaseModel):
+class GlyphFunctionDetail(FiabBaseModel):
     """Description of a single custom function available in glyph expressions."""
 
     name: str
@@ -200,7 +200,7 @@ class GlyphFunctionDetail(BaseModel):
     kind: Literal["filter", "global"]
 
 
-class GlyphFunctionsResponse(BaseModel):
+class GlyphFunctionsResponse(FiabBaseModel):
     """All custom functions (filters and globals) registered in the interpolation environment."""
 
     functions: list[GlyphFunctionDetail]

--- a/backend/src/forecastbox/routes/experiment.py
+++ b/backend/src/forecastbox/routes/experiment.py
@@ -22,7 +22,7 @@ from typing import Annotated, cast
 
 from fastapi import APIRouter, Depends
 from fastapi.exceptions import HTTPException
-from pydantic import BaseModel, PositiveInt
+from pydantic import PositiveInt
 
 from forecastbox.domain.auth.users import get_auth_context
 from forecastbox.domain.blueprint.types import BlueprintId
@@ -34,6 +34,7 @@ from forecastbox.domain.run.types import RunId
 from forecastbox.schemata.jobs import ExperimentDefinition
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.pagination import PaginationSpec
+from forecastbox.utility.pydantic import FiabBaseModel
 from forecastbox.utility.time import current_time
 
 PREFIX = "/api/v1/experiment"
@@ -51,7 +52,7 @@ router = APIRouter(
 # ---------------------------------------------------------------------------
 
 
-class ExperimentLookup(BaseModel):
+class ExperimentLookup(FiabBaseModel):
     """Identifies an experiment, optionally pinning a specific version.
 
     Used as a Depends()-based query-param group on GET endpoints, and as a
@@ -62,7 +63,7 @@ class ExperimentLookup(BaseModel):
     version: int | None = None
 
 
-class ExperimentCreateRequest(BaseModel):
+class ExperimentCreateRequest(FiabBaseModel):
     blueprint_id: BlueprintId
     blueprint_version: int | None = None
     cron_expr: str
@@ -73,11 +74,11 @@ class ExperimentCreateRequest(BaseModel):
     tags: list[str] | None = None
 
 
-class ExperimentCreateResponse(BaseModel):
+class ExperimentCreateResponse(FiabBaseModel):
     experiment_id: ExperimentDefinitionId
 
 
-class ExperimentDetail(BaseModel):
+class ExperimentDetail(FiabBaseModel):
     experiment_id: ExperimentDefinitionId
     experiment_version: int
     blueprint_id: BlueprintId
@@ -92,7 +93,7 @@ class ExperimentDetail(BaseModel):
     tags: list[str] | None = None
 
 
-class ExperimentListResponse(BaseModel):
+class ExperimentListResponse(FiabBaseModel):
     experiments: list[ExperimentDetail]
     total: int
     page: int
@@ -100,7 +101,7 @@ class ExperimentListResponse(BaseModel):
     total_pages: int
 
 
-class ExperimentUpdateRequest(BaseModel):
+class ExperimentUpdateRequest(FiabBaseModel):
     """Update a cron-schedule experiment. ``version`` must match the current version."""
 
     experiment_id: ExperimentDefinitionId
@@ -111,14 +112,14 @@ class ExperimentUpdateRequest(BaseModel):
     first_run_override: dt.datetime | None = None
 
 
-class ExperimentDeleteRequest(BaseModel):
+class ExperimentDeleteRequest(FiabBaseModel):
     """Soft-delete an experiment. ``version`` must match the current version."""
 
     experiment_id: ExperimentDefinitionId
     version: int
 
 
-class ExperimentRunDetail(BaseModel):
+class ExperimentRunDetail(FiabBaseModel):
     run_id: RunId
     attempt_count: int
     status: str
@@ -127,7 +128,7 @@ class ExperimentRunDetail(BaseModel):
     experiment_context: str | None
 
 
-class ExperimentRunsResponse(BaseModel):
+class ExperimentRunsResponse(FiabBaseModel):
     runs: list[ExperimentRunDetail]
     total: int
     page: int

--- a/backend/src/forecastbox/routes/plugins.py
+++ b/backend/src/forecastbox/routes/plugins.py
@@ -19,13 +19,13 @@ from typing import Literal
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import RedirectResponse, Response
 from fiab_core.fable import PluginCompositeId
-from pydantic import BaseModel
 
 from forecastbox.domain.auth.users import UserRead
 from forecastbox.domain.plugin.manager import PluginsStatus, modify_enabled, status_full, submit_update_single, uninstall_plugin
 from forecastbox.domain.plugin.store import PluginRemoteInfo, PluginStoreEntry, get_plugins_detail, submit_install_plugin
 from forecastbox.routes.admin import get_admin_user
 from forecastbox.utility.config import config
+from forecastbox.utility.pydantic import FiabBaseModel
 
 PREFIX = "/api/v1/plugin"
 
@@ -35,7 +35,7 @@ router = APIRouter(
 )
 
 
-class PluginDetail(BaseModel):
+class PluginDetail(FiabBaseModel):
     status: Literal["available", "disabled", "errored", "loaded"]
     """Status of the plugin, mutually exclusive. All of (disabled, errored, loaded) imply that the plugin is installed"""
     store_info: PluginStoreEntry | None = None
@@ -50,7 +50,7 @@ class PluginDetail(BaseModel):
     """In case the plugin is installed, this shows the most recent update date"""
 
 
-class PluginListing(BaseModel):
+class PluginListing(FiabBaseModel):
     plugins: dict[PluginCompositeId, PluginDetail]
 
 

--- a/backend/src/forecastbox/routes/run.py
+++ b/backend/src/forecastbox/routes/run.py
@@ -28,7 +28,6 @@ from cascade.gateway import api, client
 from cascade.low.core import DatasetId, TaskId
 from fastapi import APIRouter, Depends, Response
 from fastapi.exceptions import HTTPException
-from pydantic import BaseModel
 
 from forecastbox.domain.auth.users import get_auth_context
 from forecastbox.domain.blueprint.types import BlueprintId
@@ -40,6 +39,7 @@ from forecastbox.routes.gateway import Globals
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.config import config
 from forecastbox.utility.pagination import PaginationSpec
+from forecastbox.utility.pydantic import FiabBaseModel
 
 PREFIX = "/api/v1/run"
 
@@ -56,7 +56,7 @@ router = APIRouter(
 # ---------------------------------------------------------------------------
 
 
-class RunLookup(BaseModel):
+class RunLookup(FiabBaseModel):
     """Identifies a job execution attempt, optionally pinning a specific attempt.
 
     Used as a Depends()-based query-param group on GET endpoints, and as a
@@ -67,17 +67,17 @@ class RunLookup(BaseModel):
     attempt_count: int | None = None
 
 
-class RunCreateRequest(BaseModel):
+class RunCreateRequest(FiabBaseModel):
     blueprint_id: BlueprintId
     blueprint_version: int | None = None
 
 
-class RunCreateResponse(BaseModel):
+class RunCreateResponse(FiabBaseModel):
     run_id: RunId
     attempt_count: int
 
 
-class RunDetailResponse(BaseModel):
+class RunDetailResponse(FiabBaseModel):
     run_id: RunId
     attempt_count: int
     status: str
@@ -90,7 +90,7 @@ class RunDetailResponse(BaseModel):
     cascade_job_id: str | None = None
 
 
-class RunListResponse(BaseModel):
+class RunListResponse(FiabBaseModel):
     runs: list[RunDetailResponse]
     total: int
     page: int
@@ -98,19 +98,19 @@ class RunListResponse(BaseModel):
     total_pages: int
 
 
-class RunRestartRequest(BaseModel):
+class RunRestartRequest(FiabBaseModel):
     """Identifies the attempt to restart. ``attempt_count`` must match the current latest attempt."""
 
     run_id: RunId
     attempt_count: int
 
 
-class RunRestartResponse(BaseModel):
+class RunRestartResponse(FiabBaseModel):
     run_id: RunId
     attempt_count: int
 
 
-class RunDeleteRequest(BaseModel):
+class RunDeleteRequest(FiabBaseModel):
     """Identifies the attempt to delete. ``attempt_count`` must match the current latest attempt."""
 
     run_id: RunId

--- a/backend/src/forecastbox/utility/config.py
+++ b/backend/src/forecastbox/utility/config.py
@@ -18,8 +18,10 @@ import toml
 from cascade.low.func import pydantic_recursive_collect
 from fiab_core.artifacts import ArtifactStoreId
 from fiab_core.fable import PluginCompositeId, PluginId, PluginStoreId
-from pydantic import BaseModel, BeforeValidator, Field, PlainSerializer, SecretStr, model_validator
+from pydantic import BeforeValidator, Field, PlainSerializer, SecretStr, model_validator
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict, TomlConfigSettingsSource
+
+from forecastbox.utility.pydantic import FiabBaseModel
 
 fiab_home = Path(os.environ["FIAB_ROOT"]) if "FIAB_ROOT" in os.environ else (Path.home() / ".fiab")
 logger = logging.getLogger(__name__)
@@ -38,7 +40,7 @@ class StatusMessage:
     gateway_running = "running"
 
 
-class DatabaseSettings(BaseModel):
+class DatabaseSettings(FiabBaseModel):
     sqlite_userdb_path: str = str(fiab_home / "user.db")
     """Location of the sqlite file for user auth+info"""
     sqlite_jobdb_path: str = str(fiab_home / "job.db")
@@ -56,7 +58,7 @@ class DatabaseSettings(BaseModel):
     # NOTE keep job and user dbs separate -- latter is more sensitive and likely to be externalized
 
 
-class OIDCSettings(BaseModel):
+class OIDCSettings(FiabBaseModel):
     client_id: str | None = None
     client_secret: SecretStr | None = None
     openid_configuration_endpoint: str | None = None
@@ -72,7 +74,7 @@ class OIDCSettings(BaseModel):
         return self
 
 
-class AuthSettings(BaseModel):
+class AuthSettings(FiabBaseModel):
     jwt_secret: SecretStr = SecretStr("fiab_secret")
     """JWT secret key for authentication."""
     oidc: OIDCSettings | None = None
@@ -100,7 +102,7 @@ class AuthSettings(BaseModel):
         return errors
 
 
-class GeneralSettings(BaseModel):
+class GeneralSettings(FiabBaseModel):
     launch_browser: bool = True
     """Whether a browser window should be opened after start. Used only when
     entrypoint.main.launch_all module is used"""
@@ -109,7 +111,7 @@ class GeneralSettings(BaseModel):
 PluginRefreshStrategy = Literal["automatic", "manual"]
 
 
-class PluginSettings(BaseModel):
+class PluginSettings(FiabBaseModel):
     """A pip-installable plugin with an importible module"""
 
     pip_source: str
@@ -128,7 +130,7 @@ PluginCompositeIdReadable = Annotated[
 PluginsSettings = dict[PluginCompositeIdReadable, PluginSettings]
 
 
-class PluginStoreConfig(BaseModel):
+class PluginStoreConfig(FiabBaseModel):
     url: str
     method: Literal["file", "localSingle"]
     """In case of file, the `url` points  to a json parseable as api.plugin.store.PluginStore
@@ -157,7 +159,7 @@ def _default_plugin_stores() -> PluginStoresConfig:
     }
 
 
-class ArtifactStoreConfig(BaseModel):
+class ArtifactStoreConfig(FiabBaseModel):
     url: str
     method: Literal["file"]
 
@@ -175,7 +177,7 @@ def _default_artifact_stores() -> ArtifactStoresConfig:
     }
 
 
-class ProductSettings(BaseModel):
+class ProductSettings(FiabBaseModel):
     pproc_schema_dir: str | None = None
     """Path to the directory containing the PPROC schema files."""
 
@@ -204,7 +206,7 @@ class ProductSettings(BaseModel):
             return []
 
 
-class BackendAPISettings(BaseModel):
+class BackendAPISettings(FiabBaseModel):
     data_path: str = str(fiab_home / "data_dir")
     """Path to the data directory."""
     model_repository: str = "https://sites.ecmwf.int/repository/fiab"
@@ -233,7 +235,7 @@ class BackendAPISettings(BaseModel):
         return errors
 
 
-class CascadeSettings(BaseModel):
+class CascadeSettings(FiabBaseModel):
     default_hosts: int = 1
     """Default number of hosts for Cascade if unspecified in a job."""
     max_hosts: int = 1

--- a/backend/src/forecastbox/utility/pagination.py
+++ b/backend/src/forecastbox/utility/pagination.py
@@ -9,10 +9,12 @@
 
 """Shared pagination contract used across routes and service layers."""
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
+
+from forecastbox.utility.pydantic import FiabBaseModel
 
 
-class PaginationSpec(BaseModel):
+class PaginationSpec(FiabBaseModel):
     """Query-parameter group for paginated list endpoints.
 
     Use with ``Depends()`` in FastAPI route signatures to accept ``page`` and

--- a/backend/src/forecastbox/utility/pydantic.py
+++ b/backend/src/forecastbox/utility/pydantic.py
@@ -1,0 +1,21 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Pydantic base model for forecastbox.
+
+Prefer FiabBaseModel over pydantic.BaseModel unless the model requires dynamic field handling.
+"""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class FiabBaseModel(BaseModel):
+    """Base pydantic model for forecastbox. Forbids extra fields to catch misconfigured constructors early."""
+
+    model_config = ConfigDict(extra="forbid")

--- a/backend/src/forecastbox/utility/rsjf/forms.py
+++ b/backend/src/forecastbox/utility/rsjf/forms.py
@@ -13,8 +13,10 @@
 
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 from typing_extensions import TypedDict
+
+from forecastbox.utility.pydantic import FiabBaseModel
 
 from .jsonSchema import FieldSchema
 from .uiSchema import UISchema
@@ -35,7 +37,7 @@ class ExportedSchemas(TypedDict):
 
 
 # Combined Schema + UI
-class FieldWithUI(BaseModel):
+class FieldWithUI(FiabBaseModel):
     """Combines a JSON Schema field with an optional UI Schema for RJSF."""
 
     jsonschema: FieldSchema
@@ -44,7 +46,7 @@ class FieldWithUI(BaseModel):
     """The UI Schema blueprint for the field (controls rendering and widgets)."""
 
 
-class FormDefinition(BaseModel):
+class FormDefinition(FiabBaseModel):
     """Defines a form using a set of fields, each with JSON Schema and optional UI Schema."""
 
     title: str

--- a/backend/src/forecastbox/utility/rsjf/from_pydantic.py
+++ b/backend/src/forecastbox/utility/rsjf/from_pydantic.py
@@ -11,7 +11,7 @@ from datetime import date
 from types import NoneType, UnionType
 from typing import Callable, Literal, Union, get_args, get_origin
 
-from pydantic import BaseModel
+from pydantic import BaseModel  # NOTE we require dynamicity, cant use FiabBaseModel here
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined
 

--- a/backend/src/forecastbox/utility/rsjf/jsonSchema.py
+++ b/backend/src/forecastbox/utility/rsjf/jsonSchema.py
@@ -13,7 +13,7 @@
 
 from typing import Any, Literal, Union
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field  # NOTE we need dynamicity, cant use FiabBaseModel
 
 
 # Base Schema with discriminator

--- a/backend/src/forecastbox/utility/rsjf/uiSchema.py
+++ b/backend/src/forecastbox/utility/rsjf/uiSchema.py
@@ -13,10 +13,12 @@
 
 from typing import Any, Union
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from forecastbox.utility.pydantic import FiabBaseModel
 
 
-class UIField(BaseModel):
+class UIField(FiabBaseModel):
     """Base UI schema field for RJSF.
 
     See Also


### PR DESCRIPTION
…rbid

Create package-specific pydantic base models that set ConfigDict(extra='forbid') to catch misconfigured constructors early rather than silently ignoring extra fields.

- fiab_core/pydantic_utils.py: new FiabCoreBaseModel base class
- forecastbox/utility/pydantic.py: new FiabBaseModel base class
- All pydantic.BaseModel subclasses in both packages now inherit from their respective base model
- from_pydantic.py type annotations retain pydantic.BaseModel since they check for any pydantic model generically
- jsonSchema.BaseSchema retains extra='allow' in its own model_config, which overrides the base model setting (intentional for JSON Schema types)
- backend/development.md: note to use FiabBaseModel/FiabCoreBaseModel
