### PR TITLE
[fiab-plugin-ecmwf] fix: pass input_source to anemoi env builder

### DIFF
--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
@@ -47,7 +47,7 @@ class AnemoiBuilder:
     def _local_path(self) -> Path:
         return get_local_path(self.artifact_id)
 
-    def build(self, lead_time: int) -> Inference:  # type: ignore[reportReturnType]
+    def build(self, lead_time: int, input_source: str | None = None) -> Inference:  # type: ignore[reportReturnType]
         import functools
 
         class WrappedInference(Inference):
@@ -62,7 +62,7 @@ class AnemoiBuilder:
         return WrappedInference(
             ckpt=self._local_path(),
             lead_time=lead_time,
-            environment=get_environment(self.artifact_id),
+            environment=get_environment(self.artifact_id, input_source),
             metadata=get_metadata(self.artifact_id),
         )
 
@@ -117,7 +117,10 @@ class AnemoiSource(Source):
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         configuration = block.configuration_values
 
-        inference = AnemoiBuilder(configuration["checkpoint"]).build(lead_time=int(configuration["lead_time"]))
+        inference = AnemoiBuilder(configuration["checkpoint"]).build(
+            lead_time=int(configuration["lead_time"]),
+            input_source=configuration["input_source"],
+        )
         action = inference.from_input(
             configuration["input_source"],
             date=configuration["base_time"],


### PR DESCRIPTION
### Description

- `AnemoiBuilder.build()` does not pass the user-selected input_source through. As a result, forecasts using the `opendata` source failed at runtime.

- Add `input_source: str | None = None` kwarg to `AnemoiBuilder.build` and forward it to `get_environment`.
- `AnemoiSource.compile` now passes `configuration["input_source"]` when building the Inference.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
