### PR TITLE
Feat/detailed progress report

### DIFF
--- a/backend/src/forecastbox/domain/run/background.py
+++ b/backend/src/forecastbox/domain/run/background.py
@@ -17,11 +17,9 @@ Async database calls are dispatched back to the event loop via
 
 import asyncio
 import logging
-import uuid
 from datetime import datetime
 from typing import cast
 
-from cascade.controller.report import JobId
 from cascade.low.core import TaskId
 from fiab_core.fable import BlockInstanceId
 
@@ -120,23 +118,22 @@ def execute_background(
 
         logger.debug(f"starting background submission of {run_id=}")
         response = execute_cascade(exec_spec)
-        cascade_job_id = response.job_id or str(uuid.uuid4())
-        if response.job_id:
+        if response.job_id is not None:
+            update_kwargs: dict[str, object] = {
+                "cascade_job_id": response.job_id,
+                "outputs": run_outputs.model_dump(),
+            }
             try:
                 memcache_insert(
-                    JobId(response.job_id),
-                    cast(dict[TaskId, BlockInstanceId], task_to_block),
+                    run_id,
+                    task_to_block,
                 )
             except TooLargeEntry as e:
                 logger.warning(f"failed to cache task-to-block mapping for {run_id=}, {attempt_count=}: {repr(e)}")
-
-        update_kwargs: dict[str, object] = {"cascade_job_id": cascade_job_id}
-        if response.error:
-            update_kwargs["status"] = "failed"
-            update_kwargs["error"] = response.error[:255]
+            run_async(db.update_run_runtime(run_id, attempt_count, **update_kwargs))
         else:
-            update_kwargs["outputs"] = run_outputs.model_dump()
-        run_async(db.update_run_runtime(run_id, attempt_count, **update_kwargs))
+            error = (response.error or "no error provided by cascade")[:255]
+            run_async(db.update_run_runtime(run_id, attempt_count, status="failed", error=error))
 
     except Exception as e:
         logger.exception(f"execute_background failed for run {run_id!r} attempt {attempt_count}: {e}")

--- a/backend/src/forecastbox/domain/run/background.py
+++ b/backend/src/forecastbox/domain/run/background.py
@@ -21,6 +21,10 @@ import uuid
 from datetime import datetime
 from typing import cast
 
+from cascade.controller.report import JobId
+from cascade.low.core import TaskId
+from fiab_core.fable import BlockInstanceId
+
 from forecastbox.domain.blueprint.service import BlueprintBuilder
 from forecastbox.domain.glyphs import global_db
 from forecastbox.domain.glyphs.global_db import GlyphResolutionBuckets
@@ -38,6 +42,7 @@ from forecastbox.domain.run.db import CompilerRuntimeContext
 from forecastbox.domain.run.types import RunId
 from forecastbox.schemata.jobs import Blueprint
 from forecastbox.utility.auth import AuthContext
+from forecastbox.utility.memcache import insert as memcache_insert
 from forecastbox.utility.time import current_time
 
 logger = logging.getLogger(__name__)
@@ -100,7 +105,7 @@ def execute_background(
         relevant_glyphs_and_values = expand_glyph_values(all_glyphs_raw, roots=referenced_glyph_names)
         used_glyphs = {k: all_glyphs_raw[k] for k in relevant_glyphs_and_values.keys() if k not in PINNED_INTRINSIC_KEYS}
 
-        exec_spec, run_outputs = compile_builder(builder, relevant_glyphs_and_values)
+        exec_spec, run_outputs, task_to_block = compile_builder(builder, relevant_glyphs_and_values)
 
         persisted_context = compiler_runtime_context.model_copy(update={"glyphs": used_glyphs})
         run_async(
@@ -115,6 +120,14 @@ def execute_background(
         logger.debug(f"starting background submission of {run_id=}")
         response = execute_cascade(exec_spec)
         cascade_job_id = response.job_id or str(uuid.uuid4())
+        if response.job_id:
+            try:
+                memcache_insert(
+                    JobId(response.job_id),
+                    cast(dict[TaskId, BlockInstanceId], task_to_block),
+                )
+            except Exception as e:
+                logger.warning(f"failed to cache task-to-block mapping for {run_id=}, {attempt_count=}: {repr(e)}")
 
         update_kwargs: dict[str, object] = {"cascade_job_id": cascade_job_id}
         if response.error:

--- a/backend/src/forecastbox/domain/run/background.py
+++ b/backend/src/forecastbox/domain/run/background.py
@@ -119,10 +119,6 @@ def execute_background(
         logger.debug(f"starting background submission of {run_id=}")
         response = execute_cascade(exec_spec)
         if response.job_id is not None:
-            update_kwargs: dict[str, object] = {
-                "cascade_job_id": response.job_id,
-                "outputs": run_outputs.model_dump(),
-            }
             try:
                 memcache_insert(
                     run_id,
@@ -130,12 +126,11 @@ def execute_background(
                 )
             except TooLargeEntry as e:
                 logger.warning(f"failed to cache task-to-block mapping for {run_id=}, {attempt_count=}: {repr(e)}")
-            run_async(db.update_run_runtime(run_id, attempt_count, **update_kwargs))
+            (run_async(db.update_run_runtime(run_id, attempt_count, cascade_job_id=response.job_id, outputs=run_outputs.model_dump())),)
         else:
             error = (response.error or "no error provided by cascade")[:255]
             run_async(db.update_run_runtime(run_id, attempt_count, status="failed", error=error))
-
     except Exception as e:
-        logger.exception(f"execute_background failed for run {run_id!r} attempt {attempt_count}: {e}")
+        logger.exception(f"execute_background failed for run {run_id!r} attempt {attempt_count}: {repr(e)}")
         logger.debug(f"updating background data of {run_id=}")
         run_async(db.update_run_runtime(run_id, attempt_count, status="failed", error=repr(e)[:255]))

--- a/backend/src/forecastbox/domain/run/background.py
+++ b/backend/src/forecastbox/domain/run/background.py
@@ -42,6 +42,7 @@ from forecastbox.domain.run.db import CompilerRuntimeContext
 from forecastbox.domain.run.types import RunId
 from forecastbox.schemata.jobs import Blueprint
 from forecastbox.utility.auth import AuthContext
+from forecastbox.utility.memcache import TooLargeEntry
 from forecastbox.utility.memcache import insert as memcache_insert
 from forecastbox.utility.time import current_time
 
@@ -126,7 +127,7 @@ def execute_background(
                     JobId(response.job_id),
                     cast(dict[TaskId, BlockInstanceId], task_to_block),
                 )
-            except Exception as e:
+            except TooLargeEntry as e:
                 logger.warning(f"failed to cache task-to-block mapping for {run_id=}, {attempt_count=}: {repr(e)}")
 
         update_kwargs: dict[str, object] = {"cascade_job_id": cascade_job_id}

--- a/backend/src/forecastbox/domain/run/compile.py
+++ b/backend/src/forecastbox/domain/run/compile.py
@@ -129,7 +129,11 @@ def compile_builder(
             for node in block_graph.nodes():
                 task_id = cast(TaskId, node.name)  # TODO hack -- expose a proper interface for the name→taskId conversion in cascade
                 task_to_block[task_id] = blockId
-            sink_tasks.update(cast(TaskId, node.name) for node in block_graph.sinks)
+            sink_tasks.update(
+                cast(TaskId, node.name)
+                for node in block_graph.sinks  # TODO hack -- expose a proper interface for the name→taskId conversion in cascade
+                if not node.name.startswith("run_as_earthkit")  # TODO this may not be relevant anymore -- verify on real workflows
+            )
 
             block_output = block_outputs.get(blockId)
             if not isinstance(block_output, NoOutput):
@@ -140,16 +144,14 @@ def compile_builder(
     graph = deduplicate_nodes(graph)
     job_instance = graph2job(graph)
 
-    sink_task_ids = sorted(sink_tasks)
-    job_instance.ext_outputs = [dataset_id for task_id in sink_task_ids for dataset_id in job_instance.outputs_of(task_id)]
+    job_instance.ext_outputs = [dataset_id for task_id in sink_tasks for dataset_id in job_instance.outputs_of(task_id)]
 
     run_outputs: dict[TaskId, RunOutputCharacteristic] = {
         task_id: RunOutputCharacteristic(
-            original_block=block_id,
-            mime_type=block_to_mime.get(block_id, "application/octet-stream"),
+            original_block=task_to_block[task_id],
+            mime_type=block_to_mime[task_to_block[task_id]],
         )
-        for task_id in sink_task_ids
-        for block_id in [task_to_block[task_id]]
+        for task_id in sink_tasks
     }
 
     job = RawCascadeJob(job_type="raw_cascade_job", job_instance=job_instance)

--- a/backend/src/forecastbox/domain/run/compile.py
+++ b/backend/src/forecastbox/domain/run/compile.py
@@ -124,21 +124,17 @@ def compile_builder(
         except Exception as e:
             raise ValueError(f"compile failed at {blockId=} with {e}")
 
-        block_graph = action_lookup[blockId].graph()
-        for node in block_graph.sinks:
-            # TODO this may not be relevant anymore -- verify on real workflows
-            if node.name.startswith("run_as_earthkit"):
-                continue
-            task_id = cast(TaskId, node.name)  # TODO hack -- expose a proper interface for the name→taskId conversion in cascade
-            task_to_block[task_id] = blockId
-            if block_factory.kind == "sink":
-                sink_tasks.add(task_id)
-
-        block_output = block_outputs.get(blockId)
-        if not isinstance(block_output, NoOutput):
-            block_to_mime[blockId] = block_output.mime_type if isinstance(block_output, RawOutput) else "application/octet-stream"
-
         if block_factory.kind == "sink":
+            block_graph = action_lookup[blockId].graph()
+            for node in block_graph.nodes():
+                task_id = cast(TaskId, node.name)  # TODO hack -- expose a proper interface for the name→taskId conversion in cascade
+                task_to_block[task_id] = blockId
+            sink_tasks.update(cast(TaskId, node.name) for node in block_graph.sinks)
+
+            block_output = block_outputs.get(blockId)
+            if not isinstance(block_output, NoOutput):
+                block_to_mime[blockId] = block_output.mime_type if isinstance(block_output, RawOutput) else "application/octet-stream"
+
             graph += block_graph
 
     graph = deduplicate_nodes(graph)
@@ -147,15 +143,14 @@ def compile_builder(
     sink_task_ids = sorted(sink_tasks)
     job_instance.ext_outputs = [dataset_id for task_id in sink_task_ids for dataset_id in job_instance.outputs_of(task_id)]
 
-    run_outputs: dict[TaskId, RunOutputCharacteristic] = {}
-    for task_id in sink_task_ids:
-        block_id = task_to_block.get(task_id)
-        if block_id is None:
-            continue
-        run_outputs[task_id] = RunOutputCharacteristic(
+    run_outputs: dict[TaskId, RunOutputCharacteristic] = {
+        task_id: RunOutputCharacteristic(
             original_block=block_id,
             mime_type=block_to_mime.get(block_id, "application/octet-stream"),
         )
+        for task_id in sink_task_ids
+        for block_id in [task_to_block[task_id]]
+    }
 
     job = RawCascadeJob(job_type="raw_cascade_job", job_instance=job_instance)
 

--- a/backend/src/forecastbox/domain/run/compile.py
+++ b/backend/src/forecastbox/domain/run/compile.py
@@ -70,7 +70,9 @@ def _get_artifacts_list(graph: Graph) -> list[CompositeArtifactId]:
     return list(artifacts)
 
 
-def compile_builder(blueprint: BlueprintBuilder, glyph_values: dict[str, str]) -> tuple[ExecutionSpecification, RunOutputs]:
+def compile_builder(
+    blueprint: BlueprintBuilder, glyph_values: dict[str, str]
+) -> tuple[ExecutionSpecification, RunOutputs, dict[TaskId, BlockInstanceId]]:
     """Compile a BlueprintBuilder into an ExecutionSpecification and RunOutputs.
 
     Raises ``ValueError`` if any block cannot be validated/compiled. When ``glyph_values`` is
@@ -83,8 +85,11 @@ def compile_builder(blueprint: BlueprintBuilder, glyph_values: dict[str, str]) -
     plugins = PluginManager.plugins
     action_lookup = {}
     block_outputs: dict[BlockInstanceId, BlockInstanceOutput] = {}
-    # Maps cascade TaskId (node.name) → (originating BlockInstanceId, mime_type)
-    sink_task_to_block: dict[TaskId, tuple[BlockInstanceId, str]] = {}
+    # Maps any produced cascade TaskId (node.name) → originating BlockInstanceId.
+    task_to_block: dict[TaskId, BlockInstanceId] = {}
+    # Maps sink block ids to mime type used in RunOutputs (only relevant for external outputs).
+    block_to_mime: dict[BlockInstanceId, str] = {}
+    sink_tasks: set[TaskId] = set()
 
     for blockId in topological_order(blueprint.blocks.items(), lambda block: block.input_ids.values()):
         blockInstance = blueprint.blocks[blockId]
@@ -119,28 +124,38 @@ def compile_builder(blueprint: BlueprintBuilder, glyph_values: dict[str, str]) -
         except Exception as e:
             raise ValueError(f"compile failed at {blockId=} with {e}")
 
+        block_graph = action_lookup[blockId].graph()
+        for node in block_graph.sinks:
+            # TODO this may not be relevant anymore -- verify on real workflows
+            if node.name.startswith("run_as_earthkit"):
+                continue
+            task_id = cast(TaskId, node.name)  # TODO hack -- expose a proper interface for the name→taskId conversion in cascade
+            task_to_block[task_id] = blockId
+            if block_factory.kind == "sink":
+                sink_tasks.add(task_id)
+
+        block_output = block_outputs.get(blockId)
+        if not isinstance(block_output, NoOutput):
+            block_to_mime[blockId] = block_output.mime_type if isinstance(block_output, RawOutput) else "application/octet-stream"
+
         if block_factory.kind == "sink":
-            sink_graph = action_lookup[blockId].graph()
-            block_output = block_outputs.get(blockId)
-            if not isinstance(block_output, NoOutput):
-                mime_type = block_output.mime_type if isinstance(block_output, RawOutput) else "application/octet-stream"
-                for node in sink_graph.sinks:
-                    # TODO this may not be relevant anymore -- verify on real workflows
-                    if node.name.startswith("run_as_earthkit"):
-                        continue
-                    task_id = cast(TaskId, node.name)  # TODO hack -- expose a proper interface for the name→taskId conversion in cascade
-                    sink_task_to_block[task_id] = (blockId, mime_type)
-            graph += sink_graph
+            graph += block_graph
 
     graph = deduplicate_nodes(graph)
     job_instance = graph2job(graph)
 
-    job_instance.ext_outputs = [dataset_id for task_id in sink_task_to_block for dataset_id in job_instance.outputs_of(task_id)]
+    sink_task_ids = sorted(sink_tasks)
+    job_instance.ext_outputs = [dataset_id for task_id in sink_task_ids for dataset_id in job_instance.outputs_of(task_id)]
 
-    run_outputs: dict[TaskId, RunOutputCharacteristic] = {
-        task_id: RunOutputCharacteristic(original_block=block_id, mime_type=mime_type)
-        for task_id, (block_id, mime_type) in sink_task_to_block.items()
-    }
+    run_outputs: dict[TaskId, RunOutputCharacteristic] = {}
+    for task_id in sink_task_ids:
+        block_id = task_to_block.get(task_id)
+        if block_id is None:
+            continue
+        run_outputs[task_id] = RunOutputCharacteristic(
+            original_block=block_id,
+            mime_type=block_to_mime.get(block_id, "application/octet-stream"),
+        )
 
     job = RawCascadeJob(job_type="raw_cascade_job", job_instance=job_instance)
 
@@ -150,4 +165,4 @@ def compile_builder(blueprint: BlueprintBuilder, glyph_values: dict[str, str]) -
         environment = blueprint.environment.model_copy(update={"runtime_artifacts": merged_artifacts})
     else:
         environment = EnvironmentSpecification(runtime_artifacts=graph_artifacts)
-    return ExecutionSpecification(job=job, environment=environment), RunOutputs(outputs=run_outputs)
+    return ExecutionSpecification(job=job, environment=environment), RunOutputs(outputs=run_outputs), task_to_block

--- a/backend/src/forecastbox/domain/run/service.py
+++ b/backend/src/forecastbox/domain/run/service.py
@@ -64,6 +64,8 @@ class RunDetail(FiabBaseModel):
     cascade_job_id: str | None = None
     available_task_ids: list[TaskId] | None = None
     outputs: dict | None = None
+    completed_task_ids: dict[JobId, list[TaskId]] | None = None
+    planned_task_ids: dict[JobId, list[TaskId]] | None = None
 
 
 class ExecuteResult(FiabBaseModel):
@@ -162,7 +164,7 @@ async def restart_run(run_id: RunId, auth_context: AuthContext) -> Either[Execut
     )
 
 
-async def poll_and_update(execution: Run) -> RunDetail:
+async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunDetail:
     """Poll cascade for a Run's status, update db if changed, and return current detail."""
     run_id = RunId(str(execution.run_id))  # ty:ignore[invalid-argument-type]
     actual_attempt = cast(int, execution.attempt_count)
@@ -180,7 +182,13 @@ async def poll_and_update(execution: Run) -> RunDetail:
     else:
         available_task_ids = None
 
-    def _build(status_override: str | None = None, error_override: str | None = None, progress_override: str | None = None) -> RunDetail:
+    def _build(
+        status_override: str | None = None,
+        error_override: str | None = None,
+        progress_override: str | None = None,
+        completed_task_ids: dict[JobId, list[TaskId]] | None = None,
+        planned_task_ids: dict[JobId, list[TaskId]] | None = None,
+    ) -> RunDetail:
         return RunDetail(
             run_id=run_id,
             attempt_count=actual_attempt,
@@ -194,12 +202,17 @@ async def poll_and_update(execution: Run) -> RunDetail:
             cascade_job_id=cascade_job_id,
             available_task_ids=available_task_ids,
             outputs=raw_outputs,
+            completed_task_ids=completed_task_ids,
+            planned_task_ids=planned_task_ids,
         )
 
     if status in ("submitted", "preparing", "running") and cascade_job_id:
         job_id = JobId(cascade_job_id)
         try:
-            response = client.request_response(api.JobProgressRequest(job_ids=[job_id]), f"{config.cascade.cascade_url}")
+            response = client.request_response(
+                api.JobProgressRequest(job_ids=[job_id], detailed_report=detailed_report),
+                f"{config.cascade.cascade_url}",
+            )
             response = cast(api.JobProgressResponse, response)
         except TimeoutError:
             return _build(status_override="unknown", error_override="failed to communicate with gateway")
@@ -212,6 +225,8 @@ async def poll_and_update(execution: Run) -> RunDetail:
         if response.error:
             return _build(status_override="unknown", error_override=response.error)
 
+        completed_task_ids = response.completed_task_ids if detailed_report else None
+        planned_task_ids = response.planned_task_ids if detailed_report else None
         jobprogress = response.progresses.get(job_id)
         if jobprogress is None:
             await run_db.update_run_runtime(run_id, actual_attempt, status="failed", error="evicted from gateway")
@@ -226,6 +241,11 @@ async def poll_and_update(execution: Run) -> RunDetail:
             return _build(status_override="completed", progress_override="100.00")
         else:
             await run_db.update_run_runtime(run_id, actual_attempt, status="running", progress=jobprogress.pct)
-            return _build(status_override="running", progress_override=jobprogress.pct)
+            return _build(
+                status_override="running",
+                progress_override=jobprogress.pct,
+                completed_task_ids=completed_task_ids,
+                planned_task_ids=planned_task_ids,
+            )
 
     return _build()

--- a/backend/src/forecastbox/domain/run/service.py
+++ b/backend/src/forecastbox/domain/run/service.py
@@ -66,8 +66,8 @@ class RunDetail(FiabBaseModel):
     cascade_job_id: str | None = None
     available_task_ids: list[TaskId] | None = None
     outputs: dict | None = None
-    completed_task_ids: list[BlockInstanceId] | None = None
-    planned_task_ids: list[BlockInstanceId] | None = None
+    completed_block_ids: set[BlockInstanceId] | None = None
+    planned_block_ids: set[BlockInstanceId] | None = None
 
 
 class ExecuteResult(FiabBaseModel):
@@ -188,17 +188,17 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
         task_ids_by_job: dict[JobId, list[TaskId]] | None,
         task_to_block: dict[TaskId, BlockInstanceId] | None,
         job_id: JobId,
-    ) -> list[BlockInstanceId] | None:
+    ) -> set[BlockInstanceId] | None:
         if task_ids_by_job is None or task_to_block is None:
             return None
-        return [task_to_block[task_id] for task_id in task_ids_by_job[job_id]]
+        return {task_to_block[task_id] for task_id in task_ids_by_job[job_id]}
 
     def _build(
         status_override: str | None = None,
         error_override: str | None = None,
         progress_override: str | None = None,
-        completed_task_ids: list[BlockInstanceId] | None = None,
-        planned_task_ids: list[BlockInstanceId] | None = None,
+        completed_block_ids: set[BlockInstanceId] | None = None,
+        planned_block_ids: set[BlockInstanceId] | None = None,
     ) -> RunDetail:
         return RunDetail(
             run_id=run_id,
@@ -213,12 +213,12 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
             cascade_job_id=cascade_job_id,
             available_task_ids=available_task_ids,
             outputs=raw_outputs,
-            completed_task_ids=completed_task_ids,
-            planned_task_ids=planned_task_ids,
+            completed_block_ids=completed_block_ids,
+            planned_block_ids=planned_block_ids,
         )
 
     if status == "completed" and cascade_job_id and detailed_report:
-        return _build(completed_task_ids=[], planned_task_ids=[])
+        return _build(completed_block_ids=set(), planned_block_ids=set())
 
     if status in ("submitted", "preparing", "running") and cascade_job_id:
         job_id = JobId(cascade_job_id)
@@ -248,8 +248,19 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
         if response.error:
             return _build(status_override="unknown", error_override=response.error)
 
-        completed_task_ids = _translate_task_ids(response.completed_task_ids, task_to_block, job_id) if detailed_report else None
-        planned_task_ids = _translate_task_ids(response.planned_task_ids, task_to_block, job_id) if detailed_report else None
+        # NOTE we should check more carefuly in the None branch -- the job_id may not be part of the response
+        # if the job has not started yet -- but we should verify that in the status, etc
+        if task_to_block is not None and response.planned_task_ids is not None and job_id in response.planned_task_ids:
+            # any block that has a task planned is a planned block
+            planned_block_ids = {task_to_block[task_id] for task_id in response.planned_task_ids[job_id]}
+        else:
+            planned_block_ids = None
+        if task_to_block is not None and response.completed_task_ids is not None and job_id in response.completed_task_ids:
+            # any block that has all tasks completed is a completed block
+            uncompleted_task_to_block = {k: v for k, v in task_to_block.items() if k not in response.completed_task_ids[job_id]}
+            completed_block_ids = set(task_to_block.values()) - set(uncompleted_task_to_block.values())
+        else:
+            completed_block_ids = None
         jobprogress = response.progresses.get(job_id)
         if jobprogress is None:
             await run_db.update_run_runtime(run_id, actual_attempt, status="failed", error="evicted from gateway")
@@ -268,8 +279,8 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
                 status_override="running",
                 error_override=warning_error,
                 progress_override=jobprogress.pct,
-                completed_task_ids=completed_task_ids,
-                planned_task_ids=planned_task_ids,
+                completed_block_ids=completed_block_ids,
+                planned_block_ids=planned_block_ids,
             )
 
     return _build()

--- a/backend/src/forecastbox/domain/run/service.py
+++ b/backend/src/forecastbox/domain/run/service.py
@@ -66,8 +66,8 @@ class RunDetail(FiabBaseModel):
     cascade_job_id: str | None = None
     available_task_ids: list[TaskId] | None = None
     outputs: dict | None = None
-    completed_task_ids: dict[JobId, list[BlockInstanceId]] | None = None
-    planned_task_ids: dict[JobId, list[BlockInstanceId]] | None = None
+    completed_task_ids: list[BlockInstanceId] | None = None
+    planned_task_ids: list[BlockInstanceId] | None = None
 
 
 class ExecuteResult(FiabBaseModel):
@@ -187,20 +187,18 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
     def _translate_task_ids(
         task_ids_by_job: dict[JobId, list[TaskId]] | None,
         task_to_block: dict[TaskId, BlockInstanceId] | None,
-    ) -> dict[JobId, list[BlockInstanceId]] | None:
+        job_id: JobId,
+    ) -> list[BlockInstanceId] | None:
         if task_ids_by_job is None or task_to_block is None:
             return None
-        translated: dict[JobId, list[BlockInstanceId]] = {}
-        for job_id, task_ids in task_ids_by_job.items():
-            translated[job_id] = [task_to_block[task_id] for task_id in task_ids]
-        return translated
+        return [task_to_block[task_id] for task_id in task_ids_by_job[job_id]]
 
     def _build(
         status_override: str | None = None,
         error_override: str | None = None,
         progress_override: str | None = None,
-        completed_task_ids: dict[JobId, list[BlockInstanceId]] | None = None,
-        planned_task_ids: dict[JobId, list[BlockInstanceId]] | None = None,
+        completed_task_ids: list[BlockInstanceId] | None = None,
+        planned_task_ids: list[BlockInstanceId] | None = None,
     ) -> RunDetail:
         return RunDetail(
             run_id=run_id,
@@ -220,7 +218,7 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
         )
 
     if status == "completed" and cascade_job_id and detailed_report:
-        return _build(completed_task_ids={}, planned_task_ids={})
+        return _build(completed_task_ids=[], planned_task_ids=[])
 
     if status in ("submitted", "preparing", "running") and cascade_job_id:
         job_id = JobId(cascade_job_id)
@@ -250,8 +248,8 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
         if response.error:
             return _build(status_override="unknown", error_override=response.error)
 
-        completed_task_ids = _translate_task_ids(response.completed_task_ids, task_to_block) if detailed_report else None
-        planned_task_ids = _translate_task_ids(response.planned_task_ids, task_to_block) if detailed_report else None
+        completed_task_ids = _translate_task_ids(response.completed_task_ids, task_to_block, job_id) if detailed_report else None
+        planned_task_ids = _translate_task_ids(response.planned_task_ids, task_to_block, job_id) if detailed_report else None
         jobprogress = response.progresses.get(job_id)
         if jobprogress is None:
             await run_db.update_run_runtime(run_id, actual_attempt, status="failed", error="evicted from gateway")

--- a/backend/src/forecastbox/domain/run/service.py
+++ b/backend/src/forecastbox/domain/run/service.py
@@ -32,6 +32,7 @@ from cascade.controller.report import JobId
 from cascade.gateway import api, client
 from cascade.low.core import TaskId
 from cascade.low.func import Either
+from fiab_core.fable import BlockInstanceId
 
 import forecastbox.domain.blueprint.db as blueprint_db
 import forecastbox.domain.run.db as run_db
@@ -44,6 +45,7 @@ from forecastbox.domain.run.types import RunId
 from forecastbox.schemata.jobs import Blueprint, Run
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.config import config
+from forecastbox.utility.memcache import get as get_memcache
 from forecastbox.utility.pydantic import FiabBaseModel
 
 logger = logging.getLogger(__name__)
@@ -64,8 +66,8 @@ class RunDetail(FiabBaseModel):
     cascade_job_id: str | None = None
     available_task_ids: list[TaskId] | None = None
     outputs: dict | None = None
-    completed_task_ids: dict[JobId, list[TaskId]] | None = None
-    planned_task_ids: dict[JobId, list[TaskId]] | None = None
+    completed_task_ids: dict[JobId, list[BlockInstanceId]] | None = None
+    planned_task_ids: dict[JobId, list[BlockInstanceId]] | None = None
 
 
 class ExecuteResult(FiabBaseModel):
@@ -182,12 +184,23 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
     else:
         available_task_ids = None
 
+    def _translate_task_ids(
+        task_ids_by_job: dict[JobId, list[TaskId]] | None,
+        task_to_block: dict[TaskId, BlockInstanceId] | None,
+    ) -> dict[JobId, list[BlockInstanceId]] | None:
+        if task_ids_by_job is None or task_to_block is None:
+            return None
+        translated: dict[JobId, list[BlockInstanceId]] = {}
+        for job_id, task_ids in task_ids_by_job.items():
+            translated[job_id] = [task_to_block[task_id] for task_id in task_ids if task_id in task_to_block]
+        return translated
+
     def _build(
         status_override: str | None = None,
         error_override: str | None = None,
         progress_override: str | None = None,
-        completed_task_ids: dict[JobId, list[TaskId]] | None = None,
-        planned_task_ids: dict[JobId, list[TaskId]] | None = None,
+        completed_task_ids: dict[JobId, list[BlockInstanceId]] | None = None,
+        planned_task_ids: dict[JobId, list[BlockInstanceId]] | None = None,
     ) -> RunDetail:
         return RunDetail(
             run_id=run_id,
@@ -206,11 +219,33 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
             planned_task_ids=planned_task_ids,
         )
 
-    if status in ("submitted", "preparing", "running") and cascade_job_id:
+    if status == "completed" and cascade_job_id and detailed_report:
         job_id = JobId(cascade_job_id)
         try:
+            task_to_block = cast(dict[TaskId, BlockInstanceId], get_memcache(job_id, dict))
+            completed_blocks = sorted(set(task_to_block.values()))
+            return _build(
+                completed_task_ids={job_id: completed_blocks},
+                planned_task_ids={job_id: []},
+            )
+        except (KeyError, TypeError):
+            return _build(error_override="unable to provide completed/planned tasks")
+
+    if status in ("submitted", "preparing", "running") and cascade_job_id:
+        job_id = JobId(cascade_job_id)
+        warning_error: str | None = None
+        use_detailed_report = detailed_report and status == "running"
+        task_to_block: dict[TaskId, BlockInstanceId] | None = None
+        if use_detailed_report:
+            try:
+                task_to_block = cast(dict[TaskId, BlockInstanceId], get_memcache(job_id, dict))
+            except (KeyError, TypeError):
+                use_detailed_report = False
+                warning_error = "unable to provide completed/planned tasks"
+
+        try:
             response = client.request_response(
-                api.JobProgressRequest(job_ids=[job_id], detailed_report=detailed_report),
+                api.JobProgressRequest(job_ids=[job_id], detailed_report=use_detailed_report),
                 f"{config.cascade.cascade_url}",
             )
             response = cast(api.JobProgressResponse, response)
@@ -225,8 +260,8 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
         if response.error:
             return _build(status_override="unknown", error_override=response.error)
 
-        completed_task_ids = response.completed_task_ids if detailed_report else None
-        planned_task_ids = response.planned_task_ids if detailed_report else None
+        completed_task_ids = _translate_task_ids(response.completed_task_ids, task_to_block) if use_detailed_report else None
+        planned_task_ids = _translate_task_ids(response.planned_task_ids, task_to_block) if use_detailed_report else None
         jobprogress = response.progresses.get(job_id)
         if jobprogress is None:
             await run_db.update_run_runtime(run_id, actual_attempt, status="failed", error="evicted from gateway")
@@ -243,6 +278,7 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
             await run_db.update_run_runtime(run_id, actual_attempt, status="running", progress=jobprogress.pct)
             return _build(
                 status_override="running",
+                error_override=warning_error,
                 progress_override=jobprogress.pct,
                 completed_task_ids=completed_task_ids,
                 planned_task_ids=planned_task_ids,

--- a/backend/src/forecastbox/domain/run/service.py
+++ b/backend/src/forecastbox/domain/run/service.py
@@ -228,7 +228,7 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
         task_to_block: dict[TaskId, BlockInstanceId] | None = None
         if detailed_report:
             try:
-                task_to_block = cast(dict[TaskId, BlockInstanceId], get_memcache(job_id, dict))
+                task_to_block = cast(dict[TaskId, BlockInstanceId], get_memcache(run_id, dict))
             except (KeyError, TypeError):
                 detailed_report = False
                 warning_error = "unable to provide completed/planned tasks"

--- a/backend/src/forecastbox/domain/run/service.py
+++ b/backend/src/forecastbox/domain/run/service.py
@@ -192,7 +192,7 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
             return None
         translated: dict[JobId, list[BlockInstanceId]] = {}
         for job_id, task_ids in task_ids_by_job.items():
-            translated[job_id] = [task_to_block[task_id] for task_id in task_ids if task_id in task_to_block]
+            translated[job_id] = [task_to_block[task_id] for task_id in task_ids]
         return translated
 
     def _build(
@@ -220,32 +220,22 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
         )
 
     if status == "completed" and cascade_job_id and detailed_report:
-        job_id = JobId(cascade_job_id)
-        try:
-            task_to_block = cast(dict[TaskId, BlockInstanceId], get_memcache(job_id, dict))
-            completed_blocks = sorted(set(task_to_block.values()))
-            return _build(
-                completed_task_ids={job_id: completed_blocks},
-                planned_task_ids={job_id: []},
-            )
-        except (KeyError, TypeError):
-            return _build(error_override="unable to provide completed/planned tasks")
+        return _build(completed_task_ids={}, planned_task_ids={})
 
     if status in ("submitted", "preparing", "running") and cascade_job_id:
         job_id = JobId(cascade_job_id)
         warning_error: str | None = None
-        use_detailed_report = detailed_report and status == "running"
         task_to_block: dict[TaskId, BlockInstanceId] | None = None
-        if use_detailed_report:
+        if detailed_report:
             try:
                 task_to_block = cast(dict[TaskId, BlockInstanceId], get_memcache(job_id, dict))
             except (KeyError, TypeError):
-                use_detailed_report = False
+                detailed_report = False
                 warning_error = "unable to provide completed/planned tasks"
 
         try:
             response = client.request_response(
-                api.JobProgressRequest(job_ids=[job_id], detailed_report=use_detailed_report),
+                api.JobProgressRequest(job_ids=[job_id], detailed_report=detailed_report),
                 f"{config.cascade.cascade_url}",
             )
             response = cast(api.JobProgressResponse, response)
@@ -260,8 +250,8 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
         if response.error:
             return _build(status_override="unknown", error_override=response.error)
 
-        completed_task_ids = _translate_task_ids(response.completed_task_ids, task_to_block) if use_detailed_report else None
-        planned_task_ids = _translate_task_ids(response.planned_task_ids, task_to_block) if use_detailed_report else None
+        completed_task_ids = _translate_task_ids(response.completed_task_ids, task_to_block) if detailed_report else None
+        planned_task_ids = _translate_task_ids(response.planned_task_ids, task_to_block) if detailed_report else None
         jobprogress = response.progresses.get(job_id)
         if jobprogress is None:
             await run_db.update_run_runtime(run_id, actual_attempt, status="failed", error="evicted from gateway")

--- a/backend/src/forecastbox/routes/run.py
+++ b/backend/src/forecastbox/routes/run.py
@@ -101,6 +101,8 @@ class RunDetailResponse(FiabBaseModel):
     progress: str | None = None
     cascade_job_id: str | None = None
     outputs: RunOutputsResponse | None = None
+    completed_task_ids: dict[JobId, list[TaskId]] | None = None
+    planned_task_ids: dict[JobId, list[TaskId]] | None = None
 
 
 class RunListResponse(FiabBaseModel):
@@ -162,6 +164,8 @@ def _to_run_detail(domain_detail: service.RunDetail) -> RunDetailResponse:
         progress=domain_detail.progress,
         cascade_job_id=domain_detail.cascade_job_id,
         outputs=outputs_response,
+        completed_task_ids=domain_detail.completed_task_ids,
+        planned_task_ids=domain_detail.planned_task_ids,
     )
 
 
@@ -274,7 +278,7 @@ async def get_run(
 ) -> RunDetailResponse:
     try:
         execution = await db.get_run(spec.run_id, spec.attempt_count, auth_context=auth_context)
-        domain_detail = await service.poll_and_update(execution)
+        domain_detail = await service.poll_and_update(execution, detailed_report=True)
     except RunNotFound:
         raise HTTPException(status_code=404, detail=f"Run {spec.run_id!r} not found.")
     except RunAccessDenied:

--- a/backend/src/forecastbox/routes/run.py
+++ b/backend/src/forecastbox/routes/run.py
@@ -101,8 +101,8 @@ class RunDetailResponse(FiabBaseModel):
     progress: str | None = None
     cascade_job_id: str | None = None
     outputs: RunOutputsResponse | None = None
-    completed_task_ids: list[BlockInstanceId] | None = None
-    planned_task_ids: list[BlockInstanceId] | None = None
+    completed_block_ids: list[BlockInstanceId] | None = None
+    planned_block_ids: list[BlockInstanceId] | None = None
 
 
 class RunListResponse(FiabBaseModel):
@@ -152,6 +152,7 @@ def _to_run_detail(domain_detail: service.RunDetail) -> RunDetailResponse:
                 for task_id, char in run_outputs.outputs.items()
             }
         )
+    maybe_list = lambda s: list(s) if s is not None else None
     return RunDetailResponse(
         run_id=domain_detail.run_id,
         attempt_count=domain_detail.attempt_count,
@@ -164,8 +165,8 @@ def _to_run_detail(domain_detail: service.RunDetail) -> RunDetailResponse:
         progress=domain_detail.progress,
         cascade_job_id=domain_detail.cascade_job_id,
         outputs=outputs_response,
-        completed_task_ids=domain_detail.completed_task_ids,
-        planned_task_ids=domain_detail.planned_task_ids,
+        completed_block_ids=maybe_list(domain_detail.completed_block_ids),
+        planned_block_ids=maybe_list(domain_detail.planned_block_ids),
     )
 
 

--- a/backend/src/forecastbox/routes/run.py
+++ b/backend/src/forecastbox/routes/run.py
@@ -101,8 +101,8 @@ class RunDetailResponse(FiabBaseModel):
     progress: str | None = None
     cascade_job_id: str | None = None
     outputs: RunOutputsResponse | None = None
-    completed_task_ids: dict[JobId, list[TaskId]] | None = None
-    planned_task_ids: dict[JobId, list[TaskId]] | None = None
+    completed_task_ids: dict[JobId, list[BlockInstanceId]] | None = None
+    planned_task_ids: dict[JobId, list[BlockInstanceId]] | None = None
 
 
 class RunListResponse(FiabBaseModel):

--- a/backend/src/forecastbox/routes/run.py
+++ b/backend/src/forecastbox/routes/run.py
@@ -101,8 +101,8 @@ class RunDetailResponse(FiabBaseModel):
     progress: str | None = None
     cascade_job_id: str | None = None
     outputs: RunOutputsResponse | None = None
-    completed_task_ids: dict[JobId, list[BlockInstanceId]] | None = None
-    planned_task_ids: dict[JobId, list[BlockInstanceId]] | None = None
+    completed_task_ids: list[BlockInstanceId] | None = None
+    planned_task_ids: list[BlockInstanceId] | None = None
 
 
 class RunListResponse(FiabBaseModel):

--- a/backend/src/forecastbox/utility/memcache.py
+++ b/backend/src/forecastbox/utility/memcache.py
@@ -1,0 +1,121 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Backend-global size-limited in-memory cache."""
+
+import sys
+import threading
+from collections.abc import Mapping, Sequence
+from collections.abc import Set as AbstractSet
+from typing import Any, TypeVar, cast
+
+from pyrsistent import pmap
+from pyrsistent.typing import PMap
+
+T = TypeVar("T")
+
+
+def _deep_sizeof(value: Any, seen: set[int] | None = None) -> int:
+    if seen is None:
+        seen = set()
+
+    obj_id = id(value)
+    if obj_id in seen:
+        return 0
+    seen.add(obj_id)
+
+    size = sys.getsizeof(value)
+
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            size += _deep_sizeof(key, seen)
+            size += _deep_sizeof(child, seen)
+        return size
+
+    if isinstance(value, (str, bytes, bytearray, memoryview)):
+        return size
+
+    if isinstance(value, Sequence):
+        for child in value:
+            size += _deep_sizeof(child, seen)
+        return size
+
+    if isinstance(value, AbstractSet):
+        for child in value:
+            size += _deep_sizeof(child, seen)
+        return size
+
+    if hasattr(value, "__dict__"):
+        size += _deep_sizeof(vars(value), seen)
+
+    slots = getattr(type(value), "__slots__", ())
+    if isinstance(slots, str):
+        slots = (slots,)
+    for slot in slots:
+        if hasattr(value, slot):
+            size += _deep_sizeof(getattr(value, slot), seen)
+
+    return size
+
+
+class _MemoryCache:
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.lookup: PMap[Any, Any] = pmap()
+        self.sizes: PMap[Any, int] = pmap()
+        self.lru: list[Any] = []
+        self.max_size = 1024 * 1024 * 1024
+        self.current_size = 0
+
+    def _remove_key(self, key: Any) -> None:
+        value_size = self.sizes.get(key)
+        if value_size is not None:
+            self.current_size -= value_size
+            self.sizes = self.sizes.remove(key)
+        self.lookup = self.lookup.remove(key)
+        if key in self.lru:
+            self.lru.remove(key)
+
+
+_CACHE = _MemoryCache()
+
+
+def insert(key: Any, value: Any) -> None:
+    entry_size = _deep_sizeof((key, value))
+    if entry_size > _CACHE.max_size:
+        raise ValueError(f"value is too large for cache capacity: {entry_size} > {_CACHE.max_size}")
+
+    with _CACHE.lock:
+        if key in _CACHE.lookup:
+            _CACHE._remove_key(key)
+
+        while _CACHE.current_size + entry_size > _CACHE.max_size:
+            if not _CACHE.lru:
+                raise ValueError("cache eviction failed: no entries left but capacity is still exceeded")
+            evict_key = _CACHE.lru[-1]
+            _CACHE._remove_key(evict_key)
+
+        _CACHE.lookup = _CACHE.lookup.set(key, value)
+        _CACHE.sizes = _CACHE.sizes.set(key, entry_size)
+        _CACHE.lru.insert(0, key)
+        _CACHE.current_size += entry_size
+
+
+def pop(key: Any) -> Any:
+    with _CACHE.lock:
+        value = _CACHE.lookup[key]
+        _CACHE._remove_key(key)
+        return value
+
+
+def get(key: Any, value_type: type[T]) -> T:
+    value = _CACHE.lookup[key]
+    if not isinstance(value, value_type):
+        raise TypeError(f"cache entry for {key!r} has type {type(value).__name__}, expected {value_type.__name__}")
+    return cast(T, value)

--- a/backend/src/forecastbox/utility/memcache.py
+++ b/backend/src/forecastbox/utility/memcache.py
@@ -21,6 +21,10 @@ from pyrsistent.typing import PMap
 T = TypeVar("T")
 
 
+class TooLargeEntry(ValueError):
+    """Raised when a single cache entry exceeds cache capacity."""
+
+
 def _deep_sizeof(value: Any, seen: set[int] | None = None) -> int:
     if seen is None:
         seen = set()
@@ -89,7 +93,7 @@ _CACHE = _MemoryCache()
 def insert(key: Any, value: Any) -> None:
     entry_size = _deep_sizeof((key, value))
     if entry_size > _CACHE.max_size:
-        raise ValueError(f"value is too large for cache capacity: {entry_size} > {_CACHE.max_size}")
+        raise TooLargeEntry(f"value is too large for cache capacity: {entry_size} > {_CACHE.max_size}")
 
     with _CACHE.lock:
         if key in _CACHE.lookup:
@@ -97,7 +101,7 @@ def insert(key: Any, value: Any) -> None:
 
         while _CACHE.current_size + entry_size > _CACHE.max_size:
             if not _CACHE.lru:
-                raise ValueError("cache eviction failed: no entries left but capacity is still exceeded")
+                raise RuntimeError("cache eviction failed: no entries left but capacity is still exceeded")
             evict_key = _CACHE.lru[-1]
             _CACHE._remove_key(evict_key)
 

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -513,6 +513,9 @@ def test_blueprint_expand_missing_glyph_warnings(tmpdir: Any, backend_client_wit
     available_tasks = [task_id for task_id, char in run_detail["outputs"]["outputs"].items() if char["is_available"]]
     assert isinstance(available_tasks, list)
     assert len(available_tasks) > 0
+    assert run_detail["planned_task_ids"] == {run_detail["cascade_job_id"]: []}
+    expected_block_ids = {str(block_id) for block_id in builder.blocks.keys()}
+    assert set(run_detail["completed_task_ids"][run_detail["cascade_job_id"]]) == expected_block_ids
 
     logs_resp = backend_client_with_auth.get("/run/logs", params={"run_id": run_id})
     assert logs_resp.is_success, logs_resp.text

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -513,9 +513,8 @@ def test_blueprint_expand_missing_glyph_warnings(tmpdir: Any, backend_client_wit
     available_tasks = [task_id for task_id, char in run_detail["outputs"]["outputs"].items() if char["is_available"]]
     assert isinstance(available_tasks, list)
     assert len(available_tasks) > 0
-    assert run_detail["planned_task_ids"] == {run_detail["cascade_job_id"]: []}
-    expected_block_ids = {str(block_id) for block_id in builder.blocks.keys()}
-    assert set(run_detail["completed_task_ids"][run_detail["cascade_job_id"]]) == expected_block_ids
+    assert run_detail["planned_task_ids"] == {}
+    assert run_detail["completed_task_ids"] == {}
 
     logs_resp = backend_client_with_auth.get("/run/logs", params={"run_id": run_id})
     assert logs_resp.is_success, logs_resp.text

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -513,8 +513,8 @@ def test_blueprint_expand_missing_glyph_warnings(tmpdir: Any, backend_client_wit
     available_tasks = [task_id for task_id, char in run_detail["outputs"]["outputs"].items() if char["is_available"]]
     assert isinstance(available_tasks, list)
     assert len(available_tasks) > 0
-    assert run_detail["planned_task_ids"] == {}
-    assert run_detail["completed_task_ids"] == {}
+    assert run_detail["planned_block_ids"] == []
+    assert run_detail["completed_block_ids"] == []
 
     logs_resp = backend_client_with_auth.get("/run/logs", params={"run_id": run_id})
     assert logs_resp.is_success, logs_resp.text

--- a/backend/tests/unit/domain/run/test_run_detailed_report.py
+++ b/backend/tests/unit/domain/run/test_run_detailed_report.py
@@ -19,8 +19,8 @@ from forecastbox.utility.pagination import PaginationSpec
 
 def _run_detail(
     *,
-    completed_task_ids: dict[JobId, list[BlockInstanceId]] | None = None,
-    planned_task_ids: dict[JobId, list[BlockInstanceId]] | None = None,
+    completed_task_ids: list[BlockInstanceId] | None = None,
+    planned_task_ids: list[BlockInstanceId] | None = None,
 ) -> RunDetail:
     return RunDetail(
         run_id=RunId("run-1"),
@@ -75,8 +75,8 @@ async def test_poll_and_update_requests_detailed_report_and_translates_to_block_
     request = mock_request.call_args.args[0]
     assert request.detailed_report is True
     assert mock_get_memcache.call_args.args[0] == RunId("run-1")
-    assert detail.completed_task_ids == {JobId("job-1"): [BlockInstanceId("block-a")]}
-    assert detail.planned_task_ids == {JobId("job-1"): [BlockInstanceId("block-b")]}
+    assert detail.completed_task_ids == [BlockInstanceId("block-a")]
+    assert detail.planned_task_ids == [BlockInstanceId("block-b")]
 
 
 @pytest.mark.asyncio
@@ -135,8 +135,8 @@ async def test_poll_and_update_returns_empty_detailed_fields_for_completed_runs(
 
     detail = await run_service.poll_and_update(cast(Run, execution), detailed_report=True)
 
-    assert detail.completed_task_ids == {}
-    assert detail.planned_task_ids == {}
+    assert detail.completed_task_ids == []
+    assert detail.planned_task_ids == []
 
 
 @pytest.mark.asyncio
@@ -155,8 +155,8 @@ async def test_get_run_asks_for_detailed_report_while_list_runs_does_not() -> No
         outputs=None,
     )
     detailed = _run_detail(
-        completed_task_ids={JobId("job-1"): [BlockInstanceId("block-a")]},
-        planned_task_ids={JobId("job-1"): [BlockInstanceId("block-b")]},
+        completed_task_ids=[BlockInstanceId("block-a")],
+        planned_task_ids=[BlockInstanceId("block-b")],
     )
 
     with (
@@ -166,8 +166,8 @@ async def test_get_run_asks_for_detailed_report_while_list_runs_does_not() -> No
         patch("forecastbox.routes.run.db.list_runs", new=AsyncMock(return_value=[execution])),
     ):
         response = await get_run(RunLookup(run_id=RunId("run-1")), AuthContext(user_id="user", is_admin=True))
-        assert response.completed_task_ids == {JobId("job-1"): [BlockInstanceId("block-a")]}
-        assert response.planned_task_ids == {JobId("job-1"): [BlockInstanceId("block-b")]}
+        assert response.completed_task_ids == [BlockInstanceId("block-a")]
+        assert response.planned_task_ids == [BlockInstanceId("block-b")]
         assert mock_poll.await_args_list[0].kwargs == {"detailed_report": True}
 
         await list_runs(PaginationSpec(page=1, page_size=10), AuthContext(user_id="user", is_admin=True))

--- a/backend/tests/unit/domain/run/test_run_detailed_report.py
+++ b/backend/tests/unit/domain/run/test_run_detailed_report.py
@@ -67,13 +67,14 @@ async def test_poll_and_update_requests_detailed_report_and_translates_to_block_
 
     with (
         patch("forecastbox.domain.run.service.client.request_response", return_value=response) as mock_request,
-        patch("forecastbox.domain.run.service.get_memcache", return_value=task_to_block),
+        patch("forecastbox.domain.run.service.get_memcache", return_value=task_to_block) as mock_get_memcache,
         patch("forecastbox.domain.run.service.run_db.update_run_runtime", new=AsyncMock()),
     ):
         detail = await run_service.poll_and_update(cast(Run, execution), detailed_report=True)
 
     request = mock_request.call_args.args[0]
     assert request.detailed_report is True
+    assert mock_get_memcache.call_args.args[0] == RunId("run-1")
     assert detail.completed_task_ids == {JobId("job-1"): [BlockInstanceId("block-a")]}
     assert detail.planned_task_ids == {JobId("job-1"): [BlockInstanceId("block-b")]}
 
@@ -103,13 +104,14 @@ async def test_poll_and_update_disables_detailed_report_when_cache_misses() -> N
 
     with (
         patch("forecastbox.domain.run.service.client.request_response", return_value=response) as mock_request,
-        patch("forecastbox.domain.run.service.get_memcache", side_effect=KeyError("missing")),
+        patch("forecastbox.domain.run.service.get_memcache", side_effect=KeyError("missing")) as mock_get_memcache,
         patch("forecastbox.domain.run.service.run_db.update_run_runtime", new=AsyncMock()),
     ):
         detail = await run_service.poll_and_update(cast(Run, execution), detailed_report=True)
 
     request = mock_request.call_args.args[0]
     assert request.detailed_report is False
+    assert mock_get_memcache.call_args.args[0] == RunId("run-1")
     assert detail.error == "unable to provide completed/planned tasks"
     assert detail.completed_task_ids is None
     assert detail.planned_task_ids is None

--- a/backend/tests/unit/domain/run/test_run_detailed_report.py
+++ b/backend/tests/unit/domain/run/test_run_detailed_report.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from cascade.controller.report import JobId
 from cascade.low.core import TaskId
+from fiab_core.fable import BlockInstanceId
 
 from forecastbox.domain.blueprint.types import BlueprintId
 from forecastbox.domain.run import service as run_service
@@ -18,8 +19,8 @@ from forecastbox.utility.pagination import PaginationSpec
 
 def _run_detail(
     *,
-    completed_task_ids: dict[JobId, list[TaskId]] | None = None,
-    planned_task_ids: dict[JobId, list[TaskId]] | None = None,
+    completed_task_ids: dict[JobId, list[BlockInstanceId]] | None = None,
+    planned_task_ids: dict[JobId, list[BlockInstanceId]] | None = None,
 ) -> RunDetail:
     return RunDetail(
         run_id=RunId("run-1"),
@@ -38,7 +39,7 @@ def _run_detail(
 
 
 @pytest.mark.asyncio
-async def test_poll_and_update_requests_detailed_report_for_running_runs() -> None:
+async def test_poll_and_update_requests_detailed_report_and_translates_to_block_ids() -> None:
     execution = SimpleNamespace(
         run_id="run-1",
         attempt_count=1,
@@ -59,17 +60,59 @@ async def test_poll_and_update_requests_detailed_report_for_running_runs() -> No
         completed_task_ids={JobId("job-1"): [TaskId("task-a")]},
         planned_task_ids={JobId("job-1"): [TaskId("task-b")]},
     )
+    task_to_block = {
+        TaskId("task-a"): BlockInstanceId("block-a"),
+        TaskId("task-b"): BlockInstanceId("block-b"),
+    }
 
     with (
         patch("forecastbox.domain.run.service.client.request_response", return_value=response) as mock_request,
+        patch("forecastbox.domain.run.service.get_memcache", return_value=task_to_block),
         patch("forecastbox.domain.run.service.run_db.update_run_runtime", new=AsyncMock()),
     ):
         detail = await run_service.poll_and_update(cast(Run, execution), detailed_report=True)
 
     request = mock_request.call_args.args[0]
     assert request.detailed_report is True
-    assert detail.completed_task_ids == {JobId("job-1"): [TaskId("task-a")]}
-    assert detail.planned_task_ids == {JobId("job-1"): [TaskId("task-b")]}
+    assert detail.completed_task_ids == {JobId("job-1"): [BlockInstanceId("block-a")]}
+    assert detail.planned_task_ids == {JobId("job-1"): [BlockInstanceId("block-b")]}
+
+
+@pytest.mark.asyncio
+async def test_poll_and_update_disables_detailed_report_when_cache_misses() -> None:
+    execution = SimpleNamespace(
+        run_id="run-1",
+        attempt_count=1,
+        status="running",
+        created_at="2026-05-12T00:00:00",
+        updated_at="2026-05-12T00:00:00",
+        blueprint_id="bp-1",
+        blueprint_version=1,
+        error=None,
+        progress=None,
+        cascade_job_id="job-1",
+        outputs=None,
+    )
+    response = SimpleNamespace(
+        progresses={JobId("job-1"): SimpleNamespace(completed=False, pct="12.50", failure=None)},
+        datasets={},
+        error=None,
+        completed_task_ids=None,
+        planned_task_ids=None,
+    )
+
+    with (
+        patch("forecastbox.domain.run.service.client.request_response", return_value=response) as mock_request,
+        patch("forecastbox.domain.run.service.get_memcache", side_effect=KeyError("missing")),
+        patch("forecastbox.domain.run.service.run_db.update_run_runtime", new=AsyncMock()),
+    ):
+        detail = await run_service.poll_and_update(cast(Run, execution), detailed_report=True)
+
+    request = mock_request.call_args.args[0]
+    assert request.detailed_report is False
+    assert detail.error == "unable to provide completed/planned tasks"
+    assert detail.completed_task_ids is None
+    assert detail.planned_task_ids is None
 
 
 @pytest.mark.asyncio
@@ -88,8 +131,8 @@ async def test_get_run_asks_for_detailed_report_while_list_runs_does_not() -> No
         outputs=None,
     )
     detailed = _run_detail(
-        completed_task_ids={JobId("job-1"): [TaskId("task-a")]},
-        planned_task_ids={JobId("job-1"): [TaskId("task-b")]},
+        completed_task_ids={JobId("job-1"): [BlockInstanceId("block-a")]},
+        planned_task_ids={JobId("job-1"): [BlockInstanceId("block-b")]},
     )
 
     with (
@@ -99,8 +142,8 @@ async def test_get_run_asks_for_detailed_report_while_list_runs_does_not() -> No
         patch("forecastbox.routes.run.db.list_runs", new=AsyncMock(return_value=[execution])),
     ):
         response = await get_run(RunLookup(run_id=RunId("run-1")), AuthContext(user_id="user", is_admin=True))
-        assert response.completed_task_ids == {JobId("job-1"): [TaskId("task-a")]}
-        assert response.planned_task_ids == {JobId("job-1"): [TaskId("task-b")]}
+        assert response.completed_task_ids == {JobId("job-1"): [BlockInstanceId("block-a")]}
+        assert response.planned_task_ids == {JobId("job-1"): [BlockInstanceId("block-b")]}
         assert mock_poll.await_args_list[0].kwargs == {"detailed_report": True}
 
         await list_runs(PaginationSpec(page=1, page_size=10), AuthContext(user_id="user", is_admin=True))

--- a/backend/tests/unit/domain/run/test_run_detailed_report.py
+++ b/backend/tests/unit/domain/run/test_run_detailed_report.py
@@ -19,8 +19,8 @@ from forecastbox.utility.pagination import PaginationSpec
 
 def _run_detail(
     *,
-    completed_task_ids: list[BlockInstanceId] | None = None,
-    planned_task_ids: list[BlockInstanceId] | None = None,
+    completed_block_ids: set[BlockInstanceId] | None = None,
+    planned_block_ids: set[BlockInstanceId] | None = None,
 ) -> RunDetail:
     return RunDetail(
         run_id=RunId("run-1"),
@@ -33,8 +33,8 @@ def _run_detail(
         progress="12.50",
         cascade_job_id="job-1",
         outputs=None,
-        completed_task_ids=completed_task_ids,
-        planned_task_ids=planned_task_ids,
+        completed_block_ids=completed_block_ids,
+        planned_block_ids=planned_block_ids,
     )
 
 
@@ -75,8 +75,8 @@ async def test_poll_and_update_requests_detailed_report_and_translates_to_block_
     request = mock_request.call_args.args[0]
     assert request.detailed_report is True
     assert mock_get_memcache.call_args.args[0] == RunId("run-1")
-    assert detail.completed_task_ids == [BlockInstanceId("block-a")]
-    assert detail.planned_task_ids == [BlockInstanceId("block-b")]
+    assert detail.completed_block_ids == {BlockInstanceId("block-a")}
+    assert detail.planned_block_ids == {BlockInstanceId("block-b")}
 
 
 @pytest.mark.asyncio
@@ -113,8 +113,8 @@ async def test_poll_and_update_disables_detailed_report_when_cache_misses() -> N
     assert request.detailed_report is False
     assert mock_get_memcache.call_args.args[0] == RunId("run-1")
     assert detail.error == "unable to provide completed/planned tasks"
-    assert detail.completed_task_ids is None
-    assert detail.planned_task_ids is None
+    assert detail.completed_block_ids is None
+    assert detail.planned_block_ids is None
 
 
 @pytest.mark.asyncio
@@ -135,8 +135,8 @@ async def test_poll_and_update_returns_empty_detailed_fields_for_completed_runs(
 
     detail = await run_service.poll_and_update(cast(Run, execution), detailed_report=True)
 
-    assert detail.completed_task_ids == []
-    assert detail.planned_task_ids == []
+    assert detail.completed_block_ids == set()
+    assert detail.planned_block_ids == set()
 
 
 @pytest.mark.asyncio
@@ -155,8 +155,8 @@ async def test_get_run_asks_for_detailed_report_while_list_runs_does_not() -> No
         outputs=None,
     )
     detailed = _run_detail(
-        completed_task_ids=[BlockInstanceId("block-a")],
-        planned_task_ids=[BlockInstanceId("block-b")],
+        completed_block_ids={BlockInstanceId("block-a")},
+        planned_block_ids={BlockInstanceId("block-b")},
     )
 
     with (
@@ -166,8 +166,8 @@ async def test_get_run_asks_for_detailed_report_while_list_runs_does_not() -> No
         patch("forecastbox.routes.run.db.list_runs", new=AsyncMock(return_value=[execution])),
     ):
         response = await get_run(RunLookup(run_id=RunId("run-1")), AuthContext(user_id="user", is_admin=True))
-        assert response.completed_task_ids == [BlockInstanceId("block-a")]
-        assert response.planned_task_ids == [BlockInstanceId("block-b")]
+        assert response.completed_block_ids == [BlockInstanceId("block-a")]
+        assert response.planned_block_ids == [BlockInstanceId("block-b")]
         assert mock_poll.await_args_list[0].kwargs == {"detailed_report": True}
 
         await list_runs(PaginationSpec(page=1, page_size=10), AuthContext(user_id="user", is_admin=True))

--- a/backend/tests/unit/domain/run/test_run_detailed_report.py
+++ b/backend/tests/unit/domain/run/test_run_detailed_report.py
@@ -116,6 +116,28 @@ async def test_poll_and_update_disables_detailed_report_when_cache_misses() -> N
 
 
 @pytest.mark.asyncio
+async def test_poll_and_update_returns_empty_detailed_fields_for_completed_runs() -> None:
+    execution = SimpleNamespace(
+        run_id="run-1",
+        attempt_count=1,
+        status="completed",
+        created_at="2026-05-12T00:00:00",
+        updated_at="2026-05-12T00:00:00",
+        blueprint_id="bp-1",
+        blueprint_version=1,
+        error=None,
+        progress="100.00",
+        cascade_job_id="job-1",
+        outputs={"outputs": {"task-a": {"mime_type": "application/json", "original_block": "block-a"}}},
+    )
+
+    detail = await run_service.poll_and_update(cast(Run, execution), detailed_report=True)
+
+    assert detail.completed_task_ids == {}
+    assert detail.planned_task_ids == {}
+
+
+@pytest.mark.asyncio
 async def test_get_run_asks_for_detailed_report_while_list_runs_does_not() -> None:
     execution = SimpleNamespace(
         run_id="run-1",

--- a/backend/tests/unit/test_run_detailed_report.py
+++ b/backend/tests/unit/test_run_detailed_report.py
@@ -1,0 +1,107 @@
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from cascade.controller.report import JobId
+from cascade.low.core import TaskId
+
+from forecastbox.domain.blueprint.types import BlueprintId
+from forecastbox.domain.run import service as run_service
+from forecastbox.domain.run.service import RunDetail
+from forecastbox.domain.run.types import RunId
+from forecastbox.routes.run import RunLookup, get_run, list_runs
+from forecastbox.schemata.jobs import Run
+from forecastbox.utility.auth import AuthContext
+from forecastbox.utility.pagination import PaginationSpec
+
+
+def _run_detail(
+    *,
+    completed_task_ids: dict[JobId, list[TaskId]] | None = None,
+    planned_task_ids: dict[JobId, list[TaskId]] | None = None,
+) -> RunDetail:
+    return RunDetail(
+        run_id=RunId("run-1"),
+        attempt_count=1,
+        status="running",
+        created_at="2026-05-12T00:00:00",
+        updated_at="2026-05-12T00:00:00",
+        blueprint_id=BlueprintId("bp-1"),
+        blueprint_version=1,
+        progress="12.50",
+        cascade_job_id="job-1",
+        outputs=None,
+        completed_task_ids=completed_task_ids,
+        planned_task_ids=planned_task_ids,
+    )
+
+
+@pytest.mark.asyncio
+async def test_poll_and_update_requests_detailed_report_for_running_runs() -> None:
+    execution = SimpleNamespace(
+        run_id="run-1",
+        attempt_count=1,
+        status="running",
+        created_at="2026-05-12T00:00:00",
+        updated_at="2026-05-12T00:00:00",
+        blueprint_id="bp-1",
+        blueprint_version=1,
+        error=None,
+        progress=None,
+        cascade_job_id="job-1",
+        outputs=None,
+    )
+    response = SimpleNamespace(
+        progresses={JobId("job-1"): SimpleNamespace(completed=False, pct="12.50", failure=None)},
+        datasets={},
+        error=None,
+        completed_task_ids={JobId("job-1"): [TaskId("task-a")]},
+        planned_task_ids={JobId("job-1"): [TaskId("task-b")]},
+    )
+
+    with (
+        patch("forecastbox.domain.run.service.client.request_response", return_value=response) as mock_request,
+        patch("forecastbox.domain.run.service.run_db.update_run_runtime", new=AsyncMock()),
+    ):
+        detail = await run_service.poll_and_update(cast(Run, execution), detailed_report=True)
+
+    request = mock_request.call_args.args[0]
+    assert request.detailed_report is True
+    assert detail.completed_task_ids == {JobId("job-1"): [TaskId("task-a")]}
+    assert detail.planned_task_ids == {JobId("job-1"): [TaskId("task-b")]}
+
+
+@pytest.mark.asyncio
+async def test_get_run_asks_for_detailed_report_while_list_runs_does_not() -> None:
+    execution = SimpleNamespace(
+        run_id="run-1",
+        attempt_count=1,
+        status="running",
+        created_at="2026-05-12T00:00:00",
+        updated_at="2026-05-12T00:00:00",
+        blueprint_id="bp-1",
+        blueprint_version=1,
+        error=None,
+        progress=None,
+        cascade_job_id="job-1",
+        outputs=None,
+    )
+    detailed = _run_detail(
+        completed_task_ids={JobId("job-1"): [TaskId("task-a")]},
+        planned_task_ids={JobId("job-1"): [TaskId("task-b")]},
+    )
+
+    with (
+        patch("forecastbox.routes.run.db.get_run", new=AsyncMock(return_value=execution)),
+        patch("forecastbox.routes.run.service.poll_and_update", new=AsyncMock(side_effect=[detailed, detailed])) as mock_poll,
+        patch("forecastbox.routes.run.db.count_runs", new=AsyncMock(return_value=1)),
+        patch("forecastbox.routes.run.db.list_runs", new=AsyncMock(return_value=[execution])),
+    ):
+        response = await get_run(RunLookup(run_id=RunId("run-1")), AuthContext(user_id="user", is_admin=True))
+        assert response.completed_task_ids == {JobId("job-1"): [TaskId("task-a")]}
+        assert response.planned_task_ids == {JobId("job-1"): [TaskId("task-b")]}
+        assert mock_poll.await_args_list[0].kwargs == {"detailed_report": True}
+
+        await list_runs(PaginationSpec(page=1, page_size=10), AuthContext(user_id="user", is_admin=True))
+        assert mock_poll.await_args_list[1].kwargs == {}

--- a/backend/tests/unit/utility/test_memcache.py
+++ b/backend/tests/unit/utility/test_memcache.py
@@ -60,5 +60,5 @@ def test_insert_evicts_lru_tail(fresh_cache: memcache._MemoryCache) -> None:
 
 def test_insert_rejects_oversized_value(fresh_cache: memcache._MemoryCache) -> None:
     fresh_cache.max_size = 1
-    with pytest.raises(ValueError):
+    with pytest.raises(memcache.TooLargeEntry):
         memcache.insert("k", {"payload": "x" * 10})

--- a/backend/tests/unit/utility/test_memcache.py
+++ b/backend/tests/unit/utility/test_memcache.py
@@ -1,0 +1,64 @@
+from typing import Any
+
+import pytest
+
+import forecastbox.utility.memcache as memcache
+
+
+@pytest.fixture
+def fresh_cache(monkeypatch: pytest.MonkeyPatch) -> memcache._MemoryCache:
+    cache = memcache._MemoryCache()
+    monkeypatch.setattr(memcache, "_CACHE", cache)
+    return cache
+
+
+def test_insert_get_roundtrip(fresh_cache: memcache._MemoryCache) -> None:
+    payload = {"a": [1, 2, 3]}
+    memcache.insert("k", payload)
+
+    got = memcache.get("k", dict)
+    assert got == payload
+    assert fresh_cache.current_size > 0
+    assert fresh_cache.lru == ["k"]
+
+
+def test_get_type_mismatch_raises(fresh_cache: memcache._MemoryCache) -> None:
+    del fresh_cache
+    memcache.insert("k", {"a": 1})
+    with pytest.raises(TypeError):
+        memcache.get("k", list)
+
+
+def test_pop_removes_entry(fresh_cache: memcache._MemoryCache) -> None:
+    memcache.insert("k", [1, 2, 3])
+    before = fresh_cache.current_size
+
+    popped = memcache.pop("k")
+
+    assert popped == [1, 2, 3]
+    assert fresh_cache.current_size < before
+    with pytest.raises(KeyError):
+        memcache.get("k", list)
+    assert fresh_cache.lru == []
+
+
+def test_insert_evicts_lru_tail(fresh_cache: memcache._MemoryCache) -> None:
+    v1: dict[str, Any] = {"payload": "A" * 2048}
+    v2: dict[str, Any] = {"payload": "B" * 2048}
+    s1 = memcache._deep_sizeof(("k1", v1))
+    s2 = memcache._deep_sizeof(("k2", v2))
+    fresh_cache.max_size = s1 + s2 - 1
+
+    memcache.insert("k1", v1)
+    memcache.insert("k2", v2)
+
+    with pytest.raises(KeyError):
+        memcache.get("k1", dict)
+    assert memcache.get("k2", dict) == v2
+    assert fresh_cache.lru == ["k2"]
+
+
+def test_insert_rejects_oversized_value(fresh_cache: memcache._MemoryCache) -> None:
+    fresh_cache.max_size = 1
+    with pytest.raises(ValueError):
+        memcache.insert("k", {"payload": "x" * 10})

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1298,7 +1298,7 @@ wheels = [
 
 [[package]]
 name = "earthkit-workflows"
-version = "0.10.1"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "array-api-compat", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -1318,9 +1318,9 @@ dependencies = [
     { name = "sortedcontainers", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "xarray", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/bd/9b20e6f0aed5af575aca44b6fd49f89d3a42abf070b2e6c9a8b78d0347f5/earthkit_workflows-0.10.1.tar.gz", hash = "sha256:935b2f56e5dc0ee14dc02d6bf20010e23f9d64885a70ab36112a1d316067d97f", size = 10813566, upload-time = "2026-05-11T11:49:56.55Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/d8/27f4f5d2c0a70755f545ba1731bb2b4cf90d7d75cbe1a9bb6c4c18ad3ba3/earthkit_workflows-0.10.2.tar.gz", hash = "sha256:4b6e14e77d2982c251b2471e65e9892822ec27cca94cd95c38cae6e4737dda77", size = 10820153, upload-time = "2026-05-12T13:30:17.307Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/e2/04729a73e357fa51455abd91450f79fcd4cef86a4137c35e4718c3168f15/earthkit_workflows-0.10.1-py3-none-any.whl", hash = "sha256:0a2573fad6feee0e40da427fdada7808dc198051593863d24af6f47e27eca053", size = 186801, upload-time = "2026-05-11T11:49:55.022Z" },
+    { url = "https://files.pythonhosted.org/packages/38/76/f305e1f4c7d88c02c248b71d94c41e84115ded95e708a2ac9e2b1b5c7013/earthkit_workflows-0.10.2-py3-none-any.whl", hash = "sha256:d03edc49fe5a968786b4133740a8581cf3355012bb1f12973444b5a23fdb689a", size = 187810, upload-time = "2026-05-12T13:30:15.931Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
On the RunDetailResponse, we now provide completed_block_ids and planned_block_ids

Completed block is one such that all tasks in it were completed
Planned block is one such that at least one task in it is planned

When a run is failed or completed, this information is not available any more

We do not set these fields on the `/list` endpoint, only on the `/get` endpoint

This information can _fail_ to be provided -- we put a memcache in place to hold the complete task2block lookup, and if this cache runs out of memory, we evict. In that case it is None, and the error field contains an indication thereof (but other fields are filled as usual)

Note that the Planned blocks may be quite broad -- for example, if there is a single worker, we fuse all blocks into a single unit, and the worker plans it all at the start. If there are multiple workers and the workflow is not containing multi-input blocks, the most likely scenario is that at least one worker gets assigned a path from a source to a sink, leading again to big chunks of the blocks being planned. This limits the usefulness of this visualization. We may eventually add "task started" visualization, but that requires digging deeper for information

cc @liefra -- not making changes to frontend since its just adding new fields. Integrate at your convenience :) 
