### PR TITLE
[plugin] feat: add GRIB sink block

### DIFF
--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/__init__.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/__init__.py
@@ -12,13 +12,14 @@ from fiab_core.tools.blocks import QubedBlockBuilder
 from fiab_core.tools.plugins import QubedPluginBuilder
 
 from fiab_plugin_ecmwf.anemoi.blocks import AnemoiSource, AnemoiTransform
-from fiab_plugin_ecmwf.blocks import EkdSource, EnsembleStatistics, MapPlotSink, TemporalStatistics, ZarrSink
+from fiab_plugin_ecmwf.blocks import EkdSource, EnsembleStatistics, GribSink, MapPlotSink, TemporalStatistics, ZarrSink
 
 blocks: dict[BlockFactoryId, QubedBlockBuilder] = {
     BlockFactoryId("ekdSource"): EkdSource(),
     BlockFactoryId("ensembleStatistics"): EnsembleStatistics(),
     BlockFactoryId("temporalStatistics"): TemporalStatistics(),
     BlockFactoryId("zarrSink"): ZarrSink(),
+    BlockFactoryId("gribSink"): GribSink(),
     BlockFactoryId("anemoiSource"): AnemoiSource(),
     BlockFactoryId("anemoiTransform"): AnemoiTransform(),
     BlockFactoryId("mapPlotSink"): MapPlotSink(),

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -313,6 +313,41 @@ class ZarrSink(Sink):
         return bool(dimensions(other))
 
 
+class GribSink(Sink):
+    title: str = "GRIB Sink"
+    description: str = "Write dataset to a GRIB file on the local filesystem"
+    configuration_options: dict[str, BlockConfigurationOption] = {
+        "path": BlockConfigurationOption(
+            title="GRIB Path",
+            description="Filesystem path where the GRIB file should be written",
+            value_type="str",
+        )
+    }
+    inputs: list[str] = ["dataset"]
+
+    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
+        return Either.ok(NoOutput())
+
+    def compile(
+        self,
+        inputs: ActionLookup,
+        block_id: BlockInstanceId,
+        block: BlockInstance,
+    ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
+        input_task = block.input_ids["dataset"]
+
+        action = inputs[input_task].map(
+            Payload(
+                "fiab_plugin_ecmwf.runtime.sinks.write_grib",
+                kwargs={"path": block.configuration_values["path"]},
+            )
+        )
+        return Either.ok(action)
+
+    def intersect(self, other: QubedOutput) -> bool:
+        return bool(dimensions(other))
+
+
 class MapPlotSink(Sink):
     title: str = "Map Plot"
     description: str = "Render a geographic map using earthkit-plots"

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/runtime/sinks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/runtime/sinks.py
@@ -1,6 +1,25 @@
+import fcntl
+import pathlib
+
 import earthkit.data
 
 
 def write_zarr(fieldlist: earthkit.data.SimpleFieldList, path: str) -> str:
     fieldlist.to_target("zarr", xarray_to_zarr_kwargs={"store": path, "mode": "w"})
     return path
+
+
+def write_grib(fieldlist: earthkit.data.SimpleFieldList, path: str) -> str:
+    # Cascade fans out, so multiple workers can call this concurrently.
+    p = pathlib.Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with open(p, "ab") as fh:
+        # Acquire an exclusive lock
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        try:
+            # Let earthkit handle the actual data I/O natively
+            fieldlist.to_target("file", str(p), append=True)
+        finally:
+            # Explicitly release the lock
+            fcntl.flock(fh, fcntl.LOCK_UN)
+    return str(p)

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -23,6 +23,7 @@ from fiab_core.fable import (
 from fiab_plugin_ecmwf.blocks import (
     EkdSource,
     EnsembleStatistics,
+    GribSink,
     MapPlotSink,
     TemporalStatistics,
     ZarrSink,
@@ -93,6 +94,17 @@ def zarr_sink_configuration() -> BlockInstance:
         input_ids={"dataset": BlockInstanceId("source_output")},
         configuration_values={
             "path": "/path/to/output.zarr",
+        },
+    )
+
+
+@pytest.fixture
+def grib_sink_configuration() -> BlockInstance:
+    return BlockInstance(
+        factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="GribSink"),  # type: ignore
+        input_ids={"dataset": BlockInstanceId("source_output")},
+        configuration_values={
+            "path": "/path/to/output.grib2",
         },
     )
 
@@ -270,6 +282,60 @@ class TestZarrSink:
         assert block.intersect(other=temporal_output)  # type: ignore[arg-type]
         output = block.validate(  # type: ignore[assignment]
             block=zarr_sink_configuration,
+            inputs={"dataset": temporal_output},  # type: ignore[dict-item]
+        ).get_or_raise()
+        assert isinstance(output, NoOutput)
+
+
+class TestGribSink:
+    def test_from_ekdsource(self, grib_sink_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
+        block = GribSink()
+
+        assert block.intersect(other=ekdsource_output)  # type: ignore[arg-type]
+        output = block.validate(  # type: ignore[assignment]
+            block=grib_sink_configuration,
+            inputs={"dataset": ekdsource_output},  # type: ignore[dict-item]
+        ).get_or_raise()
+        assert isinstance(output, NoOutput)
+
+    def test_from_ensemble_statistics(
+        self,
+        grib_sink_configuration: BlockInstance,
+        ensemble_statistics_configuration: BlockInstance,
+        ekdsource_output: QubedOutput,
+    ) -> None:
+        ensemble_block = EnsembleStatistics()
+        ensemble_output = ensemble_block.validate(  # type: ignore[assignment]
+            block=ensemble_statistics_configuration,
+            inputs={"dataset": ekdsource_output},  # type: ignore[dict-item]
+        ).get_or_raise()
+
+        block = GribSink()
+
+        assert block.intersect(other=ensemble_output)  # type: ignore[arg-type]
+        output = block.validate(  # type: ignore[assignment]
+            block=grib_sink_configuration,
+            inputs={"dataset": ensemble_output},  # type: ignore[dict-item]
+        ).get_or_raise()
+        assert isinstance(output, NoOutput)
+
+    def test_from_temporal_statistics(
+        self,
+        grib_sink_configuration: BlockInstance,
+        temporal_statistics_configuration: BlockInstance,
+        ekdsource_output: QubedOutput,
+    ) -> None:
+        temporal_block = TemporalStatistics()
+        temporal_output = temporal_block.validate(  # type: ignore[assignment]
+            block=temporal_statistics_configuration,
+            inputs={"dataset": ekdsource_output},  # type: ignore[dict-item]
+        ).get_or_raise()
+
+        block = GribSink()
+
+        assert block.intersect(other=temporal_output)  # type: ignore[arg-type]
+        output = block.validate(  # type: ignore[assignment]
+            block=grib_sink_configuration,
             inputs={"dataset": temporal_output},  # type: ignore[dict-item]
         ).get_or_raise()
         assert isinstance(output, NoOutput)


### PR DESCRIPTION
This PR adds a GribSink block: A Sink block that writes a SimpleFieldList to a GRIB file via earthkit-data's file target with append=True. Concurrent writers from cascade fan-out are serialised by an advisory flock on the output file itself so multi-MB messages don't interleave.

Mirrors the existing ZarrSink shape: title/path config, NoOutput on validate, .map(write_grib) on compile. Tests mirror TestZarrSink with EkdSource / EnsembleStatistics / TemporalStatistics fixtures.

_Note_: In its current form, it does not include pass-through of the actual GRIB filename in its output (as we will need later on for the SkinnyWMS integration). It is focused solely on writing the GRIB file.

@tmi , @HCookie : Could you please have a look, especially at the `write_grib` method as it introduces a file lock, which was required in my testing; otherwise, concurrent cascade writes resulted in an inconsistent Grib file state.

Also, please note that I have no idea whether the locking, as currently implemented, would even work in an HPC environment. Could you double-check that as well?

Please amend as required.
