### PR TITLE
test: add integration test for jinja interpolation via /expand endpoint

### DIFF
--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -198,7 +198,12 @@ async def validate_expand(
             block_errors[blockId] += [f"Unknown glyphs referenced: {unknown_glyphs}"]
             invalidable.add(blockId)
             continue
-        resolution.resolve_configurations(blockInstance, all_glyphs)
+        try:
+            resolution.resolve_configurations(blockInstance, all_glyphs)
+        except Exception as exc:
+            block_errors[blockId] += [f"Jinja expression error: {exc}"]
+            invalidable.add(blockId)
+            continue
         # A glyph value may itself reference an unknown glyph (e.g. myPath="${root}/${missing}").
         # After substitution those unresolved ${...} patterns survive in the config values;
         # a second extract_glyphs pass surfaces them.

--- a/backend/src/forecastbox/domain/glyphs/resolution.py
+++ b/backend/src/forecastbox/domain/glyphs/resolution.py
@@ -62,6 +62,10 @@ def extract_glyphs(blockInstance: BlockInstance) -> Either[ExtractedGlyphs, list
         if result.t:
             glyphs.update(result.t)
             glyphed_options.add(key)
+        elif _GLYPH_PATTERN.search(value) or "${" in value:
+            # The value contains ${...} but all names are jinja globals/filters, not glyph variables.
+            # Still mark it as glyphed so its rendered result appears in resolved_configuration_options.
+            glyphed_options.add(key)
     if errors:
         return Either.error(errors)
     return Either.ok(ExtractedGlyphs(glyphs=glyphs, glyphed_options=glyphed_options))

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -649,6 +649,49 @@ def test_blueprint_composite_glyph_expand(tmpdir: Any, backend_client_with_auth:
     assert any("circular" in err.lower() or "cycle" in err.lower() for err in cyclic_data["global_errors"])
 
 
+def test_blueprint_jinja_interpolation_expand(backend_client_with_auth: httpx.Client) -> None:
+    """Jinja interpolation is validated and resolved via the /expand endpoint.
+
+    Covers:
+    - A malformed jinja expression such as ``${startDatetime | this-is-no-filter}`` results in
+      block_errors (the expand endpoint always returns 200; callers inspect block_errors).
+      Jinja2 parses ``this-is-no-filter`` as subtraction so the tokens ``is``, ``no``, ``filter``
+      are treated as unknown glyph variables and reported accordingly.
+    - A well-formed pure-jinja expression ``${(datetime(2024, 1, 15) + timedelta(days=1)) | floor_day}``
+      (using only registered globals/filters, no glyph variables) is evaluated correctly and its
+      resolved value appears in resolved_configuration_options.
+    """
+    # Malformed: hyphens make `this-is-no-filter` parsed as subtraction; the resulting "glyph"
+    # names (is, no, filter) are unknown, so the block gets an error entry.
+    source_malformed = BlockInstance(
+        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_text")),
+        configuration_values={"text": "${startDatetime | this-is-no-filter}"},
+        input_ids={},
+    )
+    builder_malformed = BlueprintBuilder(blocks={BlockInstanceId("source_text"): source_malformed})
+    response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder_malformed.model_dump())
+    assert response.is_success, response.text
+    data = response.json()
+    assert "source_text" in data["block_errors"], f"Expected block error for malformed jinja: {data}"
+    assert any("Unknown glyphs referenced" in err for err in data["block_errors"]["source_text"])
+
+    # Well-formed: pure jinja arithmetic using registered globals (datetime, timedelta) and filter (floor_day).
+    # Parentheses are required because Jinja2's | (filter) has higher precedence than +.
+    # (datetime(2024, 1, 15) + timedelta(days=1)) | floor_day = 2024-01-16 00:00:00
+    source_wellformed = BlockInstance(
+        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_text")),
+        configuration_values={"text": "${(datetime(2024, 1, 15) + timedelta(days=1)) | floor_day}"},
+        input_ids={},
+    )
+    builder_wellformed = BlueprintBuilder(blocks={BlockInstanceId("source_text"): source_wellformed})
+    response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder_wellformed.model_dump())
+    assert response.is_success, response.text
+    data = response.json()
+    assert len(data["block_errors"]) == 0, data["block_errors"]
+    resolved = data["resolved_configuration_options"]["source_text"]["text"]
+    assert resolved == "2024-01-16 00:00:00", f"Unexpected resolved value: {resolved!r}"
+
+
 def test_blueprint_composite_glyph_execute(tmpdir: Any, backend_client_with_auth: httpx.Client) -> None:
     """Execute a blueprint whose config value is resolved via a composite local glyph.
 

--- a/backend/tests/unit/domain/glyphs/test_resolution.py
+++ b/backend/tests/unit/domain/glyphs/test_resolution.py
@@ -293,10 +293,13 @@ def test_extract_glyphs_excludes_globals() -> None:
 
 
 def test_extract_glyphs_pure_arithmetic_no_variables() -> None:
+    # A value with ${...} containing only constants/globals (no glyph variable names)
+    # must still be added to glyphed_options so it gets rendered and returned in
+    # resolved_configuration_options.
     block = _block({"key": "${42 ** 10}"})
     result = extract_glyphs(block)
     assert result.e is None
-    assert result.t == ExtractedGlyphs(glyphs=set(), glyphed_options=set())
+    assert result.t == ExtractedGlyphs(glyphs=set(), glyphed_options={"key"})
 
 
 def test_extract_glyphs_multiple_variables_in_expression() -> None:


### PR DESCRIPTION
Add test_blueprint_jinja_interpolation_expand to verify:
- A malformed jinja expression (invalid filter name with hyphens) causes block_errors (Jinja2 parses hyphens as subtraction, treating is, no, filter as unknown glyph variables)
- A well-formed pure-jinja expression using registered globals/filters (datetime, timedelta, floor_day) resolves to the correct value

Fix two related bugs found during implementation:
- extract_glyphs: pure-jinja expressions with only globals/filters and no glyph variable names were not added to glyphed_options, so their rendered values never appeared in resolved_configuration_options. Fixed by checking for any dollar-brace opener in the value when result.t is empty.
- validate_expand: runtime errors from render_expression (e.g. AttributeError from operator precedence issues) were unhandled, causing 500 responses. Wrapped resolve_configurations in try/except and surface as block_errors.