### PR TITLE
[frontend] feat(executions): backend sync, outputs UX, layout polish

### DIFF
--- a/frontend/mocks/data/job.data.ts
+++ b/frontend/mocks/data/job.data.ts
@@ -60,6 +60,9 @@ const seedExecutions: Array<JobExecutionDetail> = [
         is_available: true,
       },
     },
+    // Cache is popped on terminal status; both arrays come back null.
+    completed_block_ids: null,
+    planned_block_ids: null,
   },
   {
     run_id: 'job-running-002',
@@ -79,6 +82,8 @@ const seedExecutions: Array<JobExecutionDetail> = [
         is_available: false,
       },
     },
+    completed_block_ids: ['block_source_1'],
+    planned_block_ids: ['block_source_1', 'block_product_1', 'block_sink_1'],
   },
   {
     run_id: 'job-errored-003',
@@ -92,6 +97,8 @@ const seedExecutions: Array<JobExecutionDetail> = [
     progress: '62',
     cascade_job_id: 'cascade-003',
     outputs: {},
+    completed_block_ids: null,
+    planned_block_ids: null,
   },
   {
     run_id: 'job-submitted-004',
@@ -193,6 +200,8 @@ export function restartExecution(
     status: 'submitted',
     progress: '0',
     updated_at: new Date().toISOString(),
+    completed_block_ids: null,
+    planned_block_ids: null,
   }
   return { run_id: executionId, attempt_count }
 }

--- a/frontend/src/api/types/job.types.ts
+++ b/frontend/src/api/types/job.types.ts
@@ -48,7 +48,9 @@ export const RunOutputsSchema = z
   })
   .transform((wrapper) => wrapper.outputs)
 
-/** routes/run.py: JobExecutionDetail (status narrowed from str to known values) */
+/** routes/run.py: JobExecutionDetail. `*_block_ids` are only set on
+ * /run/get and clear to `null` on terminal status, so both `null` and
+ * `undefined` are valid wire shapes. */
 export const JobExecutionDetailSchema = z.object({
   run_id: z.string(),
   attempt_count: z.number(),
@@ -61,6 +63,8 @@ export const JobExecutionDetailSchema = z.object({
   progress: z.string().nullable(),
   cascade_job_id: z.string().nullable(),
   outputs: RunOutputsSchema.nullable(),
+  completed_block_ids: z.array(z.string()).nullable().optional(),
+  planned_block_ids: z.array(z.string()).nullable().optional(),
 })
 
 /** routes/run.py: JobExecutionList */

--- a/frontend/src/components/ui/skeleton.tsx
+++ b/frontend/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from '@/lib/utils'
+
+function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn('animate-pulse rounded-md bg-accent', className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/frontend/src/features/executions/components/ExecutionCanvas.tsx
+++ b/frontend/src/features/executions/components/ExecutionCanvas.tsx
@@ -31,6 +31,7 @@ import { Loader2, Settings2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import type {
   BlockFactoryCatalogue,
+  BlockInstanceId,
   FableBuilderV1,
 } from '@/api/types/fable.types'
 import type { JobStatus } from '@/api/types/job.types'
@@ -50,10 +51,32 @@ export function useShowConfig() {
   return useContext(ShowConfigContext)
 }
 
+export interface BlockProgressInfo {
+  completedSet: ReadonlySet<BlockInstanceId>
+  plannedSet: ReadonlySet<BlockInstanceId>
+  /** Planned − completed; populated only while overall status is `running`. */
+  runningSet: ReadonlySet<BlockInstanceId>
+}
+
+const EMPTY_PROGRESS: BlockProgressInfo = {
+  completedSet: new Set(),
+  plannedSet: new Set(),
+  runningSet: new Set(),
+}
+
+const BlockProgressContext = createContext<BlockProgressInfo>(EMPTY_PROGRESS)
+
+export function useBlockProgress(): BlockProgressInfo {
+  return useContext(BlockProgressContext)
+}
+
 interface ExecutionCanvasProps {
   fable: FableBuilderV1
   catalogue: BlockFactoryCatalogue
   status?: JobStatus
+  /** Optional + nullable: backend emits only on /run/get and clears on terminal status. */
+  completedBlockIds?: ReadonlyArray<BlockInstanceId> | null
+  plannedBlockIds?: ReadonlyArray<BlockInstanceId> | null
 }
 
 const nodeTypes: Record<string, typeof ExecutionNode> = {
@@ -71,10 +94,13 @@ function ExecutionCanvasInner({
   fable,
   catalogue,
   status,
+  completedBlockIds,
+  plannedBlockIds,
 }: ExecutionCanvasProps) {
   const { t } = useTranslation('executions')
   const [showConfig, setShowConfig] = useState(true)
   const { fitView } = useReactFlow()
+  const containerRef = useRef<HTMLDivElement>(null)
   const isInitialRender = useRef(true)
 
   useEffect(() => {
@@ -88,7 +114,40 @@ function ExecutionCanvasInner({
     })
   }, [showConfig, fitView])
 
+  // React Flow's mount-time fit locks to the initial container size; refit
+  // on resize so wide↔narrow transitions don't strand nodes outside the viewport.
+  useEffect(() => {
+    const element = containerRef.current
+    if (!element) return
+    let timer = 0
+    const observer = new ResizeObserver((entries) => {
+      const { width, height } = entries[entries.length - 1].contentRect
+      if (width === 0 || height === 0) return // skip transient 0×0 during reflow
+      window.clearTimeout(timer)
+      timer = window.setTimeout(() => {
+        fitView({ padding: 0.15, duration: 200 })
+      }, 80)
+    })
+    observer.observe(element)
+    return () => {
+      observer.disconnect()
+      window.clearTimeout(timer)
+    }
+  }, [fitView])
+
   const isRunning = status === 'running'
+
+  const blockProgress = useMemo<BlockProgressInfo>(() => {
+    const completedSet = new Set<BlockInstanceId>(completedBlockIds ?? [])
+    const plannedSet = new Set<BlockInstanceId>(plannedBlockIds ?? [])
+    const runningSet = new Set<BlockInstanceId>()
+    if (isRunning) {
+      for (const id of plannedSet) {
+        if (!completedSet.has(id)) runningSet.add(id)
+      }
+    }
+    return { completedSet, plannedSet, runningSet }
+  }, [completedBlockIds, plannedBlockIds, isRunning])
 
   const { layoutedNodes, edges, canvasHeight } = useMemo(() => {
     const nodes = fableToNodes(fable, catalogue)
@@ -100,85 +159,100 @@ function ExecutionCanvasInner({
       nodeHeight: 110,
       nodeSpacingY: 40,
     })
-    const remapped = edgeList.map((e) => ({
-      ...e,
-      // While running: custom beam edge with a flowing dash over a static
-      // track. Otherwise: the default smoothstep edge.
-      type: isRunning ? ('beam' as const) : ('smoothstep' as const),
-      animated: false,
-      style: undefined,
-    }))
+    const hasPlanInfo = blockProgress.plannedSet.size > 0
+    const remapped = edgeList.map((e) => {
+      // Not running → always smoothstep.
+      // Running with detailed plan → beam only edges into currently-running
+      // blocks; finished and not-yet-started edges stay static.
+      // Running without detailed plan (older backend, or pre-plan tick) →
+      // fall back to beaming everything as before.
+      const shouldBeam =
+        isRunning && (!hasPlanInfo || blockProgress.runningSet.has(e.target))
+      return {
+        ...e,
+        type: shouldBeam ? ('beam' as const) : ('smoothstep' as const),
+        animated: false,
+        style: undefined,
+      }
+    })
     return {
       layoutedNodes: laid,
       edges: remapped,
       canvasHeight: computeCanvasHeight(laid),
     }
-  }, [fable, catalogue, isRunning])
+  }, [fable, catalogue, isRunning, blockProgress])
 
   return (
     <ShowConfigContext value={showConfig}>
-      <div
-        style={{ minHeight: `${canvasHeight}px` }}
-        className={cn(
-          'relative h-full min-h-0 flex-1 overflow-hidden rounded-lg',
-          // No border — the dotted background already provides framing.
-          // Status feedback comes from a soft glow halo only.
-          status === 'running' && 'shadow-[0_0_12px_rgba(251,191,36,0.3)]',
-          status === 'failed' && 'shadow-[0_0_12px_rgba(239,68,68,0.3)]',
-          status === 'completed' && 'shadow-[0_0_12px_rgba(34,197,94,0.25)]',
-        )}
-      >
-        {status === 'running' && (
-          <div className="absolute top-2 right-2 z-10 flex items-center gap-1.5 rounded-full bg-amber-100 px-2.5 py-1 text-sm font-medium text-amber-700">
-            <Loader2 className="h-3 w-3 animate-spin" />
-            Running...
-          </div>
-        )}
-        <ReactFlow
-          nodes={layoutedNodes}
-          edges={edges}
-          nodeTypes={nodeTypes}
-          edgeTypes={edgeTypes}
-          nodesDraggable={false}
-          nodesConnectable={false}
-          elementsSelectable={false}
-          panOnDrag={true}
-          zoomOnScroll={true}
-          fitView={true}
-          fitViewOptions={{ padding: 0.15 }}
-          proOptions={{ hideAttribution: true }}
+      <BlockProgressContext value={blockProgress}>
+        <div
+          ref={containerRef}
+          style={{ height: `${canvasHeight}px` }}
+          className={cn(
+            'relative overflow-hidden rounded-lg',
+            // Narrow: inline `height` is the authority (React Flow needs a
+            // definite height, not just `min-height`). Wide: `!h-full`
+            // overrides it so the canvas fills the bounded column.
+            'min-[1440px]:!h-full min-[1440px]:min-h-0 min-[1440px]:flex-1',
+            // No border — the dotted background already provides framing.
+            // Status feedback comes from a soft glow halo only.
+            status === 'running' && 'shadow-[0_0_12px_rgba(251,191,36,0.3)]',
+            status === 'failed' && 'shadow-[0_0_12px_rgba(239,68,68,0.3)]',
+            status === 'completed' && 'shadow-[0_0_12px_rgba(34,197,94,0.25)]',
+          )}
         >
-          <Background
-            variant={BackgroundVariant.Dots}
-            gap={24}
-            size={1.5}
-            color="#cbd5e1"
-            className="dark:opacity-30"
-          />
-          <MiniMap
-            nodeStrokeWidth={3}
-            position="bottom-right"
-            maskColor="transparent"
-            className="right-2! bottom-2! h-[60px]! w-[90px]! rounded border border-border bg-background/80 shadow-sm"
-          />
-          <Controls
-            showInteractive={false}
-            position="bottom-left"
-            className="bottom-2! left-2!"
-          />
-          <Panel position="top-left" className="top-2! left-2!">
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-7 gap-1.5 bg-background/80 text-sm backdrop-blur-sm"
-              onClick={() => setShowConfig((prev) => !prev)}
-            >
-              <Settings2 className="h-3.5 w-3.5" />
-              {showConfig ? t('detail.hideConfig') : t('detail.showConfig')}
-            </Button>
-          </Panel>
-        </ReactFlow>
-      </div>
+          {status === 'running' && (
+            <div className="absolute top-2 right-2 z-10 flex items-center gap-1.5 rounded-full bg-amber-100 px-2.5 py-1 text-sm font-medium text-amber-700">
+              <Loader2 className="h-3 w-3 animate-spin" />
+              Running...
+            </div>
+          )}
+          <ReactFlow
+            nodes={layoutedNodes}
+            edges={edges}
+            nodeTypes={nodeTypes}
+            edgeTypes={edgeTypes}
+            nodesDraggable={false}
+            nodesConnectable={false}
+            elementsSelectable={false}
+            panOnDrag={true}
+            zoomOnScroll={true}
+            fitView={true}
+            fitViewOptions={{ padding: 0.15 }}
+            proOptions={{ hideAttribution: true }}
+          >
+            <Background
+              variant={BackgroundVariant.Dots}
+              gap={24}
+              size={1.5}
+              color="#cbd5e1"
+              className="dark:opacity-30"
+            />
+            <MiniMap
+              nodeStrokeWidth={3}
+              position="bottom-right"
+              maskColor="transparent"
+              className="right-2! bottom-2! h-[60px]! w-[90px]! rounded border border-border bg-background/80 shadow-sm"
+            />
+            <Controls
+              showInteractive={false}
+              position="bottom-left"
+              className="bottom-2! left-2!"
+            />
+            <Panel position="top-left" className="top-2! left-2!">
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 gap-1.5 bg-background/80 text-sm backdrop-blur-sm"
+                onClick={() => setShowConfig((prev) => !prev)}
+              >
+                <Settings2 className="h-3.5 w-3.5" />
+                {showConfig ? t('detail.hideConfig') : t('detail.showConfig')}
+              </Button>
+            </Panel>
+          </ReactFlow>
+        </div>
+      </BlockProgressContext>
     </ShowConfigContext>
   )
 }

--- a/frontend/src/features/executions/components/ExecutionDetailPage.tsx
+++ b/frontend/src/features/executions/components/ExecutionDetailPage.tsx
@@ -39,6 +39,13 @@ import { createLogger } from '@/lib/logger'
 
 const log = createLogger('ExecutionDetailPage')
 
+// Wide-screen layout: each column claims half the row and scrolls
+// independently via its TabsContent.
+const WIDE_COLUMN =
+  'min-[1440px]:flex min-[1440px]:h-full min-[1440px]:min-w-0 min-[1440px]:flex-1 min-[1440px]:flex-col'
+const WIDE_TAB_CONTENT =
+  'min-[1440px]:min-h-0 min-[1440px]:flex-1 min-[1440px]:overflow-y-auto'
+
 export function ExecutionDetailPage() {
   const { t } = useTranslation('executions')
   const { jobId } = useParams({ from: '/_authenticated/executions/$jobId' })
@@ -147,10 +154,9 @@ export function ExecutionDetailPage() {
   return (
     <div
       className={cn(
-        // min-h reserves space for chrome (banner ~40, header ~64, footer ~120
-        // plus paddings) so the row inside can grow via flex-1 without
-        // overflowing on smaller viewports.
-        'mx-auto flex min-h-[calc(100vh-15rem)] flex-col gap-8 px-4 py-8 sm:px-6 lg:px-8',
+        // Underscores in arbitrary values emit spaces; `calc(100vh-15rem)`
+        // (no spaces) is invalid CSS and silently discarded.
+        'mx-auto flex min-h-[calc(100vh_-_15rem)] flex-col gap-8 px-4 py-8 sm:px-6 lg:px-8',
         layoutMode === 'boxed' ? 'max-w-7xl' : 'max-w-none',
       )}
     >
@@ -175,8 +181,11 @@ export function ExecutionDetailPage() {
         error={jobData.error}
         onRestart={handleRestart}
         onDelete={handleDelete}
+        onEditConfig={canEditConfig ? handleEditConfig : undefined}
         isRestartPending={restartMutation.isPending}
         isDeletePending={deleteMutation.isPending}
+        completedBlockCount={jobData.completed_block_ids?.length ?? null}
+        plannedBlockCount={jobData.planned_block_ids?.length ?? null}
       />
 
       {jobData.status === 'failed' && jobData.error && (
@@ -189,17 +198,25 @@ export function ExecutionDetailPage() {
         />
       )}
 
-      {/* Wide-screen split: at >=1440px the canvas and the tabs panel sit
-          side-by-side as equal columns, both stretching to the same height
-          (whichever side is taller dictates). Below 1440px we revert to the
-          stacked layout. */}
-      <div className="flex flex-1 flex-col gap-8 min-[1440px]:flex-row min-[1440px]:gap-6">
-        <div className="min-[1440px]:flex min-[1440px]:min-w-0 min-[1440px]:flex-1 min-[1440px]:flex-col">
+      {/* Wide: side-by-side, pinned to viewport height with independent
+          column scroll. Narrow: stacked single-document scroll. */}
+      <div
+        className={cn(
+          'flex flex-1 flex-col gap-8',
+          // Wide: pin to viewport minus chrome (~17rem). flex-none cancels
+          // the inherited flex-1 so the explicit height is honoured.
+          'min-[1440px]:h-[calc(100vh_-_17rem)] min-[1440px]:flex-row',
+          'min-[1440px]:flex-none min-[1440px]:gap-6 min-[1440px]:overflow-hidden',
+        )}
+      >
+        <div className={WIDE_COLUMN}>
           {fableData?.builder && catalogue ? (
             <ExecutionCanvas
               fable={fableData.builder}
               catalogue={catalogue}
               status={jobData.status}
+              completedBlockIds={jobData.completed_block_ids}
+              plannedBlockIds={jobData.planned_block_ids}
             />
           ) : (
             <div className="flex h-full flex-col items-center justify-center gap-2 rounded-lg border border-dashed py-12 text-center">
@@ -213,9 +230,15 @@ export function ExecutionDetailPage() {
           )}
         </div>
 
-        <div className="min-[1440px]:min-w-0 min-[1440px]:flex-1">
-          <Tabs value={activeTab} onValueChange={setActiveTab}>
-            <TabsList className="grid w-full grid-cols-3">
+        <div className={WIDE_COLUMN}>
+          <Tabs
+            value={activeTab}
+            onValueChange={setActiveTab}
+            className="min-[1440px]:flex min-[1440px]:h-full min-[1440px]:min-h-0 min-[1440px]:flex-col"
+          >
+            {/* Sticky for the mobile single-scroll layout; no-op at wide.
+                Default `bg-muted` is the sticky background — don't override. */}
+            <TabsList className="sticky top-0 z-10 grid w-full shrink-0 grid-cols-3">
               <TabsTrigger value="outputs">
                 <Package className="h-4 w-4" />
                 {t('tabs.outputs')}
@@ -232,22 +255,24 @@ export function ExecutionDetailPage() {
             <div
               ref={handleToolbarRef}
               className={cn(
-                'mt-3 flex items-center gap-3',
+                'sticky top-12 z-10 mt-3 flex shrink-0 items-center gap-3 bg-background',
                 activeTab !== 'outputs' && 'hidden',
               )}
             />
-            <TabsContent value="outputs">
+            <TabsContent value="outputs" className={WIDE_TAB_CONTENT}>
               <OutputsPanel
                 jobId={jobId}
                 status={jobData.status}
                 outputs={jobData.outputs}
+                completedBlockIds={jobData.completed_block_ids}
+                plannedBlockIds={jobData.planned_block_ids}
                 toolbarSlot={toolbarSlot}
               />
             </TabsContent>
-            <TabsContent value="logs">
+            <TabsContent value="logs" className={WIDE_TAB_CONTENT}>
               <LogsPanel jobId={jobId} status={jobData.status} />
             </TabsContent>
-            <TabsContent value="specification">
+            <TabsContent value="specification" className={WIDE_TAB_CONTENT}>
               <SpecificationPanel fableSnapshot={fableData?.builder} />
             </TabsContent>
           </Tabs>

--- a/frontend/src/features/executions/components/ExecutionNode.tsx
+++ b/frontend/src/features/executions/components/ExecutionNode.tsx
@@ -10,11 +10,16 @@
 
 import { memo } from 'react'
 import { Handle, Position } from '@xyflow/react'
+import { CheckCircle2, Loader2 } from 'lucide-react'
 import type { NodeProps } from '@xyflow/react'
 import type { FableNodeData } from '@/features/fable-builder/utils/fable-to-graph'
 import type { BlockKind } from '@/api/types/fable.types'
 import { BLOCK_KIND_METADATA, getBlockKindIcon } from '@/api/types/fable.types'
-import { useShowConfig } from '@/features/executions/components/ExecutionCanvas'
+import {
+  useBlockProgress,
+  useShowConfig,
+} from '@/features/executions/components/ExecutionCanvas'
+import { useIsBlockHovered } from '@/features/executions/stores/executionHoverStore'
 import { cn } from '@/lib/utils'
 
 const NODE_TYPE_TO_KIND: Record<string, BlockKind> = {
@@ -37,9 +42,20 @@ const MULTI_HANDLE_GAP_PX = 12
 export const ExecutionNode = memo(function ({ data, type }: NodeProps) {
   const nodeData = data as FableNodeData
   const showConfig = useShowConfig()
+  const { completedSet, runningSet, plannedSet } = useBlockProgress()
+  const isHovered = useIsBlockHovered(nodeData.instanceId)
   const kind = NODE_TYPE_TO_KIND[type] ?? 'source'
   const kindMeta = BLOCK_KIND_METADATA[kind]
   const Icon = getBlockKindIcon(kind)
+
+  const isCompleted = completedSet.has(nodeData.instanceId)
+  const isRunning = runningSet.has(nodeData.instanceId)
+  // Only dim when the backend confirmed a plan that excludes this node.
+  const isPlannedIdle =
+    plannedSet.size > 0 &&
+    plannedSet.has(nodeData.instanceId) &&
+    !isCompleted &&
+    !isRunning
 
   const inputNames = Object.keys(nodeData.instance.input_ids)
   const configEntries = Object.entries(
@@ -50,8 +66,12 @@ export const ExecutionNode = memo(function ({ data, type }: NodeProps) {
   return (
     <div
       className={cn(
-        'relative rounded-lg border bg-card shadow-sm',
+        'relative rounded-lg border bg-card shadow-sm transition-colors',
         showConfig && configEntries.length > 0 ? 'w-[200px]' : 'w-[140px]',
+        isCompleted && 'border-l-2 border-l-emerald-500',
+        isRunning && 'animate-pulse border-amber-500',
+        isPlannedIdle && 'opacity-60',
+        isHovered && 'bg-primary/10',
       )}
     >
       {inputNames.map((inputName, i) => {
@@ -74,19 +94,28 @@ export const ExecutionNode = memo(function ({ data, type }: NodeProps) {
         )
       })}
 
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="output"
-        className="h-2! w-2! border! border-border! bg-muted-foreground/40!"
-        style={{ top: `${HANDLE_Y_PX}px`, transform: 'translateY(-50%)' }}
-      />
+      {/* Sinks have no downstream — hide the source handle for them. */}
+      {kind !== 'sink' && (
+        <Handle
+          type="source"
+          position={Position.Right}
+          id="output"
+          className="h-2! w-2! border! border-border! bg-muted-foreground/40!"
+          style={{ top: `${HANDLE_Y_PX}px`, transform: 'translateY(-50%)' }}
+        />
+      )}
 
       <div className={cn('h-1 rounded-t-lg', kindMeta.topBarColor)} />
       <div className="space-y-1 p-2.5">
         <div className="flex items-center gap-1.5">
           <Icon className={cn('h-3.5 w-3.5 shrink-0', kindMeta.color)} />
           <span className="truncate text-sm font-medium">{nodeData.label}</span>
+          {isCompleted && (
+            <CheckCircle2 className="ml-auto h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          )}
+          {isRunning && (
+            <Loader2 className="ml-auto h-3.5 w-3.5 shrink-0 animate-spin text-amber-500" />
+          )}
         </div>
         <span className="text-sm text-muted-foreground">{kindMeta.label}</span>
       </div>

--- a/frontend/src/features/executions/components/ExecutionStatusHeader.tsx
+++ b/frontend/src/features/executions/components/ExecutionStatusHeader.tsx
@@ -8,15 +8,11 @@
  * does it submit to any jurisdiction.
  */
 
-/**
- * ExecutionStatusHeader Component
- *
- * Status header with name, badge, progress bar, and action buttons.
- */
+/** Status header: name, badge, elapsed timer, progress bar, action menu. */
 
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { MoreVertical, Pencil, RotateCcw, Trash2 } from 'lucide-react'
+import { MoreVertical, RotateCcw, Settings2, Trash2 } from 'lucide-react'
 import type { JobStatus } from '@/api/types/job.types'
 import { isTerminalStatus } from '@/api/types/job.types'
 import {
@@ -54,9 +50,13 @@ interface ExecutionStatusHeaderProps {
   error: string | null
   onRestart: () => void
   onDelete: () => void
-  onEdit?: () => void
+  /** Open the fable's source configuration in the builder. */
+  onEditConfig?: () => void
   isRestartPending: boolean
   isDeletePending: boolean
+  /** Subtext hidden when planned is null/undefined/empty. */
+  completedBlockCount?: number | null
+  plannedBlockCount?: number | null
 }
 
 function formatElapsed(ms: number): string {
@@ -146,32 +146,27 @@ export function ExecutionStatusHeader({
   createdAt,
   onRestart,
   onDelete,
-  onEdit,
+  onEditConfig,
   isRestartPending,
   isDeletePending,
+  completedBlockCount,
+  plannedBlockCount,
 }: ExecutionStatusHeaderProps) {
   const { t } = useTranslation('executions')
   const terminal = isTerminalStatus(status)
   const elapsed = useElapsedTime(createdAt, terminal)
 
   const progressPercent = parseFloat(progress) || 0
+  const showBlockCount =
+    typeof plannedBlockCount === 'number' &&
+    plannedBlockCount > 0 &&
+    typeof completedBlockCount === 'number'
 
   return (
     <div className="space-y-4">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <H2 className="text-2xl font-bold">{name}</H2>
-            {onEdit && (
-              <button
-                type="button"
-                onClick={onEdit}
-                className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-              >
-                <Pencil className="h-4 w-4" />
-              </button>
-            )}
-          </div>
+          <H2 className="text-2xl font-bold">{name}</H2>
           {description && (
             <P className="line-clamp-2 text-muted-foreground">{description}</P>
           )}
@@ -194,6 +189,15 @@ export function ExecutionStatusHeader({
             </span>
           )}
 
+          {showBlockCount && (
+            <span className="text-sm text-muted-foreground">
+              {t('progress.blocksComplete', {
+                completed: completedBlockCount,
+                total: plannedBlockCount,
+              })}
+            </span>
+          )}
+
           {(status === 'completed' || status === 'failed') && (
             <RestartDialog
               onRestart={onRestart}
@@ -208,7 +212,16 @@ export function ExecutionStatusHeader({
               >
                 <MoreVertical className="h-5 w-5" />
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
+              <DropdownMenuContent align="end" className="w-auto min-w-fit">
+                {onEditConfig && (
+                  <DropdownMenuItem
+                    onClick={onEditConfig}
+                    className="whitespace-nowrap"
+                  >
+                    <Settings2 className="mr-2 h-4 w-4" />
+                    {t('actions.editConfiguration')}
+                  </DropdownMenuItem>
+                )}
                 <AlertDialogTrigger
                   nativeButton={false}
                   render={

--- a/frontend/src/features/executions/components/LogsPanel.tsx
+++ b/frontend/src/features/executions/components/LogsPanel.tsx
@@ -148,7 +148,7 @@ export function LogsPanel({ jobId, status }: LogsPanelProps) {
           <div
             ref={containerRef}
             onScroll={handleScroll}
-            className="max-h-[400px] overflow-y-auto rounded-lg border bg-muted/30 p-3 font-mono text-sm"
+            className="max-h-[60dvh] overflow-y-auto rounded-lg border bg-muted/30 p-3 font-mono text-sm min-[1440px]:max-h-none min-[1440px]:flex-1"
           >
             {filteredLines.length === 0 ? (
               <P className="text-muted-foreground">{t('outputs.noOutputs')}</P>

--- a/frontend/src/features/executions/components/OutputsPanel.tsx
+++ b/frontend/src/features/executions/components/OutputsPanel.tsx
@@ -15,8 +15,11 @@ interface OutputsPanelProps {
   jobId: string
   status: JobStatus
   outputs: RunOutputs | null
-  /** DOM node to portal the toolbar into. Lifted out of the panel so the
-   * filter row can sit alongside the parent's tab triggers. */
+  /** Drive skeleton highlights for blocks currently being processed. */
+  completedBlockIds?: ReadonlyArray<string> | null
+  /** Used to show block-level skeletons before any outputs payload arrives. */
+  plannedBlockIds?: ReadonlyArray<string> | null
+  /** Portal target so the filter row can sit alongside the parent's tabs. */
   toolbarSlot?: HTMLElement | null
 }
 
@@ -24,6 +27,8 @@ export function OutputsPanel({
   jobId,
   status,
   outputs,
+  completedBlockIds,
+  plannedBlockIds,
   toolbarSlot,
 }: OutputsPanelProps) {
   return (
@@ -31,6 +36,8 @@ export function OutputsPanel({
       jobId={jobId}
       status={status}
       outputs={outputs}
+      completedBlockIds={completedBlockIds}
+      plannedBlockIds={plannedBlockIds}
       toolbarSlot={toolbarSlot}
     />
   )

--- a/frontend/src/features/executions/components/SpecificationPanel.tsx
+++ b/frontend/src/features/executions/components/SpecificationPanel.tsx
@@ -114,7 +114,7 @@ export function SpecificationPanel({ fableSnapshot }: SpecificationPanelProps) {
 
   return (
     <Card className="overflow-hidden">
-      <div className="max-h-[600px] overflow-auto p-6">
+      <div className="overflow-x-auto p-6 min-[1440px]:flex-1 min-[1440px]:overflow-auto">
         <pre className="font-mono text-sm leading-relaxed">
           <code>
             {highlighted.map((segment, i) => (

--- a/frontend/src/features/executions/outputs/OutputsView.tsx
+++ b/frontend/src/features/executions/outputs/OutputsView.tsx
@@ -8,16 +8,8 @@
  * does it submit to any jurisdiction.
  */
 
-/**
- * Coordinator for the outputs panel. Renders a flat flex-wrap grid of
- * cards, exposes MIME filter chips + a sort dropdown, and lazy-mounts
- * the active item's viewer.
- *
- * Sniffer-resolved mimes are lifted up here via `onResolved` so the chip
- * row reflects the actual format (PNG/SVG/PDF) rather than the wire mime
- * (typically `application/octet-stream` until backend ships proper
- * RawOutput.mime_type).
- */
+/** Outputs grid with MIME filter, group-by toggle, skeletons for pending
+ * items, and a lazy viewer for the active selection. */
 
 import { Package } from 'lucide-react'
 import { Suspense, useCallback, useEffect, useMemo, useState } from 'react'
@@ -27,22 +19,45 @@ import { useNavigate, useSearch } from '@tanstack/react-router'
 import { registerFirstPartyAdapters } from './adapters'
 import { MimeFilterChips } from './MimeFilterChips'
 import { OutputCard } from './OutputCard'
+import { resolveAdapter } from './registry'
+import { SkeletonOutputCard } from './SkeletonOutputCard'
 import { useResolvedAdapter } from './useResolvedAdapter'
 import type { JobStatus, RunOutputs } from '@/api/types/job.types'
 import type { OutputAdapter, OutputItem } from './types'
+import { isTerminalStatus } from '@/api/types/job.types'
+import {
+  useBlockHoverHandlers,
+  useIsBlockHovered,
+} from '@/features/executions/stores/executionHoverStore'
 import { P } from '@/components/base/typography'
 import { Card } from '@/components/ui/card'
-import { isTerminalStatus } from '@/api/types/job.types'
+import { groupByKey } from '@/lib/group-by'
+import { cn } from '@/lib/utils'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 
 // Side-effect: adapter registration runs at module load. Idempotent.
 registerFirstPartyAdapters()
+
+// Single source of truth for the group-by enum: derive the type from the array
+// so adding an option only requires touching this list and the i18n key map.
+const GROUP_BY_OPTIONS = ['none', 'block', 'mime', 'block-and-mime'] as const
+export type GroupBy = (typeof GROUP_BY_OPTIONS)[number]
 
 interface OutputsViewProps {
   jobId: string
   status: JobStatus
   outputs: RunOutputs | null
-  /** Optional DOM node to portal the toolbar (count + filter chips) into.
-   * When omitted, the toolbar renders inline above the grid. */
+  /** Drives the subtle highlight on currently-processing skeletons. */
+  completedBlockIds?: ReadonlyArray<string> | null
+  /** Surfaces block-level skeletons before any outputs payload arrives. */
+  plannedBlockIds?: ReadonlyArray<string> | null
+  /** Portal target for the toolbar; falls back to inline. */
   toolbarSlot?: HTMLElement | null
 }
 
@@ -50,6 +65,8 @@ export function OutputsView({
   jobId,
   status,
   outputs,
+  completedBlockIds,
+  plannedBlockIds,
   toolbarSlot,
 }: OutputsViewProps) {
   const { t } = useTranslation('executions')
@@ -67,44 +84,59 @@ export function OutputsView({
     )
   }, [])
 
+  /** Default order: by block (alphabetic), available before pending within
+   * the same block, taskId for stable tiebreak. Keeps items from the same
+   * block adjacent in the flat grid, and preserved as section/item order in
+   * the grouped views. */
   const items = useMemo<Array<OutputItem>>(() => {
     if (!outputs) return []
-    return Object.entries(outputs).map(([taskId, meta]) => ({
+    const list = Object.entries(outputs).map(([taskId, meta]) => ({
       jobId,
       taskId,
       mimeType: meta.mime_type,
       originalBlock: meta.original_block,
       isAvailable: meta.is_available,
     }))
+    list.sort((a, b) => {
+      if (a.originalBlock !== b.originalBlock) {
+        return a.originalBlock < b.originalBlock ? -1 : 1
+      }
+      if (a.isAvailable !== b.isAvailable) return a.isAvailable ? -1 : 1
+      return a.taskId < b.taskId ? -1 : 1
+    })
+    return list
   }, [jobId, outputs])
 
-  const availableItems = useMemo(
-    () => items.filter((i) => i.isAvailable),
-    [items],
-  )
-
-  /** Effective mime per item: sniffer-promoted if available, else the wire
-   * mime. This is what filter chips, dispatch and counts all use. */
+  /** Sniffer-promoted mime if available, else the wire mime. */
   const effectiveMime = useCallback(
     (item: OutputItem): string => resolvedMimes[item.taskId] ?? item.mimeType,
     [resolvedMimes],
   )
 
-  const { distinctMimes, mimeCounts } = useMemo(() => {
+  /** Distinct mimes + per-mime counts, drawn from available items only. */
+  const { distinctMimes, mimeCounts, availableCount } = useMemo(() => {
     const counts: Record<string, number> = {}
     const order: Array<string> = []
-    for (const item of availableItems) {
+    let availCount = 0
+    for (const item of items) {
+      if (!item.isAvailable) continue
+      availCount += 1
       const mime = effectiveMime(item)
       if (!(mime in counts)) {
         order.push(mime)
         counts[mime] = 0
       }
-      counts[mime] = (counts[mime] ?? 0) + 1
+      counts[mime] += 1
     }
-    return { distinctMimes: order, mimeCounts: counts }
-  }, [availableItems, effectiveMime])
+    return {
+      distinctMimes: order,
+      mimeCounts: counts,
+      availableCount: availCount,
+    }
+  }, [items, effectiveMime])
 
   const activeMimes = useMemo(() => parseMimes(search.mimes), [search.mimes])
+  const groupBy: GroupBy = search.groupBy ?? 'none'
 
   const setActiveMimes = (next: ReadonlyArray<string>): void => {
     void navigate({
@@ -118,15 +150,74 @@ export function OutputsView({
     })
   }
 
-  const filteredItems = useMemo(() => {
-    if (activeMimes.length === 0) return availableItems
-    return availableItems.filter((i) => activeMimes.includes(effectiveMime(i)))
-  }, [availableItems, activeMimes, effectiveMime])
+  const setGroupBy = (next: GroupBy): void => {
+    void navigate({
+      to: '/executions/$jobId',
+      params: { jobId },
+      search: (prev) => ({
+        ...prev,
+        groupBy: next === 'none' ? undefined : next,
+      }),
+      replace: true,
+    })
+  }
+
+  /** Synthesised placeholders when the outputs payload has no rows yet. */
+  const blockSkeletons = useMemo<Array<OutputItem>>(() => {
+    if (items.length > 0) return []
+    if (!plannedBlockIds || plannedBlockIds.length === 0) return []
+    return plannedBlockIds.map((blockId) => ({
+      jobId,
+      taskId: `__planned__:${blockId}`,
+      mimeType: 'application/octet-stream',
+      originalBlock: blockId,
+      isAvailable: false,
+    }))
+  }, [items.length, plannedBlockIds, jobId])
+
+  /** Single filter pass over the unified list (or synthesised fallback).
+   * Counts shown in the toolbar are derived from this same pass. */
+  const { visibleItems, visibleAvailableCount, visiblePendingCount } =
+    useMemo(() => {
+      const source = items.length > 0 ? items : blockSkeletons
+      const visible: Array<OutputItem> = []
+      let available = 0
+      let pending = 0
+      for (const item of source) {
+        if (
+          activeMimes.length > 0 &&
+          !activeMimes.includes(effectiveMime(item))
+        ) {
+          continue
+        }
+        visible.push(item)
+        if (item.isAvailable) available += 1
+        else pending += 1
+      }
+      return {
+        visibleItems: visible,
+        visibleAvailableCount: available,
+        visiblePendingCount: pending,
+      }
+    }, [items, blockSkeletons, activeMimes, effectiveMime])
 
   const isRunning = !isTerminalStatus(status)
+
+  /** Planned − completed while the run is in progress; drives the subtle
+   * amber accent on skeletons whose block is the one currently executing. */
+  const runningBlockSet = useMemo<ReadonlySet<string>>(() => {
+    if (!isRunning || !plannedBlockIds) return new Set()
+    const completed = new Set(completedBlockIds ?? [])
+    const running = new Set<string>()
+    for (const id of plannedBlockIds) {
+      if (!completed.has(id)) running.add(id)
+    }
+    return running
+  }, [isRunning, plannedBlockIds, completedBlockIds])
   const ActiveViewer = activeViewer?.adapter.Viewer ?? null
 
-  if (availableItems.length === 0) {
+  /** True empty: no outputs payload AND no planned blocks. */
+  if (items.length === 0 && blockSkeletons.length === 0) {
     return (
       <Card
         variant="flat"
@@ -151,19 +242,26 @@ export function OutputsView({
   const toolbar = (
     <div className="flex w-full flex-wrap items-center justify-between gap-3">
       <P className="text-muted-foreground">
-        {t('outputs.generated')}: {filteredItems.length}
-        {filteredItems.length !== availableItems.length &&
-          ` / ${availableItems.length}`}
+        {t('outputs.generated')}: {visibleAvailableCount}
+        {visibleAvailableCount !== availableCount && ` / ${availableCount}`}
+        {visiblePendingCount > 0 && (
+          <span className="ml-2">
+            · {t('outputs.pending')}: {visiblePendingCount}
+          </span>
+        )}
       </P>
-      {distinctMimes.length > 1 && (
-        <MimeFilterChips
-          availableMimes={distinctMimes}
-          activeMimes={activeMimes}
-          counts={mimeCounts}
-          total={availableItems.length}
-          onChange={setActiveMimes}
-        />
-      )}
+      <div className="flex flex-wrap items-center gap-3">
+        {distinctMimes.length > 1 && (
+          <MimeFilterChips
+            availableMimes={distinctMimes}
+            activeMimes={activeMimes}
+            counts={mimeCounts}
+            total={availableCount}
+            onChange={setActiveMimes}
+          />
+        )}
+        <GroupBySelect value={groupBy} onChange={setGroupBy} />
+      </div>
     </div>
   )
 
@@ -177,24 +275,19 @@ export function OutputsView({
       <div className="space-y-3 py-3">
         {!toolbarSlot && toolbar}
 
-        {filteredItems.length === 0 ? (
+        {visibleItems.length === 0 ? (
           <P className="px-1 py-6 text-center text-sm text-muted-foreground">
             {t('outputs.noMatch')}
           </P>
         ) : (
-          <div className="flex flex-wrap gap-3">
-            {filteredItems.map((item) => (
-              <div key={item.taskId} className="w-60 shrink-0">
-                <OutputCardSlot
-                  item={item}
-                  onOpenViewer={(i, adapter) =>
-                    setActiveViewer({ item: i, adapter })
-                  }
-                  onResolved={handleResolved}
-                />
-              </div>
-            ))}
-          </div>
+          <GroupedGrid
+            groupBy={groupBy}
+            items={visibleItems}
+            runningBlockSet={runningBlockSet}
+            effectiveMime={effectiveMime}
+            onOpenViewer={(item, adapter) => setActiveViewer({ item, adapter })}
+            onResolved={handleResolved}
+          />
         )}
       </div>
 
@@ -209,6 +302,286 @@ export function OutputsView({
       )}
     </Card>
   )
+}
+
+interface GroupedGridProps {
+  groupBy: GroupBy
+  items: ReadonlyArray<OutputItem>
+  runningBlockSet: ReadonlySet<string>
+  effectiveMime: (item: OutputItem) => string
+  onOpenViewer: (item: OutputItem, adapter: OutputAdapter) => void
+  onResolved: (taskId: string, mime: string) => void
+}
+
+function GroupedGrid({
+  groupBy,
+  items,
+  runningBlockSet,
+  effectiveMime,
+  onOpenViewer,
+  onResolved,
+}: GroupedGridProps) {
+  if (groupBy === 'none') {
+    return (
+      <FlexGrid
+        items={items}
+        runningBlockSet={runningBlockSet}
+        onOpenViewer={onOpenViewer}
+        onResolved={onResolved}
+      />
+    )
+  }
+
+  if (groupBy === 'block') {
+    const groups = groupByKey(items, (i) => i.originalBlock)
+    return (
+      <div className="space-y-5">
+        {groups.map(([block, groupItems]) => (
+          <Section
+            key={block}
+            title={block}
+            count={groupItems.length}
+            blockId={block}
+          >
+            <FlexGrid
+              items={groupItems}
+              runningBlockSet={runningBlockSet}
+              onOpenViewer={onOpenViewer}
+              onResolved={onResolved}
+            />
+          </Section>
+        ))}
+      </div>
+    )
+  }
+
+  if (groupBy === 'mime') {
+    const groups = groupByKey(items, effectiveMime)
+    return (
+      <div className="space-y-5">
+        {groups.map(([mime, groupItems]) => (
+          <Section
+            key={mime}
+            title={<MimeSectionLabel mime={mime} />}
+            count={groupItems.length}
+          >
+            <FlexGrid
+              items={groupItems}
+              runningBlockSet={runningBlockSet}
+              onOpenViewer={onOpenViewer}
+              onResolved={onResolved}
+            />
+          </Section>
+        ))}
+      </div>
+    )
+  }
+
+  // 'block-and-mime': outer = block, inner = mime
+  const byBlock = groupByKey(items, (i) => i.originalBlock)
+  return (
+    <div className="space-y-6">
+      {byBlock.map(([block, blockItems]) => {
+        const byMime = groupByKey(blockItems, effectiveMime)
+        return (
+          <Section
+            key={block}
+            title={block}
+            count={blockItems.length}
+            blockId={block}
+          >
+            <div className="space-y-4">
+              {byMime.map(([mime, mimeItems]) => (
+                <Subsection
+                  key={mime}
+                  title={<MimeSectionLabel mime={mime} />}
+                  count={mimeItems.length}
+                >
+                  <FlexGrid
+                    items={mimeItems}
+                    runningBlockSet={runningBlockSet}
+                    onOpenViewer={onOpenViewer}
+                    onResolved={onResolved}
+                  />
+                </Subsection>
+              ))}
+            </div>
+          </Section>
+        )
+      })}
+    </div>
+  )
+}
+
+interface FlexGridProps {
+  items: ReadonlyArray<OutputItem>
+  runningBlockSet: ReadonlySet<string>
+  onOpenViewer: (item: OutputItem, adapter: OutputAdapter) => void
+  onResolved: (taskId: string, mime: string) => void
+}
+
+function FlexGrid({
+  items,
+  runningBlockSet,
+  onOpenViewer,
+  onResolved,
+}: FlexGridProps) {
+  return (
+    <div className="grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3">
+      {items.map((item) => (
+        <FlexGridItem
+          key={item.taskId}
+          item={item}
+          isRunning={runningBlockSet.has(item.originalBlock)}
+          onOpenViewer={onOpenViewer}
+          onResolved={onResolved}
+        />
+      ))}
+    </div>
+  )
+}
+
+// Per-item subscription keeps hover-driven re-renders scoped to the matching block.
+function FlexGridItem({
+  item,
+  isRunning,
+  onOpenViewer,
+  onResolved,
+}: {
+  item: OutputItem
+  isRunning: boolean
+  onOpenViewer: (item: OutputItem, adapter: OutputAdapter) => void
+  onResolved: (taskId: string, mime: string) => void
+}) {
+  const isHovered = useIsBlockHovered(item.originalBlock)
+  const handlers = useBlockHoverHandlers(item.originalBlock)
+  return (
+    <div
+      {...handlers}
+      className={cn(
+        'rounded-lg transition-colors',
+        isHovered && 'bg-primary/10',
+      )}
+    >
+      {item.isAvailable ? (
+        <OutputCardSlot
+          item={item}
+          onOpenViewer={onOpenViewer}
+          onResolved={onResolved}
+        />
+      ) : (
+        <SkeletonOutputCard
+          originalBlock={item.originalBlock}
+          isRunning={isRunning}
+        />
+      )}
+    </div>
+  )
+}
+
+function Section({
+  title,
+  count,
+  children,
+  blockId,
+}: {
+  title: React.ReactNode
+  count: number
+  children: React.ReactNode
+  /** When set, hover on the section triggers the canvas-block highlight. */
+  blockId?: string
+}) {
+  const handlers = useBlockHoverHandlers(blockId ?? null)
+  return (
+    <section className="space-y-2" {...handlers}>
+      <header className="flex items-baseline gap-2">
+        <h3
+          className="truncate font-mono text-sm font-semibold text-foreground"
+          title={typeof title === 'string' ? title : undefined}
+        >
+          {title}
+        </h3>
+        <span className="text-sm text-muted-foreground">({count})</span>
+      </header>
+      {children}
+    </section>
+  )
+}
+
+function Subsection({
+  title,
+  count,
+  children,
+}: {
+  title: React.ReactNode
+  count: number
+  children: React.ReactNode
+}) {
+  return (
+    <section className="space-y-2 pl-3">
+      <header className="flex items-baseline gap-2">
+        <h4 className="truncate text-sm font-medium text-muted-foreground">
+          {title}
+        </h4>
+        <span className="text-sm text-muted-foreground/70">({count})</span>
+      </header>
+      {children}
+    </section>
+  )
+}
+
+/** Resolve a human label for a mime group header via the registry. */
+function MimeSectionLabel({ mime }: { mime: string }) {
+  const { t } = useTranslation('executions')
+  return <>{resolveAdapter(mime).label(t)}</>
+}
+
+function GroupBySelect({
+  value,
+  onChange,
+}: {
+  value: GroupBy
+  onChange: (next: GroupBy) => void
+}) {
+  const { t } = useTranslation('executions')
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-sm text-muted-foreground">
+        {t('outputs.groupBy.label')}
+      </span>
+      <Select value={value} onValueChange={(v) => onChange(v as GroupBy)}>
+        <SelectTrigger className="h-8 w-44 text-sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {GROUP_BY_OPTIONS.map((option) => (
+            <SelectItem key={option} value={option}>
+              {t(groupByI18nKey(option))}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
+function groupByI18nKey(
+  option: GroupBy,
+):
+  | 'outputs.groupBy.none'
+  | 'outputs.groupBy.block'
+  | 'outputs.groupBy.mime'
+  | 'outputs.groupBy.blockAndMime' {
+  switch (option) {
+    case 'none':
+      return 'outputs.groupBy.none'
+    case 'block':
+      return 'outputs.groupBy.block'
+    case 'mime':
+      return 'outputs.groupBy.mime'
+    case 'block-and-mime':
+      return 'outputs.groupBy.blockAndMime'
+  }
 }
 
 /** Per-item slot: resolves the (possibly sniff-promoted) adapter, reports

--- a/frontend/src/features/executions/outputs/SkeletonOutputCard.tsx
+++ b/frontend/src/features/executions/outputs/SkeletonOutputCard.tsx
@@ -1,0 +1,58 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Pending-output placeholder. Matches OutputCard dimensions so the grid
+ * doesn't reshuffle when an output's `is_available` flips to true.
+ */
+
+import { Skeleton } from '@/components/ui/skeleton'
+import { P } from '@/components/base/typography'
+import { cn } from '@/lib/utils'
+
+interface SkeletonOutputCardProps {
+  originalBlock: string
+  /** Pulse only fires for currently-executing blocks; idle pending cards stay static. */
+  isRunning?: boolean
+}
+
+// Stronger pulse than Tailwind's default — see `pulse-strong` in styles.css.
+const RUNNING_PULSE = 'animate-[pulse-strong_1.5s_ease-in-out_infinite]'
+
+export function SkeletonOutputCard({
+  originalBlock,
+  isRunning = false,
+}: SkeletonOutputCardProps) {
+  const pulse = isRunning ? RUNNING_PULSE : 'animate-none'
+  return (
+    <div
+      aria-busy="true"
+      aria-live="polite"
+      className="w-full space-y-2 overflow-hidden rounded-lg border bg-card p-3"
+    >
+      <Skeleton className={cn('aspect-video w-full rounded', pulse)} />
+
+      <div className="space-y-1">
+        <Skeleton className={cn('h-4 w-3/4', pulse)} />
+        <P
+          className="truncate font-mono text-xs text-muted-foreground/70"
+          title={originalBlock}
+        >
+          {originalBlock}
+        </P>
+      </div>
+
+      <div className="flex gap-1.5">
+        <Skeleton className={cn('h-7 w-9', pulse)} />
+        <Skeleton className={cn('h-7 w-9', pulse)} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/executions/outputs/viewers/PdfThumbnail.tsx
+++ b/frontend/src/features/executions/outputs/viewers/PdfThumbnail.tsx
@@ -66,8 +66,16 @@ export function PdfThumbnail({ item }: ThumbnailProps) {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- mutated by cleanup
         if (state.cancelled || !canvas) return
         const viewport = page.getViewport({ scale: 1 })
-        const targetWidth = canvas.parentElement?.clientWidth ?? 240
-        const scale = targetWidth / viewport.width
+        // Fit within both parent dimensions so portrait pages don't overflow
+        // the aspect-video container (which would otherwise produce
+        // asymmetric whitespace on the side).
+        const parent = canvas.parentElement
+        const targetWidth = parent?.clientWidth ?? 240
+        const targetHeight = parent?.clientHeight ?? 135
+        const scale = Math.min(
+          targetWidth / viewport.width,
+          targetHeight / viewport.height,
+        )
         const scaled = page.getViewport({ scale })
         canvas.width = scaled.width
         canvas.height = scaled.height

--- a/frontend/src/features/executions/stores/executionHoverStore.ts
+++ b/frontend/src/features/executions/stores/executionHoverStore.ts
@@ -1,0 +1,48 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { create } from 'zustand'
+
+interface ExecutionHoverState {
+  hoveredBlockId: string | null
+  setHoveredBlockId: (id: string | null) => void
+}
+
+export const useExecutionHoverStore = create<ExecutionHoverState>(
+  (set, get) => ({
+    hoveredBlockId: null,
+    setHoveredBlockId: (id) => {
+      if (get().hoveredBlockId === id) return
+      set({ hoveredBlockId: id })
+    },
+  }),
+)
+
+/** True when this block id is the currently-hovered one. */
+export function useIsBlockHovered(blockId: string): boolean {
+  return useExecutionHoverStore((state) => state.hoveredBlockId === blockId)
+}
+
+/** Stable enter/leave handlers that set `blockId` on enter and clear on leave.
+ * Returns `undefined` for both when `blockId` is null, so spreading on an
+ * element attaches no listeners. */
+export function useBlockHoverHandlers(blockId: string | null): {
+  onPointerEnter?: () => void
+  onPointerLeave?: () => void
+} {
+  const setHoveredBlockId = useExecutionHoverStore(
+    (state) => state.setHoveredBlockId,
+  )
+  if (blockId === null) return {}
+  return {
+    onPointerEnter: () => setHoveredBlockId(blockId),
+    onPointerLeave: () => setHoveredBlockId(null),
+  }
+}

--- a/frontend/src/features/fable-builder/components/form-mode/BlockInstanceCard.tsx
+++ b/frontend/src/features/fable-builder/components/form-mode/BlockInstanceCard.tsx
@@ -25,6 +25,7 @@ import type {
   BlockInstanceId,
   PluginBlockFactoryId,
 } from '@/api/types/fable.types'
+import { useFieldErrorMessages } from '@/features/fable-builder/hooks/useFieldErrorMessages'
 import {
   useBlockValidation,
   useFableBuilderStore,
@@ -137,9 +138,10 @@ export function BlockInstanceCard({
   const hasErrors = blockValidation?.hasErrors ?? false
   const errors = blockValidation?.errors ?? []
   const missingGlyphs = blockValidation?.missingGlyphs ?? {}
+  const fieldErrorMessages = useFieldErrorMessages()
   const mappedErrors = useMemo(
-    () => mapBlockErrorsToFields(errors, missingGlyphs),
-    [errors, missingGlyphs],
+    () => mapBlockErrorsToFields(errors, missingGlyphs, fieldErrorMessages),
+    [errors, missingGlyphs, fieldErrorMessages],
   )
 
   if (!factory) {

--- a/frontend/src/features/fable-builder/components/graph-mode/nodes/BlockErrorOverlay.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/nodes/BlockErrorOverlay.tsx
@@ -38,10 +38,10 @@ export function BlockErrorOverlay({
   return (
     <Alert
       variant="destructive"
-      className="nodrag absolute top-full right-0 left-0 z-10 mt-1 gap-1 px-2 py-1.5 text-xs shadow-md"
+      className="nodrag absolute top-full right-0 left-0 z-10 mt-1 gap-1 px-2 py-1.5 shadow-md"
     >
       <AlertCircle className="h-3 w-3" />
-      <AlertDescription className="text-xs">
+      <AlertDescription>
         {expanded ? (
           <ul className="m-0 list-disc space-y-0.5 pl-4">
             {errors.map((error, index) => (

--- a/frontend/src/features/fable-builder/components/graph-mode/nodes/InlineBlockNode.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/nodes/InlineBlockNode.tsx
@@ -17,6 +17,7 @@ import type { FableNodeData } from '@/features/fable-builder/utils/fable-to-grap
 import type { BlockFactory, BlockInstance } from '@/api/types/fable.types'
 import { BlockErrorOverlay } from '@/features/fable-builder/components/graph-mode/nodes/BlockErrorOverlay'
 import { AddNodeButton } from '@/features/fable-builder/components/graph-mode/AddNodeButton'
+import { useFieldErrorMessages } from '@/features/fable-builder/hooks/useFieldErrorMessages'
 import { useNodeDimensions } from '@/features/fable-builder/hooks/useNodeDimensions'
 import {
   useBlockValidation,
@@ -127,9 +128,10 @@ export const InlineBlockNode = memo(function ({
   const inputs = factory.inputs
 
   const missingGlyphs = blockValidation?.missingGlyphs ?? {}
+  const fieldErrorMessages = useFieldErrorMessages()
   const mappedErrors = useMemo(
-    () => mapBlockErrorsToFields(errors, missingGlyphs),
-    [errors, missingGlyphs],
+    () => mapBlockErrorsToFields(errors, missingGlyphs, fieldErrorMessages),
+    [errors, missingGlyphs, fieldErrorMessages],
   )
 
   return (

--- a/frontend/src/features/fable-builder/components/layout/ConfigPanel.tsx
+++ b/frontend/src/features/fable-builder/components/layout/ConfigPanel.tsx
@@ -11,6 +11,7 @@
 import { useMemo } from 'react'
 import { AlertCircle, Link2, Trash2, X } from 'lucide-react'
 import type { BlockFactoryCatalogue } from '@/api/types/fable.types'
+import { useFieldErrorMessages } from '@/features/fable-builder/hooks/useFieldErrorMessages'
 import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
 import {
   BLOCK_KIND_METADATA,
@@ -125,11 +126,17 @@ export function ConfigPanel({ catalogue }: ConfigPanelProps): React.ReactNode {
     selectBlock(null)
   }
 
+  const fieldErrorMessages = useFieldErrorMessages()
   // Hook must be called unconditionally — guard inside rather than early-
   // returning above it.
   const mappedErrors = useMemo(
-    () => mapBlockErrorsToFields(blockErrors ?? [], missingGlyphs ?? {}),
-    [blockErrors, missingGlyphs],
+    () =>
+      mapBlockErrorsToFields(
+        blockErrors ?? [],
+        missingGlyphs ?? {},
+        fieldErrorMessages,
+      ),
+    [blockErrors, missingGlyphs, fieldErrorMessages],
   )
 
   if (!selectedBlock || !factory) {

--- a/frontend/src/features/fable-builder/components/shared/GlyphReferencePanel.tsx
+++ b/frontend/src/features/fable-builder/components/shared/GlyphReferencePanel.tsx
@@ -175,6 +175,28 @@ export function GlyphReferencePanel({ className }: { className?: string }) {
         title={t('panel.global')}
         open={globalOpen}
         onToggle={() => setGlobalOpen(!globalOpen)}
+        action={
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <button
+                  type="button"
+                  aria-label={t('panel.addGlobal')}
+                  onClick={() => {
+                    setGlobalOpen(true)
+                    setCreateGlobalOpen(true)
+                  }}
+                  className="shrink-0 rounded p-1 text-primary hover:bg-primary/10"
+                />
+              }
+            >
+              <Plus className="h-3.5 w-3.5" />
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {t('panel.addGlobal')}
+            </TooltipContent>
+          </Tooltip>
+        }
       >
         {globalGlyphs.length > 0 ? (
           globalGlyphs.map((g) => (
@@ -187,14 +209,7 @@ export function GlyphReferencePanel({ className }: { className?: string }) {
           ))
         ) : (
           <div className="px-3 pb-2 text-sm text-muted-foreground">
-            {t('panel.noGlobal')}{' '}
-            <button
-              type="button"
-              onClick={() => setCreateGlobalOpen(true)}
-              className="text-primary hover:underline"
-            >
-              {t('panel.createOne')}
-            </button>
+            {t('panel.noGlobal')}
           </div>
         )}
       </GlyphSection>
@@ -362,27 +377,33 @@ function GlyphSection({
   title,
   open,
   onToggle,
+  action,
   children,
 }: {
   title: string
   open: boolean
   onToggle: () => void
+  /** Right-aligned slot on the header row (typically a `+` add button). */
+  action?: React.ReactNode
   children: React.ReactNode
 }) {
   return (
     <div className="border-t border-border/50">
-      <button
-        type="button"
-        onClick={onToggle}
-        className="flex w-full items-center gap-1.5 px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground"
-      >
-        {open ? (
-          <ChevronDown className="h-3.5 w-3.5" />
-        ) : (
-          <ChevronRight className="h-3.5 w-3.5" />
-        )}
-        {title}
-      </button>
+      <div className="flex w-full items-center gap-1.5 px-3 py-2 text-sm font-medium text-muted-foreground">
+        <button
+          type="button"
+          onClick={onToggle}
+          className="flex flex-1 items-center gap-1.5 text-left hover:text-foreground"
+        >
+          {open ? (
+            <ChevronDown className="h-3.5 w-3.5" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5" />
+          )}
+          {title}
+        </button>
+        {action}
+      </div>
       {open && <div className="space-y-0.5 pb-2">{children}</div>}
     </div>
   )
@@ -461,11 +482,11 @@ function LocalGlyphSection({
 
   return (
     <div className="border-t border-border/50">
-      <div className="flex w-full items-center gap-1.5 px-3 py-2">
+      <div className="flex w-full items-center gap-1.5 px-3 py-2 text-sm font-medium text-muted-foreground">
         <button
           type="button"
           onClick={onToggle}
-          className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground"
+          className="flex items-center gap-1.5 hover:text-foreground"
         >
           {open ? (
             <ChevronDown className="h-3.5 w-3.5" />
@@ -488,6 +509,24 @@ function LocalGlyphSection({
           <TooltipContent side="bottom" className="max-w-64">
             {tooltip}
           </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                aria-label={t('panel.addLocal')}
+                onClick={() => {
+                  if (!open) onToggle()
+                  setIsAdding(true)
+                }}
+                className="ml-auto shrink-0 rounded p-1 text-primary hover:bg-primary/10"
+              />
+            }
+          >
+            <Plus className="h-3.5 w-3.5" />
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{t('panel.addLocal')}</TooltipContent>
         </Tooltip>
       </div>
       {open && (
@@ -599,16 +638,7 @@ function LocalGlyphSection({
                 </P>
               ) : null}
             </div>
-          ) : (
-            <button
-              type="button"
-              onClick={() => setIsAdding(true)}
-              className="flex w-full items-center gap-1.5 px-3 py-1 text-sm text-muted-foreground hover:text-foreground"
-            >
-              <Plus className="h-3.5 w-3.5" />
-              {t('panel.addLocal')}
-            </button>
-          )}
+          ) : null}
         </div>
       )}
     </div>

--- a/frontend/src/features/fable-builder/hooks/useFieldErrorMessages.ts
+++ b/frontend/src/features/fable-builder/hooks/useFieldErrorMessages.ts
@@ -1,0 +1,26 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { FieldErrorMessages } from '@/features/fable-builder/utils/map-block-errors-to-fields'
+
+export function useFieldErrorMessages(): FieldErrorMessages {
+  const { t } = useTranslation('configure')
+  return useMemo<FieldErrorMessages>(
+    () => ({
+      unknownConfigKey: t('fieldErrors.unknownConfigKey'),
+      missingRequiredValue: t('fieldErrors.missingRequiredValue'),
+      unknownGlyph: (name) =>
+        t('fieldErrors.unknownGlyph', { glyph: `\${${name}}` }),
+    }),
+    [t],
+  )
+}

--- a/frontend/src/features/fable-builder/utils/map-block-errors-to-fields.ts
+++ b/frontend/src/features/fable-builder/utils/map-block-errors-to-fields.ts
@@ -23,6 +23,13 @@ export interface MappedBlockErrors {
   unmapped: Array<string>
 }
 
+/** Pre-translated messages — callers resolve via i18next so this util stays pure. */
+export interface FieldErrorMessages {
+  unknownConfigKey: string
+  missingRequiredValue: string
+  unknownGlyph: (name: string) => string
+}
+
 /**
  * Parse a Python-style set-of-strings literal like `{'foo', 'bar'}` into
  * a Set<string>. Returns null if parsing fails.
@@ -62,15 +69,16 @@ function pushError(
  * configuration keys.
  *
  * Recognised `errors` shapes (Python-set literals):
- * - "Block contains extra config: {...}" → "Unknown configuration key"
- * - "Block contains missing config: {...}" → "Missing required value"
+ * - "Block contains extra config: {...}" → messages.unknownConfigKey
+ * - "Block contains missing config: {...}" → messages.missingRequiredValue
  *
- * `missingGlyphs[configKey] = [name, ...]` → "Unknown glyph: ${name}" per name.
+ * `missingGlyphs[configKey] = [name, ...]` → messages.unknownGlyph(name) per name.
  * Anything else in `errors` is returned as `unmapped`.
  */
 export function mapBlockErrorsToFields(
   errors: ReadonlyArray<string>,
-  missingGlyphs: Record<string, ReadonlyArray<string>> = {},
+  missingGlyphs: Record<string, ReadonlyArray<string>>,
+  messages: FieldErrorMessages,
 ): MappedBlockErrors {
   const byConfigKey: Record<string, Array<string>> = {}
   const unmapped: Array<string> = []
@@ -84,7 +92,7 @@ export function mapBlockErrorsToFields(
         continue
       }
       for (const key of set) {
-        pushError(byConfigKey, key, 'Unknown configuration key')
+        pushError(byConfigKey, key, messages.unknownConfigKey)
       }
       continue
     }
@@ -97,7 +105,7 @@ export function mapBlockErrorsToFields(
         continue
       }
       for (const key of set) {
-        pushError(byConfigKey, key, 'Missing required value')
+        pushError(byConfigKey, key, messages.missingRequiredValue)
       }
       continue
     }
@@ -107,7 +115,7 @@ export function mapBlockErrorsToFields(
 
   for (const [configKey, glyphNames] of Object.entries(missingGlyphs)) {
     for (const name of glyphNames) {
-      pushError(byConfigKey, configKey, `Unknown glyph: \${${name}}`)
+      pushError(byConfigKey, configKey, messages.unknownGlyph(name))
     }
   }
 

--- a/frontend/src/lib/group-by.ts
+++ b/frontend/src/lib/group-by.ts
@@ -1,0 +1,27 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/** Group items by `keyFn`, preserving first-appearance order of keys. */
+export function groupByKey<T>(
+  items: ReadonlyArray<T>,
+  keyFn: (item: T) => string,
+): Array<[string, Array<T>]> {
+  const buckets = new Map<string, Array<T>>()
+  for (const item of items) {
+    const key = keyFn(item)
+    const bucket = buckets.get(key)
+    if (bucket) {
+      bucket.push(item)
+    } else {
+      buckets.set(key, [item])
+    }
+  }
+  return Array.from(buckets.entries())
+}

--- a/frontend/src/locales/en/configure.json
+++ b/frontend/src/locales/en/configure.json
@@ -22,5 +22,10 @@
     "more": "(+{{count}} more)",
     "expandAriaLabel": "Show all {{count}} errors",
     "collapseAriaLabel": "Collapse errors"
+  },
+  "fieldErrors": {
+    "unknownConfigKey": "Unknown configuration key",
+    "missingRequiredValue": "Missing required value",
+    "unknownGlyph": "Unknown glyph: {{glyph}}"
   }
 }

--- a/frontend/src/locales/en/executions.json
+++ b/frontend/src/locales/en/executions.json
@@ -21,6 +21,9 @@
     "failed": "Failed",
     "unknown": "Unknown"
   },
+  "progress": {
+    "blocksComplete": "{{completed}}/{{total}} blocks"
+  },
   "tabs": {
     "outputs": "Outputs",
     "logs": "Logs",
@@ -76,6 +79,7 @@
   },
   "outputs": {
     "generated": "Generated",
+    "pending": "Pending",
     "noOutputs": "No outputs available yet",
     "noOutputsRunning": "Outputs will appear here as they are generated.",
     "view": "View",
@@ -88,6 +92,17 @@
     },
     "filter": {
       "allMimes": "All"
+    },
+    "groupBy": {
+      "label": "Group by",
+      "none": "None",
+      "block": "Block",
+      "mime": "Content type",
+      "blockAndMime": "Block + content type"
+    },
+    "sections": {
+      "unknownBlock": "Unknown block",
+      "unknownMime": "Unknown content type"
     },
     "noMatch": "No outputs match the current filter.",
     "viewer": {

--- a/frontend/src/locales/en/glyphs.json
+++ b/frontend/src/locales/en/glyphs.json
@@ -75,7 +75,7 @@
     "createOne": "Create one",
     "addGlobal": "Add global variable",
     "manageAll": "Manage all",
-    "addLocal": "Add",
+    "addLocal": "Add local variable",
     "localKeyPlaceholder": "key",
     "localKeyInvalid": "Use letters, digits and underscores only — no hyphens, spaces or other characters.",
     "localValuePlaceholder": "value",

--- a/frontend/src/routes/_authenticated/executions.$jobId.tsx
+++ b/frontend/src/routes/_authenticated/executions.$jobId.tsx
@@ -12,10 +12,13 @@ import { createFileRoute } from '@tanstack/react-router'
 import { z } from 'zod'
 import { ExecutionDetailPage } from '@/features/executions/components/ExecutionDetailPage'
 
-/** Search params for the execution detail page. `mimes` is a comma-joined
- * list of active filter chips on the Outputs tab; missing/empty = "All". */
+/** Search params for the execution detail page.
+ * - `mimes` is a comma-joined list of active filter chips on the Outputs tab;
+ *   missing/empty = "All".
+ * - `groupBy` controls how the Outputs grid is sectioned. Missing = flat. */
 const searchSchema = z.object({
   mimes: z.string().optional(),
+  groupBy: z.enum(['block', 'mime', 'block-and-mime']).optional(),
 })
 
 export const Route = createFileRoute('/_authenticated/executions/$jobId')({

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -182,12 +182,48 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
+    /* Firefox + standards-track scrollbar styling. WebKit overrides below. */
+    scrollbar-width: thin;
+    scrollbar-color: var(--scrollbar-thumb) transparent;
   }
   body {
     @apply bg-background font-sans text-foreground;
   }
   html {
     @apply font-sans;
+  }
+
+  /* Scrollbars derived from --muted-foreground so the colour swaps with the theme. */
+  :root {
+    --scrollbar-thumb: color-mix(
+      in oklch,
+      var(--muted-foreground) 35%,
+      transparent
+    );
+    --scrollbar-thumb-hover: color-mix(
+      in oklch,
+      var(--muted-foreground) 60%,
+      transparent
+    );
+  }
+
+  /* WebKit. Transparent border + padding-box inset = thin pill thumb. */
+  *::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  *::-webkit-scrollbar-track,
+  *::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+  *::-webkit-scrollbar-thumb {
+    background-color: var(--scrollbar-thumb);
+    border: 2px solid transparent;
+    background-clip: padding-box;
+    border-radius: 9999px;
+  }
+  *::-webkit-scrollbar-thumb:hover {
+    background-color: var(--scrollbar-thumb-hover);
   }
 }
 
@@ -202,6 +238,18 @@
   }
   to {
     stroke-dashoffset: -100;
+  }
+}
+
+/* Skeleton pulse for "currently processing" — a touch more pronounced than
+ * Tailwind's default `animate-pulse` (1 → 0.5 @ 2s). */
+@keyframes pulse-strong {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
   }
 }
 

--- a/frontend/tests/integration/features/executions/job-detail.test.tsx
+++ b/frontend/tests/integration/features/executions/job-detail.test.tsx
@@ -192,11 +192,11 @@ describe('ExecutionDetailPage Integration', () => {
       await expect.element(screen.getByText(/Generated: 3/)).toBeVisible()
     })
 
-    it('shows no outputs message for running job with no available outputs', async () => {
+    it('shows pending count for running job with unavailable outputs', async () => {
       const screen = await renderDetailPage('job-running-002')
-      await expect
-        .element(screen.getByText('No outputs available yet'))
-        .toBeVisible()
+      // job-running-002 has 1 unavailable output → skeleton card + pending counter.
+      await expect.element(screen.getByText(/Pending: 1/)).toBeVisible()
+      await expect.element(screen.getByText(/Generated: 0/)).toBeVisible()
     })
 
     it('shows no outputs message for submitted job with null outputs', async () => {

--- a/frontend/tests/unit/api/job-types.test.ts
+++ b/frontend/tests/unit/api/job-types.test.ts
@@ -1,0 +1,68 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { JobExecutionDetailSchema } from '@/api/types/job.types'
+
+const baseDetail = {
+  run_id: 'run-1',
+  attempt_count: 1,
+  status: 'running' as const,
+  created_at: '2026-05-15T10:00:00',
+  updated_at: '2026-05-15T10:05:00',
+  blueprint_id: 'def-1',
+  blueprint_version: 1,
+  error: null,
+  progress: '42',
+  cascade_job_id: 'cascade-1',
+  outputs: null,
+}
+
+describe('JobExecutionDetailSchema', () => {
+  it('parses a minimal payload without the optional block-id arrays', () => {
+    const result = JobExecutionDetailSchema.parse(baseDetail)
+    expect(result.completed_block_ids).toBeUndefined()
+    expect(result.planned_block_ids).toBeUndefined()
+  })
+
+  it('parses populated block-id arrays from /run/get during a running job', () => {
+    const result = JobExecutionDetailSchema.parse({
+      ...baseDetail,
+      completed_block_ids: ['block_source_1'],
+      planned_block_ids: ['block_source_1', 'block_product_1', 'block_sink_1'],
+    })
+    expect(result.completed_block_ids).toEqual(['block_source_1'])
+    expect(result.planned_block_ids).toEqual([
+      'block_source_1',
+      'block_product_1',
+      'block_sink_1',
+    ])
+  })
+
+  it('accepts null for both fields once the backend memcache is popped', () => {
+    const result = JobExecutionDetailSchema.parse({
+      ...baseDetail,
+      status: 'completed',
+      completed_block_ids: null,
+      planned_block_ids: null,
+    })
+    expect(result.completed_block_ids).toBeNull()
+    expect(result.planned_block_ids).toBeNull()
+  })
+
+  it('rejects non-array values in the block-id fields', () => {
+    expect(() =>
+      JobExecutionDetailSchema.parse({
+        ...baseDetail,
+        completed_block_ids: 'not-an-array',
+      }),
+    ).toThrow()
+  })
+})

--- a/frontend/tests/unit/features/fable-builder/utils/map-block-errors-to-fields.test.ts
+++ b/frontend/tests/unit/features/fable-builder/utils/map-block-errors-to-fields.test.ts
@@ -9,28 +9,39 @@
  */
 
 import { describe, expect, it } from 'vitest'
+import type { FieldErrorMessages } from '@/features/fable-builder/utils/map-block-errors-to-fields'
 import { mapBlockErrorsToFields } from '@/features/fable-builder/utils/map-block-errors-to-fields'
+
+const messages: FieldErrorMessages = {
+  unknownConfigKey: 'Unknown configuration key',
+  missingRequiredValue: 'Missing required value',
+  unknownGlyph: (name) => `Unknown glyph: \${${name}}`,
+}
 
 describe('mapBlockErrorsToFields', () => {
   it('returns empty result for empty inputs', () => {
-    const result = mapBlockErrorsToFields([])
+    const result = mapBlockErrorsToFields([], {}, messages)
     expect(result).toEqual({ byConfigKey: {}, unmapped: [] })
   })
 
   describe('Block contains extra / missing config', () => {
-    it('attaches "Unknown configuration key" for extra config', () => {
-      const result = mapBlockErrorsToFields([
-        "Block contains extra config: {'orphan'}",
-      ])
+    it('attaches the unknownConfigKey message for extra config', () => {
+      const result = mapBlockErrorsToFields(
+        ["Block contains extra config: {'orphan'}"],
+        {},
+        messages,
+      )
       expect(result.byConfigKey).toEqual({
         orphan: ['Unknown configuration key'],
       })
     })
 
-    it('attaches "Missing required value" for missing config', () => {
-      const result = mapBlockErrorsToFields([
-        "Block contains missing config: {'needed', 'also_needed'}",
-      ])
+    it('attaches the missingRequiredValue message for missing config', () => {
+      const result = mapBlockErrorsToFields(
+        ["Block contains missing config: {'needed', 'also_needed'}"],
+        {},
+        messages,
+      )
       expect(result.byConfigKey).toEqual({
         needed: ['Missing required value'],
         also_needed: ['Missing required value'],
@@ -38,9 +49,11 @@ describe('mapBlockErrorsToFields', () => {
     })
 
     it('falls back to unmapped when the set literal is malformed', () => {
-      const result = mapBlockErrorsToFields([
-        'Block contains missing config: not-a-set',
-      ])
+      const result = mapBlockErrorsToFields(
+        ['Block contains missing config: not-a-set'],
+        {},
+        messages,
+      )
       expect(result.unmapped).toEqual([
         'Block contains missing config: not-a-set',
       ])
@@ -49,9 +62,7 @@ describe('mapBlockErrorsToFields', () => {
 
   describe('Missing glyphs (structured)', () => {
     it('attaches an unknown-glyph message per (configKey, glyphName) entry', () => {
-      const result = mapBlockErrorsToFields([], {
-        expver: ['runtd'],
-      })
+      const result = mapBlockErrorsToFields([], { expver: ['runtd'] }, messages)
       expect(result.byConfigKey).toEqual({
         expver: ['Unknown glyph: ${runtd}'],
       })
@@ -59,10 +70,14 @@ describe('mapBlockErrorsToFields', () => {
     })
 
     it('handles multiple glyphs on the same option and multiple options', () => {
-      const result = mapBlockErrorsToFields([], {
-        fname: ['missingRoot'],
-        suffix: ['missingRoot', 'env'],
-      })
+      const result = mapBlockErrorsToFields(
+        [],
+        {
+          fname: ['missingRoot'],
+          suffix: ['missingRoot', 'env'],
+        },
+        messages,
+      )
       expect(result.byConfigKey).toEqual({
         fname: ['Unknown glyph: ${missingRoot}'],
         suffix: ['Unknown glyph: ${missingRoot}', 'Unknown glyph: ${env}'],
@@ -70,16 +85,17 @@ describe('mapBlockErrorsToFields', () => {
     })
 
     it('treats an empty missingGlyphs map as a no-op', () => {
-      const result = mapBlockErrorsToFields([], {})
+      const result = mapBlockErrorsToFields([], {}, messages)
       expect(result).toEqual({ byConfigKey: {}, unmapped: [] })
     })
   })
 
   it('passes through unrecognised errors as unmapped', () => {
-    const result = mapBlockErrorsToFields([
-      'Plugin not found',
-      'BlockFactory not found in the catalogue',
-    ])
+    const result = mapBlockErrorsToFields(
+      ['Plugin not found', 'BlockFactory not found in the catalogue'],
+      {},
+      messages,
+    )
     expect(result.byConfigKey).toEqual({})
     expect(result.unmapped).toEqual([
       'Plugin not found',
@@ -91,11 +107,29 @@ describe('mapBlockErrorsToFields', () => {
     const result = mapBlockErrorsToFields(
       ["Block contains missing config: {'date'}", 'Plugin not found'],
       { expver: ['runtd'] },
+      messages,
     )
     expect(result.byConfigKey).toEqual({
       date: ['Missing required value'],
       expver: ['Unknown glyph: ${runtd}'],
     })
     expect(result.unmapped).toEqual(['Plugin not found'])
+  })
+
+  it('uses the provided messages object verbatim (caller-supplied i18n)', () => {
+    const localized: FieldErrorMessages = {
+      unknownConfigKey: 'Schlüssel unbekannt',
+      missingRequiredValue: 'Wert fehlt',
+      unknownGlyph: (name) => `Unbekannter Glyph: ${name}`,
+    }
+    const result = mapBlockErrorsToFields(
+      ["Block contains missing config: {'date'}"],
+      { expver: ['runtd'] },
+      localized,
+    )
+    expect(result.byConfigKey).toEqual({
+      date: ['Wert fehlt'],
+      expver: ['Unbekannter Glyph: runtd'],
+    })
   })
 })


### PR DESCRIPTION
Aligns the frontend with the new `/api/v1/run/get` per-block progress fields from backend PRs #435 / #438, then layers a UX pass for the execution detail page driven by the new data.

### Backend alignment

- `JobExecutionDetailSchema` carries `completed_block_ids` and `planned_block_ids` (nullable + optional — backend clears them on terminal status).
- MSW fixtures + schema unit tests cover the four wire shapes (missing / populated / null / invalid).
- `mapBlockErrorsToFields` takes a `FieldErrorMessages` object instead of hardcoded English 

### Execution detail layout

- ≥ 1440 px: canvas and tabs panel pinned to viewport height, scroll independently — outputs grids no longer push the page tall.
- Mobile: single page-scroll preserved; Tabs row sticks at the viewport top so the user keeps their bearings while scrolling.
- LogsPanel / SpecificationPanel internal scroll boxes simplified.

### Outputs panel

- Skeleton placeholders for not-yet-available outputs, sorted by block by default so same-block tiles sit adjacent.
- Group-by toggle: None / Block / Content type / Block + content type; state persists in the URL.
- Hovering an output card or block-section tints the matching canvas node via a shared Zustand hover store.
- Currently-running tile gets a stronger pulse than idle ones; the rest stay static so attention follows live work.
- PDF thumbnails now fit both container dimensions (portrait pages no longer overflow the aspect-video card).

### Canvas

- Per-block progress decoration: green check on completed nodes, amber pulse + spinner on the currently-running block, dimmed on planned-idle.
- BeamEdge animation scoped to edges into the running set when plan info is present; falls back to "beam everything" otherwise.
- Source handle hidden on sink blocks.
- ResizeObserver-driven re-fit so wide ↔ narrow transitions don't strand nodes outside the viewport.

### Status header

- "X / Y blocks complete" subtext next to the elapsed time.
- New "Edit Configuration" item in the kebab menu — navigates to `/configure` with the run's `fableId`.
- Dropdown content sized to content so the label fits on one line.

### Variables panel (configure screen)

- Consistent `+` add buttons on the Local and Global section header rows, matching the top-of-panel one. Dropped the now-redundant inline "Create one" link in Global's empty state and the bottom `+ Add` row in Local.

### Code quality

- `useFieldErrorMessages` hook replaces three identical useMemo blocks across `BlockInstanceCard`, `InlineBlockNode`, `ConfigPanel`.
- `useIsBlockHovered` / `useBlockHoverHandlers` hooks consolidate hover store access.
- `groupByKey` extracted to `src/lib/group-by.ts`.
- `BlockErrorOverlay`: `text-xs` → `text-sm` for `UI_DESIGN.md` compliance.
- Themed scrollbars derived from `--muted-foreground` (auto-swaps in dark).
- Fixed pre-existing `calc(100vh-Xrem)` (no spaces) Tailwind class — invalid CSS that browsers silently discarded.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
