### PR TITLE
Use stored run output mime

### DIFF
--- a/backend/src/forecastbox/domain/run/cascade.py
+++ b/backend/src/forecastbox/domain/run/cascade.py
@@ -20,6 +20,7 @@ import xarray as xr
 from cascade.gateway.api import JobSpec, ResultRetrievalResponse, SubmitJobRequest, SubmitJobResponse, decoded_result
 from cascade.gateway.client import request_response
 from cascade.low.core import JobInstance, JobInstanceRich, TaskId
+from cascade.low.func import Either
 from fiab_core.fable import BlockInstanceId
 from pydantic import Field
 
@@ -42,47 +43,80 @@ class ExecutionSpecification(FiabBaseModel):
     shared: bool = Field(default=False)
 
 
-def encode_result(result: ResultRetrievalResponse) -> tuple[bytes, str]:
-    """Converts cascade Result response to bytes+mime"""
+def encode_result(result: ResultRetrievalResponse, mime_type: str) -> Either[bytes, str]:  # ty: ignore[invalid-type-arguments]
+    """Converts cascade Result response to bytes for a known mime type."""
+    # TODO this function should change as follows:
+    # - the preferred way is that cascade tasks return simply bytes, so thats what we'll start with
+    # - the (tuple) thing should be completely dropped, it increases memory pressure and we dont really
+    #   need that safety. First, drop it from all plugins, then from here
+    # - all the other options should be deleted, first ensured they are not used in plugins
     obj = decoded_result(result, job=None)  # type: ignore
-    if isinstance(obj, bytes):
-        return obj, "application/pickle"
     if isinstance(obj, tuple):
-        if len(obj) == 2 and isinstance(obj[0], bytes):
-            return obj[0], obj[1]
-        else:
-            raise ValueError("Tuple result must contain exactly two elements: (bytes, mime_type)")
+        if len(obj) != 2 or not isinstance(obj[0], bytes) or not isinstance(obj[1], str):
+            return Either.error("Tuple result must contain exactly two elements: (bytes, mime_type)")
+        if obj[1] != mime_type:
+            return Either.error(f"Result mime mismatch: expected {mime_type!r}, got {obj[1]!r}")
+        return Either.ok(obj[0])
 
-    try:
-        from earthkit.plots import (  # type: ignore[unresolved-import]
-            Figure,  # NOTE plots is an optional dependency -- import inside body allowed
-        )
+    if isinstance(obj, bytes):
+        return Either.ok(obj)
 
-        if isinstance(obj, Figure):
+    if mime_type == "image/png":
+        try:
+            from earthkit.plots import (  # type: ignore[unresolved-import]
+                Figure,  # NOTE plots is an optional dependency -- import inside body allowed
+            )
+
+            if isinstance(obj, Figure):
+                buf = io.BytesIO()
+                obj.save(buf)
+                return Either.ok(buf.getvalue())
+        except ImportError:
+            pass
+        if isinstance(obj, bytes):
+            return Either.ok(obj)
+        return Either.error(f"Expected image/png-compatible result, got {type(obj).__name__}")
+
+    if mime_type == "application/grib":
+        if isinstance(obj, earthkit.data.FieldList):
+            encoder = earthkit.data.create_encoder("grib")
+            if isinstance(obj, earthkit.data.Field):
+                return Either.ok(encoder.encode(obj).to_bytes())  # type: ignore
+            elif isinstance(obj, earthkit.data.FieldList):
+                return Either.ok(encoder.encode(obj[0], template=obj[0]).to_bytes())  # type: ignore
+        return Either.error(f"Expected application/grib-compatible result, got {type(obj).__name__}")
+
+    if mime_type in ("application/netcdf", "application/x-netcdf"):
+        if isinstance(obj, (xr.Dataset, xr.DataArray)):
             buf = io.BytesIO()
-            obj.save(buf)
-            return buf.getvalue(), "image/png"
-    except ImportError:
-        pass
+            obj.to_netcdf(buf, format="NETCDF4")  # type: ignore
+            return Either.ok(buf.getvalue())
+        return Either.error(f"Expected netcdf-compatible result, got {type(obj).__name__}")
 
-    if isinstance(obj, earthkit.data.FieldList):
-        encoder = earthkit.data.create_encoder("grib")
-        if isinstance(obj, earthkit.data.Field):
-            return encoder.encode(obj).to_bytes(), "application/grib"  # type: ignore
-        elif isinstance(obj, earthkit.data.FieldList):
-            return encoder.encode(obj[0], template=obj[0]).to_bytes(), "application/grib"  # type: ignore
+    if mime_type == "application/numpy":
+        if isinstance(obj, np.ndarray):
+            buf = io.BytesIO()
+            np.save(buf, obj)
+            return Either.ok(buf.getvalue())
+        return Either.error(f"Expected numpy-compatible result, got {type(obj).__name__}")
 
-    elif isinstance(obj, (xr.Dataset, xr.DataArray)):
-        buf = io.BytesIO()
-        obj.to_netcdf(buf, format="NETCDF4")  # type: ignore
-        return buf.getvalue(), "application/netcdf"
+    if mime_type == "application/pickle":
+        return Either.ok(cloudpickle.dumps(obj))
 
-    elif isinstance(obj, np.ndarray):
-        buf = io.BytesIO()
-        np.save(buf, obj)
-        return buf.getvalue(), "application/numpy"
+    if mime_type == "application/clpkl":
+        return Either.ok(cloudpickle.dumps(obj))
 
-    return cloudpickle.dumps(obj), "application/clpkl"
+    if mime_type == "text/plain":
+        if isinstance(obj, str):
+            return Either.ok(obj.encode("utf-8"))
+        return Either.error(f"Expected text/plain-compatible result, got {type(obj).__name__}")
+
+    if mime_type == "application/octet-stream":
+        if isinstance(obj, str):
+            return Either.ok(obj.encode("utf-8"))
+        return Either.error(f"Expected bytes-compatible result, got {type(obj).__name__}")
+
+    return Either.error(f"Unsupported mime type {mime_type!r} for result decoding")
 
 
 class RunOutputCharacteristic(FiabBaseModel):

--- a/backend/src/forecastbox/domain/run/service.py
+++ b/backend/src/forecastbox/domain/run/service.py
@@ -30,7 +30,7 @@ from typing import cast
 
 from cascade.controller.report import JobId
 from cascade.gateway import api, client
-from cascade.low.core import TaskId
+from cascade.low.core import DatasetId, TaskId
 from cascade.low.func import Either
 from fiab_core.fable import BlockInstanceId
 
@@ -39,6 +39,7 @@ import forecastbox.domain.run.db as run_db
 from forecastbox.domain.blueprint.types import BlueprintId
 from forecastbox.domain.experiment.types import ExperimentDefinitionId
 from forecastbox.domain.run.background import execute_background
+from forecastbox.domain.run.cascade import RunOutputs
 from forecastbox.domain.run.db import CompilerRuntimeContext
 from forecastbox.domain.run.exceptions import RunNotFound
 from forecastbox.domain.run.types import RunId
@@ -79,6 +80,24 @@ class ExecuteResult(FiabBaseModel):
     """Logical execution id (Run.id)."""
     attempt_count: int
     """Attempt number; always 1 on a fresh execution."""
+
+
+def get_mime_of_output(execution: Run, dataset_id: DatasetId) -> Either[str, str]:  # ty: ignore[invalid-type-arguments]
+    """Return the declared mime type for a run output task."""
+    raw_outputs = cast(dict | None, execution.outputs)
+    if raw_outputs is None:
+        return Either.error(f"Run {execution.run_id!r} has no recorded outputs yet")
+
+    try:
+        outputs = RunOutputs.model_validate(raw_outputs)
+    except Exception as e:
+        return Either.error(f"Run {execution.run_id!r} has invalid output metadata: {e!r}")
+
+    task_id = dataset_id.task
+    characteristic = outputs.outputs.get(task_id)
+    if characteristic is None:
+        return Either.error(f"Output {task_id!r} not found for run {execution.run_id!r}")
+    return Either.ok(characteristic.mime_type)
 
 
 async def get_blueprint_for_execution(blueprint_id: BlueprintId, blueprint_version: int | None) -> Blueprint | None:

--- a/backend/src/forecastbox/routes/run.py
+++ b/backend/src/forecastbox/routes/run.py
@@ -374,20 +374,22 @@ async def get_run_output_content(
     auth_context: AuthContext = Depends(get_auth_context),
 ) -> Response:
     """Retrieve the result of a specific output task, encoded as bytes."""
-    _, cascade_job_id = await _resolve_run_with_cascade(spec, auth_context)
+    execution, cascade_job_id = await _resolve_run_with_cascade(spec, auth_context)
+    dataset = DatasetId(task=TaskId(dataset_id), output="0")
+    mime_result = service.get_mime_of_output(execution, dataset)
+    if mime_result.t is None:
+        raise HTTPException(500, f"Result mime lookup failed: {mime_result.e}")
     response = client.request_response(
-        api.ResultRetrievalRequest(job_id=JobId(cascade_job_id), dataset_id=DatasetId(task=TaskId(dataset_id), output="0")),
+        api.ResultRetrievalRequest(job_id=JobId(cascade_job_id), dataset_id=dataset),
         f"{config.cascade.cascade_url}",
     )
     response = cast(api.ResultRetrievalResponse, response)
     if response.error:
         raise HTTPException(500, f"Result retrieval failed: {response.error}")
-    try:
-        bytez, media_type = encode_result(response)
-    except Exception as e:
-        logger.exception("decoding failure")
-        raise HTTPException(500, f"Result decoding failed: {repr(e)}")
-    return Response(bytez, media_type=media_type)
+    encoded = encode_result(response, mime_result.t)
+    if encoded.t is None:
+        raise HTTPException(500, f"Result decoding failed: {encoded.e}")
+    return Response(encoded.t, media_type=mime_result.t)
 
 
 @router.get("/logs")

--- a/backend/tests/unit/domain/run/test_cascade.py
+++ b/backend/tests/unit/domain/run/test_cascade.py
@@ -1,0 +1,33 @@
+import pytest
+from cascade.gateway.api import ResultRetrievalResponse
+
+from forecastbox.domain.run import cascade
+
+
+def test_encode_result_accepts_matching_tuple_mime(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cascade, "decoded_result", lambda result, job=None: (b"payload", "text/plain"))
+
+    result = cascade.encode_result(ResultRetrievalResponse(result="ignored", error=None), "text/plain")
+
+    assert result.t == b"payload"
+    assert result.e is None
+
+
+def test_encode_result_rejects_mismatched_tuple_mime(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cascade, "decoded_result", lambda result, job=None: (b"payload", "image/png"))
+
+    result = cascade.encode_result(ResultRetrievalResponse(result="ignored", error=None), "text/plain")
+
+    assert result.t is None
+    assert result.e is not None
+    assert "mime mismatch" in result.e
+
+
+def test_encode_result_rejects_unexpected_text_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cascade, "decoded_result", lambda result, job=None: 123)
+
+    result = cascade.encode_result(ResultRetrievalResponse(result="ignored", error=None), "text/plain")
+
+    assert result.t is None
+    assert result.e is not None
+    assert "text/plain-compatible" in result.e

--- a/backend/tests/unit/domain/run/test_service.py
+++ b/backend/tests/unit/domain/run/test_service.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+from typing import cast
+
+from cascade.low.core import DatasetId, TaskId
+from fiab_core.fable import BlockInstanceId
+
+from forecastbox.domain.run import service
+from forecastbox.domain.run.cascade import RunOutputCharacteristic, RunOutputs
+from forecastbox.schemata.jobs import Run
+
+
+def test_get_mime_of_output_returns_declared_mime() -> None:
+    execution = cast(
+        Run,
+        SimpleNamespace(
+            run_id="run-1",
+            outputs=RunOutputs(
+                outputs={
+                    TaskId("task-a"): RunOutputCharacteristic(
+                        original_block=BlockInstanceId("block-a"),
+                        mime_type="text/plain",
+                    )
+                }
+            ).model_dump(),
+        ),
+    )
+
+    result = service.get_mime_of_output(execution, DatasetId(task=TaskId("task-a"), output="0"))
+
+    assert result.t == "text/plain"
+    assert result.e is None
+
+
+def test_get_mime_of_output_rejects_unknown_task() -> None:
+    execution = cast(
+        Run,
+        SimpleNamespace(
+            run_id="run-1",
+            outputs=RunOutputs(
+                outputs={
+                    TaskId("task-a"): RunOutputCharacteristic(
+                        original_block=BlockInstanceId("block-a"),
+                        mime_type="text/plain",
+                    )
+                }
+            ).model_dump(),
+        ),
+    )
+
+    result = service.get_mime_of_output(execution, DatasetId(task=TaskId("task-b"), output="0"))
+
+    assert result.t is None
+    assert result.e is not None
+    assert "not found" in result.e


### PR DESCRIPTION
We used to derive the mime type from the actual object that cascade returns as the task output

We change that to utilize the mime type that has been derived during compilation

cc @liefra -- this should allow you to remove the workarounds you were forced to introduce. However, I have *not* verified that all blocks in the plugins set the mime type correctly during compilation. I'd say we best merge this, remove workarounds, and if we detect a mime type issue, we go and fix the plugin in the first place.