### PR TITLE
Feat/skinny wms

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
   "pydantic-settings",
   "pyrsistent",
   "python-multipart",
+  "skinnywms",
   "starlette>=1.0", # NOTE we actually dont depend on starlette directly, only via fastapi/sse, but our code is already assuming 1.0+
   "sse-starlette",
   "toml",

--- a/backend/src/forecastbox/domain/lens/__init__.py
+++ b/backend/src/forecastbox/domain/lens/__init__.py
@@ -1,0 +1,8 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.

--- a/backend/src/forecastbox/domain/lens/__init__.py
+++ b/backend/src/forecastbox/domain/lens/__init__.py
@@ -6,3 +6,13 @@
 # In applying this licence, ECMWF does not waive the privileges and immunities
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
+
+"""
+Manages the Lens domain -- external inspection tools (e.g. skinnyWMS) that clients
+can launch against the outputs of individual Runs for interactive visualisation and
+exploration.
+
+Does not depend on any other domain, and is not depended on by any other domain.
+The association between a Lens instance and a specific Run output is handled
+explicitly by the client.
+"""

--- a/backend/src/forecastbox/domain/lens/manager.py
+++ b/backend/src/forecastbox/domain/lens/manager.py
@@ -100,15 +100,20 @@ def start_skinny_wms(local_path: str) -> LensInstanceId:
             raise TimeoutError("Failed to acquire lens manager lock")
         LensInstanceManager.instances = LensInstanceManager.instances.set(instance_id, instance)
 
-    cmd = ["uv", "run", "gunicorn", "--bind", f"0.0.0.0:{port}", "skinnywms.wmssvr:application"]
-    env = {**os.environ, "SKINNYWMS_DATA_PATH": local_path}
-    process: subprocess.Popen[bytes] = subprocess.Popen(
-        cmd,
-        env=env,
-        start_new_session=True,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+    failed: str | None = None
+    try:
+        cmd = ["uv", "run", "gunicorn", "--bind", f"127.0.0.1:{port}", "skinnywms.wmssvr:application"]
+        env = {**os.environ, "SKINNYWMS_DATA_PATH": local_path}
+        process: subprocess.Popen[bytes] = subprocess.Popen(
+            cmd,
+            env=env,
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except Exception as e:
+        failed = repr(e)
+        logger.error(f"failed to start skinny wms: {failed}")
 
     with timed_acquire(LensInstanceManager.lock, timeout_acquire) as acquired:
         if not acquired:
@@ -119,6 +124,9 @@ def start_skinny_wms(local_path: str) -> LensInstanceId:
             shutdown_popen(process)
             FreePortsManager.release_port(port)
             raise RuntimeError(f"Lens instance {instance_id} was removed during startup")
+        if failed is not None:
+            FreePortsManager.release_port(port)
+            raise RuntimeError(f"Lens instance {instance_id} failed to start with {failed}")
         updated = LensInstance(
             process=process,
             lens_params=instance.lens_params,

--- a/backend/src/forecastbox/domain/lens/manager.py
+++ b/backend/src/forecastbox/domain/lens/manager.py
@@ -1,0 +1,176 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Lens domain -- managing external inspection tool processes (Lens Instances).
+
+Lenses are external processes (e.g. skinnyWMS) that allow interactive inspection
+of Run outputs. This module manages their lifecycle: starting, monitoring, and stopping.
+
+Synchronization uses a single lock protecting the LensInstanceManager's instances map.
+Pyrsistent immutable structures allow safe lock-free reads.
+"""
+
+import logging
+import os
+import subprocess
+import threading
+import uuid
+from dataclasses import dataclass
+from typing import Any, Literal, NewType
+
+from cascade.low.func import assert_never
+from pyrsistent import pmap
+from pyrsistent.typing import PMap
+
+from forecastbox.utility.concurrent import FreePortsManager, shutdown_popen, timed_acquire
+from forecastbox.utility.pydantic import FiabBaseModel
+
+logger = logging.getLogger(__name__)
+
+LensInstanceId = NewType("LensInstanceId", str)
+LensName = Literal["skinnyWMS"]
+
+timeout_acquire = 1
+
+
+class LensStatus(FiabBaseModel):
+    status: Literal["starting", "running", "terminated", "failed"]
+    lens_name: LensName
+    lens_params: dict[str, Any]
+
+
+@dataclass
+class LensInstance:
+    process: subprocess.Popen[bytes] | None
+    lens_params: dict[str, Any]
+    lens_name: LensName
+    ports: set[int]
+
+
+class LensInstanceManager:
+    lock: threading.Lock = threading.Lock()
+    instances: PMap[LensInstanceId, LensInstance] = pmap()
+
+
+def _compute_status(instance: LensInstance) -> LensStatus:
+    if instance.lens_name == "skinnyWMS":
+        if instance.process is None:
+            status: Literal["starting", "running", "terminated", "failed"] = "starting"
+        elif instance.process.poll() is None:
+            status = "running"
+        elif instance.process.returncode == 0:
+            status = "terminated"
+        else:
+            status = "failed"
+    else:
+        assert_never(instance.lens_name)
+
+    return LensStatus(status=status, lens_name=instance.lens_name, lens_params=instance.lens_params)
+
+
+def start_skinny_wms(local_path: str) -> LensInstanceId:
+    """Start a skinnyWMS instance serving the given local_path.
+
+    Claims a port, registers the instance (process=None while starting), spawns
+    the process via uv, then updates the instance with the running process.
+    If the instance was removed from the manager during startup, shuts down the
+    process and raises RuntimeError.
+    """
+    port = FreePortsManager.claim_port()
+    instance_id = LensInstanceId(str(uuid.uuid4()))
+    instance = LensInstance(
+        process=None,
+        lens_params={"local_path": local_path},
+        lens_name="skinnyWMS",
+        ports={port},
+    )
+
+    with timed_acquire(LensInstanceManager.lock, timeout_acquire) as acquired:
+        if not acquired:
+            FreePortsManager.release_port(port)
+            raise TimeoutError("Failed to acquire lens manager lock")
+        LensInstanceManager.instances = LensInstanceManager.instances.set(instance_id, instance)
+
+    cmd = ["uv", "run", "skinny-wms", "--path", local_path]
+    env = {**os.environ, "SKINNYWMS_PORT": str(port), "SKINNYWMS_HOST": "127.0.0.1"}
+    process: subprocess.Popen[bytes] = subprocess.Popen(
+        cmd,
+        env=env,
+        start_new_session=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    with timed_acquire(LensInstanceManager.lock, timeout_acquire) as acquired:
+        if not acquired:
+            shutdown_popen(process)
+            FreePortsManager.release_port(port)
+            raise TimeoutError("Failed to acquire lens manager lock for update")
+        if instance_id not in LensInstanceManager.instances:
+            shutdown_popen(process)
+            FreePortsManager.release_port(port)
+            raise RuntimeError(f"Lens instance {instance_id} was removed during startup")
+        updated = LensInstance(
+            process=process,
+            lens_params=instance.lens_params,
+            lens_name=instance.lens_name,
+            ports=instance.ports,
+        )
+        LensInstanceManager.instances = LensInstanceManager.instances.set(instance_id, updated)
+
+    return instance_id
+
+
+def get_status(instance_id: LensInstanceId) -> LensStatus:
+    """Return the status of a lens instance. Raises KeyError if not found."""
+    instance = LensInstanceManager.instances.get(instance_id)
+    if instance is None:
+        raise KeyError(instance_id)
+    return _compute_status(instance)
+
+
+def list_instances() -> list[tuple[LensInstanceId, LensStatus]]:
+    """Return all lens instances with their current status. Lock-free read."""
+    instances = LensInstanceManager.instances
+    return [(iid, _compute_status(inst)) for iid, inst in instances.items()]
+
+
+def stop_instance(instance_id: LensInstanceId) -> None:
+    """Stop and remove a lens instance, releasing its ports.
+
+    Raises KeyError if the instance is not found.
+    The port is always released in a finally block to prevent leaks.
+    """
+    instance: LensInstance | None = None
+    try:
+        with timed_acquire(LensInstanceManager.lock, timeout_acquire) as acquired:
+            if not acquired:
+                raise TimeoutError("Failed to acquire lens manager lock")
+            if instance_id not in LensInstanceManager.instances:
+                raise KeyError(instance_id)
+            instance = LensInstanceManager.instances[instance_id]
+            LensInstanceManager.instances = LensInstanceManager.instances.remove(instance_id)
+        if instance.process is not None:
+            shutdown_popen(instance.process)
+    finally:
+        if instance is not None:
+            for port in instance.ports:
+                FreePortsManager.release_port(port)
+
+
+def shutdown_all_instances() -> None:
+    """Stop all running lens instances. Used during application shutdown."""
+    instances = LensInstanceManager.instances
+    for instance_id in list(instances.keys()):
+        try:
+            stop_instance(instance_id)
+        except KeyError:
+            pass  # already removed
+        except Exception as e:
+            logger.warning(f"Failed to stop lens instance {instance_id} during shutdown: {repr(e)}")

--- a/backend/src/forecastbox/domain/lens/manager.py
+++ b/backend/src/forecastbox/domain/lens/manager.py
@@ -100,8 +100,8 @@ def start_skinny_wms(local_path: str) -> LensInstanceId:
             raise TimeoutError("Failed to acquire lens manager lock")
         LensInstanceManager.instances = LensInstanceManager.instances.set(instance_id, instance)
 
-    cmd = ["uv", "run", "skinny-wms", "--path", local_path]
-    env = {**os.environ, "SKINNYWMS_PORT": str(port), "SKINNYWMS_HOST": "127.0.0.1"}
+    cmd = ["uv", "run", "gunicorn", "--bind", f"0.0.0.0:{port}", "skinnywms.wmssvr:application"]
+    env = {**os.environ, "SKINNYWMS_DATA_PATH": local_path}
     process: subprocess.Popen[bytes] = subprocess.Popen(
         cmd,
         env=env,

--- a/backend/src/forecastbox/domain/lens/manager.py
+++ b/backend/src/forecastbox/domain/lens/manager.py
@@ -28,21 +28,23 @@ from cascade.low.func import assert_never
 from pyrsistent import pmap
 from pyrsistent.typing import PMap
 
-from forecastbox.utility.concurrent import FreePortsManager, shutdown_popen, timed_acquire
+from forecastbox.utility.concurrent import FreePortsManager, NoFreePortsException, shutdown_popen, timed_acquire
 from forecastbox.utility.pydantic import FiabBaseModel
 
 logger = logging.getLogger(__name__)
 
 LensInstanceId = NewType("LensInstanceId", str)
 LensName = Literal["skinnyWMS"]
+LensStatus = Literal["starting", "running", "terminated", "failed"]
 
 timeout_acquire = 1
 
 
-class LensStatus(FiabBaseModel):
-    status: Literal["starting", "running", "terminated", "failed"]
+class LensInstanceDetail(FiabBaseModel):
+    status: LensStatus
     lens_name: LensName
     lens_params: dict[str, Any]
+    ports: set[int]
 
 
 @dataclass
@@ -58,10 +60,11 @@ class LensInstanceManager:
     instances: PMap[LensInstanceId, LensInstance] = pmap()
 
 
-def _compute_status(instance: LensInstance) -> LensStatus:
+def _compute_status(instance: LensInstance) -> LensInstanceDetail:
+    status: LensStatus
     if instance.lens_name == "skinnyWMS":
         if instance.process is None:
-            status: Literal["starting", "running", "terminated", "failed"] = "starting"
+            status = "starting"
         elif instance.process.poll() is None:
             status = "running"
         elif instance.process.returncode == 0:
@@ -71,7 +74,7 @@ def _compute_status(instance: LensInstance) -> LensStatus:
     else:
         assert_never(instance.lens_name)
 
-    return LensStatus(status=status, lens_name=instance.lens_name, lens_params=instance.lens_params)
+    return LensInstanceDetail(status=status, lens_name=instance.lens_name, lens_params=instance.lens_params, ports=instance.ports)
 
 
 def start_skinny_wms(local_path: str) -> LensInstanceId:
@@ -127,7 +130,7 @@ def start_skinny_wms(local_path: str) -> LensInstanceId:
     return instance_id
 
 
-def get_status(instance_id: LensInstanceId) -> LensStatus:
+def get_status(instance_id: LensInstanceId) -> LensInstanceDetail:
     """Return the status of a lens instance. Raises KeyError if not found."""
     instance = LensInstanceManager.instances.get(instance_id)
     if instance is None:
@@ -135,7 +138,7 @@ def get_status(instance_id: LensInstanceId) -> LensStatus:
     return _compute_status(instance)
 
 
-def list_instances() -> list[tuple[LensInstanceId, LensStatus]]:
+def list_instances() -> list[tuple[LensInstanceId, LensInstanceDetail]]:
     """Return all lens instances with their current status. Lock-free read."""
     instances = LensInstanceManager.instances
     return [(iid, _compute_status(inst)) for iid, inst in instances.items()]
@@ -164,7 +167,7 @@ def stop_instance(instance_id: LensInstanceId) -> None:
                 FreePortsManager.release_port(port)
 
 
-def shutdown_all_instances() -> None:
+def shutdown_all_lens_instances() -> None:
     """Stop all running lens instances. Used during application shutdown."""
     instances = LensInstanceManager.instances
     for instance_id in list(instances.keys()):

--- a/backend/src/forecastbox/entrypoint/app.py
+++ b/backend/src/forecastbox/entrypoint/app.py
@@ -33,7 +33,7 @@ from forecastbox.domain.admin import get_local_release
 from forecastbox.domain.artifact.base import get_artifact_local_path
 from forecastbox.domain.artifact.manager import ArtifactManager, join_artifact_manager, submit_refresh_catalog
 from forecastbox.domain.experiment.scheduling.background import start_scheduler, stop_scheduler
-from forecastbox.domain.lens.manager import shutdown_all_instances
+from forecastbox.domain.lens.manager import shutdown_all_lens_instances
 from forecastbox.domain.plugin.manager import join_updater_thread, submit_load_plugins
 from forecastbox.domain.plugin.store import join_stores_thread, submit_initialize_stores
 from forecastbox.routes.gateway import shutdown_processes
@@ -63,7 +63,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     yield
     if config.api.allow_scheduler:
         stop_scheduler()
-    shutdown_all_instances()
+    shutdown_all_lens_instances()
     await shutdown_processes()
     join_updater_thread(timeout_sec=10)
     join_stores_thread(timeout_sec=10)

--- a/backend/src/forecastbox/entrypoint/app.py
+++ b/backend/src/forecastbox/entrypoint/app.py
@@ -33,6 +33,7 @@ from forecastbox.domain.admin import get_local_release
 from forecastbox.domain.artifact.base import get_artifact_local_path
 from forecastbox.domain.artifact.manager import ArtifactManager, join_artifact_manager, submit_refresh_catalog
 from forecastbox.domain.experiment.scheduling.background import start_scheduler, stop_scheduler
+from forecastbox.domain.lens.manager import shutdown_all_instances
 from forecastbox.domain.plugin.manager import join_updater_thread, submit_load_plugins
 from forecastbox.domain.plugin.store import join_stores_thread, submit_initialize_stores
 from forecastbox.routes.gateway import shutdown_processes
@@ -62,6 +63,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     yield
     if config.api.allow_scheduler:
         stop_scheduler()
+    shutdown_all_instances()
     await shutdown_processes()
     join_updater_thread(timeout_sec=10)
     join_stores_thread(timeout_sec=10)

--- a/backend/src/forecastbox/entrypoint/bootstrap/procs.py
+++ b/backend/src/forecastbox/entrypoint/bootstrap/procs.py
@@ -4,14 +4,13 @@
 """
 
 import logging
-import os
-import signal
 from dataclasses import dataclass
 from multiprocessing import connection
 from multiprocessing.process import BaseProcess
-from typing import cast
 
 import psutil
+
+from forecastbox.utility.concurrent import shutdown_correctly
 
 logger = logging.getLogger(__name__)
 
@@ -26,16 +25,7 @@ class ChildProcessGroup:
 
     def shutdown(self) -> None:
         for p in self.procs:
-            if p.is_alive():
-                # p.interrupt() # TODO after 3.14 add
-                os.kill(cast(int, p.pid), signal.SIGINT)
-                p.join(3)
-            if p.is_alive():
-                p.terminate()
-                p.join(3)
-            if p.is_alive():
-                p.kill()
-                p.join(3)
+            shutdown_correctly(p)
 
 
 def previous_cleanup() -> None:

--- a/backend/src/forecastbox/routes/lens.py
+++ b/backend/src/forecastbox/routes/lens.py
@@ -15,10 +15,12 @@ against Run outputs. Routes cover: start, status, stop, list, and supported lens
 """
 
 import logging
+from typing import Any
 
 from fastapi import APIRouter, HTTPException
 
 from forecastbox.domain.lens.manager import (
+    LensInstanceDetail,
     LensInstanceId,
     LensStatus,
     get_status,
@@ -26,6 +28,7 @@ from forecastbox.domain.lens.manager import (
     start_skinny_wms,
     stop_instance,
 )
+from forecastbox.utility.concurrent import NoFreePortsException
 from forecastbox.utility.pydantic import FiabBaseModel
 
 PREFIX = "/api/v1/lens"
@@ -38,7 +41,26 @@ router = APIRouter(
 )
 
 
-class LensDetail(FiabBaseModel):
+class LensInstanceDetailResponse(FiabBaseModel):
+    """API response model for a lens instance detail. Mirrors LensInstanceDetail fields
+    to decouple the public contract from internal domain refactoring."""
+
+    status: LensStatus
+    lens_name: str
+    lens_params: dict[str, Any]
+    ports: set[int]
+
+    @classmethod
+    def from_detail(cls, detail: LensInstanceDetail) -> "LensInstanceDetailResponse":
+        return cls(
+            status=detail.status,
+            lens_name=detail.lens_name,
+            lens_params=detail.lens_params,
+            ports=detail.ports,
+        )
+
+
+class SupportedLensDetail(FiabBaseModel):
     name: str
     route: str
     params: dict[str, str]
@@ -49,17 +71,17 @@ def start_skinny_wms_endpoint(local_path: str) -> LensInstanceId:
     """Start a skinnyWMS lens instance serving data from the given local path."""
     try:
         return start_skinny_wms(local_path)
-    except KeyError:
+    except NoFreePortsException:
         raise HTTPException(status_code=503, detail="No free ports available for a new lens instance")
     except TimeoutError:
         raise HTTPException(status_code=503, detail="Lens manager is busy")
 
 
 @router.get("/status")
-def get_lens_status(lens_instance_id: LensInstanceId) -> LensStatus:
+def get_lens_status(lens_instance_id: LensInstanceId) -> LensInstanceDetailResponse:
     """Get the status of a lens instance."""
     try:
-        return get_status(lens_instance_id)
+        return LensInstanceDetailResponse.from_detail(get_status(lens_instance_id))
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Lens instance {lens_instance_id!r} not found")
 
@@ -77,16 +99,16 @@ def stop_lens(lens_instance_id: LensInstanceId) -> str:
 
 
 @router.get("/list")
-def list_lenses() -> list[tuple[LensInstanceId, LensStatus]]:
+def list_lenses() -> list[tuple[LensInstanceId, LensInstanceDetailResponse]]:
     """List all active lens instances with their current status."""
-    return list_instances()
+    return [(iid, LensInstanceDetailResponse.from_detail(detail)) for iid, detail in list_instances()]
 
 
 @router.get("/supported")
-def list_supported_lenses() -> list[LensDetail]:
+def list_supported_lenses() -> list[SupportedLensDetail]:
     """List all supported lens types with their start route and parameters."""
     return [
-        LensDetail(
+        SupportedLensDetail(
             name="skinnyWMS",
             route=f"{PREFIX}/start/skinnyWMS",
             params={"local_path": "Absolute path to the data directory or file to serve"},

--- a/backend/src/forecastbox/routes/lens.py
+++ b/backend/src/forecastbox/routes/lens.py
@@ -1,0 +1,94 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Lens routes — /lens/*. Corresponds to the `domain.lens` domain.
+
+Lenses are external inspection tools (e.g. skinnyWMS) that clients can launch
+against Run outputs. Routes cover: start, status, stop, list, and supported lenses.
+"""
+
+import logging
+
+from fastapi import APIRouter, HTTPException
+
+from forecastbox.domain.lens.manager import (
+    LensInstanceId,
+    LensStatus,
+    get_status,
+    list_instances,
+    start_skinny_wms,
+    stop_instance,
+)
+from forecastbox.utility.pydantic import FiabBaseModel
+
+PREFIX = "/api/v1/lens"
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    tags=["lens"],
+    responses={404: {"description": "Not found"}},
+)
+
+
+class LensDetail(FiabBaseModel):
+    name: str
+    route: str
+    params: dict[str, str]
+
+
+@router.post("/start/skinnyWMS")
+def start_skinny_wms_endpoint(local_path: str) -> LensInstanceId:
+    """Start a skinnyWMS lens instance serving data from the given local path."""
+    try:
+        return start_skinny_wms(local_path)
+    except KeyError:
+        raise HTTPException(status_code=503, detail="No free ports available for a new lens instance")
+    except TimeoutError:
+        raise HTTPException(status_code=503, detail="Lens manager is busy")
+
+
+@router.get("/status")
+def get_lens_status(lens_instance_id: LensInstanceId) -> LensStatus:
+    """Get the status of a lens instance."""
+    try:
+        return get_status(lens_instance_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail=f"Lens instance {lens_instance_id!r} not found")
+
+
+@router.delete("/stop")
+def stop_lens(lens_instance_id: LensInstanceId) -> str:
+    """Stop and remove a lens instance."""
+    try:
+        stop_instance(lens_instance_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail=f"Lens instance {lens_instance_id!r} not found")
+    except TimeoutError:
+        raise HTTPException(status_code=503, detail="Lens manager is busy")
+    return "ok"
+
+
+@router.get("/list")
+def list_lenses() -> list[tuple[LensInstanceId, LensStatus]]:
+    """List all active lens instances with their current status."""
+    return list_instances()
+
+
+@router.get("/supported")
+def list_supported_lenses() -> list[LensDetail]:
+    """List all supported lens types with their start route and parameters."""
+    return [
+        LensDetail(
+            name="skinnyWMS",
+            route=f"{PREFIX}/start/skinnyWMS",
+            params={"local_path": "Absolute path to the data directory or file to serve"},
+        )
+    ]

--- a/backend/src/forecastbox/routes/lens.py
+++ b/backend/src/forecastbox/routes/lens.py
@@ -14,8 +14,12 @@ Lenses are external inspection tools (e.g. skinnyWMS) that clients can launch
 against Run outputs. Routes cover: start, status, stop, list, and supported lenses.
 """
 
+# TODO currently no authentication here. Add auth and propagate into the manager itself
+# TODO currently no log propagation -- consider routing stdout of skinnywms to files, and allow retrieval here via a new route
+
 import logging
-from typing import Any
+import pathlib
+from typing import Any, Self
 
 from fastapi import APIRouter, HTTPException
 
@@ -45,18 +49,20 @@ class LensInstanceDetailResponse(FiabBaseModel):
     """API response model for a lens instance detail. Mirrors LensInstanceDetail fields
     to decouple the public contract from internal domain refactoring."""
 
+    lens_instance_id: LensInstanceId
     status: LensStatus
     lens_name: str
     lens_params: dict[str, Any]
-    ports: set[int]
+    ports: list[int]
 
     @classmethod
-    def from_detail(cls, detail: LensInstanceDetail) -> "LensInstanceDetailResponse":
+    def from_detail(cls, lens_instance_id: LensInstanceId, detail: LensInstanceDetail) -> Self:
         return cls(
+            lens_instance_id=lens_instance_id,
             status=detail.status,
             lens_name=detail.lens_name,
             lens_params=detail.lens_params,
-            ports=detail.ports,
+            ports=list(detail.ports),
         )
 
 
@@ -70,6 +76,8 @@ class SupportedLensDetail(FiabBaseModel):
 def start_skinny_wms_endpoint(local_path: str) -> LensInstanceId:
     """Start a skinnyWMS lens instance serving data from the given local path."""
     try:
+        if not pathlib.Path(local_path).exists():
+            raise HTTPException(status_code=400, detail="Provided path does not exist")
         return start_skinny_wms(local_path)
     except NoFreePortsException:
         raise HTTPException(status_code=503, detail="No free ports available for a new lens instance")
@@ -81,7 +89,7 @@ def start_skinny_wms_endpoint(local_path: str) -> LensInstanceId:
 def get_lens_status(lens_instance_id: LensInstanceId) -> LensInstanceDetailResponse:
     """Get the status of a lens instance."""
     try:
-        return LensInstanceDetailResponse.from_detail(get_status(lens_instance_id))
+        return LensInstanceDetailResponse.from_detail(lens_instance_id, get_status(lens_instance_id))
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Lens instance {lens_instance_id!r} not found")
 
@@ -99,9 +107,9 @@ def stop_lens(lens_instance_id: LensInstanceId) -> str:
 
 
 @router.get("/list")
-def list_lenses() -> list[tuple[LensInstanceId, LensInstanceDetailResponse]]:
+def list_lenses() -> list[LensInstanceDetailResponse]:
     """List all active lens instances with their current status."""
-    return [(iid, LensInstanceDetailResponse.from_detail(detail)) for iid, detail in list_instances()]
+    return [LensInstanceDetailResponse.from_detail(iid, detail) for iid, detail in list_instances()]
 
 
 @router.get("/supported")

--- a/backend/src/forecastbox/utility/concurrent.py
+++ b/backend/src/forecastbox/utility/concurrent.py
@@ -8,11 +8,15 @@
 # nor does it submit to any jurisdiction.
 
 import logging
+import os
+import signal
+import subprocess
 import threading
 from collections.abc import Callable, Sequence
 from concurrent.futures import Future
 from contextlib import contextmanager
-from typing import Any, Iterator
+from multiprocessing.process import BaseProcess
+from typing import Any, Iterator, cast
 
 logger = logging.getLogger(__name__)
 
@@ -42,3 +46,60 @@ def delayed_thread(future: Future[Any], fn: Callable[..., Any], args: Sequence[A
         fn(*args)
 
     return threading.Thread(target=_target)
+
+
+class FreePortsManager:
+    """Manages a pool of ports available for assignment to external processes."""
+
+    free_ports: set[int] = set(range(19000, 19100))
+    lock: threading.Lock = threading.Lock()
+
+    @staticmethod
+    def claim_port() -> int:
+        """Claim a free port from the pool. Raises KeyError if no ports are available."""
+        with FreePortsManager.lock:
+            return FreePortsManager.free_ports.pop()
+
+    @staticmethod
+    def release_port(port: int) -> None:
+        """Return a port to the pool."""
+        with FreePortsManager.lock:
+            FreePortsManager.free_ports.add(port)
+
+
+def shutdown_correctly(process: BaseProcess) -> None:
+    """Gracefully shut down a multiprocessing BaseProcess: SIGINT -> terminate -> kill."""
+    if process.is_alive():
+        os.kill(cast(int, process.pid), signal.SIGINT)
+        process.join(3)
+    if process.is_alive():
+        process.terminate()
+        process.join(3)
+    if process.is_alive():
+        process.kill()
+        process.join(3)
+
+
+def shutdown_popen(process: "subprocess.Popen[bytes]") -> None:
+    """Gracefully shut down a subprocess.Popen (started with start_new_session=True): SIGINT group -> terminate -> kill."""
+    if process.poll() is None:
+        try:
+            os.killpg(os.getpgid(process.pid), signal.SIGINT)
+        except (ProcessLookupError, OSError):
+            pass
+        try:
+            process.wait(3)
+        except subprocess.TimeoutExpired:
+            pass
+    if process.poll() is None:
+        process.terminate()
+        try:
+            process.wait(3)
+        except subprocess.TimeoutExpired:
+            pass
+    if process.poll() is None:
+        process.kill()
+        try:
+            process.wait(3)
+        except subprocess.TimeoutExpired:
+            pass

--- a/backend/src/forecastbox/utility/concurrent.py
+++ b/backend/src/forecastbox/utility/concurrent.py
@@ -52,15 +52,18 @@ class NoFreePortsException(Exception):
     """Raised when no ports are available in the FreePortsManager pool."""
 
 
+# TODO utilize more across the codebase
 class FreePortsManager:
     """Manages a pool of ports available for assignment to external processes."""
 
+    # NOTE maybe a list would be better, and go cyclically -- should behave better wrt recyclation
     free_ports: set[int] = set(range(19000, 19100))
     lock: threading.Lock = threading.Lock()
 
     @staticmethod
     def claim_port() -> int:
         """Claim a free port from the pool. Raises NoFreePortsException if no ports are available."""
+        # TODO some simple bind test here, loop and return
         with timed_acquire(FreePortsManager.lock, 1) as acquired:
             if not acquired:
                 raise TimeoutError("FreePortsManager lock could not be acquired")

--- a/backend/src/forecastbox/utility/concurrent.py
+++ b/backend/src/forecastbox/utility/concurrent.py
@@ -48,6 +48,10 @@ def delayed_thread(future: Future[Any], fn: Callable[..., Any], args: Sequence[A
     return threading.Thread(target=_target)
 
 
+class NoFreePortsException(Exception):
+    """Raised when no ports are available in the FreePortsManager pool."""
+
+
 class FreePortsManager:
     """Manages a pool of ports available for assignment to external processes."""
 
@@ -56,14 +60,20 @@ class FreePortsManager:
 
     @staticmethod
     def claim_port() -> int:
-        """Claim a free port from the pool. Raises KeyError if no ports are available."""
-        with FreePortsManager.lock:
+        """Claim a free port from the pool. Raises NoFreePortsException if no ports are available."""
+        with timed_acquire(FreePortsManager.lock, 1) as acquired:
+            if not acquired:
+                raise TimeoutError("FreePortsManager lock could not be acquired")
+            if not FreePortsManager.free_ports:
+                raise NoFreePortsException("No free ports available in the pool")
             return FreePortsManager.free_ports.pop()
 
     @staticmethod
     def release_port(port: int) -> None:
         """Return a port to the pool."""
-        with FreePortsManager.lock:
+        with timed_acquire(FreePortsManager.lock, 1) as acquired:
+            if not acquired:
+                raise TimeoutError("FreePortsManager lock could not be acquired")
             FreePortsManager.free_ports.add(port)
 
 
@@ -80,7 +90,7 @@ def shutdown_correctly(process: BaseProcess) -> None:
         process.join(3)
 
 
-def shutdown_popen(process: "subprocess.Popen[bytes]") -> None:
+def shutdown_popen(process: subprocess.Popen[bytes]) -> None:
     """Gracefully shut down a subprocess.Popen (started with start_new_session=True): SIGINT group -> terminate -> kill."""
     if process.poll() is None:
         try:

--- a/backend/tests/unit/domain/lens/test_lens_manager.py
+++ b/backend/tests/unit/domain/lens/test_lens_manager.py
@@ -1,0 +1,230 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Unit tests for the lens domain manager."""
+
+import subprocess
+from collections.abc import Iterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pyrsistent import pmap
+
+from forecastbox.domain.lens.manager import (
+    LensInstance,
+    LensInstanceId,
+    LensInstanceManager,
+    LensStatus,
+    _compute_status,
+    get_status,
+    list_instances,
+    shutdown_all_instances,
+    stop_instance,
+)
+from forecastbox.utility.concurrent import FreePortsManager
+
+
+@pytest.fixture(autouse=True)
+def reset_lens_manager() -> Iterator[None]:
+    """Reset manager state and port pool between tests."""
+    original_instances = LensInstanceManager.instances
+    original_ports = FreePortsManager.free_ports.copy()
+    yield
+    LensInstanceManager.instances = original_instances
+    FreePortsManager.free_ports = original_ports
+
+
+def _make_instance(process: subprocess.Popen | None = None, returncode: int | None = None) -> LensInstance:
+    if process is None and returncode is not None:
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.poll.return_value = returncode
+        mock_proc.returncode = returncode
+        process = mock_proc
+    return LensInstance(
+        process=process,
+        lens_params={"local_path": "/data"},
+        lens_name="skinnyWMS",
+        ports={19000},
+    )
+
+
+class TestComputeStatus:
+    def test_no_process_is_starting(self) -> None:
+        instance = _make_instance(process=None)
+        status = _compute_status(instance)
+        assert status.status == "starting"
+        assert status.lens_name == "skinnyWMS"
+        assert status.lens_params == {"local_path": "/data"}
+
+    def test_running_process_is_running(self) -> None:
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.poll.return_value = None  # still alive
+        instance = _make_instance(process=mock_proc)
+        assert _compute_status(instance).status == "running"
+
+    def test_process_exited_zero_is_terminated(self) -> None:
+        instance = _make_instance(returncode=0)
+        assert _compute_status(instance).status == "terminated"
+
+    def test_process_exited_nonzero_is_failed(self) -> None:
+        instance = _make_instance(returncode=1)
+        assert _compute_status(instance).status == "failed"
+
+    def test_process_exited_negative_is_failed(self) -> None:
+        instance = _make_instance(returncode=-15)
+        assert _compute_status(instance).status == "failed"
+
+
+class TestGetStatus:
+    def test_raises_key_error_for_unknown_id(self) -> None:
+        with pytest.raises(KeyError):
+            get_status(LensInstanceId("no-such-id"))
+
+    def test_returns_status_for_known_id(self) -> None:
+        iid = LensInstanceId("test-id")
+        instance = _make_instance(process=None)
+        LensInstanceManager.instances = pmap({iid: instance})
+        result = get_status(iid)
+        assert isinstance(result, LensStatus)
+        assert result.status == "starting"
+
+
+class TestListInstances:
+    def test_empty_returns_empty_list(self) -> None:
+        LensInstanceManager.instances = pmap()
+        assert list_instances() == []
+
+    def test_returns_all_instances_with_status(self) -> None:
+        iid1 = LensInstanceId("id-1")
+        iid2 = LensInstanceId("id-2")
+        mock_alive = MagicMock(spec=subprocess.Popen)
+        mock_alive.poll.return_value = None
+        LensInstanceManager.instances = pmap(
+            {
+                iid1: _make_instance(process=None),
+                iid2: _make_instance(process=mock_alive),
+            }
+        )
+        results = list_instances()
+        assert len(results) == 2
+        statuses = {iid: s.status for iid, s in results}
+        assert statuses[iid1] == "starting"
+        assert statuses[iid2] == "running"
+
+
+class TestStopInstance:
+    def test_raises_key_error_for_unknown_id(self) -> None:
+        LensInstanceManager.instances = pmap()
+        with pytest.raises(KeyError):
+            stop_instance(LensInstanceId("ghost"))
+
+    def test_removes_instance_from_manager(self) -> None:
+        iid = LensInstanceId("to-stop")
+        LensInstanceManager.instances = pmap({iid: _make_instance(process=None)})
+        FreePortsManager.free_ports = set()
+        stop_instance(iid)
+        assert iid not in LensInstanceManager.instances
+
+    def test_releases_port_on_success(self) -> None:
+        iid = LensInstanceId("port-release")
+        instance = _make_instance(process=None)
+        port = next(iter(instance.ports))
+        LensInstanceManager.instances = pmap({iid: instance})
+        FreePortsManager.free_ports = set()
+        stop_instance(iid)
+        assert port in FreePortsManager.free_ports
+
+    def test_shuts_down_running_process(self) -> None:
+        iid = LensInstanceId("with-process")
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.poll.return_value = None
+        instance = LensInstance(
+            process=mock_proc,
+            lens_params={"local_path": "/data"},
+            lens_name="skinnyWMS",
+            ports={19005},
+        )
+        LensInstanceManager.instances = pmap({iid: instance})
+        FreePortsManager.free_ports = set()
+        with patch("forecastbox.domain.lens.manager.shutdown_popen") as mock_shutdown:
+            stop_instance(iid)
+        mock_shutdown.assert_called_once_with(mock_proc)
+
+    def test_releases_port_even_when_shutdown_raises(self) -> None:
+        iid = LensInstanceId("error-case")
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.poll.return_value = None
+        instance = LensInstance(
+            process=mock_proc,
+            lens_params={"local_path": "/data"},
+            lens_name="skinnyWMS",
+            ports={19010},
+        )
+        LensInstanceManager.instances = pmap({iid: instance})
+        FreePortsManager.free_ports = set()
+        with patch("forecastbox.domain.lens.manager.shutdown_popen", side_effect=RuntimeError("boom")):
+            with pytest.raises(RuntimeError):
+                stop_instance(iid)
+        assert 19010 in FreePortsManager.free_ports
+
+
+class TestShutdownAllInstances:
+    def test_stops_all_instances(self) -> None:
+        iid1 = LensInstanceId("all-1")
+        iid2 = LensInstanceId("all-2")
+        LensInstanceManager.instances = pmap(
+            {
+                iid1: _make_instance(process=None),
+                iid2: _make_instance(process=None),
+            }
+        )
+        FreePortsManager.free_ports = set()
+        shutdown_all_instances()
+        assert LensInstanceManager.instances == pmap()
+
+    def test_continues_after_individual_failure(self) -> None:
+        iid1 = LensInstanceId("fail-1")
+        iid2 = LensInstanceId("ok-2")
+        LensInstanceManager.instances = pmap(
+            {
+                iid1: _make_instance(process=None),
+                iid2: _make_instance(process=None),
+            }
+        )
+        FreePortsManager.free_ports = set()
+
+        original_stop = stop_instance
+        call_count = [0]
+
+        def flaky_stop(iid: LensInstanceId) -> None:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise RuntimeError("transient failure")
+            original_stop(iid)
+
+        with patch("forecastbox.domain.lens.manager.stop_instance", side_effect=flaky_stop):
+            shutdown_all_instances()  # should not raise
+
+
+class TestFreePortsManager:
+    def test_claim_returns_port(self) -> None:
+        FreePortsManager.free_ports = {19050}
+        port = FreePortsManager.claim_port()
+        assert port == 19050
+        assert 19050 not in FreePortsManager.free_ports
+
+    def test_claim_raises_when_empty(self) -> None:
+        FreePortsManager.free_ports = set()
+        with pytest.raises(KeyError):
+            FreePortsManager.claim_port()
+
+    def test_release_adds_port_back(self) -> None:
+        FreePortsManager.free_ports = set()
+        FreePortsManager.release_port(19055)
+        assert 19055 in FreePortsManager.free_ports

--- a/backend/tests/unit/domain/lens/test_lens_manager.py
+++ b/backend/tests/unit/domain/lens/test_lens_manager.py
@@ -18,16 +18,16 @@ from pyrsistent import pmap
 
 from forecastbox.domain.lens.manager import (
     LensInstance,
+    LensInstanceDetail,
     LensInstanceId,
     LensInstanceManager,
-    LensStatus,
     _compute_status,
     get_status,
     list_instances,
-    shutdown_all_instances,
+    shutdown_all_lens_instances,
     stop_instance,
 )
-from forecastbox.utility.concurrent import FreePortsManager
+from forecastbox.utility.concurrent import FreePortsManager, NoFreePortsException
 
 
 @pytest.fixture(autouse=True)
@@ -91,7 +91,7 @@ class TestGetStatus:
         instance = _make_instance(process=None)
         LensInstanceManager.instances = pmap({iid: instance})
         result = get_status(iid)
-        assert isinstance(result, LensStatus)
+        assert isinstance(result, LensInstanceDetail)
         assert result.status == "starting"
 
 
@@ -185,7 +185,7 @@ class TestShutdownAllInstances:
             }
         )
         FreePortsManager.free_ports = set()
-        shutdown_all_instances()
+        shutdown_all_lens_instances()
         assert LensInstanceManager.instances == pmap()
 
     def test_continues_after_individual_failure(self) -> None:
@@ -209,7 +209,7 @@ class TestShutdownAllInstances:
             original_stop(iid)
 
         with patch("forecastbox.domain.lens.manager.stop_instance", side_effect=flaky_stop):
-            shutdown_all_instances()  # should not raise
+            shutdown_all_lens_instances()  # should not raise
 
 
 class TestFreePortsManager:
@@ -221,7 +221,7 @@ class TestFreePortsManager:
 
     def test_claim_raises_when_empty(self) -> None:
         FreePortsManager.free_ports = set()
-        with pytest.raises(KeyError):
+        with pytest.raises(NoFreePortsException):
             FreePortsManager.claim_port()
 
     def test_release_adds_port_back(self) -> None:

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -417,6 +417,15 @@ wheels = [
 ]
 
 [[package]]
+name = "blinker"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
 name = "botocore"
 version = "1.42.69"
 source = { registry = "https://pypi.org/simple" }
@@ -1489,6 +1498,28 @@ wheels = [
 ]
 
 [[package]]
+name = "ecmwflibs"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "findlibs" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/58/461209b849601db4167e294cca90fd236c433c8d93f4828195e69727d608/ecmwflibs-0.7.0-cp311-cp311-macosx_10_9_x86_64.macosx_15_0_arm64.whl", hash = "sha256:9e0bc9a57399076f190cfe6d73a00380c8e26d87f11824d958f2bc7f8464706d", size = 45803052, upload-time = "2026-04-21T21:25:02.134Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8b/6f9dce5a538c3fca100dca786404b9429cf88ac43e976980c0e188571d6f/ecmwflibs-0.7.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:018ea2e5b4747da7a09b5255f4dd30f770888e977840b486b6921a6f7325dba5", size = 89464127, upload-time = "2026-04-21T21:38:47.029Z" },
+    { url = "https://files.pythonhosted.org/packages/80/86/8a297ff355fb0fc5cea31f3a62ff3d0328c9608a1d3f40ac4c1072f7268a/ecmwflibs-0.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:4718c99da7d19e1721d662001e9354769c7462d1f745dec297b493eda302fa00", size = 47782574, upload-time = "2026-04-21T22:30:05.022Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/46/13b20c4f89ffb11ae9ddf015db6c53ec16df51039531c403b2cf23dc4bd6/ecmwflibs-0.7.0-cp312-cp312-macosx_10_13_x86_64.macosx_15_0_arm64.whl", hash = "sha256:4448f6dcf1fd65752b566478a2e33469fc2bcadae99353546c249f5e1ad1beb8", size = 45803057, upload-time = "2026-04-21T21:24:58.584Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/b2/d9b04e2884693151635c29fca649d8973e7f06c95201493edd3bea442aab/ecmwflibs-0.7.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1cdc12f353b858083fb94f5d6a69d89cd11b77169e1f6affde41a193a5ac118a", size = 89464014, upload-time = "2026-04-21T21:38:39.2Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/b6/94b0ac8ff2db0a51eff4b7e13806bcd6b10bc81e40468c0ba280e127ae64/ecmwflibs-0.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:516ca23d164bb1bb5a313b7e4ea00859ce54dffbb001fd4ae5a39614822f0e5d", size = 47782575, upload-time = "2026-04-21T22:29:57.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d0/766452aa394cd1b253a4cddbeffc67fc6107294594659e7fc3d6051e1ac5/ecmwflibs-0.7.0-cp313-cp313-macosx_10_13_x86_64.macosx_15_0_arm64.whl", hash = "sha256:127c65f8c0d9a0f9113f5540f50c1c03f8511b76c4b1d02fbb17cbf74892d048", size = 45803060, upload-time = "2026-04-21T21:25:17.059Z" },
+    { url = "https://files.pythonhosted.org/packages/44/80/18e706dfcea6ea2c2345d4a08352070c5c3882fc8e11cded0e31b303d802/ecmwflibs-0.7.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6368ae02f92f5a4bf2838c42482a608c476db85aabbbcde92a689e19e5854a18", size = 89464210, upload-time = "2026-04-21T21:38:41.197Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/26/ec9e52dce401a05ea3e52da5afaf5a8307650faa00cd3cf550b1e07895a5/ecmwflibs-0.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:71c71a6ff30bea37a9e41d927d8d49cb241b669b63252ff1dd0b339642fff9bc", size = 47782570, upload-time = "2026-04-21T22:30:00.694Z" },
+    { url = "https://files.pythonhosted.org/packages/70/f5/cccdcc447d8d661421726f2945f220ff7ce2a3f474724ca92123ddbf5110/ecmwflibs-0.7.0-cp314-cp314-macosx_10_15_x86_64.macosx_15_0_arm64.whl", hash = "sha256:37863b7fc46452ad8bacc45600d1a498581b1146e0ce290667e2be799da24efe", size = 45803121, upload-time = "2026-04-21T21:25:02.109Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/40/1600f5dde9274c2ab33fbe5ca8e635c08c4d798fa363aad1bdd914c34aad/ecmwflibs-0.7.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:62bbcdc9b6bf44e6829facee06920119d099c37580c6242cc1f7e7c5c66d95f7", size = 90355068, upload-time = "2026-04-21T21:38:46.762Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/f0/91e57fefed70633672a5ab00c7933a3f2aa084e1ffa01c5974e2cb66a04c/ecmwflibs-0.7.0-cp314-cp314-win_amd64.whl", hash = "sha256:5523866814f6e026833a8859985e5b4010974671efa90d18c7a1c45936e313ca", size = 49001970, upload-time = "2026-04-21T22:30:03.229Z" },
+]
+
+[[package]]
 name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1759,6 +1790,36 @@ wheels = [
 ]
 
 [[package]]
+name = "flask"
+version = "3.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "blinker" },
+    { name = "click" },
+    { name = "itsdangerous" },
+    { name = "jinja2" },
+    { name = "markupsafe" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
+]
+
+[[package]]
+name = "flask-cors"
+version = "6.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flask" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/74/0fc0fa68d62f21daef41017dafab19ef4b36551521260987eb3a5394c7ba/flask_cors-6.0.2.tar.gz", hash = "sha256:6e118f3698249ae33e429760db98ce032a8bf9913638d085ca0f4c5534ad2423", size = 13472, upload-time = "2025-12-12T20:31:42.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/af/72ad54402e599152de6d067324c46fe6a4f531c7c65baf7e96c63db55eaf/flask_cors-6.0.2-py3-none-any.whl", hash = "sha256:e57544d415dfd7da89a9564e1e3a9e515042df76e12130641ca6f3f2f03b699a", size = 13257, upload-time = "2025-12-12T20:31:41.3Z" },
+]
+
+[[package]]
 name = "flexcache"
 version = "0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1851,6 +1912,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyrsistent" },
     { name = "python-multipart" },
+    { name = "skinnywms" },
     { name = "sse-starlette" },
     { name = "starlette" },
     { name = "toml" },
@@ -1887,6 +1949,7 @@ requires-dist = [
     { name = "pydantic-settings" },
     { name = "pyrsistent" },
     { name = "python-multipart" },
+    { name = "skinnywms" },
     { name = "sse-starlette" },
     { name = "starlette", specifier = ">=1.0" },
     { name = "toml" },
@@ -1921,6 +1984,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441, upload-time = "2026-02-05T21:50:53.743Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505, upload-time = "2026-02-05T21:50:51.819Z" },
+]
+
+[[package]]
+name = "future-annotations"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tokenize-rt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/3a/168feb6471a3142b1a501947e2f45afbbe9753e44f9d05317553ad7c04c0/future_annotations-1.0.0.tar.gz", hash = "sha256:c707d19f7c74e08d9e67b310fd6a7438ff510ba5cbfb7334695627f8f69c6378", size = 5582, upload-time = "2020-09-11T01:57:41.35Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/a6/95dd5f6dd2a785d69fa2fd2c7c217c13a6eb9c1f37eddc232eb11bfd8fa7/future_annotations-1.0.0-py2.py3-none-any.whl", hash = "sha256:a38cc5d9602181a7eb04550d34644508a63e5550c82c4b45b28b86923be203d2", size = 5618, upload-time = "2020-09-11T01:57:40.378Z" },
+]
+
+[[package]]
+name = "geojson"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/5a/33e761df75c732fcea94aaf01f993d823138581d10c91133da58bc231e63/geojson-3.2.0.tar.gz", hash = "sha256:b860baba1e8c6f71f8f5f6e3949a694daccf40820fa8f138b3f712bd85804903", size = 24574, upload-time = "2024-12-21T19:35:29.835Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/a7fa2d650602731c90e0a86279841b4586e14228199e8c09165ba4863e29/geojson-3.2.0-py3-none-any.whl", hash = "sha256:69d14156469e13c79479672eafae7b37e2dcd19bdfd77b53f74fa8fe29910b52", size = 15040, upload-time = "2024-12-21T19:37:02.149Z" },
 ]
 
 [[package]]
@@ -2014,6 +2098,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
     { url = "https://files.pythonhosted.org/packages/29/4b/45d90626aef8e65336bed690106d1382f7a43665e2249017e9527df8823b/greenlet-3.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a", size = 237086, upload-time = "2026-02-20T20:20:45.786Z" },
+]
+
+[[package]]
+name = "gunicorn"
+version = "25.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/f4/e78fa054248fab913e2eab0332c6c2cb07421fca1ce56d8fe43b6aef57a4/gunicorn-25.3.0.tar.gz", hash = "sha256:f74e1b2f9f76f6cd1ca01198968bd2dd65830edc24b6e8e4d78de8320e2fe889", size = 634883, upload-time = "2026-03-27T00:00:26.092Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/c8/8aaf447698c4d59aa853fd318eed300b5c9e44459f242ab8ead6c9c09792/gunicorn-25.3.0-py3-none-any.whl", hash = "sha256:cacea387dab08cd6776501621c295a904fe8e3b7aae9a1a3cbb26f4e7ed54660", size = 208403, upload-time = "2026-03-27T00:00:27.386Z" },
 ]
 
 [[package]]
@@ -2198,6 +2294,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
 ]
 
 [[package]]
@@ -2468,6 +2573,16 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/06/d7e393d07dc31e656330d5a058f34e972bf590e7dc882922b426f3aec4a0/lru_dict-1.4.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:804ee76f98afc3d50e9a2e9c835a6820877aa6391f2add520a57f86b3f55ec3a", size = 13904, upload-time = "2025-11-02T10:02:12.144Z" },
     { url = "https://files.pythonhosted.org/packages/e8/1e/0eee8bcc16bf01b265ac83e4b870596e2f3bcc40d88aa7ec25407180fe44/lru_dict-1.4.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:3be24e24c8998302ea1c28f997505fa6843f507aad3c7d5c3a82cc01c5c11be4", size = 14062, upload-time = "2025-11-02T10:02:12.878Z" },
 ]
+
+[[package]]
+name = "magics"
+version = "1.5.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "findlibs" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/f8/7247ee384c0044c4d9d950a3d2ea1003dca89c626eaf4a90ce0eb3a02d99/Magics-1.5.8.tar.gz", hash = "sha256:7df4241802fb552ee052da18190a5266a8faff7feecc70779cb5e1809625fb90", size = 22594, upload-time = "2022-04-13T14:19:33.093Z" }
 
 [[package]]
 name = "makefun"
@@ -4596,6 +4711,28 @@ wheels = [
 ]
 
 [[package]]
+name = "skinnywms"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dask", extra = ["array"] },
+    { name = "ecmwflibs" },
+    { name = "flask" },
+    { name = "flask-cors" },
+    { name = "future-annotations" },
+    { name = "geojson" },
+    { name = "gunicorn" },
+    { name = "magics" },
+    { name = "netcdf4" },
+    { name = "python-dateutil" },
+    { name = "xarray" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/f3/f092e9217a5b5e728b0e497b16515e1d6413b543ed35fa81b482f8778a6e/skinnywms-0.13.0.tar.gz", hash = "sha256:864e7ef78e92aab6ba416747c9d903d900c594b7d5ee3fb843a9546768738034", size = 18538039, upload-time = "2026-04-22T13:40:30.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/1d/5d311099c129ad817da786a5e8ce18022c4a634a73d42062a927d3c7f066/skinnywms-0.13.0-py3-none-any.whl", hash = "sha256:f15f118fb478f77f1a72f3d8cb336c4653fe481edc12a44477a10d75efa136b1", size = 19020821, upload-time = "2026-04-22T13:40:28.075Z" },
+]
+
+[[package]]
 name = "smmap"
 version = "5.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -4730,6 +4867,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
+]
+
+[[package]]
+name = "tokenize-rt"
+version = "6.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/ed/8f07e893132d5051d86a553e749d5c89b2a4776eb3a579b72ed61f8559ca/tokenize_rt-6.2.0.tar.gz", hash = "sha256:8439c042b330c553fdbe1758e4a05c0ed460dbbbb24a606f11f0dee75da4cad6", size = 5476, upload-time = "2025-05-23T23:48:00.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/f0/3fe8c6e69135a845f4106f2ff8b6805638d4e85c264e70114e8126689587/tokenize_rt-6.2.0-py2.py3-none-any.whl", hash = "sha256:a152bf4f249c847a66497a4a95f63376ed68ac6abf092a2f7cfb29d044ecff44", size = 6004, upload-time = "2025-05-23T23:47:58.812Z" },
 ]
 
 [[package]]
@@ -4933,6 +5079,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds skinnyWMS integration, under a new domain called "Lens"

A few new routes:
 - start/skinnyWMS(localPath) -> lensInstanceId: launches the server
 - list, get, stop, ... -- the usual crud stuff

The expected integration --
1. the user runs a job where mime type of some output would be "skinnyWMS-compatible" (something like `text/plain; skinnyWMS-compat`)
2. the frontend would allow (in like a dropdown on the output) a new option "launch skinny"
3. when the user clicks on this, the frontend fetches the output value (which is text/plain -- a local path), and starts the skinnyWMS with this
4. the backend at first returns like id + starting status
5. once the status is running, the frontend can do a redirect/new tab to localhost+port where the port is in the `get` response