### PR TITLE
feat(spa): enhance SPA routing and chunk loading error handling

### DIFF
--- a/backend/src/forecastbox/entrypoint/app.py
+++ b/backend/src/forecastbox/entrypoint/app.py
@@ -134,16 +134,32 @@ frontend = os.environ.get("FIAB_TEST_FRONTEND") or os.path.join(os.path.dirname(
 
 
 class SPAStaticFiles(StaticFiles):
-    """Custom StaticFiles class to handle SPA routing."""
+    """Custom StaticFiles class to handle SPA routing.
+
+    - Asset-shaped paths (anything with a file extension or under /assets/)
+      that 404 stay 404, so the browser surfaces a useful "chunk failed
+    - SPA routes (no extension) fall through to index.html.
+    - Cache-Control headers: hashed assets cached forever; index.html uses
+      stale-while-revalidate so deploys propagate without blocking nav.
+    """
 
     async def get_response(self, path: str, scope: Any) -> Response:
         try:
-            return await super().get_response(path, scope)
+            response = await super().get_response(path, scope)
         except HTTPException as ex:
             if ex.status_code == 404:
-                return FileResponse(os.path.join(frontend, "index.html"))
+                last_segment = path.rsplit("/", 1)[-1]
+                if path.startswith("assets/") or "." in last_segment:
+                    raise  # genuine asset miss -- let the 404 propagate
+                response = FileResponse(os.path.join(frontend, "index.html"))
             else:
                 raise
+
+        if path.startswith("assets/"):
+            response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+        elif path == "" or path.endswith(".html"):
+            response.headers["Cache-Control"] = "public, max-age=0, stale-while-revalidate=60"
+        return response
 
 
 app.mount("/", SPAStaticFiles(directory=frontend, html=True, follow_symlink=True), name="static")

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -25,6 +25,20 @@ import { setupGlobalErrorHandlers } from '@/lib/globalErrorHandler'
 
 setupGlobalErrorHandlers()
 
+// If a dynamically-imported chunk 404s (typically: user has a stale
+// index.html during a deploy), reload to pick up the fresh index.html
+// and matching chunk hashes. sessionStorage prevents an infinite reload loop
+// if the failure persists on the new bundle too.
+window.addEventListener('vite:preloadError', (event) => {
+  if (sessionStorage.getItem('vite:preload-reload')) return
+  sessionStorage.setItem('vite:preload-reload', String(Date.now()))
+  event.preventDefault()
+  window.location.reload()
+})
+window.addEventListener('load', () => {
+  sessionStorage.removeItem('vite:preload-reload')
+})
+
 // Create a new router instance
 const router = createRouter({
   routeTree,


### PR DESCRIPTION
Stops the misleading `'text/html' is not a valid JavaScript MIME type` error after deploys when a stale cached `index.html` references chunk hashes that no longer exist.

Improved SPA routing to distinguish asset paths and apply appropriate caching strategies. Added logic to handle chunk loading errors, enabling automatic reload with updated index.html to resolve stale asset issues.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
