### PR TITLE
[backend] make plugins lazy loaded

### DIFF
--- a/backend/packages/fiab-core/src/fiab_core/tools/plugins.py
+++ b/backend/packages/fiab-core/src/fiab_core/tools/plugins.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Callable, cast
 
 from cascade.low.func import Either
 from earthkit.workflows.fluent import Action
@@ -43,7 +43,7 @@ class QubedPluginBuilder:
         factory = self.block_builders[block.factory_id.factory]
         return factory.compile(inputs, block_id, block)
 
-    def as_plugin(self) -> Plugin:
+    def as_plugin(self) -> Callable[[], Plugin]:
         def _generic_expand(block: BlockInstanceOutput) -> list[BlockFactoryId]:
             if isinstance(block, QubedOutput):
                 return self.expand(block)
@@ -58,7 +58,7 @@ class QubedPluginBuilder:
                 inputs_validated = cast(dict[str, QubedOutput], inputs)
                 return self.validate(block, inputs_validated)
 
-        return Plugin(
+        return lambda: Plugin(
             catalogue=BlockFactoryCatalogue(
                 factories={factory_id: factory.as_catalogue() for factory_id, factory in self.block_builders.items()}
             ),

--- a/backend/packages/fiab-plugin-demo/tests/test_blocks.py
+++ b/backend/packages/fiab-plugin-demo/tests/test_blocks.py
@@ -51,11 +51,11 @@ def dummy_output() -> QubedOutput:
 
 
 def test_plugin_catalogue_contains_all_demo_blocks() -> None:
-    assert set(plugin.catalogue.factories.keys()) == EXPECTED_FACTORY_IDS
+    assert set(plugin().catalogue.factories.keys()) == EXPECTED_FACTORY_IDS
 
 
 def test_plugin_expands_qubed_output_to_all_demo_blocks(dummy_output: QubedOutput) -> None:
-    assert set(plugin.expander(dummy_output)) == EXPECTED_FACTORY_IDS
+    assert set(plugin().expander(dummy_output)) == EXPECTED_FACTORY_IDS
 
 
 @pytest.mark.parametrize(

--- a/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
+++ b/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
@@ -17,17 +17,12 @@ from fiab_core.plugin import Error, Plugin
 
 
 def _get_checkpoint_enum_type() -> str:
-    try:
-        available = ArtifactsProvider.get_checkpoint_lookup()
-    except Exception:
-        return "str"
-    if not available:
-        return "str"
+    available = ArtifactsProvider.get_checkpoint_lookup()
     values = ", ".join(f"'{CompositeArtifactId.to_str(k)}'" for k in available.keys())
     return f"enum[{values}]"
 
 
-catalogue = BlockFactoryCatalogue(
+catalogue = lambda: BlockFactoryCatalogue(
     factories={
         BlockFactoryId("source_42"): BlockFactory(
             kind="source",
@@ -165,4 +160,4 @@ def compiler(lookup: ActionLookup, bid: BlockInstanceId, instance: BlockInstance
     return Either.ok(action)
 
 
-plugin = Plugin(catalogue=catalogue, validator=validator, expander=expander, compiler=compiler)
+plugin = lambda: Plugin(catalogue=catalogue(), validator=validator, expander=expander, compiler=compiler)

--- a/backend/packages/fiab-plugin-test/tests/conftest.py
+++ b/backend/packages/fiab-plugin-test/tests/conftest.py
@@ -1,0 +1,10 @@
+from unittest.mock import MagicMock
+
+import pytest
+from fiab_core.artifacts import ArtifactsProvider, CompositeArtifactId
+
+
+@pytest.fixture(scope="session", autouse=True)
+def register_artifacts_provider() -> None:
+    fake_id = CompositeArtifactId.from_str("mystore:mycheckpoint")
+    ArtifactsProvider.register_get_checkpoint_lookup(lambda: {fake_id: MagicMock()})

--- a/backend/packages/fiab-plugin-test/tests/test_base.py
+++ b/backend/packages/fiab-plugin-test/tests/test_base.py
@@ -57,49 +57,21 @@ def test_source_filesize_missing_file_raises(tmp_path: pathlib.Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# _get_checkpoint_enum_type helper
-# ---------------------------------------------------------------------------
-
-
-def test_get_checkpoint_enum_type_returns_str_when_provider_unregistered() -> None:
-    original = ArtifactsProvider._get_checkpoint_lookup
-    ArtifactsProvider._get_checkpoint_lookup = None  # type: ignore[assignment]
-    try:
-        result = _get_checkpoint_enum_type()
-    finally:
-        ArtifactsProvider._get_checkpoint_lookup = original
-    assert result == "str"
-
-
-def test_get_checkpoint_enum_type_returns_str_when_no_checkpoints() -> None:
-    with patch.object(ArtifactsProvider, "get_checkpoint_lookup", return_value={}):
-        result = _get_checkpoint_enum_type()
-    assert result == "str"
-
-
-def test_get_checkpoint_enum_type_returns_enum_with_checkpoints() -> None:
-    fake_id = CompositeArtifactId.from_str("mystore:mycheckpoint")
-    with patch.object(ArtifactsProvider, "get_checkpoint_lookup", return_value={fake_id: MagicMock()}):
-        result = _get_checkpoint_enum_type()
-    assert result == "enum['mystore:mycheckpoint']"
-
-
-# ---------------------------------------------------------------------------
 # catalogue
 # ---------------------------------------------------------------------------
 
 
 def test_catalogue_contains_source_filesize() -> None:
-    assert BlockFactoryId("source_filesize") in catalogue.factories
+    assert BlockFactoryId("source_filesize") in catalogue().factories
 
 
 def test_source_filesize_factory_is_source_kind() -> None:
-    factory = catalogue.factories[BlockFactoryId("source_filesize")]
+    factory = catalogue().factories[BlockFactoryId("source_filesize")]
     assert factory.kind == "source"
 
 
 def test_source_filesize_factory_has_checkpoint_option() -> None:
-    factory = catalogue.factories[BlockFactoryId("source_filesize")]
+    factory = catalogue().factories[BlockFactoryId("source_filesize")]
     assert "checkpoint" in factory.configuration_options
 
 

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -117,10 +117,14 @@ def load_single(plugin: PluginSettings) -> Plugin | str:
         errors.append(f"failed to import plugin {plugin.module_name}")
     elif not hasattr(plugin_impl, "plugin"):
         errors.append(f"plugin {plugin.module_name} does not have a `plugin` attribute")
-    elif not isinstance(getattr(plugin_impl, "plugin"), Plugin):
-        errors.append(f"plugin {plugin.module_name}'s `plugin` is not a Plugin")
-    else:
-        return getattr(plugin_impl, "plugin")
+    try:
+        maybe_plugin = getattr(plugin_impl, "plugin")()
+        if not isinstance(maybe_plugin, Plugin):
+            errors.append(f"plugin {plugin.module_name}'s `plugin()` does not give a Plugin")
+        else:
+            return maybe_plugin
+    except Exception as e:
+        errors.append("failed to invoke plugin(): {repr(e)}")
     return "\n".join(errors)
 
 


### PR DESCRIPTION
1. Makes plugin loading (possibly) lazy -- instead of expecting a `plugin: Plugin` class, we expect a plugin function whole invocation should return a `Plugin`
2. We remove the try-catch around artifacts manager invocation in the test plugin. This was not possible with eager plugins as it caused a runtime crash