### PR TITLE
[backend] detect model compatibility mvp

### DIFF
--- a/backend/packages/fiab-core/src/fiab_core/artifacts.py
+++ b/backend/packages/fiab-core/src/fiab_core/artifacts.py
@@ -56,6 +56,9 @@ class MlModelCheckpoint(FiabCoreBaseModel):
     display_description: str = Field(description="Additional info about the model")
     comment: str = Field("", description="Additional internal data at the store level")
     disk_size_bytes: int = Field(description="Physical storage footprint of the checkpoint")
+    minimum_gpu_memory_mib: int | None = Field(
+        default=None, description="If this model *requires* gpu, then what is the minimum realistic size in MiB"
+    )
     pip_package_constraints: list[str] = Field(
         description="Pip-compatible constraints for requisite python packages such as torch or anemoi-inference"
     )

--- a/backend/src/forecastbox/domain/artifact/compatibility.py
+++ b/backend/src/forecastbox/domain/artifact/compatibility.py
@@ -1,0 +1,80 @@
+import logging
+import platform
+import subprocess
+from dataclasses import dataclass
+
+from fiab_core.artifacts import MlModelCheckpoint, Platform
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PlatformInfo:
+    """Platform Name and GPU memory (VRAM).
+    - macOS: Returns total system memory (Unified Memory).
+    - Linux (NVIDIA): Parses nvidia-smi for total VRAM.
+    """
+
+    platform_name: Platform | None
+    gpu_memory_mib: int | None
+
+
+def get_platform_info() -> PlatformInfo | None:
+    system = platform.system()
+
+    # --- macOS Logic (Unified Memory) ---
+    if system == "Darwin":
+        try:
+            # sysctl reports bytes; we convert to MiB
+            cmd = ["sysctl", "-n", "hw.memsize"]
+            mem_bytes = int(subprocess.check_output(cmd).strip())
+            return PlatformInfo(platform_name="macos", gpu_memory_mib=mem_bytes // (1024**2))
+        except Exception as e:
+            logger.error(f"Error fetching macOS memory: {e}")
+            return PlatformInfo(platform_name="macos", gpu_memory_mib=None)
+
+    # --- Linux Logic (NVIDIA VRAM) ---
+    elif system == "Linux":
+        try:
+            # Query nvidia-smi specifically for memory.total
+            # format=csv,nounits,noheader makes parsing trivial
+            cmd = ["nvidia-smi", "--query-gpu=memory.total", "--format=csv,nounits,noheader"]
+            output = subprocess.check_output(cmd, encoding="utf-8").strip()
+
+            # If multiple GPUs exist, this returns multiple lines
+            gpu_memory_mib = sum([int(x) for x in output.split("\n")])
+            return PlatformInfo(platform_name="linux", gpu_memory_mib=gpu_memory_mib)
+        except FileNotFoundError:
+            logger.debug("nvidia-smi not found. Ensure NVIDIA drivers are installed.")
+            return PlatformInfo(platform_name="linux", gpu_memory_mib=None)
+        except Exception as e:
+            logger.error(f"Error fetching NVIDIA memory: {e}")
+            return PlatformInfo(platform_name="linux", gpu_memory_mib=None)
+        # TODO support amd rocm, intel, etc
+
+    else:
+        logger.error(f"System {system} not explicitly supported!")
+        return PlatformInfo(platform_name=None, gpu_memory_mib=None)
+
+
+def get_model_checkpoint_compatibility(model_checkpoint: MlModelCheckpoint, platform_info: PlatformInfo | None) -> tuple[bool, str | None]:
+    errors = []
+    if platform_info is None:
+        errors.append("local PlatformInfo not detected")
+    else:
+        if platform_info.platform_name not in model_checkpoint.supported_platforms:
+            errors.append(
+                f"the local platform {platform_info.platform_name} is not supported by the model ({','.join(model_checkpoint.supported_platforms)})"
+            )
+        if model_checkpoint.minimum_gpu_memory_mib is not None:
+            if platform_info.gpu_memory_mib is None:
+                errors.append(f"no gpu found, but the model requires one")
+            else:
+                if platform_info.gpu_memory_mib < model_checkpoint.minimum_gpu_memory_mib:
+                    errors.append(
+                        f"found only {platform_info.gpu_memory_mib} MiB gpu memory, but model needs {model_checkpoint.minimum_gpu_memory_mib}"
+                    )
+    if errors:
+        return False, ";".join(errors)
+    else:
+        return True, None

--- a/backend/src/forecastbox/domain/artifact/io.py
+++ b/backend/src/forecastbox/domain/artifact/io.py
@@ -19,13 +19,15 @@ import shutil
 import tempfile
 from collections.abc import Callable
 from pathlib import Path
+from typing import cast
 
 import httpx
 from cascade.low.func import assert_never
-from fiab_core.artifacts import ArtifactLocalId, ArtifactResolved, ArtifactStoreId, MlModelCheckpoint
+from fiab_core.artifacts import ArtifactLocalId, ArtifactResolved, ArtifactStoreId, ArtifactType, MlModelCheckpoint
 from pyrsistent import pmap
 
 from forecastbox.domain.artifact.base import ArtifactCatalog, CompositeArtifactId, artifacts_subdir, get_artifact_local_path
+from forecastbox.domain.artifact.compatibility import get_model_checkpoint_compatibility, get_platform_info
 from forecastbox.utility.config import ArtifactStoresConfig
 from forecastbox.utility.httpx import fetch_content
 
@@ -35,6 +37,7 @@ logger = logging.getLogger(__name__)
 def get_artifacts_catalog(artifact_stores_config: ArtifactStoresConfig) -> ArtifactCatalog:
     """Query each artifact store and return a composed catalog of all available artifacts."""
     catalog = {}
+    platform_info = get_platform_info()
 
     with httpx.Client(follow_redirects=True) as client:
         for store_id, store_config in artifact_stores_config.items():
@@ -44,14 +47,19 @@ def get_artifacts_catalog(artifact_stores_config: ArtifactStoresConfig) -> Artif
                 artifacts = store_data.get("artifacts", {})
                 for artifact_id, artifact_data in artifacts.items():
                     composite_id = CompositeArtifactId(artifact_store_id=store_id, artifact_local_id=ArtifactLocalId(artifact_id))
-                    artifact_type = artifact_data["artifact_type"]
+                    artifact_type = cast(ArtifactType, artifact_data["artifact_type"])
                     store_info_data = artifact_data["store_info"]
-                    # TODO set compatibility information
+                    if artifact_type == "MlModelCheckpoint":
+                        store_info = MlModelCheckpoint(**store_info_data)
+                        is_locally_compatible, local_compatibility_detail = get_model_checkpoint_compatibility(store_info, platform_info)
+                    else:
+                        assert_never(artifact_type)
+
                     catalog[composite_id] = ArtifactResolved(
                         artifact_type=artifact_type,
-                        store_info=MlModelCheckpoint(**store_info_data),
-                        is_locally_compatible=True,
-                        local_compatibility_detail=None,
+                        store_info=store_info,
+                        is_locally_compatible=is_locally_compatible,
+                        local_compatibility_detail=local_compatibility_detail,
                     )
                     logger.debug(f"Loaded artifact {composite_id} from store {store_id}")
             else:

--- a/backend/tests/unit/test_artifacts.py
+++ b/backend/tests/unit/test_artifacts.py
@@ -43,7 +43,7 @@ def sample_checkpoint() -> MlModelCheckpoint:
         display_description="Test Description",
         disk_size_bytes=1024,
         pip_package_constraints=["torch>=2.0"],
-        supported_platforms=["linux"],
+        supported_platforms=["linux", "macos"],
         input_characteristics=["input_source"],
         output_qube={},
         timestep="1h",


### PR DESCRIPTION
1/ extend optionally the fiab_core.artifacts.MlModelCheckpoint contract class to contain minimum gpu memory, defaulting to "not required"
2/ mvp for checking model compatibility, via "is the platform in `supported` & if model needs gpu, we either need to have that much unified memory on mac *or* that much nvidia-smi total memory

cc @HCookie -- we can start adding mem bounds to model artifacts if we'll run into user issue reports

cc @liefra -- this is how the local_compatibility_detail will look irl

note: I intentionally put things as soft here -- we do use the compatibility check to derive the checkpoint enum for the anemoi task, but I dont think this is hard enforced by the backend. Thus the user should still be able to put the value there if they believe our compatibility check is not correct. And the backend does not prevent download of incompatible checkpoint. I think this is a good behaviour -- so as we'll be improving the type system, we need to think about how to distinguish these "type mismatch" from genuine ones like confusing dates and figs etc. It's similar to the "None being valid for storing a configuration preset" -- we will need fine-grained validation