### PR TITLE
fix: add missing dependency for earthkit-regrid in MapPlotSink metadata

### DIFF
--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -384,7 +384,7 @@ class MapPlotSink(Sink):
                     # "groupby": block.configuration_values["groupby"] or "valid_datetime",
                     # "style_schema": block.configuration_values["style_schema"] or "inbuilt://fiab",
                 },
-                metadata={"environment": ["earthkit-plots<1.0.0"]},
+                metadata={"environment": ["earthkit-plots<1.0.0", "earthkit-regrid<1.0.0"]},
             )
         )
         return Either.ok(action)


### PR DESCRIPTION
### Description
This pull request makes a minor update to the `compile` method in `blocks.py` by adding a new environment dependency.

- **Dependency updates:**
  * The `metadata["environment"]` list now includes `"earthkit-regrid<1.0.0"` in addition to the existing `"earthkit-plots<1.0.0"`, ensuring that the required package is available for the action.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
