### PR TITLE
feat: pass structured output_qube to MlModelDetail

### DIFF
--- a/backend/src/forecastbox/domain/artifact/base.py
+++ b/backend/src/forecastbox/domain/artifact/base.py
@@ -13,6 +13,7 @@ Base definitions pertaining to artifacts such as ml model checkpoints
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from fiab_core.artifacts import ArtifactResolved, CompositeArtifactId, Platform
 from pyrsistent.typing import PMap
@@ -44,7 +45,7 @@ class MlModelDetail:
     disk_size_bytes: int
     pip_package_constraints: list[str]
     supported_platforms: list[Platform]
-    output_characteristics: list[str]
+    output_characteristics: dict[str, Any]
     input_characteristics: list[str]
     is_available: bool
     is_locally_compatible: bool

--- a/backend/src/forecastbox/domain/artifact/manager.py
+++ b/backend/src/forecastbox/domain/artifact/manager.py
@@ -217,7 +217,7 @@ def get_model_details(composite_id: CompositeArtifactId) -> MlModelDetail:
             disk_size_bytes=checkpoint.disk_size_bytes,
             pip_package_constraints=checkpoint.pip_package_constraints,
             supported_platforms=checkpoint.supported_platforms,
-            output_characteristics=[str(checkpoint.output_qube)],  # TODO Add qubed to detail, and display properly in the frontend
+            output_characteristics=checkpoint.output_qube,
             input_characteristics=checkpoint.input_characteristics,
             is_available=composite_id in ArtifactManager.locally_available,
             is_locally_compatible=artifact.is_locally_compatible,


### PR DESCRIPTION
Changes the `MlModelDetail.output_characteristics` to `dict[str, Any]`  and passes the checkpoint's output_qube through directly so it can be visualised using qube data structure. 

Narrows MlModelDetail.output_characteristics to dict[str, Any]  and passes the checkpoint's output_qube through directly. 

The frontend already accepts this shape and renders it through QubeTree.

Note: This PR uses `dict[str, Any]` on the frontend side, it is validated using a QubeTree. The frontend will complain if the data structure does not match the expected format. 

@HCookie , @tmi : Please have a look and feel free to amend as needed.


