### PR TITLE
[frontend]: align with backend validation v2

### DIFF
--- a/frontend/src/api/types/fable.types.ts
+++ b/frontend/src/api/types/fable.types.ts
@@ -321,6 +321,8 @@ export interface BlockValidationState {
   errors: Array<string>
   hasErrors: boolean
   possibleExpansions: Array<PluginBlockFactoryId>
+  /** Unknown glyph names per option, from /blueprint/expand. */
+  missingGlyphs: Record<string, Array<string>>
 }
 
 export interface FableValidationState {
@@ -622,18 +624,24 @@ export function toValidationState(
     ...Object.keys(expansion.block_errors),
     ...Object.keys(expansion.possible_expansions),
     ...Object.keys(missingRequiredByBlock),
+    ...Object.keys(expansion.missing_glyphs),
   ])
 
   for (const blockId of allBlockIds) {
     const backendErrors = expansion.block_errors[blockId] ?? []
     const missingErrors = missingRequiredByBlock[blockId] ?? []
     const errors = [...backendErrors, ...missingErrors]
+    const missingGlyphs = expansion.missing_glyphs[blockId] ?? {}
+    const hasMissingGlyphs = Object.values(missingGlyphs).some(
+      (names) => names.length > 0,
+    )
     blockStates[blockId] = {
       errors,
-      hasErrors: errors.length > 0,
+      hasErrors: errors.length > 0 || hasMissingGlyphs,
       possibleExpansions: toPluginFactoryIds(
         expansion.possible_expansions[blockId] ?? [],
       ),
+      missingGlyphs,
     }
   }
 

--- a/frontend/src/components/base/fields/fields/DateTimeField.tsx
+++ b/frontend/src/components/base/fields/fields/DateTimeField.tsx
@@ -106,13 +106,18 @@ function DateAndTimeInputs({
   const { date, time } = splitDatetime(value)
   const displayedTime = time || DEFAULT_TIME
 
+  // Time picker emits HH:MM; backend requires HH:MM:SS.
+  function composeIso(d: string, hhmm: string): string {
+    return `${d}T${hhmm}:00`
+  }
+
   function handleDateChange(nextDate: string) {
     if (!nextDate) {
       // Clearing the date clears the whole value; the stored form is all-or-nothing.
       onChange('')
       return
     }
-    onChange(`${nextDate}T${time || DEFAULT_TIME}`)
+    onChange(composeIso(nextDate, time || DEFAULT_TIME))
   }
 
   function handleTimeChange(nextTime: string) {
@@ -120,7 +125,7 @@ function DateAndTimeInputs({
     // If the user picks a time before a date, default the date to today so
     // the time they just typed doesn't silently revert on re-render.
     const effectiveDate = date || todayLocalISO()
-    onChange(`${effectiveDate}T${effective}`)
+    onChange(composeIso(effectiveDate, effective))
   }
 
   return (

--- a/frontend/src/features/executions/components/ExecutionCanvas.tsx
+++ b/frontend/src/features/executions/components/ExecutionCanvas.tsx
@@ -73,7 +73,7 @@ function ExecutionCanvasInner({
   status,
 }: ExecutionCanvasProps) {
   const { t } = useTranslation('executions')
-  const [showConfig, setShowConfig] = useState(false)
+  const [showConfig, setShowConfig] = useState(true)
   const { fitView } = useReactFlow()
   const isInitialRender = useRef(true)
 

--- a/frontend/src/features/fable-builder/components/form-mode/BlockInstanceCard.tsx
+++ b/frontend/src/features/fable-builder/components/form-mode/BlockInstanceCard.tsx
@@ -136,9 +136,10 @@ export function BlockInstanceCard({
 
   const hasErrors = blockValidation?.hasErrors ?? false
   const errors = blockValidation?.errors ?? []
+  const missingGlyphs = blockValidation?.missingGlyphs ?? {}
   const mappedErrors = useMemo(
-    () => mapBlockErrorsToFields(errors, instance.configuration_values),
-    [errors, instance.configuration_values],
+    () => mapBlockErrorsToFields(errors, missingGlyphs),
+    [errors, missingGlyphs],
   )
 
   if (!factory) {

--- a/frontend/src/features/fable-builder/components/graph-mode/nodes/BlockErrorOverlay.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/nodes/BlockErrorOverlay.tsx
@@ -14,7 +14,9 @@
  * relayout; shared between BlockNode and InlineBlockNode.
  */
 
-import { AlertCircle } from 'lucide-react'
+import { useState } from 'react'
+import { AlertCircle, ChevronDown, ChevronUp } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 
 export function BlockErrorOverlay({
@@ -22,17 +24,62 @@ export function BlockErrorOverlay({
 }: {
   errors: ReadonlyArray<string>
 }) {
+  const { t } = useTranslation('configure')
+  const [expanded, setExpanded] = useState(false)
   if (errors.length === 0) return null
+
+  const hasMore = errors.length > 1
+
+  function toggle(event: React.MouseEvent | React.KeyboardEvent) {
+    event.stopPropagation()
+    setExpanded((value) => !value)
+  }
+
   return (
     <Alert
       variant="destructive"
       className="nodrag absolute top-full right-0 left-0 z-10 mt-1 gap-1 px-2 py-1.5 text-xs shadow-md"
     >
       <AlertCircle className="h-3 w-3" />
-      <AlertDescription className="line-clamp-2 text-xs">
-        {errors[0]}
-        {errors.length > 1 && ` (+${errors.length - 1} more)`}
+      <AlertDescription className="text-xs">
+        {expanded ? (
+          <ul className="m-0 list-disc space-y-0.5 pl-4">
+            {errors.map((error, index) => (
+              <li key={index}>{error}</li>
+            ))}
+          </ul>
+        ) : (
+          <>
+            <span className="line-clamp-2">{errors[0]}</span>
+            {hasMore && (
+              <span className="opacity-80">
+                {' '}
+                {t('errors.more', { count: errors.length - 1 })}
+              </span>
+            )}
+          </>
+        )}
       </AlertDescription>
+      <button
+        type="button"
+        onClick={toggle}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') toggle(event)
+        }}
+        aria-expanded={expanded}
+        aria-label={
+          expanded
+            ? t('errors.collapseAriaLabel')
+            : t('errors.expandAriaLabel', { count: errors.length })
+        }
+        className="-mr-1 ml-auto flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded hover:bg-destructive/15"
+      >
+        {expanded ? (
+          <ChevronUp className="h-3 w-3" />
+        ) : (
+          <ChevronDown className="h-3 w-3" />
+        )}
+      </button>
     </Alert>
   )
 }

--- a/frontend/src/features/fable-builder/components/graph-mode/nodes/InlineBlockNode.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/nodes/InlineBlockNode.tsx
@@ -126,9 +126,10 @@ export const InlineBlockNode = memo(function ({
   const configOptions = Object.entries(factory.configuration_options)
   const inputs = factory.inputs
 
+  const missingGlyphs = blockValidation?.missingGlyphs ?? {}
   const mappedErrors = useMemo(
-    () => mapBlockErrorsToFields(errors, instance.configuration_values),
-    [errors, instance.configuration_values],
+    () => mapBlockErrorsToFields(errors, missingGlyphs),
+    [errors, missingGlyphs],
   )
 
   return (

--- a/frontend/src/features/fable-builder/components/layout/ConfigPanel.tsx
+++ b/frontend/src/features/fable-builder/components/layout/ConfigPanel.tsx
@@ -68,6 +68,12 @@ export function ConfigPanel({ catalogue }: ConfigPanelProps): React.ReactNode {
         null)
       : null,
   )
+  const missingGlyphs = useFableBuilderStore((state) =>
+    state.selectedBlockId
+      ? (state.validationState?.blockStates[state.selectedBlockId]
+          ?.missingGlyphs ?? null)
+      : null,
+  )
   const selectBlock = useFableBuilderStore((state) => state.selectBlock)
   const updateBlockConfig = useFableBuilderStore(
     (state) => state.updateBlockConfig,
@@ -121,10 +127,9 @@ export function ConfigPanel({ catalogue }: ConfigPanelProps): React.ReactNode {
 
   // Hook must be called unconditionally — guard inside rather than early-
   // returning above it.
-  const configurationValues = selectedBlock?.configuration_values
   const mappedErrors = useMemo(
-    () => mapBlockErrorsToFields(blockErrors ?? [], configurationValues ?? {}),
-    [blockErrors, configurationValues],
+    () => mapBlockErrorsToFields(blockErrors ?? [], missingGlyphs ?? {}),
+    [blockErrors, missingGlyphs],
   )
 
   if (!selectedBlock || !factory) {

--- a/frontend/src/features/fable-builder/utils/map-block-errors-to-fields.ts
+++ b/frontend/src/features/fable-builder/utils/map-block-errors-to-fields.ts
@@ -10,15 +10,11 @@
 
 /**
  * Best-effort mapping from backend block-level error strings to individual
- * config keys. The backend currently returns block errors as flat strings
- * (see backend/src/forecastbox/domain/blueprint/service.py), so the frontend
- * parses known message shapes to provide per-field UI highlights.
+ * config keys. The backend returns block errors as flat strings, so the
+ * frontend parses known message shapes to provide per-field UI highlights.
+ * Unknown-glyph references arrive structured (not as strings) and are
+ * attributed via the optional `missingGlyphs` parameter.
  */
-
-import {
-  containsGlyphs,
-  extractGlyphKey,
-} from '@/features/fable-builder/utils/glyph-display'
 
 export interface MappedBlockErrors {
   /** Field-level errors keyed by configuration option key. */
@@ -26,8 +22,6 @@ export interface MappedBlockErrors {
   /** Errors that could not be attributed to a specific field. */
   unmapped: Array<string>
 }
-
-const GLYPH_PATTERN = /\$\{(\w+)\}/g
 
 /**
  * Parse a Python-style set-of-strings literal like `{'foo', 'bar'}` into
@@ -50,19 +44,6 @@ function parsePythonStringSet(input: string): Set<string> | null {
   return names.size > 0 ? names : null
 }
 
-/**
- * Return the set of glyph names referenced inside a config value
- * (e.g. `${runId}-foo` → {"runId"}).
- */
-function referencedGlyphs(value: string): Set<string> {
-  const names = new Set<string>()
-  if (!containsGlyphs(value)) return names
-  for (const match of value.matchAll(GLYPH_PATTERN)) {
-    names.add(extractGlyphKey(match[0]))
-  }
-  return names
-}
-
 function pushError(
   out: Record<string, Array<string>>,
   configKey: string,
@@ -77,49 +58,24 @@ function pushError(
 }
 
 /**
- * Map block-level backend errors onto specific configuration keys.
+ * Map block-level backend errors and structured missing glyphs onto specific
+ * configuration keys.
  *
- * Recognised message shapes:
- * - "Unknown glyphs referenced: {'foo', 'bar'}" — each unknown glyph is
- *   attached to every config key whose value references it.
- * - "Block contains extra config: {'foo', 'bar'}" — attached as "Unknown
- *   configuration key" to each listed key.
- * - "Block contains missing config: {'foo', 'bar'}" — attached as
- *   "Missing required value" to each listed key.
+ * Recognised `errors` shapes (Python-set literals):
+ * - "Block contains extra config: {...}" → "Unknown configuration key"
+ * - "Block contains missing config: {...}" → "Missing required value"
  *
- * Everything else is returned as `unmapped`.
+ * `missingGlyphs[configKey] = [name, ...]` → "Unknown glyph: ${name}" per name.
+ * Anything else in `errors` is returned as `unmapped`.
  */
 export function mapBlockErrorsToFields(
   errors: ReadonlyArray<string>,
-  configurationValues: Record<string, string>,
+  missingGlyphs: Record<string, ReadonlyArray<string>> = {},
 ): MappedBlockErrors {
   const byConfigKey: Record<string, Array<string>> = {}
   const unmapped: Array<string> = []
 
   for (const error of errors) {
-    const unknownGlyphs = error.match(/^Unknown glyphs referenced:\s*(.+)$/)
-    if (unknownGlyphs) {
-      const set = parsePythonStringSet(unknownGlyphs[1])
-      if (!set || set.size === 0) {
-        unmapped.push(error)
-        continue
-      }
-      let attributed = false
-      for (const [configKey, value] of Object.entries(configurationValues)) {
-        const refs = referencedGlyphs(value)
-        for (const name of refs) {
-          if (set.has(name)) {
-            pushError(byConfigKey, configKey, `Unknown glyph: \${${name}}`)
-            attributed = true
-          }
-        }
-      }
-      if (!attributed) {
-        unmapped.push(error)
-      }
-      continue
-    }
-
     const extraConfig = error.match(/^Block contains extra config:\s*(.+)$/)
     if (extraConfig) {
       const set = parsePythonStringSet(extraConfig[1])
@@ -147,6 +103,12 @@ export function mapBlockErrorsToFields(
     }
 
     unmapped.push(error)
+  }
+
+  for (const [configKey, glyphNames] of Object.entries(missingGlyphs)) {
+    for (const name of glyphNames) {
+      pushError(byConfigKey, configKey, `Unknown glyph: \${${name}}`)
+    }
   }
 
   return { byConfigKey, unmapped }

--- a/frontend/src/locales/en/configure.json
+++ b/frontend/src/locales/en/configure.json
@@ -17,5 +17,10 @@
     "saveAsNew": "Save as New",
     "update": "Update",
     "save": "Save"
+  },
+  "errors": {
+    "more": "(+{{count}} more)",
+    "expandAriaLabel": "Show all {{count}} errors",
+    "collapseAriaLabel": "Collapse errors"
   }
 }

--- a/frontend/tests/integration/components/fields/field-renderer.test.tsx
+++ b/frontend/tests/integration/components/fields/field-renderer.test.tsx
@@ -187,7 +187,7 @@ describe('FieldRenderer Integration', () => {
       await expect.element(timeInput).toHaveValue('00:00')
     })
 
-    it('combines date + time into a datetime-local string on date pick', async () => {
+    it('combines date + time into an ISO 8601 string with seconds on date pick', async () => {
       const screen = await renderWithProviders(
         <ControlledFieldRenderer valueType="datetime" label="DateValue" />,
       )
@@ -195,7 +195,7 @@ describe('FieldRenderer Integration', () => {
       await dateInput.fill('2026-07-15')
       await expect
         .element(screen.getByTestId('current-value'))
-        .toHaveTextContent('2026-07-15T00:00')
+        .toHaveTextContent('2026-07-15T00:00:00')
     })
 
     it('renders date input for "date-iso8601"', async () => {

--- a/frontend/tests/unit/api/fable-types.test.ts
+++ b/frontend/tests/unit/api/fable-types.test.ts
@@ -81,6 +81,48 @@ describe('toValidationState', () => {
     expect(result.blockStates.b1.hasErrors).toBe(true)
   })
 
+  it('exposes structured missing_glyphs per block and marks the block as invalid', () => {
+    const expansion: FableValidationExpansion = {
+      global_errors: [],
+      block_errors: {},
+      possible_sources: [],
+      possible_expansions: {},
+      resolved_configuration_options: {},
+      missing_glyphs: {
+        sink_file: {
+          fname: ['missingRoot'],
+          suffix: ['missingRoot', 'env'],
+        },
+      },
+    }
+
+    const result = toValidationState(expansion)
+
+    expect(result.blockStates.sink_file.missingGlyphs).toEqual({
+      fname: ['missingRoot'],
+      suffix: ['missingRoot', 'env'],
+    })
+    expect(result.blockStates.sink_file.errors).toEqual([])
+    expect(result.blockStates.sink_file.hasErrors).toBe(true)
+    expect(result.isValid).toBe(false)
+  })
+
+  it('treats empty missing_glyphs entries as no warnings', () => {
+    const expansion: FableValidationExpansion = {
+      global_errors: [],
+      block_errors: {},
+      possible_sources: [],
+      possible_expansions: {},
+      resolved_configuration_options: {},
+      missing_glyphs: { sink_file: {} },
+    }
+
+    const result = toValidationState(expansion)
+
+    expect(result.blockStates.sink_file.missingGlyphs).toEqual({})
+    expect(result.blockStates.sink_file.hasErrors).toBe(false)
+  })
+
   it('maps expansion items with restrictions to factory IDs for existing UI flows', () => {
     const expansion: FableValidationExpansion = {
       global_errors: [],

--- a/frontend/tests/unit/features/fable-builder/utils/map-block-errors-to-fields.test.ts
+++ b/frontend/tests/unit/features/fable-builder/utils/map-block-errors-to-fields.test.ts
@@ -12,92 +12,74 @@ import { describe, expect, it } from 'vitest'
 import { mapBlockErrorsToFields } from '@/features/fable-builder/utils/map-block-errors-to-fields'
 
 describe('mapBlockErrorsToFields', () => {
-  it('returns empty result for empty errors', () => {
-    const result = mapBlockErrorsToFields([], { foo: 'bar' })
+  it('returns empty result for empty inputs', () => {
+    const result = mapBlockErrorsToFields([])
     expect(result).toEqual({ byConfigKey: {}, unmapped: [] })
-  })
-
-  describe('Unknown glyphs referenced', () => {
-    it('attaches unknown glyph to matching config key', () => {
-      const result = mapBlockErrorsToFields(
-        ["Unknown glyphs referenced: {'runtd'}"],
-        { expver: '${runtd}', date: '2026-04-15' },
-      )
-      expect(result.byConfigKey).toEqual({
-        expver: ['Unknown glyph: ${runtd}'],
-      })
-      expect(result.unmapped).toEqual([])
-    })
-
-    it('attaches to every config key that references an unknown glyph', () => {
-      const result = mapBlockErrorsToFields(
-        ["Unknown glyphs referenced: {'foo'}"],
-        { a: 'prefix-${foo}', b: '${foo}-suffix', c: 'plain' },
-      )
-      expect(result.byConfigKey).toEqual({
-        a: ['Unknown glyph: ${foo}'],
-        b: ['Unknown glyph: ${foo}'],
-      })
-    })
-
-    it('handles multiple unknown glyphs in one error', () => {
-      const result = mapBlockErrorsToFields(
-        ["Unknown glyphs referenced: {'foo', 'bar'}"],
-        { a: '${foo}', b: '${bar}', c: '${foo}-${bar}' },
-      )
-      expect(result.byConfigKey).toEqual({
-        a: ['Unknown glyph: ${foo}'],
-        b: ['Unknown glyph: ${bar}'],
-        c: ['Unknown glyph: ${foo}', 'Unknown glyph: ${bar}'],
-      })
-    })
-
-    it('falls back to unmapped when no config value references the unknown glyph', () => {
-      const result = mapBlockErrorsToFields(
-        ["Unknown glyphs referenced: {'ghost'}"],
-        { expver: '${runId}' },
-      )
-      expect(result.byConfigKey).toEqual({})
-      expect(result.unmapped).toEqual(["Unknown glyphs referenced: {'ghost'}"])
-    })
-
-    it('falls back to unmapped when the set literal is malformed', () => {
-      const result = mapBlockErrorsToFields(
-        ['Unknown glyphs referenced: not-a-set'],
-        { expver: '${runtd}' },
-      )
-      expect(result.unmapped).toEqual(['Unknown glyphs referenced: not-a-set'])
-    })
   })
 
   describe('Block contains extra / missing config', () => {
     it('attaches "Unknown configuration key" for extra config', () => {
-      const result = mapBlockErrorsToFields(
-        ["Block contains extra config: {'orphan'}"],
-        {},
-      )
+      const result = mapBlockErrorsToFields([
+        "Block contains extra config: {'orphan'}",
+      ])
       expect(result.byConfigKey).toEqual({
         orphan: ['Unknown configuration key'],
       })
     })
 
     it('attaches "Missing required value" for missing config', () => {
-      const result = mapBlockErrorsToFields(
-        ["Block contains missing config: {'needed', 'also_needed'}"],
-        {},
-      )
+      const result = mapBlockErrorsToFields([
+        "Block contains missing config: {'needed', 'also_needed'}",
+      ])
       expect(result.byConfigKey).toEqual({
         needed: ['Missing required value'],
         also_needed: ['Missing required value'],
       })
     })
+
+    it('falls back to unmapped when the set literal is malformed', () => {
+      const result = mapBlockErrorsToFields([
+        'Block contains missing config: not-a-set',
+      ])
+      expect(result.unmapped).toEqual([
+        'Block contains missing config: not-a-set',
+      ])
+    })
+  })
+
+  describe('Missing glyphs (structured)', () => {
+    it('attaches an unknown-glyph message per (configKey, glyphName) entry', () => {
+      const result = mapBlockErrorsToFields([], {
+        expver: ['runtd'],
+      })
+      expect(result.byConfigKey).toEqual({
+        expver: ['Unknown glyph: ${runtd}'],
+      })
+      expect(result.unmapped).toEqual([])
+    })
+
+    it('handles multiple glyphs on the same option and multiple options', () => {
+      const result = mapBlockErrorsToFields([], {
+        fname: ['missingRoot'],
+        suffix: ['missingRoot', 'env'],
+      })
+      expect(result.byConfigKey).toEqual({
+        fname: ['Unknown glyph: ${missingRoot}'],
+        suffix: ['Unknown glyph: ${missingRoot}', 'Unknown glyph: ${env}'],
+      })
+    })
+
+    it('treats an empty missingGlyphs map as a no-op', () => {
+      const result = mapBlockErrorsToFields([], {})
+      expect(result).toEqual({ byConfigKey: {}, unmapped: [] })
+    })
   })
 
   it('passes through unrecognised errors as unmapped', () => {
-    const result = mapBlockErrorsToFields(
-      ['Plugin not found', 'BlockFactory not found in the catalogue'],
-      { expver: '${runId}' },
-    )
+    const result = mapBlockErrorsToFields([
+      'Plugin not found',
+      'BlockFactory not found in the catalogue',
+    ])
     expect(result.byConfigKey).toEqual({})
     expect(result.unmapped).toEqual([
       'Plugin not found',
@@ -105,18 +87,14 @@ describe('mapBlockErrorsToFields', () => {
     ])
   })
 
-  it('mixes mapped and unmapped in a single call', () => {
+  it('combines parsed errors, structured missing glyphs, and unmapped errors', () => {
     const result = mapBlockErrorsToFields(
-      [
-        "Unknown glyphs referenced: {'runtd'}",
-        'Plugin not found',
-        "Block contains missing config: {'date'}",
-      ],
-      { expver: '${runtd}' },
+      ["Block contains missing config: {'date'}", 'Plugin not found'],
+      { expver: ['runtd'] },
     )
     expect(result.byConfigKey).toEqual({
-      expver: ['Unknown glyph: ${runtd}'],
       date: ['Missing required value'],
+      expver: ['Unknown glyph: ${runtd}'],
     })
     expect(result.unmapped).toEqual(['Plugin not found'])
   })


### PR DESCRIPTION
Aligns the fable builder validation surfaces with the backend's validation v2 contract (#430).

### Missing glyph warnings — surface as field-level errors


- `BlockValidationState` gains `missingGlyphs: Record<string, string[]>`, populated from `expansion.missing_glyphs[blockId]` and counted toward  `hasErrors`.
- `mapBlockErrorsToFields` takes the structured glyphs as a second parameter and pushes `Unknown glyph: ${name}` directly per option — no regex round-trip.
- Removes the dead `Unknown glyphs referenced:` parser branch and now-unused helpers (`referencedGlyphs`, `GLYPH_PATTERN`, and the local imports of  `containsGlyphs` / `extractGlyphKey`).

### Block error overlay — expandable list

The validation banner below a graph node previously showed only the first error line-clamp-2 with a `(+N more)` count and no way to read the rest. Added a chevron toggle so the expanded state renders all errors as a bulleted list. Stays absolutely positioned so toggling never resizes the node and triggers a React Flow relayout. New i18n keys under `configure.errors.*` for aria-labels.

### Datetime field — full ISO 8601

HTML `<input type="time">` emits `HH:MM`. The field was composing wire values as `${date}T${HH:MM}`, which validation v2's strict ISO 8601 parser rejects (`Cannot parse '2026-05-11T00:00' as datetime`). `DateTimeField` now pads `:00` so the stored form is `YYYY-MM-DDTHH:MM:SS`. Round-trips through the picker correctly — `splitDatetime` already tolerated trailing seconds on read.

### Execution canvas — show config by default

`ExecutionCanvas` now opens with `showConfig: true` instead of `false`. Tiny one-liner; toggle still works to hide.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
