### PR TITLE
Add select variable block with restrictions

### DIFF
--- a/backend/packages/fiab-core/src/fiab_core/tools/blocks.py
+++ b/backend/packages/fiab-core/src/fiab_core/tools/blocks.py
@@ -25,6 +25,7 @@ from fiab_core.fable import (
     BlockInstanceOutput,
     BlockKind,
     ConfigurationOptionId,
+    ConfigurationOptionRestriction,
     QubedOutput,
 )
 from fiab_core.plugin import Error
@@ -171,6 +172,9 @@ class QubedBlockBuilder(abc.ABC):
 
     def intersect(self, other: QubedOutput) -> bool:
         raise NotImplementedError
+
+    def restrictions(self, other: QubedOutput) -> ConfigurationOptionRestriction:
+        return {}
 
     def as_catalogue(self) -> BlockFactory:
         return BlockFactory(

--- a/backend/packages/fiab-core/src/fiab_core/tools/plugins.py
+++ b/backend/packages/fiab-core/src/fiab_core/tools/plugins.py
@@ -52,7 +52,7 @@ class QubedPluginBuilder:
         expansions: list[BlockExpansion] = []
         for factory_id, factory in self.block_builders.items():
             if factory.intersect(block):
-                expansions.append(BlockExpansion(factory=factory_id))
+                expansions.append(BlockExpansion(factory=factory_id, restrictions=factory.restrictions(block)))
         return expansions
 
     def compile(

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/__init__.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/__init__.py
@@ -12,12 +12,13 @@ from fiab_core.tools.blocks import QubedBlockBuilder
 from fiab_core.tools.plugins import QubedPluginBuilder
 
 from fiab_plugin_ecmwf.anemoi.blocks import AnemoiSource, AnemoiTransform
-from fiab_plugin_ecmwf.blocks import EkdSource, EnsembleStatistics, MapPlotSink, TemporalStatistics, ZarrSink
+from fiab_plugin_ecmwf.blocks import EkdSource, EnsembleStatistics, MapPlotSink, SelectVariable, TemporalStatistics, ZarrSink
 
 blocks: dict[BlockFactoryId, QubedBlockBuilder] = {
     BlockFactoryId("ekdSource"): EkdSource(),
     BlockFactoryId("ensembleStatistics"): EnsembleStatistics(),
     BlockFactoryId("temporalStatistics"): TemporalStatistics(),
+    BlockFactoryId("selectVariable"): SelectVariable(),
     BlockFactoryId("zarrSink"): ZarrSink(),
     BlockFactoryId("anemoiSource"): AnemoiSource(),
     BlockFactoryId("anemoiTransform"): AnemoiTransform(),

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -18,13 +18,15 @@ from fiab_core.fable import (
     BlockInstanceId,
     BlockInstanceOutput,
     ConfigurationOptionId,
+    ConfigurationOptionRestriction,
     NoOutput,
     QubedOutput,
     RawOutput,
 )
 from fiab_core.plugin import Error
 from fiab_core.tools.blocks import BlockInstanceRich as BlockInstance
-from fiab_core.tools.blocks import Product, Sink, Source
+from fiab_core.tools.blocks import Product, Sink, Source, Transform
+from fiab_core.types import ClosedEnumType
 from qubed import Qube
 
 from .qubed_utils import axes, contains, coxpand, dimensions
@@ -37,6 +39,7 @@ STATISTIC = ConfigurationOptionId("statistic")
 PATH = ConfigurationOptionId("path")
 DOMAIN = ConfigurationOptionId("domain")
 FORMAT = ConfigurationOptionId("format")
+VARIABLE = ConfigurationOptionId("variable")
 
 IFS_REQUEST = {
     "class": "od",
@@ -187,10 +190,7 @@ class EnsembleStatistics(Product):
     inputs: list[str] = ["dataset"]
 
     def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
-        input_dataset = inputs.get("dataset")
-        if not isinstance(input_dataset, QubedOutput):
-            actual_type = type(input_dataset).__name__ if input_dataset is not None else "None"
-            return Either.error(f"Unsupported input type for 'dataset': expected QubedOutput, got {actual_type}")
+        input_dataset = inputs["dataset"]
 
         param = block.config_as_str(PARAM_DIM)
         if not contains(input_dataset, {PARAM_DIM: param}):
@@ -235,10 +235,7 @@ class TemporalStatistics(Product):
     inputs: list[str] = ["dataset"]
 
     def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
-        input_dataset = inputs.get("dataset")
-        if not isinstance(input_dataset, QubedOutput):
-            actual_type = type(input_dataset).__name__ if input_dataset is not None else "None"
-            return Either.error(f"Unsupported input type for 'dataset': expected QubedOutput, got {actual_type}")
+        input_dataset = inputs["dataset"]
 
         param = block.config_as_str(PARAM_DIM)
         if not contains(input_dataset, {PARAM_DIM: param}):
@@ -306,6 +303,49 @@ class ZarrSink(Sink):
 
     def intersect(self, other: QubedOutput) -> bool:
         return bool(dimensions(other))
+
+
+class SelectVariable(Transform):
+    title: str = "Select Variable"
+    description: str = "Select one variable from the input dataset"
+    configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {
+        VARIABLE: BlockConfigurationOption(
+            title="Variable",
+            description="Variable to select from the dataset",
+            value_type="str",
+        )
+    }
+    inputs: list[str] = ["dataset"]
+
+    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
+        input_dataset = inputs.get("dataset")
+        if not isinstance(input_dataset, QubedOutput):
+            actual_type = type(input_dataset).__name__ if input_dataset is not None else "None"
+            return Either.error(f"Unsupported input type for 'dataset': expected QubedOutput, got {actual_type}")
+
+        variable = block.config_as_str(VARIABLE)
+        if not contains(input_dataset, {PARAM_DIM: variable}):
+            return Either.error(f"variable {variable} is not in the input parameters: {axes(input_dataset).get(PARAM_DIM, [])}")
+
+        output = coxpand(input_dataset, PARAM_DIM, {PARAM_DIM: [variable]})
+        return Either.ok(output)
+
+    def compile(
+        self,
+        inputs: ActionLookup,
+        block_id: BlockInstanceId,
+        block: BlockInstance,
+    ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
+        input_task = block.input_ids["dataset"]
+        selected = inputs[input_task].select({PARAM_DIM: block.config_as_str(VARIABLE)})
+        return Either.ok(selected)
+
+    def restrictions(self, other: QubedOutput) -> ConfigurationOptionRestriction:
+        values = [value for value in axes(other).get(PARAM_DIM, set()) if isinstance(value, str)]
+        return {VARIABLE: ClosedEnumType(sorted(values))} if values else {}
+
+    def intersect(self, other: QubedOutput) -> bool:
+        return contains(other, PARAM_DIM)
 
 
 class MapPlotSink(Sink):

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -9,6 +9,7 @@
 
 
 from datetime import date
+from unittest.mock import MagicMock
 
 import pytest
 from fiab_core.fable import (
@@ -25,12 +26,16 @@ from fiab_core.fable import (
     BlockInstance as BlockInstanceBase,
 )
 from fiab_core.tools.blocks import BlockInstanceRich as BlockInstance
+from qubed import Qube
 
+from fiab_plugin_ecmwf import plugin
 from fiab_plugin_ecmwf.anemoi.utils import get_checkpoint_enum_type
 from fiab_plugin_ecmwf.blocks import (
+    VARIABLE,
     EkdSource,
     EnsembleStatistics,
     MapPlotSink,
+    SelectVariable,
     TemporalStatistics,
     ZarrSink,
 )
@@ -124,6 +129,22 @@ def temporal_statistics_configuration() -> BlockInstance:
             ),
         ),
         TemporalStatistics.configuration_options,
+    )
+
+
+@pytest.fixture
+def select_variable_configuration() -> BlockInstance:
+    return BlockInstance.from_block(
+        BlockInstanceBase(
+            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="SelectVariable"),  # type: ignore
+            input_ids={"dataset": BlockInstanceId("source_output")},
+            configuration_values=_config(
+                {
+                    "variable": "2t",
+                }
+            ),
+        ),
+        SelectVariable.configuration_options,
     )
 
 
@@ -337,6 +358,51 @@ class TestZarrSink:
             inputs={"dataset": temporal_output},  # type: ignore[dict-item]
         ).get_or_raise()
         assert isinstance(output, NoOutput)
+
+
+class TestSelectVariable:
+    def test_catalogue_value_type_is_canonical(self) -> None:
+        assert SelectVariable.configuration_options[VARIABLE].value_type == "str"
+
+    def test_from_ekdsource(self, select_variable_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
+        block = SelectVariable()
+        assert block.intersect(other=ekdsource_output)  # type: ignore[arg-type]
+        output = block.validate(block=select_variable_configuration, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
+        assert isinstance(output, QubedOutput)
+        assert output.dataqube is not None
+        assert axes(output)["param"] == {"2t"}
+
+    def test_missing_variable(self, select_variable_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
+        block = SelectVariable()
+        config = select_variable_configuration.model_copy(update={"configuration_values": _config({"variable": "nonexistent"})})
+        result = block.validate(block=config, inputs={"dataset": ekdsource_output})  # type: ignore[dict-item]
+        with pytest.raises(Exception, match="variable nonexistent is not in the input parameters"):
+            result.get_or_raise()
+
+    def test_compile_calls_select(self, select_variable_configuration: BlockInstance) -> None:
+        block = SelectVariable()
+        input_action = MagicMock()
+        selected_action = MagicMock()
+        input_action.select.return_value = selected_action
+
+        result = block.compile(
+            inputs={BlockInstanceId("source_output"): input_action},  # type: ignore[dict-item]
+            block_id=BlockInstanceId("select_variable"),
+            block=select_variable_configuration,
+        )
+        assert result.t is selected_action
+        input_action.select.assert_called_once_with({ConfigurationOptionId("param"): "2t"})
+
+    def test_expander_adds_variable_restrictions(self, ekdsource_output: QubedOutput) -> None:
+        expansions = plugin().expander(ekdsource_output)
+        select_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("selectVariable"))
+        assert select_expansion.restrictions[VARIABLE].serialize() == "enumClosed[2t,msl]"
+
+    def test_expander_skips_restriction_for_non_string_axes(self) -> None:
+        output = QubedOutput(dataqube=Qube.from_datacube({"param": [1, 2]}))
+        expansions = plugin().expander(output)
+        select_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("selectVariable"))
+        assert select_expansion.restrictions == {}
 
 
 def test_anemoi_catalogue_value_types_are_canonical(registered_provider: None) -> None:


### PR DESCRIPTION
Adding the `select` Block to the plugin as suggested by @corentincarton 

cc @HCookie @jinmannwong -- this is a minimal showcase how to utilize the newly added `constraint` thing. That is, the `select`'s variable type is `str` in vanilla state, but for the `/expand` call, it actually inspects the variables it can see in the input, and change the configuration type from `str` to `enumClosed[<the variables in the input>]`. There are no changes to the existing blocks -- there is a new `restrictions` method which is similar to `intersect`, except now instead of `bool` you return whether there are any restrictions. There is a default implementation of "no restrictions", so only override you feel like it.

cc @liefra  -- this is the best action at the moment to test UI interaction with the newly added `constraints` to the `/expand` call