### PR TITLE
fix(glyphs): expand jinja filter expressions in glyph values

### DIFF
--- a/backend/src/forecastbox/domain/glyphs/resolution.py
+++ b/backend/src/forecastbox/domain/glyphs/resolution.py
@@ -10,7 +10,6 @@
 """Core parsing and resolution of ${glyph} interpolation in BlockInstance configuration values."""
 
 import datetime as dt
-import re
 from dataclasses import dataclass
 
 from cascade.low.func import Either
@@ -18,9 +17,6 @@ from fiab_core.fable import BlockInstance
 
 from forecastbox.domain.glyphs.exceptions import GlyphCircularReferenceError
 from forecastbox.domain.glyphs.jinja_interpolation import extract_glyph_names, render_expression
-
-# Used only by expand_glyph_values for simple ${varname} chain detection and substitution.
-_GLYPH_PATTERN = re.compile(r"\$\{(\w+)\}")
 
 PINNED_INTRINSIC_KEYS: frozenset[str] = frozenset({"startDatetime", "attemptCount"})
 """Intrinsic glyph keys that are always forced to their fresh intrinsic value in each attempt,
@@ -62,7 +58,7 @@ def extract_glyphs(blockInstance: BlockInstance) -> Either[ExtractedGlyphs, list
         if result.t:
             glyphs.update(result.t)
             glyphed_options.add(key)
-        elif _GLYPH_PATTERN.search(value) or "${" in value:
+        elif "${" in value:
             # The value contains ${...} but all names are jinja globals/filters, not glyph variables.
             # Still mark it as glyphed so its rendered result appears in resolved_configuration_options.
             glyphed_options.add(key)
@@ -138,21 +134,42 @@ def expand_glyph_values(glyph_values: dict[str, str], roots: set[str] | None = N
         if key in memo:
             return memo[key]
         value = source[key]
-        if not _GLYPH_PATTERN.search(value):
+
+        # Use AST-based parsing to find all referenced glyph names, including inside jinja
+        # filter expressions like ${submitDatetime | floor_day}.
+        refs_result = extract_glyph_names(value)
+        if refs_result.e is not None or not refs_result.t:
+            # Malformed expression or no glyph references — keep value as-is.
             memo[key] = value
             return value
+
+        refs = refs_result.t
         visiting = visiting | {key}
 
-        def substitute(m: re.Match[str]) -> str:
-            ref = m.group(1)
-            if ref not in source:
-                return m.group(0)
+        for ref in refs & source.keys():
             if ref in visiting:
                 cycle_path = " -> ".join(sorted(visiting)) + f" -> {ref}"
                 raise GlyphCircularReferenceError(f"Circular glyph reference detected: {cycle_path}")
-            return _expand(ref, visiting)
 
-        expanded = _GLYPH_PATTERN.sub(substitute, value)
+        # Build the jinja context:
+        # - known refs are recursively expanded to their final values,
+        # - unknown refs are mapped to "${ref}" so they survive in the output string
+        #   and can be surfaced as errors by the downstream block-level validation.
+        sub_glyphs: dict[str, str] = {}
+        for ref in refs:
+            if ref in source:
+                sub_glyphs[ref] = _expand(ref, visiting)
+            else:
+                sub_glyphs[ref] = f"${{{ref}}}"
+
+        try:
+            expanded = render_expression(value, sub_glyphs)
+        except Exception:
+            # Rendering can fail when a jinja filter is applied to an unknown-ref
+            # placeholder string (e.g. floor_day on "${unknownGlyph}"). Fall back to
+            # keeping the original value so downstream validation can surface the error.
+            expanded = value
+
         memo[key] = expanded
         return expanded
 

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -653,6 +653,31 @@ def test_blueprint_composite_glyph_expand(tmpdir: Any, backend_client_with_auth:
     assert len(cyclic_data["global_errors"]) > 0
     assert any("circular" in err.lower() or "cycle" in err.lower() for err in cyclic_data["global_errors"])
 
+    # A local glyph whose value contains a jinja filter expression referencing an intrinsic
+    # glyph must be fully evaluated via expand_glyph_values (regression test for the
+    # fix that extended expand_glyph_values to handle jinja expressions, not just plain ${var}).
+    glyphs_resp2 = backend_client_with_auth.get("/blueprint/glyphs/list", params={"glyph_type": "intrinsic"})
+    assert glyphs_resp2.is_success, glyphs_resp2.text
+    submit_example = next(g["valueExample"] for g in glyphs_resp2.json()["glyphs"] if g["name"] == "submitDatetime")
+    # floor_day of the example value: strip time component
+    expected_floored = submit_example[:10] + " 00:00:00"
+    source_jinja = BlockInstance(
+        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_text")),
+        configuration_values={"text": "${jinjaFilterGlyph}"},
+        input_ids={},
+    )
+    builder_jinja = BlueprintBuilder(
+        blocks={BlockInstanceId("source_jinja"): source_jinja},
+        local_glyphs={"jinjaFilterGlyph": "${submitDatetime | floor_day}"},
+    )
+    response_jinja = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder_jinja.model_dump())
+    assert response_jinja.is_success, response_jinja.text
+    jinja_data = response_jinja.json()
+    assert len(jinja_data["global_errors"]) == 0, jinja_data["global_errors"]
+    assert len(jinja_data["block_errors"]) == 0, jinja_data["block_errors"]
+    resolved_jinja = jinja_data["resolved_configuration_options"]["source_jinja"]["text"]
+    assert resolved_jinja == expected_floored, f"Expected {expected_floored!r}, got {resolved_jinja!r}"
+
 
 def test_blueprint_jinja_interpolation_expand(backend_client_with_auth: httpx.Client) -> None:
     """Jinja interpolation is validated and resolved via the /expand endpoint.

--- a/backend/tests/unit/domain/glyphs/test_resolution.py
+++ b/backend/tests/unit/domain/glyphs/test_resolution.py
@@ -258,6 +258,63 @@ def test_expand_roots_none_equivalent_to_no_roots() -> None:
 
 
 # ---------------------------------------------------------------------------
+# expand_glyph_values — jinja expression support (bug fix regression tests)
+# ---------------------------------------------------------------------------
+
+
+def test_expand_glyph_with_jinja_filter() -> None:
+    """A glyph value containing a jinja filter expression is fully evaluated.
+
+    Previously, expand_glyph_values used a regex that only matched ${word} and
+    skipped ${submitDatetime | floor_day}, leaving the raw string in the map.
+    """
+    glyphs = {"submitDatetime": "2024-01-15 06:00:00", "myDate": "${submitDatetime | floor_day}"}
+    result = expand_glyph_values(glyphs)
+    assert result["myDate"] == "2024-01-15 00:00:00"
+
+
+def test_expand_nested_glyph_with_jinja_filter() -> None:
+    """Transitive expansion works when an intermediate glyph contains a jinja filter."""
+    glyphs = {
+        "submitDatetime": "2024-01-15 06:00:00",
+        "baseDate": "${submitDatetime | floor_day}",
+        "path": "${baseDate}/output",
+    }
+    result = expand_glyph_values(glyphs)
+    assert result["baseDate"] == "2024-01-15 00:00:00"
+    assert result["path"] == "2024-01-15 00:00:00/output"
+
+
+def test_expand_glyph_with_mixed_known_filter_and_unknown() -> None:
+    """A glyph value mixing a jinja filter on a known ref with an unknown ref.
+
+    The known filter is evaluated; the unknown ref placeholder survives so the
+    downstream block-level validation can report it.
+    """
+    glyphs = {"submitDatetime": "2024-01-15 06:00:00", "mixed": "${submitDatetime | floor_day}/${missing}"}
+    result = expand_glyph_values(glyphs)
+    assert result["mixed"] == "2024-01-15 00:00:00/${missing}"
+
+
+def test_expand_glyph_filter_on_unknown_ref_kept_as_is() -> None:
+    """When a jinja filter is applied to an unknown ref, the value is kept unchanged.
+
+    Rendering would fail (floor_day on a placeholder string), so we fall back to
+    the original value rather than surfacing a cryptic render error.
+    """
+    glyphs = {"myDate": "${unknownGlyph | floor_day}"}
+    result = expand_glyph_values(glyphs)
+    assert result["myDate"] == "${unknownGlyph | floor_day}"
+
+
+def test_expand_glyph_chained_datetime_filters() -> None:
+    """Chained filters on a known datetime glyph are fully evaluated."""
+    glyphs = {"submitDatetime": "2024-01-15 06:30:00", "rounded": "${submitDatetime | add_days(1) | floor_day}"}
+    result = expand_glyph_values(glyphs)
+    assert result["rounded"] == "2024-01-16 00:00:00"
+
+
+# ---------------------------------------------------------------------------
 # extract_glyphs — jinja2 expression syntax
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
expand_glyph_values used a regex ($\{(\w+)\}) that only matched simple ${word} patterns. Jinja expressions like
${submitDatetime | floor_day} were silently skipped, so the raw expression string ended up as the glyph's value. When a block config referenced that glyph (e.g. ${myDate}), resolve_configurations substituted the literal string, leaving the jinja expression unrendered. The second extract_glyphs pass then found the variable name inside the expression (e.g. submitDatetime) and falsely reported it as an unknown glyph.

Fix: replace the regex with extract_glyph_names (AST-based) for reference detection and render_expression (jinja rendering) for expansion. Unknown refs are passed to the jinja context as "${ref}" strings so they survive in the output and continue to be reported by downstream block-level validation. Rendering errors (e.g. a datetime filter applied to an unknown-ref placeholder) are caught and the original value is kept, preserving the existing fallback behaviour.

Add unit tests covering: jinja filter on a known glyph, transitive chain through a filtered glyph, mixed known+unknown with filter, filter on fully-unknown ref kept as-is, chained datetime filters.

Extend the composite_glyph_expand integration test with a case where a local glyph is defined as ${submitDatetime | floor_day} and its expansion is verified end-to-end via the /expand endpoint.

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
