### PR TITLE
[plugin]: declare standard output MIME for Map Plot blocks

### DIFF
--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -28,6 +28,7 @@ from fiab_core.tools.blocks import Product, Sink, Source
 from qubed import Qube
 
 from .qubed_utils import axes, contains, coxpand, dimensions
+from .runtime.plots import FORMAT_MIME_TYPES
 
 SOURCE = ConfigurationOptionId("source")
 DATE = ConfigurationOptionId("date")
@@ -357,7 +358,7 @@ class MapPlotSink(Sink):
         #         f"Invalid groupby value: {groupby_value}, must be one of {set(['valid_datetime', 'step', 'number', 'none']).intersection(dimensions(input_dataset))}"
         #     )
 
-        return Either.ok(RawOutput(type_fqn=f"image/{block.config_as_str(FORMAT)}"))
+        return Either.ok(RawOutput(mime_type=FORMAT_MIME_TYPES[block.config_as_str(FORMAT)]))
 
     def compile(
         self,

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/runtime/plots.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/runtime/plots.py
@@ -21,6 +21,14 @@ logger = logging.getLogger(__name__)
 
 WIND_SHORTNAMES = ["u", "v", "10u", "10v", "100u", "100v"]
 
+# Map Plot `format` -> output MIME. blocks.py declares it and map_plot returns
+# it; the two must match or the run-output endpoint rejects the result.
+FORMAT_MIME_TYPES: dict[str, str] = {
+    "png": "image/png",
+    "pdf": "application/pdf",
+    "svg": "image/svg+xml",
+}
+
 
 def _configure_schema(style_schema: str) -> None:
     """Configure the earthkit-plots schema from a schema identifier.
@@ -63,7 +71,7 @@ def _export_figure(figure: "Figure", fmt: str = "png", dpi: int = 100) -> tuple[
     """Serialise a Figure to bytes and return ``(data, mime_type)``."""
     buf = io.BytesIO()
     figure.save(buf, format=fmt, dpi=dpi)
-    return buf.getvalue(), f"image/{fmt}"
+    return buf.getvalue(), FORMAT_MIME_TYPES[fmt]
 
 
 def map_plot(

--- a/backend/packages/fiab-plugin-ecmwf/tests/runtime/test_plots.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/runtime/test_plots.py
@@ -1,0 +1,25 @@
+# (C) Copyright 2026- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from unittest.mock import Mock
+
+import pytest
+
+from fiab_plugin_ecmwf.runtime.plots import FORMAT_MIME_TYPES, _export_figure
+
+
+@pytest.mark.parametrize(
+    ("fmt", "expected_mime"),
+    [("png", "image/png"), ("pdf", "application/pdf"), ("svg", "image/svg+xml")],
+)
+def test_export_figure_returns_standard_mime(fmt: str, expected_mime: str) -> None:
+    """_export_figure tags bytes with the same standard MIME MapPlotSink declares."""
+    _, mime = _export_figure(Mock(), fmt=fmt)  # type: ignore[arg-type]
+    assert mime == expected_mime
+    assert FORMAT_MIME_TYPES[fmt] == expected_mime

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -441,3 +441,22 @@ class TestMapPlotSink:
         assert block.intersect(other=ensemble_output)  # type: ignore[arg-type]
         output = block.validate(block=map_plot_sink_configuration, inputs={"dataset": ensemble_output}).get_or_raise()  # type: ignore[dict-item]
         assert isinstance(output, RawOutput)
+
+    @pytest.mark.parametrize(
+        ("fmt", "expected_mime"),
+        [("png", "image/png"), ("pdf", "application/pdf"), ("svg", "image/svg+xml")],
+    )
+    def test_validate_declares_standard_mime(self, ekdsource_output: QubedOutput, fmt: str, expected_mime: str) -> None:
+        """validate() must set RawOutput.mime_type to the format's standard MIME."""
+        block = MapPlotSink()
+        config = BlockInstance.from_block(
+            BlockInstanceBase(
+                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("MapPlotSink")),  # type: ignore
+                input_ids={"dataset": BlockInstanceId("source_output")},
+                configuration_values=_config({"param": ["2t"], "domain": "global", "format": fmt}),
+            ),
+            MapPlotSink.configuration_options,
+        )
+        output = block.validate(block=config, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
+        assert isinstance(output, RawOutput)
+        assert output.mime_type == expected_mime


### PR DESCRIPTION
This is a follow-up plugin-related PR ensuring that the `MapPlotSink` correctly set the MIME type using `mime_type`.

ISSUE: `MapPlotSink.validate()` set its output MIME on `RawOutput.type_fqn` instead of `.mime_type` — the field compile reads — so Map Plot outputs recorded `application/octet-stream`. Now that the run-output endpoint trusts the stored
MIME, that mismatched the runtime's `image/*` result and returned 500; plots stopped rendering.

FIX: Declares it on `.mime_type` with standard types (`application/pdf`, `image/svg+xml`), shared between `blocks.py` and `runtime/plots.py` via a `FORMAT_MIME_TYPES` map. Adds tests for both sides.




### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
