### PR TITLE
[backend.glyphs.jinja] fix datetime

### DIFF
--- a/backend/src/forecastbox/domain/experiment/scheduling/job_utils.py
+++ b/backend/src/forecastbox/domain/experiment/scheduling/job_utils.py
@@ -20,9 +20,9 @@ import forecastbox.domain.experiment.db as experiment_db
 from forecastbox.domain.blueprint.types import BlueprintId
 from forecastbox.domain.experiment.scheduling.dt_utils import calculate_next_run
 from forecastbox.domain.experiment.types import ExperimentDefinitionId
-from forecastbox.domain.glyphs.resolution import value_dt2str
 from forecastbox.domain.run.db import CompilerRuntimeContext
 from forecastbox.schemata.jobs import Blueprint
+from forecastbox.utility.time import value_dt2str
 
 
 @dataclass(frozen=True, eq=True, slots=True)

--- a/backend/src/forecastbox/domain/glyphs/intrinsic.py
+++ b/backend/src/forecastbox/domain/glyphs/intrinsic.py
@@ -13,8 +13,7 @@ import uuid
 from datetime import datetime
 from typing import Literal
 
-from forecastbox.domain.glyphs.resolution import value_dt2str
-from forecastbox.utility.time import current_time
+from forecastbox.utility.time import current_time, value_dt2str
 
 # fmt: off
 AvailableIntrinsicGlyphs = Literal[

--- a/backend/src/forecastbox/domain/glyphs/jinja_interpolation.py
+++ b/backend/src/forecastbox/domain/glyphs/jinja_interpolation.py
@@ -27,7 +27,8 @@ from jinja2.sandbox import SandboxedEnvironment
 
 # Only the canonical backend datetime format is auto-coerced; other date-like strings
 # (e.g. "2024-01-15") are intentionally kept as strings to avoid silent format changes.
-_CANONICAL_DATETIME_FMT = "%Y-%m-%d %H:%M:%S"
+# We use the simple ISO 8601 format.
+_CANONICAL_DATETIME_FMT = "%Y-%m-%dT%H:%M:%S"
 
 
 def _try_parse_datetime(value: str) -> datetime | str:

--- a/backend/src/forecastbox/domain/glyphs/resolution.py
+++ b/backend/src/forecastbox/domain/glyphs/resolution.py
@@ -38,14 +38,6 @@ class ExtractedGlyphs:
     """Keys from configuration_values that contain at least one glyph reference."""
 
 
-def value_dt2str(value: dt.datetime) -> str:
-    """Convert a datetime to the canonical string format used for all runtime glyphs.
-
-    To ensure that all runtime glyphs are stringified the same way.
-    """
-    return value.strftime("%Y-%m-%d %H:%M:%S")
-
-
 def extract_glyphs(blockInstance: BlockInstance) -> Either[ExtractedGlyphs, list[str]]:  # type: ignore[invalid-argument]
     """Extract all ${...} references from the blockInstance's configuration_values.
 

--- a/backend/src/forecastbox/domain/run/compile.py
+++ b/backend/src/forecastbox/domain/run/compile.py
@@ -23,11 +23,12 @@ from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
 from forecastbox.domain.blueprint.configuration_values import convert_known_configuration_values
 from forecastbox.domain.blueprint.service import BlueprintBuilder
 from forecastbox.domain.glyphs.intrinsic import AvailableIntrinsicGlyphs, get_values_and_examples
-from forecastbox.domain.glyphs.resolution import merge_glyph_values, resolve_configurations, value_dt2str
+from forecastbox.domain.glyphs.resolution import merge_glyph_values, resolve_configurations
 from forecastbox.domain.plugin.manager import PluginManager
 from forecastbox.domain.run.cascade import ExecutionSpecification, RawCascadeJob, RunOutputCharacteristic, RunOutputs
 from forecastbox.domain.run.types import RunId
 from forecastbox.utility.graph import topological_order
+from forecastbox.utility.time import value_dt2str
 
 
 def resolve_intrinsic_glyph_values(

--- a/backend/src/forecastbox/domain/run/service.py
+++ b/backend/src/forecastbox/domain/run/service.py
@@ -47,6 +47,7 @@ from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.config import config
 from forecastbox.utility.memcache import get as get_memcache
 from forecastbox.utility.pydantic import FiabBaseModel
+from forecastbox.utility.time import value_dt2str
 
 logger = logging.getLogger(__name__)
 
@@ -204,8 +205,8 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
             run_id=run_id,
             attempt_count=actual_attempt,
             status=status_override or status,
-            created_at=str(execution.created_at),
-            updated_at=str(execution.updated_at),
+            created_at=value_dt2str(execution.created_at),
+            updated_at=value_dt2str(execution.updated_at),
             blueprint_id=BlueprintId(str(execution.blueprint_id)),  # ty:ignore[invalid-argument-type]
             blueprint_version=cast(int, execution.blueprint_version),
             error=error_override if error_override is not None else cast(str | None, execution.error),

--- a/backend/src/forecastbox/utility/time.py
+++ b/backend/src/forecastbox/utility/time.py
@@ -11,6 +11,8 @@
 
 from datetime import datetime, timedelta
 
+from sqlalchemy import Column
+
 
 def current_time() -> datetime:
     """Return the current time used for scheduling decisions or submit time derivation."""
@@ -18,3 +20,8 @@ def current_time() -> datetime:
     # *Not* used for internal liveness measurement etc. Primarily to ensure the same timezone
     # etc are being used.
     return datetime.now()
+
+
+def value_dt2str(value: datetime | Column) -> str:
+    """Convert a datetime to the canonical string format used for all client-exposed serialization."""
+    return value.strftime("%Y-%m-%dT%H:%M:%S")

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -877,7 +877,7 @@ def test_blueprint_composite_glyph_expand(tmpdir: Any, backend_client_with_auth:
     assert glyphs_resp2.is_success, glyphs_resp2.text
     submit_example = next(g["valueExample"] for g in glyphs_resp2.json()["glyphs"] if g["name"] == "submitDatetime")
     # floor_day of the example value: strip time component
-    expected_floored = submit_example[:10] + " 00:00:00"
+    expected_floored = submit_example[:10] + "T00:00:00"
     source_jinja = BlockInstance(
         factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_text")),
         configuration_values=_config({"text": "${jinjaFilterGlyph}"}),
@@ -931,7 +931,7 @@ def test_blueprint_jinja_interpolation_expand(backend_client_with_auth: httpx.Cl
 
     # Well-formed: pure jinja arithmetic using registered globals (datetime, timedelta) and filter (floor_day).
     # Parentheses are required because Jinja2's | (filter) has higher precedence than +.
-    # (datetime(2024, 1, 15) + timedelta(days=1)) | floor_day = 2024-01-16 00:00:00
+    # (datetime(2024, 1, 15) + timedelta(days=1)) | floor_day = 2024-01-16T00:00:00
     source_wellformed = BlockInstance(
         factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_text")),
         configuration_values=_config({"text": "${(datetime(2024, 1, 15) + timedelta(days=1)) | floor_day}"}),
@@ -943,7 +943,7 @@ def test_blueprint_jinja_interpolation_expand(backend_client_with_auth: httpx.Cl
     data = response.json()
     assert len(data["block_errors"]) == 0, data["block_errors"]
     resolved = data["resolved_configuration_options"]["source_text"]["text"]
-    assert resolved == "2024-01-16 00:00:00", f"Unexpected resolved value: {resolved!r}"
+    assert resolved == "2024-01-16T00:00:00", f"Unexpected resolved value: {resolved!r}"
 
 
 def test_blueprint_composite_glyph_execute(tmpdir: Any, backend_client_with_auth: httpx.Client) -> None:

--- a/backend/tests/integration/test_schedule.py
+++ b/backend/tests/integration/test_schedule.py
@@ -23,8 +23,8 @@ from forecastbox.domain.blueprint.service import BlueprintBuilder
 from forecastbox.domain.blueprint.service import BlueprintSaveCommand as BlueprintSaveRequest
 from forecastbox.domain.blueprint.types import BlueprintId
 from forecastbox.domain.experiment.types import ExperimentDefinitionId
-from forecastbox.domain.glyphs.resolution import value_dt2str
 from forecastbox.routes.experiment import ExperimentCreateRequest, ExperimentUpdateRequest
+from forecastbox.utility.time import value_dt2str
 
 from .conftest import testPluginId
 from .utils import (

--- a/backend/tests/unit/domain/glyphs/test_resolution.py
+++ b/backend/tests/unit/domain/glyphs/test_resolution.py
@@ -23,7 +23,8 @@ from fiab_core.fable import (
 )
 
 from forecastbox.domain.glyphs.exceptions import GlyphCircularReferenceError
-from forecastbox.domain.glyphs.resolution import ExtractedGlyphs, expand_glyph_values, extract_glyphs, resolve_configurations, value_dt2str
+from forecastbox.domain.glyphs.resolution import ExtractedGlyphs, expand_glyph_values, extract_glyphs, resolve_configurations
+from forecastbox.utility.time import value_dt2str
 
 
 def _block(config: dict[str, str]) -> BlockInstance:
@@ -144,12 +145,12 @@ def test_resolve_configurations_mutates_in_place() -> None:
 
 def test_value_dt2str_format() -> None:
     d = dt.datetime(2026, 3, 15, 12, 5, 9)
-    assert value_dt2str(d) == "2026-03-15 12:05:09"
+    assert value_dt2str(d) == "2026-03-15T12:05:09"
 
 
 def test_value_dt2str_midnight() -> None:
     d = dt.datetime(2026, 1, 1, 0, 0, 0)
-    assert value_dt2str(d) == "2026-01-01 00:00:00"
+    assert value_dt2str(d) == "2026-01-01T00:00:00"
 
 
 # ---------------------------------------------------------------------------
@@ -284,21 +285,21 @@ def test_expand_glyph_with_jinja_filter() -> None:
     Previously, expand_glyph_values used a regex that only matched ${word} and
     skipped ${submitDatetime | floor_day}, leaving the raw string in the map.
     """
-    glyphs = {"submitDatetime": "2024-01-15 06:00:00", "myDate": "${submitDatetime | floor_day}"}
+    glyphs = {"submitDatetime": "2024-01-15T06:00:00", "myDate": "${submitDatetime | floor_day}"}
     result = expand_glyph_values(glyphs)
-    assert result["myDate"] == "2024-01-15 00:00:00"
+    assert result["myDate"] == "2024-01-15T00:00:00"
 
 
 def test_expand_nested_glyph_with_jinja_filter() -> None:
     """Transitive expansion works when an intermediate glyph contains a jinja filter."""
     glyphs = {
-        "submitDatetime": "2024-01-15 06:00:00",
+        "submitDatetime": "2024-01-15T06:00:00",
         "baseDate": "${submitDatetime | floor_day}",
         "path": "${baseDate}/output",
     }
     result = expand_glyph_values(glyphs)
-    assert result["baseDate"] == "2024-01-15 00:00:00"
-    assert result["path"] == "2024-01-15 00:00:00/output"
+    assert result["baseDate"] == "2024-01-15T00:00:00"
+    assert result["path"] == "2024-01-15T00:00:00/output"
 
 
 def test_expand_glyph_with_mixed_known_filter_and_unknown() -> None:
@@ -307,9 +308,9 @@ def test_expand_glyph_with_mixed_known_filter_and_unknown() -> None:
     The known filter is evaluated; the unknown ref placeholder survives so the
     downstream block-level validation can report it.
     """
-    glyphs = {"submitDatetime": "2024-01-15 06:00:00", "mixed": "${submitDatetime | floor_day}/${missing}"}
+    glyphs = {"submitDatetime": "2024-01-15T06:00:00", "mixed": "${submitDatetime | floor_day}/${missing}"}
     result = expand_glyph_values(glyphs)
-    assert result["mixed"] == "2024-01-15 00:00:00/${missing}"
+    assert result["mixed"] == "2024-01-15T00:00:00/${missing}"
 
 
 def test_expand_glyph_filter_on_unknown_ref_kept_as_is() -> None:
@@ -325,9 +326,9 @@ def test_expand_glyph_filter_on_unknown_ref_kept_as_is() -> None:
 
 def test_expand_glyph_chained_datetime_filters() -> None:
     """Chained filters on a known datetime glyph are fully evaluated."""
-    glyphs = {"submitDatetime": "2024-01-15 06:30:00", "rounded": "${submitDatetime | add_days(1) | floor_day}"}
+    glyphs = {"submitDatetime": "2024-01-15T06:30:00", "rounded": "${submitDatetime | add_days(1) | floor_day}"}
     result = expand_glyph_values(glyphs)
-    assert result["rounded"] == "2024-01-16 00:00:00"
+    assert result["rounded"] == "2024-01-16T00:00:00"
 
 
 # ---------------------------------------------------------------------------
@@ -394,50 +395,50 @@ def test_extract_glyphs_malformed_expression_returns_error() -> None:
 # resolve_configurations — jinja2 datetime filters
 # ---------------------------------------------------------------------------
 
-_DT = "2024-01-15 06:00:00"
+_DT = "2024-01-15T06:00:00"
 _GLYPHS = {"submitDatetime": _DT}
 
 
 def test_resolve_add_days() -> None:
     block = _block({"key": "${submitDatetime | add_days(1)}"})
     resolve_configurations(block, _GLYPHS)
-    assert _value(block, "key") == "2024-01-16 06:00:00"
+    assert _value(block, "key") == "2024-01-16T06:00:00"
 
 
 def test_resolve_sub_days() -> None:
     block = _block({"key": "${submitDatetime | sub_days(2)}"})
     resolve_configurations(block, _GLYPHS)
-    assert _value(block, "key") == "2024-01-13 06:00:00"
+    assert _value(block, "key") == "2024-01-13T06:00:00"
 
 
 def test_resolve_add_hours() -> None:
     block = _block({"key": "${submitDatetime | add_hours(6)}"})
     resolve_configurations(block, _GLYPHS)
-    assert _value(block, "key") == "2024-01-15 12:00:00"
+    assert _value(block, "key") == "2024-01-15T12:00:00"
 
 
 def test_resolve_floor_day() -> None:
     block = _block({"key": "${submitDatetime | floor_day}"})
-    resolve_configurations(block, {"submitDatetime": "2024-01-15 06:30:00"})
-    assert _value(block, "key") == "2024-01-15 00:00:00"
+    resolve_configurations(block, {"submitDatetime": "2024-01-15T06:30:00"})
+    assert _value(block, "key") == "2024-01-15T00:00:00"
 
 
 def test_resolve_floor_hour() -> None:
     block = _block({"key": "${submitDatetime | floor_hour}"})
-    resolve_configurations(block, {"submitDatetime": "2024-01-15 06:45:00"})
-    assert _value(block, "key") == "2024-01-15 06:00:00"
+    resolve_configurations(block, {"submitDatetime": "2024-01-15T06:45:00"})
+    assert _value(block, "key") == "2024-01-15T06:00:00"
 
 
 def test_resolve_chained_datetime_filters() -> None:
     block = _block({"key": "${submitDatetime | add_days(1) | floor_day}"})
-    resolve_configurations(block, {"submitDatetime": "2024-01-15 14:30:00"})
-    assert _value(block, "key") == "2024-01-16 00:00:00"
+    resolve_configurations(block, {"submitDatetime": "2024-01-15T14:30:00"})
+    assert _value(block, "key") == "2024-01-16T00:00:00"
 
 
 def test_resolve_timedelta_global() -> None:
     block = _block({"key": "${submitDatetime + timedelta(days=1)}"})
     resolve_configurations(block, _GLYPHS)
-    assert _value(block, "key") == "2024-01-16 06:00:00"
+    assert _value(block, "key") == "2024-01-16T06:00:00"
 
 
 def test_resolve_string_upper() -> None:
@@ -486,4 +487,4 @@ def test_resolve_date_like_string_not_coerced() -> None:
 def test_resolve_mixed_literal_and_expression() -> None:
     block = _block({"key": "prefix_${submitDatetime | floor_day}_suffix"})
     resolve_configurations(block, _GLYPHS)
-    assert _value(block, "key") == "prefix_2024-01-15 00:00:00_suffix"
+    assert _value(block, "key") == "prefix_2024-01-15T00:00:00_suffix"

--- a/backend/tests/unit/domain/run/test_run_detailed_report.py
+++ b/backend/tests/unit/domain/run/test_run_detailed_report.py
@@ -1,3 +1,4 @@
+import datetime as dt
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock, patch
@@ -44,8 +45,8 @@ async def test_poll_and_update_requests_detailed_report_and_translates_to_block_
         run_id="run-1",
         attempt_count=1,
         status="running",
-        created_at="2026-05-12T00:00:00",
-        updated_at="2026-05-12T00:00:00",
+        created_at=dt.datetime.strptime("2026-05-12T00:00:00", "%Y-%m-%dT%H:%M:%S"),
+        updated_at=dt.datetime.strptime("2026-05-12T00:00:00", "%Y-%m-%dT%H:%M:%S"),
         blueprint_id="bp-1",
         blueprint_version=1,
         error=None,
@@ -85,8 +86,8 @@ async def test_poll_and_update_disables_detailed_report_when_cache_misses() -> N
         run_id="run-1",
         attempt_count=1,
         status="running",
-        created_at="2026-05-12T00:00:00",
-        updated_at="2026-05-12T00:00:00",
+        created_at=dt.datetime.strptime("2026-05-12T00:00:00", "%Y-%m-%dT%H:%M:%S"),
+        updated_at=dt.datetime.strptime("2026-05-12T00:00:00", "%Y-%m-%dT%H:%M:%S"),
         blueprint_id="bp-1",
         blueprint_version=1,
         error=None,
@@ -123,8 +124,8 @@ async def test_poll_and_update_returns_empty_detailed_fields_for_completed_runs(
         run_id="run-1",
         attempt_count=1,
         status="completed",
-        created_at="2026-05-12T00:00:00",
-        updated_at="2026-05-12T00:00:00",
+        created_at=dt.datetime.strptime("2026-05-12T00:00:00", "%Y-%m-%dT%H:%M:%S"),
+        updated_at=dt.datetime.strptime("2026-05-12T00:00:00", "%Y-%m-%dT%H:%M:%S"),
         blueprint_id="bp-1",
         blueprint_version=1,
         error=None,
@@ -145,8 +146,8 @@ async def test_get_run_asks_for_detailed_report_while_list_runs_does_not() -> No
         run_id="run-1",
         attempt_count=1,
         status="running",
-        created_at="2026-05-12T00:00:00",
-        updated_at="2026-05-12T00:00:00",
+        created_at=dt.datetime.strptime("2026-05-12T00:00:00", "%Y-%m-%dT%H:%M:%S"),
+        updated_at=dt.datetime.strptime("2026-05-12T00:00:00", "%Y-%m-%dT%H:%M:%S"),
         blueprint_id="bp-1",
         blueprint_version=1,
         error=None,

--- a/backend/tests/unit/scheduling/test_experiment_runnable.py
+++ b/backend/tests/unit/scheduling/test_experiment_runnable.py
@@ -73,7 +73,7 @@ async def test_experiment2runnable_success(mock_get_jd: AsyncMock, mock_get_exp:
     assert runnable.max_acceptable_delay_hours == 24
     assert runnable.scheduled_at == exec_time
     assert runnable.next_run_at is not None  # cron_expr computes a next run
-    assert runnable.compiler_runtime_context == CompilerRuntimeContext(glyphs={"submitDatetime": "2026-01-01 00:00:00"})
+    assert runnable.compiler_runtime_context == CompilerRuntimeContext(glyphs={"submitDatetime": "2026-01-01T00:00:00"})
     assert runnable.blueprint is jd
 
 


### PR DESCRIPTION
Changes the jinja datetime handling to be aligned with type system in fiab core, ie, we use ISO 8601. Bit heavyhanded, ie, the alignment is accidental, not guaranteed -- if we'll need more alignments in the future, this will need more work

Additionally, it changes to ISO 8601  _other_ reported datetime strings by the backend, such as created_at or updated_at, to keep it consistent. It some tests, we compare the value of submitDatetime glyph with the actual value of created_at, and backend derives those from the same source datetime, therefore we want to unify the format as well

There is a chance I've not covered all datetime strings in all responses, we are not protected at type level sadly -- I will be improving as time goes, but merge this one right away as it fixes an active bug

cc @liefra 



