### PR TITLE
[backend] minor justfile improvement

### DIFF
--- a/backend/justfile
+++ b/backend/justfile
@@ -9,4 +9,5 @@ dev:
         if [[ ! -d .fiab ]] ; then mkdir -p .fiab/data_dir ; fi
         echo "1761908420:d0.0.1" > .fiab/pylock.toml.timestamp
     fi
+    if [[ ! -d .venv ]] ; then uv sync --extra runtime --all-packages ; fi
     FIAB_ROOT=.fiab uv run --no-sync python -m forecastbox.entrypoint.main


### PR DESCRIPTION
on a vanilla checkout, `just dev` didnt work properly because the venv is not sync and we run explicitly with --no-sync

adding a uv sync call if no .venv exists. Wont work in all cases, such as when the user has explicitly overridden the uv project env, or when the venv exists but is not synced, etc. But a tiny bit more foolproof

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
