### PR TITLE
Feat/compilation detail

### DIFF
--- a/backend/src/forecastbox/domain/run/background.py
+++ b/backend/src/forecastbox/domain/run/background.py
@@ -37,11 +37,11 @@ from forecastbox.domain.run import db
 from forecastbox.domain.run.cascade import execute_cascade
 from forecastbox.domain.run.compile import compile_builder, resolve_intrinsic_glyph_values
 from forecastbox.domain.run.db import CompilerRuntimeContext
+from forecastbox.domain.run.detail import store_compilation_detail
 from forecastbox.domain.run.types import RunId
 from forecastbox.schemata.jobs import Blueprint
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.memcache import TooLargeEntry
-from forecastbox.utility.memcache import insert as memcache_insert
 from forecastbox.utility.time import current_time
 
 logger = logging.getLogger(__name__)
@@ -104,7 +104,7 @@ def execute_background(
         relevant_glyphs_and_values = expand_glyph_values(all_glyphs_raw, roots=referenced_glyph_names)
         used_glyphs = {k: all_glyphs_raw[k] for k in relevant_glyphs_and_values.keys() if k not in PINNED_INTRINSIC_KEYS}
 
-        exec_spec, run_outputs, task_to_block = compile_builder(builder, relevant_glyphs_and_values)
+        exec_spec, run_outputs, compilation_detail = compile_builder(builder, relevant_glyphs_and_values)
 
         persisted_context = compiler_runtime_context.model_copy(update={"glyphs": used_glyphs})
         run_async(
@@ -120,12 +120,12 @@ def execute_background(
         response = execute_cascade(exec_spec)
         if response.job_id is not None:
             try:
-                memcache_insert(
+                store_compilation_detail(
                     run_id,
-                    task_to_block,
+                    compilation_detail,
                 )
             except TooLargeEntry as e:
-                logger.warning(f"failed to cache task-to-block mapping for {run_id=}, {attempt_count=}: {repr(e)}")
+                logger.warning(f"failed to cache compilation detail for {run_id=}, {attempt_count=}: {repr(e)}")
             (run_async(db.update_run_runtime(run_id, attempt_count, cascade_job_id=response.job_id, outputs=run_outputs.model_dump())),)
         else:
             error = (response.error or "no error provided by cascade")[:255]

--- a/backend/src/forecastbox/domain/run/compile.py
+++ b/backend/src/forecastbox/domain/run/compile.py
@@ -10,7 +10,6 @@
 """Compilation of a BlueprintBuilder into an ExecutionSpecification."""
 
 from datetime import datetime
-from typing import cast
 
 from cascade.low.core import DatasetId, TaskId
 from cascade.low.func import assert_never
@@ -26,7 +25,7 @@ from forecastbox.domain.glyphs.intrinsic import AvailableIntrinsicGlyphs, get_va
 from forecastbox.domain.glyphs.resolution import merge_glyph_values, resolve_configurations
 from forecastbox.domain.plugin.manager import PluginManager
 from forecastbox.domain.run.cascade import ExecutionSpecification, RawCascadeJob, RunOutputCharacteristic, RunOutputs
-from forecastbox.domain.run.detail import CompilationDetail, TaskDetail, fluentNode_to_detail
+from forecastbox.domain.run.detail import CompilationDetail, TaskDetail, _fluentName_to_taskId, fluentNode_to_detail
 from forecastbox.domain.run.types import RunId
 from forecastbox.utility.graph import topological_order
 from forecastbox.utility.time import value_dt2str
@@ -87,8 +86,6 @@ def compile_builder(
     plugins = PluginManager.plugins
     action_lookup = {}
     block_outputs: dict[BlockInstanceId, BlockInstanceOutput] = {}
-    # Maps any produced cascade TaskId (node.name) → originating BlockInstanceId.
-    task_to_block: dict[TaskId, BlockInstanceId] = {}
     # Maps any produced cascade TaskId → TaskDetail.
     task_detail: dict[TaskId, TaskDetail] = {}
     # Maps sink block ids to mime type used in RunOutputs (only relevant for external outputs).
@@ -131,12 +128,11 @@ def compile_builder(
         if block_factory.kind == "sink":
             block_graph = action_lookup[blockId].graph()
             for node in block_graph.nodes():
-                task_id = cast(TaskId, node.name)  # TODO hack -- expose a proper interface for the name→taskId conversion in cascade
-                task_to_block[task_id] = blockId
-                task_detail[task_id] = fluentNode_to_detail(node, blockId)
+                task_id, detail = fluentNode_to_detail(node, blockId)
+                task_detail[task_id] = detail
             sink_tasks.update(
-                cast(TaskId, node.name)
-                for node in block_graph.sinks  # TODO hack -- expose a proper interface for the name→taskId conversion in cascade
+                _fluentName_to_taskId(node.name)
+                for node in block_graph.sinks
                 if not node.name.startswith("run_as_earthkit")  # TODO this may not be relevant anymore -- verify on real workflows
             )
 
@@ -153,8 +149,8 @@ def compile_builder(
 
     run_outputs: dict[TaskId, RunOutputCharacteristic] = {
         task_id: RunOutputCharacteristic(
-            original_block=task_to_block[task_id],
-            mime_type=block_to_mime[task_to_block[task_id]],
+            original_block=task_detail[task_id].block,
+            mime_type=block_to_mime[task_detail[task_id].block],
         )
         for task_id in sink_tasks
     }
@@ -167,5 +163,5 @@ def compile_builder(
         environment = blueprint.environment.model_copy(update={"runtime_artifacts": merged_artifacts})
     else:
         environment = EnvironmentSpecification(runtime_artifacts=graph_artifacts)
-    compilation_detail = CompilationDetail(task_to_block=task_to_block, task_detail=task_detail)
+    compilation_detail = CompilationDetail(task_detail=task_detail)
     return ExecutionSpecification(job=job, environment=environment), RunOutputs(outputs=run_outputs), compilation_detail

--- a/backend/src/forecastbox/domain/run/compile.py
+++ b/backend/src/forecastbox/domain/run/compile.py
@@ -82,6 +82,8 @@ def compile_builder(
     Sets ``job_instance.ext_outputs`` to the authoritative list of cascade external
     outputs (previously a side effect of ``execute_cascade``).
     """
+    # TODO this is a bulky method, returning a tuple of things -- worth simplifying,
+    # like a single dto or perhaps derive the RunOutputs from CompilationDetail
     graph = Graph([])
     plugins = PluginManager.plugins
     action_lookup = {}
@@ -125,6 +127,10 @@ def compile_builder(
         except Exception as e:
             raise ValueError(f"compile failed at {blockId=} with {e}")
 
+        # TODO this is inefficient -- every task in a source block gets traversed as
+        # many times as there are sinks. Instead, we should utilize the Context for
+        # metadata enrichment during compilation to inject BlockId, and retrieve that
+        # at the end. Sinks should also be collected from the cascade graph presumably
         if block_factory.kind == "sink":
             block_graph = action_lookup[blockId].graph()
             for node in block_graph.nodes():

--- a/backend/src/forecastbox/domain/run/compile.py
+++ b/backend/src/forecastbox/domain/run/compile.py
@@ -26,6 +26,7 @@ from forecastbox.domain.glyphs.intrinsic import AvailableIntrinsicGlyphs, get_va
 from forecastbox.domain.glyphs.resolution import merge_glyph_values, resolve_configurations
 from forecastbox.domain.plugin.manager import PluginManager
 from forecastbox.domain.run.cascade import ExecutionSpecification, RawCascadeJob, RunOutputCharacteristic, RunOutputs
+from forecastbox.domain.run.detail import CompilationDetail, TaskDetail, fluentNode_to_detail
 from forecastbox.domain.run.types import RunId
 from forecastbox.utility.graph import topological_order
 from forecastbox.utility.time import value_dt2str
@@ -73,7 +74,7 @@ def _get_artifacts_list(graph: Graph) -> list[CompositeArtifactId]:
 
 def compile_builder(
     blueprint: BlueprintBuilder, glyph_values: dict[str, str]
-) -> tuple[ExecutionSpecification, RunOutputs, dict[TaskId, BlockInstanceId]]:
+) -> tuple[ExecutionSpecification, RunOutputs, CompilationDetail]:
     """Compile a BlueprintBuilder into an ExecutionSpecification and RunOutputs.
 
     Raises ``ValueError`` if any block cannot be validated/compiled. When ``glyph_values`` is
@@ -88,6 +89,8 @@ def compile_builder(
     block_outputs: dict[BlockInstanceId, BlockInstanceOutput] = {}
     # Maps any produced cascade TaskId (node.name) → originating BlockInstanceId.
     task_to_block: dict[TaskId, BlockInstanceId] = {}
+    # Maps any produced cascade TaskId → TaskDetail.
+    task_detail: dict[TaskId, TaskDetail] = {}
     # Maps sink block ids to mime type used in RunOutputs (only relevant for external outputs).
     block_to_mime: dict[BlockInstanceId, str] = {}
     sink_tasks: set[TaskId] = set()
@@ -130,6 +133,7 @@ def compile_builder(
             for node in block_graph.nodes():
                 task_id = cast(TaskId, node.name)  # TODO hack -- expose a proper interface for the name→taskId conversion in cascade
                 task_to_block[task_id] = blockId
+                task_detail[task_id] = fluentNode_to_detail(node, blockId)
             sink_tasks.update(
                 cast(TaskId, node.name)
                 for node in block_graph.sinks  # TODO hack -- expose a proper interface for the name→taskId conversion in cascade
@@ -163,4 +167,5 @@ def compile_builder(
         environment = blueprint.environment.model_copy(update={"runtime_artifacts": merged_artifacts})
     else:
         environment = EnvironmentSpecification(runtime_artifacts=graph_artifacts)
-    return ExecutionSpecification(job=job, environment=environment), RunOutputs(outputs=run_outputs), task_to_block
+    compilation_detail = CompilationDetail(task_to_block=task_to_block, task_detail=task_detail)
+    return ExecutionSpecification(job=job, environment=environment), RunOutputs(outputs=run_outputs), compilation_detail

--- a/backend/src/forecastbox/domain/run/detail.py
+++ b/backend/src/forecastbox/domain/run/detail.py
@@ -1,0 +1,75 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""A granular detail of a Run, including compilation-produced lookups and metadata."""
+
+from cascade.low.core import TaskId
+from earthkit.workflows.graph.nodes import Node
+from fiab_core.fable import BlockInstanceId
+
+from forecastbox.domain.run.exceptions import CompilationDetailCorrupted, CompilationDetailNotFound
+from forecastbox.domain.run.types import RunId
+from forecastbox.utility.memcache import get as memcache_get
+from forecastbox.utility.memcache import insert as memcache_insert
+from forecastbox.utility.pydantic import FiabBaseModel
+
+
+class TaskDetail(FiabBaseModel):
+    """Task-level detail for a single node in the compiled graph."""
+
+    block: BlockInstanceId
+    display_name: str
+    parents: list[TaskId]
+
+
+class CompilationDetail(FiabBaseModel):
+    """Detail produced by compilation of a BlueprintBuilder."""
+
+    task_to_block: dict[TaskId, BlockInstanceId]
+    task_detail: dict[TaskId, TaskDetail] = {}
+
+
+def fluentNode_to_detail(node: Node, block: BlockInstanceId) -> TaskDetail:
+    """Convert an earthkit.workflows Node to a TaskDetail.
+
+    Parameters
+    ----------
+    node:
+        A graph node from an earthkit.workflows Action.
+    block:
+        The BlockInstanceId that owns this node.
+    """
+    parents = [TaskId(output.parent.name) for output in node.inputs.values()]
+    return TaskDetail(block=block, display_name=node.name, parents=parents)
+
+
+def store_compilation_detail(run_id: RunId, compilation_detail: CompilationDetail) -> None:
+    """Persist a CompilationDetail for the given run in the in-memory cache.
+
+    May raise ``TooLargeEntry`` if the detail exceeds cache capacity.
+    """
+    memcache_insert(run_id, compilation_detail)
+
+
+def retrieve_compilation_detail(run_id: RunId) -> CompilationDetail:
+    """Retrieve the CompilationDetail for the given run from the in-memory cache.
+
+    Raises
+    ------
+    CompilationDetailNotFound
+        If no detail is cached for this run.
+    CompilationDetailCorrupted
+        If the cached value cannot be interpreted as a CompilationDetail.
+    """
+    try:
+        return memcache_get(run_id, CompilationDetail)
+    except KeyError:
+        raise CompilationDetailNotFound(f"No compilation detail found for run {run_id!r}")
+    except TypeError as e:
+        raise CompilationDetailCorrupted(f"Compilation detail for run {run_id!r} is corrupted: {e}")

--- a/backend/src/forecastbox/domain/run/detail.py
+++ b/backend/src/forecastbox/domain/run/detail.py
@@ -47,6 +47,7 @@ def fluentNode_to_detail(node: Node, block: BlockInstanceId) -> tuple[TaskId, Ta
     """Convert an earthkit.workflows Node to a (TaskId, TaskDetail) pair."""
     task_id = _fluentName_to_taskId(node.name)
     parents = [_fluentName_to_taskId(output.parent.name) for output in node.inputs.values()]
+    # TODO retrieve display name from the fluent metadata if present, node.name should be fallback
     return task_id, TaskDetail(block=block, display_name=node.name, parents=parents)
 
 

--- a/backend/src/forecastbox/domain/run/detail.py
+++ b/backend/src/forecastbox/domain/run/detail.py
@@ -31,22 +31,23 @@ class TaskDetail(FiabBaseModel):
 class CompilationDetail(FiabBaseModel):
     """Detail produced by compilation of a BlueprintBuilder."""
 
-    task_to_block: dict[TaskId, BlockInstanceId]
     task_detail: dict[TaskId, TaskDetail] = {}
 
 
-def fluentNode_to_detail(node: Node, block: BlockInstanceId) -> TaskDetail:
-    """Convert an earthkit.workflows Node to a TaskDetail.
+def _fluentName_to_taskId(name: str) -> TaskId:
+    """Convert an earthkit node name to a TaskId.
 
-    Parameters
-    ----------
-    node:
-        A graph node from an earthkit.workflows Action.
-    block:
-        The BlockInstanceId that owns this node.
+    Centralises the name→TaskId conversion, which is currently a positional hack
+    (node.name happens to equal the cascade TaskId string).
     """
-    parents = [TaskId(output.parent.name) for output in node.inputs.values()]
-    return TaskDetail(block=block, display_name=node.name, parents=parents)
+    return TaskId(name)
+
+
+def fluentNode_to_detail(node: Node, block: BlockInstanceId) -> tuple[TaskId, TaskDetail]:
+    """Convert an earthkit.workflows Node to a (TaskId, TaskDetail) pair."""
+    task_id = _fluentName_to_taskId(node.name)
+    parents = [_fluentName_to_taskId(output.parent.name) for output in node.inputs.values()]
+    return task_id, TaskDetail(block=block, display_name=node.name, parents=parents)
 
 
 def store_compilation_detail(run_id: RunId, compilation_detail: CompilationDetail) -> None:

--- a/backend/src/forecastbox/domain/run/exceptions.py
+++ b/backend/src/forecastbox/domain/run/exceptions.py
@@ -20,3 +20,11 @@ class RunNotFound(Exception):
 
 class RunAccessDenied(Exception):
     """Raised when the actor lacks permission to read or mutate a Run."""
+
+
+class CompilationDetailNotFound(Exception):
+    """Raised when no cached CompilationDetail exists for the given run."""
+
+
+class CompilationDetailCorrupted(Exception):
+    """Raised when the cached CompilationDetail cannot be deserialized correctly."""

--- a/backend/src/forecastbox/domain/run/service.py
+++ b/backend/src/forecastbox/domain/run/service.py
@@ -245,10 +245,10 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
         if detailed_report:
             try:
                 compilation_detail = retrieve_compilation_detail(run_id)
-                task_to_block = compilation_detail.task_to_block
-            except (CompilationDetailNotFound, CompilationDetailCorrupted):
+                task_to_block = {task_id: td.block for task_id, td in compilation_detail.task_detail.items()}
+            except (CompilationDetailNotFound, CompilationDetailCorrupted) as e:
                 detailed_report = False
-                warning_error = "unable to provide completed/planned tasks"
+                warning_error = f"unable to provide completed/planned tasks: {repr(e)}"
 
         try:
             response = client.request_response(

--- a/backend/src/forecastbox/domain/run/service.py
+++ b/backend/src/forecastbox/domain/run/service.py
@@ -41,12 +41,12 @@ from forecastbox.domain.experiment.types import ExperimentDefinitionId
 from forecastbox.domain.run.background import execute_background
 from forecastbox.domain.run.cascade import RunOutputs
 from forecastbox.domain.run.db import CompilerRuntimeContext
-from forecastbox.domain.run.exceptions import RunNotFound
+from forecastbox.domain.run.detail import retrieve_compilation_detail
+from forecastbox.domain.run.exceptions import CompilationDetailCorrupted, CompilationDetailNotFound, RunNotFound
 from forecastbox.domain.run.types import RunId
 from forecastbox.schemata.jobs import Blueprint, Run
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.config import config
-from forecastbox.utility.memcache import get as get_memcache
 from forecastbox.utility.memcache import pop as pop_memcache
 from forecastbox.utility.pydantic import FiabBaseModel
 from forecastbox.utility.time import value_dt2str
@@ -244,8 +244,9 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
         task_to_block: dict[TaskId, BlockInstanceId] | None = None
         if detailed_report:
             try:
-                task_to_block = cast(dict[TaskId, BlockInstanceId], get_memcache(run_id, dict))
-            except (KeyError, TypeError):
+                compilation_detail = retrieve_compilation_detail(run_id)
+                task_to_block = compilation_detail.task_to_block
+            except (CompilationDetailNotFound, CompilationDetailCorrupted):
                 detailed_report = False
                 warning_error = "unable to provide completed/planned tasks"
 
@@ -292,7 +293,6 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
             return _build(status_override="failed", error_override=jobprogress.failure)
         elif jobprogress.completed or jobprogress.pct == "100.00":
             await run_db.update_run_runtime(run_id, actual_attempt, status="completed", progress="100.00")
-            pop_memcache(run_id)
             return _build(status_override="completed", progress_override="100.00")
         else:
             await run_db.update_run_runtime(run_id, actual_attempt, status="running", progress=jobprogress.pct)

--- a/backend/src/forecastbox/routes/run.py
+++ b/backend/src/forecastbox/routes/run.py
@@ -312,15 +312,9 @@ async def get_compilation_detail(
     """Return task-level compilation detail for a run.
 
     If ``block_id`` is provided, only tasks belonging to that block are returned.
-    Returns 404 if the run is not found or if no compilation detail is available
-    (e.g. the run has not yet been submitted, or the cache entry has expired).
+    Returns 404 if no compilation detail is available (e.g. run not yet submitted,
+    or cache entry expired).
     """
-    try:
-        await db.get_run(spec.run_id, spec.attempt_count, auth_context=auth_context)
-    except RunNotFound:
-        raise HTTPException(status_code=404, detail=f"Run {spec.run_id!r} not found.")
-    except RunAccessDenied:
-        raise HTTPException(status_code=403, detail=f"Access denied to execution {spec.run_id!r}.")
     try:
         detail = retrieve_compilation_detail(spec.run_id)
     except CompilationDetailNotFound:

--- a/backend/src/forecastbox/routes/run.py
+++ b/backend/src/forecastbox/routes/run.py
@@ -12,7 +12,7 @@ Run entity routes — /run/*. Corresponds to `domain.run` backend-managed entity
 
 Contains three categories of routes:
  - CRD+List endpoints (no update, this is backend-managed entity), and a restart endpoint (which is effectively another create),
- - Further detail endpoints -- inspecting outputs, getting logs
+ - Further detail endpoints -- inspecting outputs, getting logs, and retrieving compilation detail
 """
 
 import asyncio
@@ -35,7 +35,8 @@ from forecastbox.domain.auth.users import get_auth_context
 from forecastbox.domain.blueprint.types import BlueprintId
 from forecastbox.domain.run import db, service
 from forecastbox.domain.run.cascade import RunOutputs
-from forecastbox.domain.run.exceptions import RunAccessDenied, RunNotFound
+from forecastbox.domain.run.detail import retrieve_compilation_detail
+from forecastbox.domain.run.exceptions import CompilationDetailCorrupted, CompilationDetailNotFound, RunAccessDenied, RunNotFound
 from forecastbox.domain.run.types import RunId
 from forecastbox.routes.gateway import Globals
 from forecastbox.utility.auth import AuthContext
@@ -130,6 +131,21 @@ class RunDeleteRequest(FiabBaseModel):
 
     run_id: RunId
     attempt_count: int
+
+
+class CompilationDetailTask(FiabBaseModel):
+    """Task-level detail as returned by the /getCompilationDetail endpoint."""
+
+    task_id: TaskId
+    block: BlockInstanceId
+    display_name: str
+    parents: list[TaskId]
+
+
+class CompilationDetailResponse(FiabBaseModel):
+    """Response for /getCompilationDetail, containing a list of task-level details."""
+
+    tasks: list[CompilationDetailTask]
 
 
 # ---------------------------------------------------------------------------
@@ -285,6 +301,46 @@ async def get_run(
     except RunAccessDenied:
         raise HTTPException(status_code=403, detail=f"Access denied to execution {spec.run_id!r}.")
     return _to_run_detail(domain_detail)
+
+
+@router.get("/getCompilationDetail")
+async def get_compilation_detail(
+    spec: Annotated[RunLookup, Depends()],
+    block_id: str | None = None,
+    auth_context: AuthContext = Depends(get_auth_context),
+) -> CompilationDetailResponse:
+    """Return task-level compilation detail for a run.
+
+    If ``block_id`` is provided, only tasks belonging to that block are returned.
+    Returns 404 if the run is not found or if no compilation detail is available
+    (e.g. the run has not yet been submitted, or the cache entry has expired).
+    """
+    try:
+        await db.get_run(spec.run_id, spec.attempt_count, auth_context=auth_context)
+    except RunNotFound:
+        raise HTTPException(status_code=404, detail=f"Run {spec.run_id!r} not found.")
+    except RunAccessDenied:
+        raise HTTPException(status_code=403, detail=f"Access denied to execution {spec.run_id!r}.")
+    try:
+        detail = retrieve_compilation_detail(spec.run_id)
+    except CompilationDetailNotFound:
+        raise HTTPException(status_code=404, detail=f"Compilation detail for run {spec.run_id!r} not found.")
+    except CompilationDetailCorrupted:
+        raise HTTPException(status_code=500, detail=f"Compilation detail for run {spec.run_id!r} is corrupted.")
+    task_detail = detail.task_detail
+    if block_id is not None:
+        filter_block = BlockInstanceId(block_id)  # ty: ignore[invalid-argument-type]
+        task_detail = {k: v for k, v in task_detail.items() if v.block == filter_block}
+    tasks = [
+        CompilationDetailTask(
+            task_id=task_id,
+            block=td.block,
+            display_name=td.display_name,
+            parents=td.parents,
+        )
+        for task_id, td in task_detail.items()
+    ]
+    return CompilationDetailResponse(tasks=tasks)
 
 
 @router.post("/delete")

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -39,7 +39,7 @@ from fiab_core.fable import BlockFactoryId, BlockInstance, BlockInstanceId, Conf
 from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
 from forecastbox.domain.blueprint.service import BlueprintBuilder, BlueprintSaveCommand
 from forecastbox.domain.glyphs.intrinsic import AvailableIntrinsicGlyphs
-from forecastbox.routes.run import RunCreateResponse
+from forecastbox.routes.run import CompilationDetailResponse, RunCreateResponse
 
 from .conftest import fake_artifact_store_id, test_blueprint_artifact_id, testPluginId
 from .utils import compare_with_tolerance, retry_until
@@ -983,6 +983,12 @@ def test_blueprint_composite_glyph_execute(tmpdir: Any, backend_client_with_auth
 
     ensure_completed_v2(backend_client_with_auth, run_id, sleep=1, attempts=120)
 
+    # Verify compilation detail is accessible and has the expected number of tasks
+    detail_resp = backend_client_with_auth.get("/run/getCompilationDetail", params={"run_id": run_id})
+    assert detail_resp.is_success, detail_resp.text
+    detail = CompilationDetailResponse.model_validate(detail_resp.json())
+    assert len(detail.tasks) == 2, f"Expected 2 tasks, got {len(detail.tasks)}: {detail.tasks}"
+
     output = pathlib.Path(f"{tmpdir}/composite_exec_output.txt")
     content = output.read_text()
     # Content must be "exec_global/<run_id>"
@@ -1318,3 +1324,9 @@ def test_blueprint_artifact_execute(tmpdir: Any, backend_client_with_auth: httpx
 
     output = pathlib.Path(f"{tmpdir}/filesize_{run_id}.txt")
     assert output.read_text() == "64", f"Expected file size 64, got: {output.read_text()}"
+
+    # Verify compilation detail is accessible and has the expected number of tasks
+    detail_resp = backend_client_with_auth.get("/run/getCompilationDetail", params={"run_id": run_id})
+    assert detail_resp.is_success, detail_resp.text
+    detail = CompilationDetailResponse.model_validate(detail_resp.json())
+    assert len(detail.tasks) == 2, f"Expected 2 tasks, got {len(detail.tasks)}: {detail.tasks}"

--- a/backend/tests/unit/domain/run/test_detail.py
+++ b/backend/tests/unit/domain/run/test_detail.py
@@ -17,6 +17,7 @@ from fiab_core.fable import BlockInstanceId
 from forecastbox.domain.run.detail import (
     CompilationDetail,
     TaskDetail,
+    _fluentName_to_taskId,
     fluentNode_to_detail,
     retrieve_compilation_detail,
     store_compilation_detail,
@@ -60,7 +61,8 @@ def _make_node(name: str, parent_names: list[str]) -> SimpleNamespace:
 def test_fluentNode_to_detail_source_node() -> None:
     """A source node has no inputs, so parents should be empty."""
     node = _make_node("source_42:abc123", [])
-    detail = fluentNode_to_detail(node, BlockInstanceId("my_block"))  # type: ignore[arg-type]
+    task_id, detail = fluentNode_to_detail(node, BlockInstanceId("my_block"))  # type: ignore[arg-type]
+    assert task_id == TaskId("source_42:abc123")
     assert detail.block == BlockInstanceId("my_block")
     assert detail.display_name == "source_42:abc123"
     assert detail.parents == []
@@ -69,7 +71,8 @@ def test_fluentNode_to_detail_source_node() -> None:
 def test_fluentNode_to_detail_sink_node_with_parent() -> None:
     """A sink node has one input whose parent name becomes its parent task_id."""
     node = _make_node("sink_file:def456", ["source_42:abc123"])
-    detail = fluentNode_to_detail(node, BlockInstanceId("sink_block"))  # type: ignore[arg-type]
+    task_id, detail = fluentNode_to_detail(node, BlockInstanceId("sink_block"))  # type: ignore[arg-type]
+    assert task_id == TaskId("sink_file:def456")
     assert detail.block == BlockInstanceId("sink_block")
     assert detail.display_name == "sink_file:def456"
     assert detail.parents == [TaskId("source_42:abc123")]
@@ -78,7 +81,7 @@ def test_fluentNode_to_detail_sink_node_with_parent() -> None:
 def test_fluentNode_to_detail_multiple_parents() -> None:
     """A node with multiple inputs gets all parent task_ids."""
     node = _make_node("join_node:ghi789", ["left:aaa", "right:bbb"])
-    detail = fluentNode_to_detail(node, BlockInstanceId("join_block"))  # type: ignore[arg-type]
+    _, detail = fluentNode_to_detail(node, BlockInstanceId("join_block"))  # type: ignore[arg-type]
     assert len(detail.parents) == 2
     assert TaskId("left:aaa") in detail.parents
     assert TaskId("right:bbb") in detail.parents
@@ -90,16 +93,13 @@ def test_fluentNode_to_detail_multiple_parents() -> None:
 
 
 def test_compilation_detail_defaults() -> None:
-    task_to_block = {TaskId("task-a"): BlockInstanceId("block-a")}
-    detail = CompilationDetail(task_to_block=task_to_block)
-    assert detail.task_to_block == task_to_block
+    detail = CompilationDetail()
     assert detail.task_detail == {}
 
 
 def test_compilation_detail_with_task_detail() -> None:
-    task_to_block = {TaskId("task-a"): BlockInstanceId("block-a")}
     task_detail = {TaskId("task-a"): TaskDetail(block=BlockInstanceId("block-a"), display_name="func:hash", parents=[])}
-    detail = CompilationDetail(task_to_block=task_to_block, task_detail=task_detail)
+    detail = CompilationDetail(task_detail=task_detail)
     assert detail.task_detail[TaskId("task-a")].display_name == "func:hash"
 
 
@@ -109,14 +109,14 @@ def test_compilation_detail_with_task_detail() -> None:
 
 
 def test_store_and_retrieve_round_trip() -> None:
-    run_id = RunId("test-run-id")
-    task_to_block = {TaskId("task-a"): BlockInstanceId("block-a")}
-    detail = CompilationDetail(task_to_block=task_to_block)
+    run_id = RunId("test-run-id-2")
+    task_detail = {TaskId("task-a"): TaskDetail(block=BlockInstanceId("block-a"), display_name="func:hash", parents=[])}
+    detail = CompilationDetail(task_detail=task_detail)
 
     store_compilation_detail(run_id, detail)
     retrieved = retrieve_compilation_detail(run_id)
 
-    assert retrieved.task_to_block == task_to_block
+    assert retrieved.task_detail == task_detail
 
 
 def test_retrieve_raises_not_found_for_missing_key() -> None:

--- a/backend/tests/unit/domain/run/test_detail.py
+++ b/backend/tests/unit/domain/run/test_detail.py
@@ -1,0 +1,133 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from cascade.low.core import TaskId
+from fiab_core.fable import BlockInstanceId
+
+from forecastbox.domain.run.detail import (
+    CompilationDetail,
+    TaskDetail,
+    fluentNode_to_detail,
+    retrieve_compilation_detail,
+    store_compilation_detail,
+)
+from forecastbox.domain.run.exceptions import CompilationDetailCorrupted, CompilationDetailNotFound
+from forecastbox.domain.run.types import RunId
+
+# ---------------------------------------------------------------------------
+# TaskDetail
+# ---------------------------------------------------------------------------
+
+
+def test_task_detail_construction() -> None:
+    td = TaskDetail(
+        block=BlockInstanceId("my_sink"),
+        display_name="some_func:abc123",
+        parents=[TaskId("parent_task:xyz")],
+    )
+    assert td.block == BlockInstanceId("my_sink")
+    assert td.display_name == "some_func:abc123"
+    assert td.parents == [TaskId("parent_task:xyz")]
+
+
+def test_task_detail_no_parents() -> None:
+    td = TaskDetail(block=BlockInstanceId("source"), display_name="source_func:hash", parents=[])
+    assert td.parents == []
+
+
+# ---------------------------------------------------------------------------
+# fluentNode_to_detail
+# ---------------------------------------------------------------------------
+
+
+def _make_node(name: str, parent_names: list[str]) -> SimpleNamespace:
+    """Build a minimal earthkit-like Node stub."""
+    parents = [SimpleNamespace(parent=SimpleNamespace(name=pname)) for pname in parent_names]
+    inputs = {f"input{i}": p for i, p in enumerate(parents)}
+    return SimpleNamespace(name=name, inputs=inputs)
+
+
+def test_fluentNode_to_detail_source_node() -> None:
+    """A source node has no inputs, so parents should be empty."""
+    node = _make_node("source_42:abc123", [])
+    detail = fluentNode_to_detail(node, BlockInstanceId("my_block"))  # type: ignore[arg-type]
+    assert detail.block == BlockInstanceId("my_block")
+    assert detail.display_name == "source_42:abc123"
+    assert detail.parents == []
+
+
+def test_fluentNode_to_detail_sink_node_with_parent() -> None:
+    """A sink node has one input whose parent name becomes its parent task_id."""
+    node = _make_node("sink_file:def456", ["source_42:abc123"])
+    detail = fluentNode_to_detail(node, BlockInstanceId("sink_block"))  # type: ignore[arg-type]
+    assert detail.block == BlockInstanceId("sink_block")
+    assert detail.display_name == "sink_file:def456"
+    assert detail.parents == [TaskId("source_42:abc123")]
+
+
+def test_fluentNode_to_detail_multiple_parents() -> None:
+    """A node with multiple inputs gets all parent task_ids."""
+    node = _make_node("join_node:ghi789", ["left:aaa", "right:bbb"])
+    detail = fluentNode_to_detail(node, BlockInstanceId("join_block"))  # type: ignore[arg-type]
+    assert len(detail.parents) == 2
+    assert TaskId("left:aaa") in detail.parents
+    assert TaskId("right:bbb") in detail.parents
+
+
+# ---------------------------------------------------------------------------
+# CompilationDetail
+# ---------------------------------------------------------------------------
+
+
+def test_compilation_detail_defaults() -> None:
+    task_to_block = {TaskId("task-a"): BlockInstanceId("block-a")}
+    detail = CompilationDetail(task_to_block=task_to_block)
+    assert detail.task_to_block == task_to_block
+    assert detail.task_detail == {}
+
+
+def test_compilation_detail_with_task_detail() -> None:
+    task_to_block = {TaskId("task-a"): BlockInstanceId("block-a")}
+    task_detail = {TaskId("task-a"): TaskDetail(block=BlockInstanceId("block-a"), display_name="func:hash", parents=[])}
+    detail = CompilationDetail(task_to_block=task_to_block, task_detail=task_detail)
+    assert detail.task_detail[TaskId("task-a")].display_name == "func:hash"
+
+
+# ---------------------------------------------------------------------------
+# store_compilation_detail / retrieve_compilation_detail
+# ---------------------------------------------------------------------------
+
+
+def test_store_and_retrieve_round_trip() -> None:
+    run_id = RunId("test-run-id")
+    task_to_block = {TaskId("task-a"): BlockInstanceId("block-a")}
+    detail = CompilationDetail(task_to_block=task_to_block)
+
+    store_compilation_detail(run_id, detail)
+    retrieved = retrieve_compilation_detail(run_id)
+
+    assert retrieved.task_to_block == task_to_block
+
+
+def test_retrieve_raises_not_found_for_missing_key() -> None:
+    run_id = RunId("nonexistent-run-id")
+    with patch("forecastbox.domain.run.detail.memcache_get", side_effect=KeyError("missing")):
+        with pytest.raises(CompilationDetailNotFound, match="nonexistent-run-id"):
+            retrieve_compilation_detail(run_id)
+
+
+def test_retrieve_raises_corrupted_for_wrong_type() -> None:
+    run_id = RunId("corrupted-run-id")
+    with patch("forecastbox.domain.run.detail.memcache_get", side_effect=TypeError("wrong type")):
+        with pytest.raises(CompilationDetailCorrupted, match="corrupted-run-id"):
+            retrieve_compilation_detail(run_id)

--- a/backend/tests/unit/domain/run/test_run_detailed_report.py
+++ b/backend/tests/unit/domain/run/test_run_detailed_report.py
@@ -10,7 +10,7 @@ from fiab_core.fable import BlockInstanceId
 
 from forecastbox.domain.blueprint.types import BlueprintId
 from forecastbox.domain.run import service as run_service
-from forecastbox.domain.run.detail import CompilationDetail
+from forecastbox.domain.run.detail import CompilationDetail, TaskDetail
 from forecastbox.domain.run.exceptions import CompilationDetailNotFound
 from forecastbox.domain.run.service import RunDetail
 from forecastbox.domain.run.types import RunId
@@ -63,11 +63,12 @@ async def test_poll_and_update_requests_detailed_report_and_translates_to_block_
         completed_task_ids={JobId("job-1"): [TaskId("task-a")]},
         planned_task_ids={JobId("job-1"): [TaskId("task-b")]},
     )
-    task_to_block = {
-        TaskId("task-a"): BlockInstanceId("block-a"),
-        TaskId("task-b"): BlockInstanceId("block-b"),
-    }
-    compilation_detail = CompilationDetail(task_to_block=task_to_block)
+    compilation_detail = CompilationDetail(
+        task_detail={
+            TaskId("task-a"): TaskDetail(block=BlockInstanceId("block-a"), display_name="func_a:hash", parents=[]),
+            TaskId("task-b"): TaskDetail(block=BlockInstanceId("block-b"), display_name="func_b:hash", parents=[]),
+        }
+    )
 
     with (
         patch("forecastbox.domain.run.service.client.request_response", return_value=response) as mock_request,
@@ -118,7 +119,7 @@ async def test_poll_and_update_disables_detailed_report_when_cache_misses() -> N
     request = mock_request.call_args.args[0]
     assert request.detailed_report is False
     assert mock_retrieve.call_args.args[0] == RunId("run-1")
-    assert detail.error == "unable to provide completed/planned tasks"
+    assert detail.error == "unable to provide completed/planned tasks: CompilationDetailNotFound('missing')"
     assert detail.completed_block_ids is None
     assert detail.planned_block_ids is None
 

--- a/backend/tests/unit/domain/run/test_run_detailed_report.py
+++ b/backend/tests/unit/domain/run/test_run_detailed_report.py
@@ -10,6 +10,8 @@ from fiab_core.fable import BlockInstanceId
 
 from forecastbox.domain.blueprint.types import BlueprintId
 from forecastbox.domain.run import service as run_service
+from forecastbox.domain.run.detail import CompilationDetail
+from forecastbox.domain.run.exceptions import CompilationDetailNotFound
 from forecastbox.domain.run.service import RunDetail
 from forecastbox.domain.run.types import RunId
 from forecastbox.routes.run import RunLookup, get_run, list_runs
@@ -65,17 +67,18 @@ async def test_poll_and_update_requests_detailed_report_and_translates_to_block_
         TaskId("task-a"): BlockInstanceId("block-a"),
         TaskId("task-b"): BlockInstanceId("block-b"),
     }
+    compilation_detail = CompilationDetail(task_to_block=task_to_block)
 
     with (
         patch("forecastbox.domain.run.service.client.request_response", return_value=response) as mock_request,
-        patch("forecastbox.domain.run.service.get_memcache", return_value=task_to_block) as mock_get_memcache,
+        patch("forecastbox.domain.run.service.retrieve_compilation_detail", return_value=compilation_detail) as mock_retrieve,
         patch("forecastbox.domain.run.service.run_db.update_run_runtime", new=AsyncMock()),
     ):
         detail = await run_service.poll_and_update(cast(Run, execution), detailed_report=True)
 
     request = mock_request.call_args.args[0]
     assert request.detailed_report is True
-    assert mock_get_memcache.call_args.args[0] == RunId("run-1")
+    assert mock_retrieve.call_args.args[0] == RunId("run-1")
     assert detail.completed_block_ids == {BlockInstanceId("block-a")}
     assert detail.planned_block_ids == {BlockInstanceId("block-b")}
 
@@ -105,14 +108,16 @@ async def test_poll_and_update_disables_detailed_report_when_cache_misses() -> N
 
     with (
         patch("forecastbox.domain.run.service.client.request_response", return_value=response) as mock_request,
-        patch("forecastbox.domain.run.service.get_memcache", side_effect=KeyError("missing")) as mock_get_memcache,
+        patch(
+            "forecastbox.domain.run.service.retrieve_compilation_detail", side_effect=CompilationDetailNotFound("missing")
+        ) as mock_retrieve,
         patch("forecastbox.domain.run.service.run_db.update_run_runtime", new=AsyncMock()),
     ):
         detail = await run_service.poll_and_update(cast(Run, execution), detailed_report=True)
 
     request = mock_request.call_args.args[0]
     assert request.detailed_report is False
-    assert mock_get_memcache.call_args.args[0] == RunId("run-1")
+    assert mock_retrieve.call_args.args[0] == RunId("run-1")
     assert detail.error == "unable to provide completed/planned tasks"
     assert detail.completed_block_ids is None
     assert detail.planned_block_ids is None


### PR DESCRIPTION
This exposes the underlying cascade subgraph to the frontend, for better visualization

It is done via a new endpoint, /getCompilationDetail, which requires a runId and optionally accepts a block id -- without blockId, retrieves the whole graph, when blockId is given it filters only to the respective block

it returns nodes of the cascade graph, as a list, each element containing a display name and ids of the parents. Note that if you give a block id in the request to filter and that block id is not a source, then you will get elements in that list whose parents are _not_ in the response

the display name is currently the long verbose name with a hash. There are a few things we can think about:
 - do we want to store some better display_name in the metadata during compilation?
 - do we want to put there some *type* into the metadata? Like "compute node", "auxiliary manipulation node", "data fetch node", "data store node", etc? We could derive like color or icon from it (the original graph viz also wasn't homo)
 - do we want to put in some "grouping" information, to provide hints to visualization like "all these nodes are a single parallel computation group"?
 
:point_up: cc @corentincarton @jinmannwong @HCookie 

there are a few internal inefficiencies, and the RunProgress response does _not_ yet contain the granular level of task-id, I will add this later -- but this should already enable some integrations, cc @liefra 
