### PR TITLE
fix: artifact store pointing to main instead of commit

### DIFF
--- a/backend/src/forecastbox/utility/config.py
+++ b/backend/src/forecastbox/utility/config.py
@@ -170,8 +170,7 @@ ArtifactStoresConfig = dict[ArtifactStoreId, ArtifactStoreConfig]
 def _default_artifact_stores() -> ArtifactStoresConfig:
     return {
         ArtifactStoreId("ecmwf"): ArtifactStoreConfig(
-            # TODO fix pre merge
-            url="https://raw.githubusercontent.com/ecmwf/forecast-in-a-box/d092af0130a1bc4b09d25d9f1785b94fe1e54b18/install/artifacts.json",
+            url="https://raw.githubusercontent.com/ecmwf/forecast-in-a-box/refs/heads/main/install/artifacts.json",
             method="file",
         ),
     }


### PR DESCRIPTION
### Description
This pull request updates the default configuration for the ECMWF artifact store to ensure it always points to the latest artifacts. The most important change is:

Configuration update:

* Updated the `url` in the `ArtifactStoreConfig` for ECMWF to reference the `main` branch instead of a specific commit, ensuring the artifact store always uses the latest version.
### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
