### PR TITLE
[backend] add memcache pops to run polls

### DIFF
--- a/backend/src/forecastbox/domain/run/service.py
+++ b/backend/src/forecastbox/domain/run/service.py
@@ -46,6 +46,7 @@ from forecastbox.schemata.jobs import Blueprint, Run
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.config import config
 from forecastbox.utility.memcache import get as get_memcache
+from forecastbox.utility.memcache import pop as pop_memcache
 from forecastbox.utility.pydantic import FiabBaseModel
 from forecastbox.utility.time import value_dt2str
 
@@ -218,10 +219,7 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
             planned_block_ids=planned_block_ids,
         )
 
-    if status == "completed" and cascade_job_id and detailed_report:
-        return _build(completed_block_ids=set(), planned_block_ids=set())
-
-    if status in ("submitted", "preparing", "running") and cascade_job_id:
+    if status in ("submitted", "preparing", "running", "unknown") and cascade_job_id:
         job_id = JobId(cascade_job_id)
         warning_error: str | None = None
         task_to_block: dict[TaskId, BlockInstanceId] | None = None
@@ -266,13 +264,16 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
         if jobprogress is None:
             await run_db.update_run_runtime(run_id, actual_attempt, status="failed", error="evicted from gateway")
             available_task_ids = []
+            pop_memcache(run_id)
             return _build(status_override="failed", error_override="evicted from gateway")
         elif jobprogress.failure:
             await run_db.update_run_runtime(run_id, actual_attempt, status="failed", error=jobprogress.failure)
             available_task_ids = []
+            pop_memcache(run_id)
             return _build(status_override="failed", error_override=jobprogress.failure)
         elif jobprogress.completed or jobprogress.pct == "100.00":
             await run_db.update_run_runtime(run_id, actual_attempt, status="completed", progress="100.00")
+            pop_memcache(run_id)
             return _build(status_override="completed", progress_override="100.00")
         else:
             await run_db.update_run_runtime(run_id, actual_attempt, status="running", progress=jobprogress.pct)

--- a/backend/src/forecastbox/utility/memcache.py
+++ b/backend/src/forecastbox/utility/memcache.py
@@ -9,6 +9,7 @@
 
 """Backend-global size-limited in-memory cache."""
 
+import logging
 import sys
 import threading
 from collections.abc import Mapping, Sequence
@@ -19,6 +20,8 @@ from pyrsistent import pmap
 from pyrsistent.typing import PMap
 
 T = TypeVar("T")
+
+logger = logging.getLogger(__name__)
 
 
 class TooLargeEntry(ValueError):
@@ -78,13 +81,14 @@ class _MemoryCache:
         self.current_size = 0
 
     def _remove_key(self, key: Any) -> None:
-        value_size = self.sizes.get(key)
-        if value_size is not None:
+        try:
+            value_size = self.sizes[key]
             self.current_size -= value_size
             self.sizes = self.sizes.remove(key)
-        self.lookup = self.lookup.remove(key)
-        if key in self.lru:
+            self.lookup = self.lookup.remove(key)
             self.lru.remove(key)
+        except Exception as e:
+            logger.warning(f"failure during cache removal of {key}, cache may be inconsistent! {repr(e)}")
 
 
 _CACHE = _MemoryCache()
@@ -111,11 +115,15 @@ def insert(key: Any, value: Any) -> None:
         _CACHE.current_size += entry_size
 
 
-def pop(key: Any) -> Any:
-    with _CACHE.lock:
-        value = _CACHE.lookup[key]
-        _CACHE._remove_key(key)
-        return value
+def pop(key: Any) -> Any | None:
+    if key in _CACHE.lookup:
+        with _CACHE.lock:
+            if key in _CACHE.lookup:
+                value = _CACHE.lookup[key]
+                _CACHE._remove_key(key)
+                return value
+            else:
+                return None
 
 
 def get(key: Any, value_type: type[T]) -> T:

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -513,8 +513,8 @@ def test_blueprint_expand_missing_glyph_warnings(tmpdir: Any, backend_client_wit
     available_tasks = [task_id for task_id, char in run_detail["outputs"]["outputs"].items() if char["is_available"]]
     assert isinstance(available_tasks, list)
     assert len(available_tasks) > 0
-    assert run_detail["planned_block_ids"] == []
-    assert run_detail["completed_block_ids"] == []
+    assert run_detail["planned_block_ids"] == None
+    assert run_detail["completed_block_ids"] == None
 
     logs_resp = backend_client_with_auth.get("/run/logs", params={"run_id": run_id})
     assert logs_resp.is_success, logs_resp.text

--- a/backend/tests/unit/domain/run/test_run_detailed_report.py
+++ b/backend/tests/unit/domain/run/test_run_detailed_report.py
@@ -136,8 +136,8 @@ async def test_poll_and_update_returns_empty_detailed_fields_for_completed_runs(
 
     detail = await run_service.poll_and_update(cast(Run, execution), detailed_report=True)
 
-    assert detail.completed_block_ids == set()
-    assert detail.planned_block_ids == set()
+    assert detail.completed_block_ids == None
+    assert detail.planned_block_ids == None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
When we poll for run status in cascade, during the transition to 'completed', we pop the compilation lookup from the memcache to reduce the memory pressure

We additionally put in some safety guards to the cache pop itself, and simplify the polling logic. This in turn causes some empty lists/sets become Nones, which we fix in tests accordingly
