### PR TITLE
fix: Add config additions for initial conditions

### DIFF
--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
@@ -41,6 +41,7 @@ INPUT_SOURCE_EXTRAS: dict[str, list[str]] = {
     "polytope": ["anemoi-plugins-ecmwf-inference[polytope]"],
     "mars": ["earthkit-data[mars]"],
 }
+INPUT_SOURCE_CONFIGURATION_OPTIONS = {"polytope": {"collection": "initial-conditions"}}
 
 
 class AnemoiBuilder:
@@ -68,6 +69,7 @@ class AnemoiBuilder:
         env = get_environment(self.artifact_id)
         if extra_environment:
             env.extend(extra_environment)
+
         return WrappedInference(
             ckpt=self._local_path(),
             lead_time=lead_time,
@@ -129,8 +131,12 @@ class AnemoiSource(Source):
         inference = AnemoiBuilder(configuration["checkpoint"]).build(
             lead_time=int(configuration["lead_time"]), extra_environment=INPUT_SOURCE_EXTRAS.get(configuration["input_source"], [])
         )
+        input_source = configuration["input_source"]
+        if input_source in INPUT_SOURCE_CONFIGURATION_OPTIONS and not isinstance(input_source, dict):
+            input_source = {input_source: INPUT_SOURCE_CONFIGURATION_OPTIONS[input_source]}
+
         action = inference.from_input(
-            configuration["input_source"],
+            input_source,
             date=configuration["base_time"],
             ensemble_members=int(configuration.get("ensemble_members") or 1),
         )


### PR DESCRIPTION
### Description
This pull request introduces enhancements to how input source configuration options are handled in the `fiab-plugin-ecmwf` package, specifically in the `anemoi/blocks.py` module. The main change is the addition of a mechanism to supply extra configuration options for certain input sources, improving flexibility and maintainability.

Key changes:

**Input source configuration handling:**

* Added the `INPUT_SOURCE_CONFIGURATION_OPTIONS` dictionary to specify extra configuration options (such as `"collection": "initial-conditions"`) for specific input sources like `"polytope"`.
* Updated the `compile` function to check if the input source requires extra configuration options and, if so, wraps it in a dictionary accordingly before passing it to `from_input`. This ensures that input sources like `"polytope"` are properly configured.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
