### PR TITLE
Select blocks

### DIFF
--- a/backend/packages/fiab-core/src/fiab_core/types.py
+++ b/backend/packages/fiab-core/src/fiab_core/types.py
@@ -92,8 +92,6 @@ class FableType(ABC):
             inner_type = FableType.parse(inner_type_expr)
             if isinstance(inner_type, ListType):
                 raise NotFableType("Nested lists are not supported")
-            if isinstance(inner_type, ClosedEnumType):
-                return ClosedEnumListType(inner_type.items)
             return ListType(inner_type)
 
         raise NotFableType(
@@ -255,11 +253,3 @@ class ListType(FableType):
 
     def serialize(self) -> str:
         return f"list[{self.item_type.serialize()}]"
-
-
-class ClosedEnumListType(ListType):
-    """List type whose items must be members of a closed enumeration."""
-
-    def __init__(self, items: list[str]) -> None:
-        self.items = items
-        super().__init__(ClosedEnumType(items))

--- a/backend/packages/fiab-core/src/fiab_core/types.py
+++ b/backend/packages/fiab-core/src/fiab_core/types.py
@@ -92,6 +92,8 @@ class FableType(ABC):
             inner_type = FableType.parse(inner_type_expr)
             if isinstance(inner_type, ListType):
                 raise NotFableType("Nested lists are not supported")
+            if isinstance(inner_type, ClosedEnumType):
+                return ClosedEnumListType(inner_type.items)
             return ListType(inner_type)
 
         raise NotFableType(
@@ -253,3 +255,11 @@ class ListType(FableType):
 
     def serialize(self) -> str:
         return f"list[{self.item_type.serialize()}]"
+
+
+class ClosedEnumListType(ListType):
+    """List type whose items must be members of a closed enumeration."""
+
+    def __init__(self, items: list[str]) -> None:
+        self.items = items
+        super().__init__(ClosedEnumType(items))

--- a/backend/packages/fiab-core/tests/test_types.py
+++ b/backend/packages/fiab-core/tests/test_types.py
@@ -14,7 +14,6 @@ from datetime import date, datetime
 import pytest
 
 from fiab_core.types import (
-    ClosedEnumListType,
     ClosedEnumType,
     DatetimeType,
     DateType,
@@ -286,8 +285,8 @@ class TestFableTypeParse:
 
     def test_parse_list_of_enum(self) -> None:
         t = FableType.parse("list[enumClosed[a,b]]")
-        assert isinstance(t, ClosedEnumListType)
         assert isinstance(t, ListType)
+        assert isinstance(t.item_type, ClosedEnumType)
         assert t.validate_convert("a,b,a") == ["a", "b", "a"]
         assert t.serialize() == "list[enumClosed[a,b]]"
 

--- a/backend/packages/fiab-core/tests/test_types.py
+++ b/backend/packages/fiab-core/tests/test_types.py
@@ -14,6 +14,7 @@ from datetime import date, datetime
 import pytest
 
 from fiab_core.types import (
+    ClosedEnumListType,
     ClosedEnumType,
     DatetimeType,
     DateType,
@@ -285,8 +286,10 @@ class TestFableTypeParse:
 
     def test_parse_list_of_enum(self) -> None:
         t = FableType.parse("list[enumClosed[a,b]]")
+        assert isinstance(t, ClosedEnumListType)
         assert isinstance(t, ListType)
         assert t.validate_convert("a,b,a") == ["a", "b", "a"]
+        assert t.serialize() == "list[enumClosed[a,b]]"
 
     def test_parse_nested_lists_raises_error(self) -> None:
         with pytest.raises(NotFableType):

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/__init__.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/__init__.py
@@ -13,12 +13,13 @@ from fiab_core.tools.plugins import QubedPluginBuilder
 
 from fiab_plugin_ecmwf.anemoi.blocks import AnemoiSource, AnemoiTransform
 from fiab_plugin_ecmwf.blocks import (
+    ENSEMBLE,
+    PARAM,
+    STEP,
     EkdSource,
     EnsembleStatistics,
     MapPlotSink,
-    SelectMembers,
-    SelectParameters,
-    SelectSteps,
+    SelectDimension,
     TemporalStatistics,
     ZarrSink,
 )
@@ -27,9 +28,21 @@ blocks: dict[BlockFactoryId, QubedBlockBuilder] = {
     BlockFactoryId("ekdSource"): EkdSource(),
     BlockFactoryId("ensembleStatistics"): EnsembleStatistics(),
     BlockFactoryId("temporalStatistics"): TemporalStatistics(),
-    BlockFactoryId("selectParameters"): SelectParameters(),
-    BlockFactoryId("selectSteps"): SelectSteps(),
-    BlockFactoryId("selectMembers"): SelectMembers(),
+    BlockFactoryId("selectParameters"): SelectDimension(
+        option_id=PARAM,
+        item_python_type=str,
+        selection_label="parameters",
+    ),
+    BlockFactoryId("selectSteps"): SelectDimension(
+        option_id=STEP,
+        item_python_type=int,
+        selection_label="steps",
+    ),
+    BlockFactoryId("selectMembers"): SelectDimension(
+        option_id=ENSEMBLE,
+        item_python_type=int,
+        selection_label="members",
+    ),
     BlockFactoryId("zarrSink"): ZarrSink(),
     BlockFactoryId("anemoiSource"): AnemoiSource(),
     BlockFactoryId("anemoiTransform"): AnemoiTransform(),

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/__init__.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/__init__.py
@@ -12,13 +12,24 @@ from fiab_core.tools.blocks import QubedBlockBuilder
 from fiab_core.tools.plugins import QubedPluginBuilder
 
 from fiab_plugin_ecmwf.anemoi.blocks import AnemoiSource, AnemoiTransform
-from fiab_plugin_ecmwf.blocks import EkdSource, EnsembleStatistics, MapPlotSink, SelectVariable, TemporalStatistics, ZarrSink
+from fiab_plugin_ecmwf.blocks import (
+    EkdSource,
+    EnsembleStatistics,
+    MapPlotSink,
+    SelectMembers,
+    SelectParameters,
+    SelectSteps,
+    TemporalStatistics,
+    ZarrSink,
+)
 
 blocks: dict[BlockFactoryId, QubedBlockBuilder] = {
     BlockFactoryId("ekdSource"): EkdSource(),
     BlockFactoryId("ensembleStatistics"): EnsembleStatistics(),
     BlockFactoryId("temporalStatistics"): TemporalStatistics(),
-    BlockFactoryId("selectVariable"): SelectVariable(),
+    BlockFactoryId("selectParameters"): SelectParameters(),
+    BlockFactoryId("selectSteps"): SelectSteps(),
+    BlockFactoryId("selectMembers"): SelectMembers(),
     BlockFactoryId("zarrSink"): ZarrSink(),
     BlockFactoryId("anemoiSource"): AnemoiSource(),
     BlockFactoryId("anemoiTransform"): AnemoiTransform(),

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -8,7 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 import logging
-from typing import Any, ClassVar, cast
+from typing import Any, cast
 
 import numpy as np
 from cascade.low.func import Either
@@ -308,11 +308,38 @@ class ZarrSink(Sink):
 SelectAxisValue = str | int
 
 
-class _SelectDimension(Transform):
-    option_id: ClassVar[ConfigurationOptionId]
-    item_python_type: ClassVar[type[str] | type[int]]
-    selection_label: ClassVar[str]
+class SelectDimension(Transform):
     inputs: list[str] = ["dataset"]
+
+    def __init__(
+        self,
+        *,
+        option_id: ConfigurationOptionId,
+        item_python_type: type[str] | type[int],
+        selection_label: str,
+    ) -> None:
+        label_title = selection_label.title()
+        label_sentence = selection_label[:1].upper() + selection_label[1:]
+
+        self.title = f"Select {label_title}"
+        self.description = f"Select {selection_label} from the input dataset"
+        self.option_id = option_id
+        self.item_python_type = item_python_type
+        self.selection_label = selection_label
+        self.configuration_options = {
+            option_id: BlockConfigurationOption(
+                title=label_title,
+                description=f"{label_sentence} to select from the dataset",
+                value_type=f"list[{self._value_type_name()}]",
+            )
+        }
+
+    def _value_type_name(self) -> str:
+        if self.item_python_type is str:
+            return "str"
+        if self.item_python_type is int:
+            return "int"
+        raise TypeError(f"Unsupported select value type {self.item_python_type!r}")
 
     def _selected_values(self, block: BlockInstance) -> list[SelectAxisValue]:
         if self.item_python_type is str:
@@ -361,51 +388,6 @@ class _SelectDimension(Transform):
 
     def intersect(self, other: QubedOutput) -> bool:
         return contains(other, self.option_id)
-
-
-class SelectParameters(_SelectDimension):
-    title: str = "Select Parameters"
-    description: str = "Select parameters from the input dataset"
-    option_id: ClassVar[ConfigurationOptionId] = PARAM
-    item_python_type: ClassVar[type[str] | type[int]] = str
-    selection_label: ClassVar[str] = "parameters"
-    configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {
-        PARAM: BlockConfigurationOption(
-            title="Parameters",
-            description="Parameters to select from the dataset",
-            value_type="list[str]",
-        )
-    }
-
-
-class SelectSteps(_SelectDimension):
-    title: str = "Select Steps"
-    description: str = "Select forecast steps from the input dataset"
-    option_id: ClassVar[ConfigurationOptionId] = STEP
-    item_python_type: ClassVar[type[str] | type[int]] = int
-    selection_label: ClassVar[str] = "steps"
-    configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {
-        STEP: BlockConfigurationOption(
-            title="Steps",
-            description="Forecast steps to select from the dataset",
-            value_type="list[int]",
-        )
-    }
-
-
-class SelectMembers(_SelectDimension):
-    title: str = "Select Members"
-    description: str = "Select ensemble members from the input dataset"
-    option_id: ClassVar[ConfigurationOptionId] = ENSEMBLE
-    item_python_type: ClassVar[type[str] | type[int]] = int
-    selection_label: ClassVar[str] = "members"
-    configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {
-        ENSEMBLE: BlockConfigurationOption(
-            title="Ensemble Members",
-            description="Ensemble members to select from the dataset",
-            value_type="list[int]",
-        )
-    }
 
 
 class MapPlotSink(Sink):

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -26,7 +26,7 @@ from fiab_core.fable import (
 from fiab_core.plugin import Error
 from fiab_core.tools.blocks import BlockInstanceRich as BlockInstance
 from fiab_core.tools.blocks import Product, Sink, Source, Transform
-from fiab_core.types import ClosedEnumType
+from fiab_core.types import ClosedEnumListType
 from qubed import Qube
 
 from .qubed_utils import axes, contains, coxpand, dimensions
@@ -34,12 +34,13 @@ from .qubed_utils import axes, contains, coxpand, dimensions
 SOURCE = ConfigurationOptionId("source")
 DATE = ConfigurationOptionId("date")
 EXPVER = ConfigurationOptionId("expver")
-PARAM_DIM = ConfigurationOptionId("param")
 STATISTIC = ConfigurationOptionId("statistic")
 PATH = ConfigurationOptionId("path")
 DOMAIN = ConfigurationOptionId("domain")
 FORMAT = ConfigurationOptionId("format")
-VARIABLE = ConfigurationOptionId("variable")
+PARAM = ConfigurationOptionId("param")
+ENSEMBLE = ConfigurationOptionId("number")
+STEP = ConfigurationOptionId("step")
 
 IFS_REQUEST = {
     "class": "od",
@@ -62,8 +63,6 @@ IFS_REQUEST = {
     "type": "pf",
     "number": list(range(1, 6)),
 }
-ENSEMBLE_DIM = "number"
-STEP_DIM = "step"
 
 logger = logging.getLogger(__name__)
 
@@ -93,17 +92,17 @@ class EkdSource(Source):
             description="The expver value of the forecast",
             value_type="str",
         ),
-        PARAM_DIM: BlockConfigurationOption(
+        PARAM: BlockConfigurationOption(
             title="Parameters",
             description="Parameters to select and plot (e.g. '2t', 'msl')",
             value_type="list[str]",
         ),
-        ConfigurationOptionId("step"): BlockConfigurationOption(
+        STEP: BlockConfigurationOption(
             title="Steps",
             description="Forecast steps to select (e.g. '0,6,12,...')",
             value_type="list[int]",
         ),
-        ConfigurationOptionId("number"): BlockConfigurationOption(
+        ENSEMBLE: BlockConfigurationOption(
             title="Ensemble Members",
             description="Ensemble members to select (e.g. '1,2,3,...')",
             value_type="list[int]",
@@ -112,16 +111,16 @@ class EkdSource(Source):
     inputs: list[str] = []
 
     def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
-        param = block.config_as_list(PARAM_DIM, str, allow_empty=False)
-        step = block.config_as_list("step", int)
-        number = block.config_as_list("number", int)
+        param = block.config_as_list(PARAM, str, allow_empty=False)
+        step = block.config_as_list(STEP, int)
+        ensemble = block.config_as_list(ENSEMBLE, int)
 
         output = QubedOutput(
             dataqube=Qube.from_datacube(
                 {
-                    PARAM_DIM: param,
-                    ENSEMBLE_DIM: number,
-                    STEP_DIM: step,
+                    PARAM: param,
+                    ENSEMBLE: ensemble,
+                    STEP: step,
                 }
             )
         )
@@ -133,9 +132,9 @@ class EkdSource(Source):
         block_id: BlockInstanceId,
         block: BlockInstance,
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
-        param = block.config_as_list(PARAM_DIM, str, allow_empty=False)
-        step = block.config_as_list("step", int)
-        number = block.config_as_list("number", int)
+        param = block.config_as_list(PARAM, str, allow_empty=False)
+        step = block.config_as_list(STEP, int)
+        ensemble = block.config_as_list(ENSEMBLE, int)
 
         action = (
             from_source(
@@ -149,25 +148,25 @@ class EkdSource(Source):
                                     **IFS_REQUEST,
                                     "date": block.config_as_date(DATE).isoformat(),
                                     "expver": block.config_as_str(EXPVER),
-                                    PARAM_DIM: p,
-                                    ENSEMBLE_DIM: number,
-                                    STEP_DIM: step,
+                                    PARAM: p,
+                                    ENSEMBLE: number,
+                                    STEP: step,
                                 }
                             },
                         )
                         for p in param
                     ]
                 ),
-                coords={PARAM_DIM: param},
+                coords={PARAM: param},
             )
             .expand(
-                (ENSEMBLE_DIM, number),
+                (ENSEMBLE, ensemble),
                 "number",
-                dim_size=len(number),
+                dim_size=len(ensemble),
                 backend_kwargs={"method": "isel"},
             )
             .expand(
-                (STEP_DIM, step),
+                (STEP, step),
                 "step",
                 dim_size=len(step),
                 backend_kwargs={"method": "isel"},
@@ -180,7 +179,7 @@ class EnsembleStatistics(Product):
     title: str = "Ensemble Statistics"
     description: str = "Computes ensemble mean or standard deviation"
     configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {
-        PARAM_DIM: BlockConfigurationOption(title="Parameter", description="Parameter name like '2t'", value_type="str"),
+        PARAM: BlockConfigurationOption(title="Parameter", description="Parameter name like '2t'", value_type="str"),
         STATISTIC: BlockConfigurationOption(
             title="Statistic",
             description="Statistic to compute over the ensemble",
@@ -192,11 +191,11 @@ class EnsembleStatistics(Product):
     def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
         input_dataset = inputs["dataset"]
 
-        param = block.config_as_str(PARAM_DIM)
-        if not contains(input_dataset, {PARAM_DIM: param}):
-            return Either.error(f"param {param} is not in the input parameters: {axes(input_dataset).get(PARAM_DIM, [])}")
+        param = block.config_as_str(PARAM)
+        if not contains(input_dataset, {PARAM: param}):
+            return Either.error(f"param {param} is not in the input parameters: {axes(input_dataset).get(PARAM, [])}")
 
-        output = coxpand(input_dataset, [PARAM_DIM, ENSEMBLE_DIM], {PARAM_DIM: [param]})
+        output = coxpand(input_dataset, [PARAM, ENSEMBLE], {PARAM: [param]})
         return Either.ok(output)
 
     def compile(
@@ -208,24 +207,24 @@ class EnsembleStatistics(Product):
         input_task = block.input_ids["dataset"]
         input_task_action = inputs[input_task]
         stat = block.config_as_str(STATISTIC)
-        param = input_task_action.select({PARAM_DIM: block.config_as_str(PARAM_DIM)})
+        param = input_task_action.select({PARAM: block.config_as_str(PARAM)})
         if stat == "mean":
-            action = param.mean(dim=ENSEMBLE_DIM)
+            action = param.mean(dim=ENSEMBLE)
         elif stat == "std":
-            action = param.std(dim=ENSEMBLE_DIM)
+            action = param.std(dim=ENSEMBLE)
         else:
             return Either.error(f"Unsupported statistic '{stat}'")
         return Either.ok(action)
 
     def intersect(self, other: QubedOutput) -> bool:
-        return contains(other, ENSEMBLE_DIM) and contains(other, PARAM_DIM)
+        return contains(other, ENSEMBLE) and contains(other, PARAM)
 
 
 class TemporalStatistics(Product):
     title: str = "Temporal Statistics"
     description: str = "Computes temporal statistics"
     configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {
-        PARAM_DIM: BlockConfigurationOption(title=PARAM_DIM, description="Param name like '2t'", value_type="str"),
+        PARAM: BlockConfigurationOption(title=PARAM, description="Param name like '2t'", value_type="str"),
         STATISTIC: BlockConfigurationOption(
             title="Statistic",
             description="Statistic to compute over steps",
@@ -237,10 +236,10 @@ class TemporalStatistics(Product):
     def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
         input_dataset = inputs["dataset"]
 
-        param = block.config_as_str(PARAM_DIM)
-        if not contains(input_dataset, {PARAM_DIM: param}):
-            return Either.error(f"param {param} is not in the input parameters: {axes(input_dataset).get(PARAM_DIM, [])}")
-        output = coxpand(input_dataset, [PARAM_DIM, STEP_DIM], {PARAM_DIM: [param]})
+        param = block.config_as_str(PARAM)
+        if not contains(input_dataset, {PARAM: param}):
+            return Either.error(f"param {param} is not in the input parameters: {axes(input_dataset).get(PARAM, [])}")
+        output = coxpand(input_dataset, [PARAM, STEP], {PARAM: [param]})
         return Either.ok(output)
 
     def compile(
@@ -252,21 +251,21 @@ class TemporalStatistics(Product):
         input_task = block.input_ids["dataset"]
         input_task_action = inputs[input_task]
         stat = block.config_as_str(STATISTIC)
-        param = input_task_action.select({PARAM_DIM: block.config_as_str(PARAM_DIM)})
+        param = input_task_action.select({PARAM: block.config_as_str(PARAM)})
         if stat == "mean":
-            action = param.mean(dim=STEP_DIM)
+            action = param.mean(dim=STEP)
         elif stat == "std":
-            action = param.std(dim=STEP_DIM)
+            action = param.std(dim=STEP)
         elif stat == "min":
-            action = param.min(dim=STEP_DIM)
+            action = param.min(dim=STEP)
         elif stat == "max":
-            action = param.max(dim=STEP_DIM)
+            action = param.max(dim=STEP)
         else:
             return Either.error(f"Unsupported temporal statistic: {stat}")
         return Either.ok(action)
 
     def intersect(self, other: QubedOutput) -> bool:
-        return contains(other, STEP_DIM) and contains(other, PARAM_DIM)
+        return contains(other, STEP) and contains(other, PARAM)
 
 
 class ZarrSink(Sink):
@@ -305,14 +304,14 @@ class ZarrSink(Sink):
         return bool(dimensions(other))
 
 
-class SelectVariable(Transform):
-    title: str = "Select Variable"
-    description: str = "Select one variable from the input dataset"
+class SelectParameters(Transform):
+    title: str = "Select Parameters"
+    description: str = "Select parameters from the input dataset"
     configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {
-        VARIABLE: BlockConfigurationOption(
-            title="Variable",
-            description="Variable to select from the dataset",
-            value_type="str",
+        PARAM: BlockConfigurationOption(
+            title="Parameters",
+            description="Parameters to select from the dataset",
+            value_type="list[str]",
         )
     }
     inputs: list[str] = ["dataset"]
@@ -323,11 +322,11 @@ class SelectVariable(Transform):
             actual_type = type(input_dataset).__name__ if input_dataset is not None else "None"
             return Either.error(f"Unsupported input type for 'dataset': expected QubedOutput, got {actual_type}")
 
-        variable = block.config_as_str(VARIABLE)
-        if not contains(input_dataset, {PARAM_DIM: variable}):
-            return Either.error(f"variable {variable} is not in the input parameters: {axes(input_dataset).get(PARAM_DIM, [])}")
+        parameters = block.config_as_list(PARAM, str, allow_empty=False)
+        if not contains(input_dataset, {PARAM: parameters}):
+            return Either.error(f"parameters {parameters} are not in the input parameters: {axes(input_dataset).get(PARAM, [])}")
 
-        output = coxpand(input_dataset, PARAM_DIM, {PARAM_DIM: [variable]})
+        output = coxpand(input_dataset, PARAM, {PARAM: parameters})
         return Either.ok(output)
 
     def compile(
@@ -337,22 +336,111 @@ class SelectVariable(Transform):
         block: BlockInstance,
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         input_task = block.input_ids["dataset"]
-        selected = inputs[input_task].select({PARAM_DIM: block.config_as_str(VARIABLE)})
+        parameters = block.config_as_list(PARAM, str, allow_empty=False)
+        selected = inputs[input_task].select({PARAM: parameters if len(parameters) > 1 else parameters[0]})
         return Either.ok(selected)
 
     def restrictions(self, other: QubedOutput) -> ConfigurationOptionRestriction:
-        values = [value for value in axes(other).get(PARAM_DIM, set()) if isinstance(value, str)]
-        return {VARIABLE: ClosedEnumType(sorted(values))} if values else {}
+        values = [value for value in axes(other).get(PARAM, set()) if isinstance(value, str)]
+        return {PARAM: ClosedEnumListType(sorted(values))} if values else {}
 
     def intersect(self, other: QubedOutput) -> bool:
-        return contains(other, PARAM_DIM)
+        return contains(other, PARAM)
+
+
+class SelectSteps(Transform):
+    title: str = "Select Steps"
+    description: str = "Select forecast steps from the input dataset"
+    configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {
+        STEP: BlockConfigurationOption(
+            title="Steps",
+            description="Forecast steps to select from the dataset",
+            value_type="list[int]",
+        )
+    }
+    inputs: list[str] = ["dataset"]
+
+    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
+        input_dataset = inputs.get("dataset")
+        if not isinstance(input_dataset, QubedOutput):
+            actual_type = type(input_dataset).__name__ if input_dataset is not None else "None"
+            return Either.error(f"Unsupported input type for 'dataset': expected QubedOutput, got {actual_type}")
+
+        steps = block.config_as_list(STEP, int, allow_empty=False)
+        if not contains(input_dataset, {STEP: steps}):
+            return Either.error(f"steps {steps} are not in the input steps: {axes(input_dataset).get(STEP, [])}")
+
+        output = coxpand(input_dataset, STEP, {STEP: steps})
+        return Either.ok(output)
+
+    def compile(
+        self,
+        inputs: ActionLookup,
+        block_id: BlockInstanceId,
+        block: BlockInstance,
+    ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
+        input_task = block.input_ids["dataset"]
+        steps = block.config_as_list(STEP, int, allow_empty=False)
+        selected = inputs[input_task].select({STEP: steps if len(steps) > 1 else steps[0]})
+        return Either.ok(selected)
+
+    def restrictions(self, other: QubedOutput) -> ConfigurationOptionRestriction:
+        values = [value for value in axes(other).get(STEP, set()) if isinstance(value, int)]
+        return {STEP: ClosedEnumListType([str(value) for value in sorted(values)])} if values else {}
+
+    def intersect(self, other: QubedOutput) -> bool:
+        return contains(other, STEP)
+
+
+class SelectMembers(Transform):
+    title: str = "Select Members"
+    description: str = "Select ensemble members from the input dataset"
+    configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {
+        ENSEMBLE: BlockConfigurationOption(
+            title="Ensemble Members",
+            description="Ensemble members to select from the dataset",
+            value_type="list[int]",
+        )
+    }
+    inputs: list[str] = ["dataset"]
+
+    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
+        input_dataset = inputs.get("dataset")
+        if not isinstance(input_dataset, QubedOutput):
+            actual_type = type(input_dataset).__name__ if input_dataset is not None else "None"
+            return Either.error(f"Unsupported input type for 'dataset': expected QubedOutput, got {actual_type}")
+
+        members = block.config_as_list(ENSEMBLE, int, allow_empty=False)
+        if not contains(input_dataset, {ENSEMBLE: members}):
+            return Either.error(f"members {members} are not in the input members: {axes(input_dataset).get(ENSEMBLE, [])}")
+
+        output = coxpand(input_dataset, ENSEMBLE, {ENSEMBLE: members})
+        return Either.ok(output)
+
+    def compile(
+        self,
+        inputs: ActionLookup,
+        block_id: BlockInstanceId,
+        block: BlockInstance,
+    ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
+        input_task = block.input_ids["dataset"]
+        members = block.config_as_list(ENSEMBLE, int, allow_empty=False)
+        selected = inputs[input_task].select({ENSEMBLE: members if len(members) > 1 else members[0]})
+        return Either.ok(selected)
+
+    def restrictions(self, other: QubedOutput) -> ConfigurationOptionRestriction:
+        values = [value for value in axes(other).get(ENSEMBLE, set()) if isinstance(value, int)]
+        return {ENSEMBLE: ClosedEnumListType([str(value) for value in sorted(values)])} if values else {}
+
+    def intersect(self, other: QubedOutput) -> bool:
+        return contains(other, ENSEMBLE)
 
 
 class MapPlotSink(Sink):
     title: str = "Map Plot"
     description: str = "Render a geographic map using earthkit-plots"
     configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {
-        PARAM_DIM: BlockConfigurationOption(
+        PARAM: BlockConfigurationOption(
             title="Parameters",
             description="Parameters to select and plot (e.g. '2t', 'msl')",
             value_type="list[str]",
@@ -387,10 +475,10 @@ class MapPlotSink(Sink):
             actual_type = type(input_dataset).__name__ if input_dataset is not None else "None"
             return Either.error(f"Unsupported input type for 'dataset': expected QubedOutput, got {actual_type}")
 
-        params = block.config_as_list(PARAM_DIM, str, allow_empty=False)
-        missing = [p for p in params if not contains(input_dataset, {PARAM_DIM: p})]
+        params = block.config_as_list(PARAM, str, allow_empty=False)
+        missing = [p for p in params if not contains(input_dataset, {PARAM: p})]
         if missing:
-            return Either.error(f"params {missing} are not in the input parameters: {axes(input_dataset).get(PARAM_DIM, [])}")
+            return Either.error(f"params {missing} are not in the input parameters: {axes(input_dataset).get(PARAM, [])}")
 
         # Disabled for now
         # groupby_value = block.configuration_values["groupby"]
@@ -416,8 +504,8 @@ class MapPlotSink(Sink):
         block: BlockInstance,
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         input_task = block.input_ids["dataset"]
-        params = block.config_as_list(PARAM_DIM, str, allow_empty=False)
-        selected = inputs[input_task].select({PARAM_DIM: params if len(params) > 1 else params[0]})
+        params = block.config_as_list(PARAM, str, allow_empty=False)
+        selected = inputs[input_task].select({PARAM: params if len(params) > 1 else params[0]})
 
         # Disabled for now
         # groupby = block.configuration_values["groupby"] or "valid_datetime"
@@ -439,5 +527,9 @@ class MapPlotSink(Sink):
         )
         return Either.ok(action)
 
+    def restrictions(self, other: QubedOutput) -> ConfigurationOptionRestriction:
+        values = [value for value in axes(other).get(PARAM, set()) if isinstance(value, str)]
+        return {PARAM: ClosedEnumListType(sorted(values))} if values else {}
+
     def intersect(self, other: QubedOutput) -> bool:
-        return contains(other, PARAM_DIM)
+        return contains(other, PARAM)

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -27,7 +27,7 @@ from fiab_core.fable import (
 from fiab_core.plugin import Error
 from fiab_core.tools.blocks import BlockInstanceRich as BlockInstance
 from fiab_core.tools.blocks import Product, Sink, Source, Transform
-from fiab_core.types import ClosedEnumListType
+from fiab_core.types import ClosedEnumType, ListType
 from qubed import Qube
 
 from .qubed_utils import axes, contains, coxpand, dimensions
@@ -384,7 +384,7 @@ class SelectDimension(Transform):
 
     def restrictions(self, other: QubedOutput) -> ConfigurationOptionRestriction:
         values = self._restriction_value_strings(axes(other).get(self.option_id, set()))
-        return {self.option_id: ClosedEnumListType(values)} if values else {}
+        return {self.option_id: ListType(ClosedEnumType(values))} if values else {}
 
     def intersect(self, other: QubedOutput) -> bool:
         return contains(other, self.option_id)
@@ -483,7 +483,7 @@ class MapPlotSink(Sink):
 
     def restrictions(self, other: QubedOutput) -> ConfigurationOptionRestriction:
         values = [value for value in axes(other).get(PARAM, set()) if isinstance(value, str)]
-        return {PARAM: ClosedEnumListType(sorted(values))} if values else {}
+        return {PARAM: ListType(ClosedEnumType(sorted(values)))} if values else {}
 
     def intersect(self, other: QubedOutput) -> bool:
         return contains(other, PARAM)

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -8,6 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 import logging
+from typing import Any, ClassVar, cast
 
 import numpy as np
 from cascade.low.func import Either
@@ -304,9 +305,70 @@ class ZarrSink(Sink):
         return bool(dimensions(other))
 
 
-class SelectParameters(Transform):
+SelectAxisValue = str | int
+
+
+class _SelectDimension(Transform):
+    option_id: ClassVar[ConfigurationOptionId]
+    item_python_type: ClassVar[type[str] | type[int]]
+    selection_label: ClassVar[str]
+    inputs: list[str] = ["dataset"]
+
+    def _selected_values(self, block: BlockInstance) -> list[SelectAxisValue]:
+        if self.item_python_type is str:
+            return cast(list[SelectAxisValue], block.config_as_list(self.option_id, str, allow_empty=False))
+        if self.item_python_type is int:
+            return cast(list[SelectAxisValue], block.config_as_list(self.option_id, int, allow_empty=False))
+        raise TypeError(f"Unsupported select value type {self.item_python_type!r}")
+
+    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
+        input_dataset = inputs.get("dataset")
+        if not isinstance(input_dataset, QubedOutput):
+            actual_type = type(input_dataset).__name__ if input_dataset is not None else "None"
+            return Either.error(f"Unsupported input type for 'dataset': expected QubedOutput, got {actual_type}")
+
+        selected_values = self._selected_values(block)
+        if not contains(input_dataset, {self.option_id: selected_values}):
+            return Either.error(
+                f"{self.selection_label} {selected_values} are not in the input "
+                f"{self.selection_label}: {axes(input_dataset).get(self.option_id, [])}"
+            )
+
+        output = coxpand(input_dataset, self.option_id, {self.option_id: selected_values})
+        return Either.ok(output)
+
+    def compile(
+        self,
+        inputs: ActionLookup,
+        block_id: BlockInstanceId,
+        block: BlockInstance,
+    ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
+        input_task = block.input_ids["dataset"]
+        selected_values = self._selected_values(block)
+        selected = inputs[input_task].select({self.option_id: selected_values if len(selected_values) > 1 else selected_values[0]})
+        return Either.ok(selected)
+
+    def _restriction_value_strings(self, axis_values: set[Any]) -> list[str]:
+        if self.item_python_type is str:
+            return sorted(value for value in axis_values if isinstance(value, str))
+        if self.item_python_type is int:
+            return [str(value) for value in sorted(value for value in axis_values if type(value) is int)]
+        raise TypeError(f"Unsupported select value type {self.item_python_type!r}")
+
+    def restrictions(self, other: QubedOutput) -> ConfigurationOptionRestriction:
+        values = self._restriction_value_strings(axes(other).get(self.option_id, set()))
+        return {self.option_id: ClosedEnumListType(values)} if values else {}
+
+    def intersect(self, other: QubedOutput) -> bool:
+        return contains(other, self.option_id)
+
+
+class SelectParameters(_SelectDimension):
     title: str = "Select Parameters"
     description: str = "Select parameters from the input dataset"
+    option_id: ClassVar[ConfigurationOptionId] = PARAM
+    item_python_type: ClassVar[type[str] | type[int]] = str
+    selection_label: ClassVar[str] = "parameters"
     configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {
         PARAM: BlockConfigurationOption(
             title="Parameters",
@@ -314,43 +376,14 @@ class SelectParameters(Transform):
             value_type="list[str]",
         )
     }
-    inputs: list[str] = ["dataset"]
-
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
-        input_dataset = inputs.get("dataset")
-        if not isinstance(input_dataset, QubedOutput):
-            actual_type = type(input_dataset).__name__ if input_dataset is not None else "None"
-            return Either.error(f"Unsupported input type for 'dataset': expected QubedOutput, got {actual_type}")
-
-        parameters = block.config_as_list(PARAM, str, allow_empty=False)
-        if not contains(input_dataset, {PARAM: parameters}):
-            return Either.error(f"parameters {parameters} are not in the input parameters: {axes(input_dataset).get(PARAM, [])}")
-
-        output = coxpand(input_dataset, PARAM, {PARAM: parameters})
-        return Either.ok(output)
-
-    def compile(
-        self,
-        inputs: ActionLookup,
-        block_id: BlockInstanceId,
-        block: BlockInstance,
-    ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
-        input_task = block.input_ids["dataset"]
-        parameters = block.config_as_list(PARAM, str, allow_empty=False)
-        selected = inputs[input_task].select({PARAM: parameters if len(parameters) > 1 else parameters[0]})
-        return Either.ok(selected)
-
-    def restrictions(self, other: QubedOutput) -> ConfigurationOptionRestriction:
-        values = [value for value in axes(other).get(PARAM, set()) if isinstance(value, str)]
-        return {PARAM: ClosedEnumListType(sorted(values))} if values else {}
-
-    def intersect(self, other: QubedOutput) -> bool:
-        return contains(other, PARAM)
 
 
-class SelectSteps(Transform):
+class SelectSteps(_SelectDimension):
     title: str = "Select Steps"
     description: str = "Select forecast steps from the input dataset"
+    option_id: ClassVar[ConfigurationOptionId] = STEP
+    item_python_type: ClassVar[type[str] | type[int]] = int
+    selection_label: ClassVar[str] = "steps"
     configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {
         STEP: BlockConfigurationOption(
             title="Steps",
@@ -358,43 +391,14 @@ class SelectSteps(Transform):
             value_type="list[int]",
         )
     }
-    inputs: list[str] = ["dataset"]
-
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
-        input_dataset = inputs.get("dataset")
-        if not isinstance(input_dataset, QubedOutput):
-            actual_type = type(input_dataset).__name__ if input_dataset is not None else "None"
-            return Either.error(f"Unsupported input type for 'dataset': expected QubedOutput, got {actual_type}")
-
-        steps = block.config_as_list(STEP, int, allow_empty=False)
-        if not contains(input_dataset, {STEP: steps}):
-            return Either.error(f"steps {steps} are not in the input steps: {axes(input_dataset).get(STEP, [])}")
-
-        output = coxpand(input_dataset, STEP, {STEP: steps})
-        return Either.ok(output)
-
-    def compile(
-        self,
-        inputs: ActionLookup,
-        block_id: BlockInstanceId,
-        block: BlockInstance,
-    ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
-        input_task = block.input_ids["dataset"]
-        steps = block.config_as_list(STEP, int, allow_empty=False)
-        selected = inputs[input_task].select({STEP: steps if len(steps) > 1 else steps[0]})
-        return Either.ok(selected)
-
-    def restrictions(self, other: QubedOutput) -> ConfigurationOptionRestriction:
-        values = [value for value in axes(other).get(STEP, set()) if isinstance(value, int)]
-        return {STEP: ClosedEnumListType([str(value) for value in sorted(values)])} if values else {}
-
-    def intersect(self, other: QubedOutput) -> bool:
-        return contains(other, STEP)
 
 
-class SelectMembers(Transform):
+class SelectMembers(_SelectDimension):
     title: str = "Select Members"
     description: str = "Select ensemble members from the input dataset"
+    option_id: ClassVar[ConfigurationOptionId] = ENSEMBLE
+    item_python_type: ClassVar[type[str] | type[int]] = int
+    selection_label: ClassVar[str] = "members"
     configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {
         ENSEMBLE: BlockConfigurationOption(
             title="Ensemble Members",
@@ -402,38 +406,6 @@ class SelectMembers(Transform):
             value_type="list[int]",
         )
     }
-    inputs: list[str] = ["dataset"]
-
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
-        input_dataset = inputs.get("dataset")
-        if not isinstance(input_dataset, QubedOutput):
-            actual_type = type(input_dataset).__name__ if input_dataset is not None else "None"
-            return Either.error(f"Unsupported input type for 'dataset': expected QubedOutput, got {actual_type}")
-
-        members = block.config_as_list(ENSEMBLE, int, allow_empty=False)
-        if not contains(input_dataset, {ENSEMBLE: members}):
-            return Either.error(f"members {members} are not in the input members: {axes(input_dataset).get(ENSEMBLE, [])}")
-
-        output = coxpand(input_dataset, ENSEMBLE, {ENSEMBLE: members})
-        return Either.ok(output)
-
-    def compile(
-        self,
-        inputs: ActionLookup,
-        block_id: BlockInstanceId,
-        block: BlockInstance,
-    ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
-        input_task = block.input_ids["dataset"]
-        members = block.config_as_list(ENSEMBLE, int, allow_empty=False)
-        selected = inputs[input_task].select({ENSEMBLE: members if len(members) > 1 else members[0]})
-        return Either.ok(selected)
-
-    def restrictions(self, other: QubedOutput) -> ConfigurationOptionRestriction:
-        values = [value for value in axes(other).get(ENSEMBLE, set()) if isinstance(value, int)]
-        return {ENSEMBLE: ClosedEnumListType([str(value) for value in sorted(values)])} if values else {}
-
-    def intersect(self, other: QubedOutput) -> bool:
-        return contains(other, ENSEMBLE)
 
 
 class MapPlotSink(Sink):

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -149,7 +149,7 @@ class EkdSource(Source):
                                     "date": block.config_as_date(DATE).isoformat(),
                                     "expver": block.config_as_str(EXPVER),
                                     PARAM: p,
-                                    ENSEMBLE: number,
+                                    ENSEMBLE: ensemble,
                                     STEP: step,
                                 }
                             },

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -31,11 +31,17 @@ from qubed import Qube
 from fiab_plugin_ecmwf import plugin
 from fiab_plugin_ecmwf.anemoi.utils import get_checkpoint_enum_type
 from fiab_plugin_ecmwf.blocks import (
-    VARIABLE,
+    ENSEMBLE,
+    ENSEMBLE_DIM,
+    PARAM_DIM,
+    STEP,
+    STEP_DIM,
     EkdSource,
     EnsembleStatistics,
     MapPlotSink,
-    SelectVariable,
+    SelectMembers,
+    SelectParameters,
+    SelectSteps,
     TemporalStatistics,
     ZarrSink,
 )
@@ -133,18 +139,50 @@ def temporal_statistics_configuration() -> BlockInstance:
 
 
 @pytest.fixture
-def select_variable_configuration() -> BlockInstance:
+def select_parameters_configuration() -> BlockInstance:
     return BlockInstance.from_block(
         BlockInstanceBase(
-            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="SelectVariable"),  # type: ignore
+            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="SelectParameters"),  # type: ignore
             input_ids={"dataset": BlockInstanceId("source_output")},
             configuration_values=_config(
                 {
-                    "variable": "2t",
+                    "param": ["2t"],
                 }
             ),
         ),
-        SelectVariable.configuration_options,
+        SelectParameters.configuration_options,
+    )
+
+
+@pytest.fixture
+def select_steps_configuration() -> BlockInstance:
+    return BlockInstance.from_block(
+        BlockInstanceBase(
+            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="SelectSteps"),  # type: ignore
+            input_ids={"dataset": BlockInstanceId("source_output")},
+            configuration_values=_config(
+                {
+                    "step": [0],
+                }
+            ),
+        ),
+        SelectSteps.configuration_options,
+    )
+
+
+@pytest.fixture
+def select_members_configuration() -> BlockInstance:
+    return BlockInstance.from_block(
+        BlockInstanceBase(
+            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="SelectMembers"),  # type: ignore
+            input_ids={"dataset": BlockInstanceId("source_output")},
+            configuration_values=_config(
+                {
+                    "number": [1],
+                }
+            ),
+        ),
+        SelectMembers.configuration_options,
     )
 
 
@@ -360,48 +398,203 @@ class TestZarrSink:
         assert isinstance(output, NoOutput)
 
 
-class TestSelectVariable:
+class TestSelectParameters:
     def test_catalogue_value_type_is_canonical(self) -> None:
-        assert SelectVariable.configuration_options[VARIABLE].value_type == "str"
+        assert SelectParameters.configuration_options[PARAM_DIM].value_type == "list[str]"
 
-    def test_from_ekdsource(self, select_variable_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
-        block = SelectVariable()
+    def test_from_ekdsource(self, select_parameters_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
+        block = SelectParameters()
         assert block.intersect(other=ekdsource_output)  # type: ignore[arg-type]
-        output = block.validate(block=select_variable_configuration, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
+        output = block.validate(block=select_parameters_configuration, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
         assert isinstance(output, QubedOutput)
         assert output.dataqube is not None
         assert axes(output)["param"] == {"2t"}
 
-    def test_missing_variable(self, select_variable_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
-        block = SelectVariable()
-        config = select_variable_configuration.model_copy(update={"configuration_values": _config({"variable": "nonexistent"})})
+    def test_from_ekdsource_multiple_parameters(
+        self, select_parameters_configuration: BlockInstance, ekdsource_output: QubedOutput
+    ) -> None:
+        block = SelectParameters()
+        config = select_parameters_configuration.model_copy(update={"configuration_values": _config({"param": ["2t", "msl"]})})
+        output = block.validate(block=config, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
+        assert axes(output)["param"] == {"2t", "msl"}
+
+    def test_missing_parameters(self, select_parameters_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
+        block = SelectParameters()
+        config = select_parameters_configuration.model_copy(update={"configuration_values": _config({"param": ["nonexistent"]})})
         result = block.validate(block=config, inputs={"dataset": ekdsource_output})  # type: ignore[dict-item]
-        with pytest.raises(Exception, match="variable nonexistent is not in the input parameters"):
+        with pytest.raises(Exception, match="parameters \\['nonexistent'\\] are not in the input parameters"):
             result.get_or_raise()
 
-    def test_compile_calls_select(self, select_variable_configuration: BlockInstance) -> None:
-        block = SelectVariable()
+    def test_compile_calls_select(self, select_parameters_configuration: BlockInstance) -> None:
+        block = SelectParameters()
         input_action = MagicMock()
         selected_action = MagicMock()
         input_action.select.return_value = selected_action
 
         result = block.compile(
             inputs={BlockInstanceId("source_output"): input_action},  # type: ignore[dict-item]
-            block_id=BlockInstanceId("select_variable"),
-            block=select_variable_configuration,
+            block_id=BlockInstanceId("select_parameters"),
+            block=select_parameters_configuration,
         )
         assert result.t is selected_action
         input_action.select.assert_called_once_with({ConfigurationOptionId("param"): "2t"})
 
-    def test_expander_adds_variable_restrictions(self, ekdsource_output: QubedOutput) -> None:
+    def test_compile_calls_select_with_multiple_parameters(self, select_parameters_configuration: BlockInstance) -> None:
+        block = SelectParameters()
+        input_action = MagicMock()
+        selected_action = MagicMock()
+        input_action.select.return_value = selected_action
+        config = select_parameters_configuration.model_copy(update={"configuration_values": _config({"param": ["2t", "msl"]})})
+
+        result = block.compile(
+            inputs={BlockInstanceId("source_output"): input_action},  # type: ignore[dict-item]
+            block_id=BlockInstanceId("select_parameters"),
+            block=config,
+        )
+        assert result.t is selected_action
+        input_action.select.assert_called_once_with({ConfigurationOptionId("param"): ["2t", "msl"]})
+
+    def test_expander_adds_parameters_restrictions(self, ekdsource_output: QubedOutput) -> None:
         expansions = plugin().expander(ekdsource_output)
-        select_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("selectVariable"))
-        assert select_expansion.restrictions[VARIABLE].serialize() == "enumClosed[2t,msl]"
+        select_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("selectParameters"))
+        assert select_expansion.restrictions[PARAM_DIM].serialize() == "list[enumClosed[2t,msl]]"
 
     def test_expander_skips_restriction_for_non_string_axes(self) -> None:
         output = QubedOutput(dataqube=Qube.from_datacube({"param": [1, 2]}))
         expansions = plugin().expander(output)
-        select_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("selectVariable"))
+        select_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("selectParameters"))
+        assert select_expansion.restrictions == {}
+
+
+class TestSelectSteps:
+    def test_catalogue_value_type_is_canonical(self) -> None:
+        assert SelectSteps.configuration_options[STEP].value_type == "list[int]"
+
+    def test_from_ekdsource(self, select_steps_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
+        block = SelectSteps()
+        assert block.intersect(other=ekdsource_output)  # type: ignore[arg-type]
+        output = block.validate(block=select_steps_configuration, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
+        assert isinstance(output, QubedOutput)
+        assert output.dataqube is not None
+        assert axes(output)[STEP_DIM] == {0}
+
+    def test_from_ekdsource_multiple_steps(self, select_steps_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
+        block = SelectSteps()
+        config = select_steps_configuration.model_copy(update={"configuration_values": _config({"step": [0, 6]})})
+        output = block.validate(block=config, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
+        assert axes(output)[STEP_DIM] == {0, 6}
+
+    def test_missing_steps(self, select_steps_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
+        block = SelectSteps()
+        config = select_steps_configuration.model_copy(update={"configuration_values": _config({"step": [999]})})
+        result = block.validate(block=config, inputs={"dataset": ekdsource_output})  # type: ignore[dict-item]
+        with pytest.raises(Exception, match="steps \\[999\\] are not in the input steps"):
+            result.get_or_raise()
+
+    def test_compile_calls_select(self, select_steps_configuration: BlockInstance) -> None:
+        block = SelectSteps()
+        input_action = MagicMock()
+        selected_action = MagicMock()
+        input_action.select.return_value = selected_action
+
+        result = block.compile(
+            inputs={BlockInstanceId("source_output"): input_action},  # type: ignore[dict-item]
+            block_id=BlockInstanceId("select_steps"),
+            block=select_steps_configuration,
+        )
+        assert result.t is selected_action
+        input_action.select.assert_called_once_with({STEP_DIM: 0})
+
+    def test_compile_calls_select_with_multiple_steps(self, select_steps_configuration: BlockInstance) -> None:
+        block = SelectSteps()
+        input_action = MagicMock()
+        selected_action = MagicMock()
+        input_action.select.return_value = selected_action
+        config = select_steps_configuration.model_copy(update={"configuration_values": _config({"step": [0, 6]})})
+
+        result = block.compile(
+            inputs={BlockInstanceId("source_output"): input_action},  # type: ignore[dict-item]
+            block_id=BlockInstanceId("select_steps"),
+            block=config,
+        )
+        assert result.t is selected_action
+        input_action.select.assert_called_once_with({STEP_DIM: [0, 6]})
+
+    def test_expander_adds_step_restrictions(self, ekdsource_output: QubedOutput) -> None:
+        expansions = plugin().expander(ekdsource_output)
+        select_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("selectSteps"))
+        assert select_expansion.restrictions[STEP].serialize() == "list[enumClosed[0,6,12]]"
+
+    def test_expander_skips_restriction_for_non_int_axes(self) -> None:
+        output = QubedOutput(dataqube=Qube.from_datacube({STEP_DIM: ["0", "6"]}))
+        expansions = plugin().expander(output)
+        select_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("selectSteps"))
+        assert select_expansion.restrictions == {}
+
+
+class TestSelectMembers:
+    def test_catalogue_value_type_is_canonical(self) -> None:
+        assert SelectMembers.configuration_options[ENSEMBLE].value_type == "list[int]"
+
+    def test_from_ekdsource(self, select_members_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
+        block = SelectMembers()
+        assert block.intersect(other=ekdsource_output)  # type: ignore[arg-type]
+        output = block.validate(block=select_members_configuration, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
+        assert isinstance(output, QubedOutput)
+        assert output.dataqube is not None
+        assert axes(output)[ENSEMBLE_DIM] == {1}
+
+    def test_from_ekdsource_multiple_members(self, select_members_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
+        block = SelectMembers()
+        config = select_members_configuration.model_copy(update={"configuration_values": _config({"number": [1, 2]})})
+        output = block.validate(block=config, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
+        assert axes(output)[ENSEMBLE_DIM] == {1, 2}
+
+    def test_missing_members(self, select_members_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
+        block = SelectMembers()
+        config = select_members_configuration.model_copy(update={"configuration_values": _config({"number": [999]})})
+        result = block.validate(block=config, inputs={"dataset": ekdsource_output})  # type: ignore[dict-item]
+        with pytest.raises(Exception, match="members \\[999\\] are not in the input members"):
+            result.get_or_raise()
+
+    def test_compile_calls_select(self, select_members_configuration: BlockInstance) -> None:
+        block = SelectMembers()
+        input_action = MagicMock()
+        selected_action = MagicMock()
+        input_action.select.return_value = selected_action
+
+        result = block.compile(
+            inputs={BlockInstanceId("source_output"): input_action},  # type: ignore[dict-item]
+            block_id=BlockInstanceId("select_members"),
+            block=select_members_configuration,
+        )
+        assert result.t is selected_action
+        input_action.select.assert_called_once_with({ENSEMBLE_DIM: 1})
+
+    def test_compile_calls_select_with_multiple_members(self, select_members_configuration: BlockInstance) -> None:
+        block = SelectMembers()
+        input_action = MagicMock()
+        selected_action = MagicMock()
+        input_action.select.return_value = selected_action
+        config = select_members_configuration.model_copy(update={"configuration_values": _config({"number": [1, 2]})})
+
+        result = block.compile(
+            inputs={BlockInstanceId("source_output"): input_action},  # type: ignore[dict-item]
+            block_id=BlockInstanceId("select_members"),
+            block=config,
+        )
+        assert result.t is selected_action
+        input_action.select.assert_called_once_with({ENSEMBLE_DIM: [1, 2]})
+
+    def test_expander_adds_member_restrictions(self, ekdsource_output: QubedOutput) -> None:
+        expansions = plugin().expander(ekdsource_output)
+        select_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("selectMembers"))
+        assert select_expansion.restrictions[ENSEMBLE].serialize() == "list[enumClosed[1,2,3,4,5]]"
+
+    def test_expander_skips_restriction_for_non_int_axes(self) -> None:
+        output = QubedOutput(dataqube=Qube.from_datacube({ENSEMBLE_DIM: ["1", "2"]}))
+        expansions = plugin().expander(output)
+        select_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("selectMembers"))
         assert select_expansion.restrictions == {}
 
 
@@ -422,6 +615,17 @@ class TestMapPlotSink:
         block = MapPlotSink()
         collapsed = collapse(ekdsource_output, "param")
         assert not block.intersect(other=collapsed)  # type: ignore[arg-type]
+
+    def test_expander_adds_parameters_restrictions(self, ekdsource_output: QubedOutput) -> None:
+        expansions = plugin().expander(ekdsource_output)
+        map_plot_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("mapPlotSink"))
+        assert map_plot_expansion.restrictions[PARAM_DIM].serialize() == "list[enumClosed[2t,msl]]"
+
+    def test_expander_skips_restriction_for_non_string_axes(self) -> None:
+        output = QubedOutput(dataqube=Qube.from_datacube({"param": [1, 2]}))
+        expansions = plugin().expander(output)
+        map_plot_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("mapPlotSink"))
+        assert map_plot_expansion.restrictions == {}
 
     def test_validate_from_ekdsource(self, map_plot_sink_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
         block = MapPlotSink()

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -414,6 +414,7 @@ class TestSelectParameters:
         block = SelectParameters()
         config = select_parameters_configuration.model_copy(update={"configuration_values": _config({"param": ["2t", "msl"]})})
         output = block.validate(block=config, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
+        assert isinstance(output, QubedOutput)
         assert axes(output)["param"] == {"2t", "msl"}
 
     def test_missing_parameters(self, select_parameters_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
@@ -480,6 +481,7 @@ class TestSelectSteps:
         block = SelectSteps()
         config = select_steps_configuration.model_copy(update={"configuration_values": _config({"step": [0, 6]})})
         output = block.validate(block=config, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
+        assert isinstance(output, QubedOutput)
         assert axes(output)[STEP] == {0, 6}
 
     def test_missing_steps(self, select_steps_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
@@ -546,6 +548,7 @@ class TestSelectMembers:
         block = SelectMembers()
         config = select_members_configuration.model_copy(update={"configuration_values": _config({"number": [1, 2]})})
         output = block.validate(block=config, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
+        assert isinstance(output, QubedOutput)
         assert axes(output)[ENSEMBLE] == {1, 2}
 
     def test_missing_members(self, select_members_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -32,10 +32,8 @@ from fiab_plugin_ecmwf import plugin
 from fiab_plugin_ecmwf.anemoi.utils import get_checkpoint_enum_type
 from fiab_plugin_ecmwf.blocks import (
     ENSEMBLE,
-    ENSEMBLE_DIM,
-    PARAM_DIM,
+    PARAM,
     STEP,
-    STEP_DIM,
     EkdSource,
     EnsembleStatistics,
     MapPlotSink,
@@ -400,7 +398,7 @@ class TestZarrSink:
 
 class TestSelectParameters:
     def test_catalogue_value_type_is_canonical(self) -> None:
-        assert SelectParameters.configuration_options[PARAM_DIM].value_type == "list[str]"
+        assert SelectParameters.configuration_options[PARAM].value_type == "list[str]"
 
     def test_from_ekdsource(self, select_parameters_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
         block = SelectParameters()
@@ -457,7 +455,7 @@ class TestSelectParameters:
     def test_expander_adds_parameters_restrictions(self, ekdsource_output: QubedOutput) -> None:
         expansions = plugin().expander(ekdsource_output)
         select_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("selectParameters"))
-        assert select_expansion.restrictions[PARAM_DIM].serialize() == "list[enumClosed[2t,msl]]"
+        assert select_expansion.restrictions[PARAM].serialize() == "list[enumClosed[2t,msl]]"
 
     def test_expander_skips_restriction_for_non_string_axes(self) -> None:
         output = QubedOutput(dataqube=Qube.from_datacube({"param": [1, 2]}))
@@ -476,13 +474,13 @@ class TestSelectSteps:
         output = block.validate(block=select_steps_configuration, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
         assert isinstance(output, QubedOutput)
         assert output.dataqube is not None
-        assert axes(output)[STEP_DIM] == {0}
+        assert axes(output)[STEP] == {0}
 
     def test_from_ekdsource_multiple_steps(self, select_steps_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
         block = SelectSteps()
         config = select_steps_configuration.model_copy(update={"configuration_values": _config({"step": [0, 6]})})
         output = block.validate(block=config, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
-        assert axes(output)[STEP_DIM] == {0, 6}
+        assert axes(output)[STEP] == {0, 6}
 
     def test_missing_steps(self, select_steps_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
         block = SelectSteps()
@@ -503,7 +501,7 @@ class TestSelectSteps:
             block=select_steps_configuration,
         )
         assert result.t is selected_action
-        input_action.select.assert_called_once_with({STEP_DIM: 0})
+        input_action.select.assert_called_once_with({STEP: 0})
 
     def test_compile_calls_select_with_multiple_steps(self, select_steps_configuration: BlockInstance) -> None:
         block = SelectSteps()
@@ -518,7 +516,7 @@ class TestSelectSteps:
             block=config,
         )
         assert result.t is selected_action
-        input_action.select.assert_called_once_with({STEP_DIM: [0, 6]})
+        input_action.select.assert_called_once_with({STEP: [0, 6]})
 
     def test_expander_adds_step_restrictions(self, ekdsource_output: QubedOutput) -> None:
         expansions = plugin().expander(ekdsource_output)
@@ -526,7 +524,7 @@ class TestSelectSteps:
         assert select_expansion.restrictions[STEP].serialize() == "list[enumClosed[0,6,12]]"
 
     def test_expander_skips_restriction_for_non_int_axes(self) -> None:
-        output = QubedOutput(dataqube=Qube.from_datacube({STEP_DIM: ["0", "6"]}))
+        output = QubedOutput(dataqube=Qube.from_datacube({STEP: ["0", "6"]}))
         expansions = plugin().expander(output)
         select_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("selectSteps"))
         assert select_expansion.restrictions == {}
@@ -542,13 +540,13 @@ class TestSelectMembers:
         output = block.validate(block=select_members_configuration, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
         assert isinstance(output, QubedOutput)
         assert output.dataqube is not None
-        assert axes(output)[ENSEMBLE_DIM] == {1}
+        assert axes(output)[ENSEMBLE] == {1}
 
     def test_from_ekdsource_multiple_members(self, select_members_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
         block = SelectMembers()
         config = select_members_configuration.model_copy(update={"configuration_values": _config({"number": [1, 2]})})
         output = block.validate(block=config, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
-        assert axes(output)[ENSEMBLE_DIM] == {1, 2}
+        assert axes(output)[ENSEMBLE] == {1, 2}
 
     def test_missing_members(self, select_members_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
         block = SelectMembers()
@@ -569,7 +567,7 @@ class TestSelectMembers:
             block=select_members_configuration,
         )
         assert result.t is selected_action
-        input_action.select.assert_called_once_with({ENSEMBLE_DIM: 1})
+        input_action.select.assert_called_once_with({ENSEMBLE: 1})
 
     def test_compile_calls_select_with_multiple_members(self, select_members_configuration: BlockInstance) -> None:
         block = SelectMembers()
@@ -584,7 +582,7 @@ class TestSelectMembers:
             block=config,
         )
         assert result.t is selected_action
-        input_action.select.assert_called_once_with({ENSEMBLE_DIM: [1, 2]})
+        input_action.select.assert_called_once_with({ENSEMBLE: [1, 2]})
 
     def test_expander_adds_member_restrictions(self, ekdsource_output: QubedOutput) -> None:
         expansions = plugin().expander(ekdsource_output)
@@ -592,7 +590,7 @@ class TestSelectMembers:
         assert select_expansion.restrictions[ENSEMBLE].serialize() == "list[enumClosed[1,2,3,4,5]]"
 
     def test_expander_skips_restriction_for_non_int_axes(self) -> None:
-        output = QubedOutput(dataqube=Qube.from_datacube({ENSEMBLE_DIM: ["1", "2"]}))
+        output = QubedOutput(dataqube=Qube.from_datacube({ENSEMBLE: ["1", "2"]}))
         expansions = plugin().expander(output)
         select_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("selectMembers"))
         assert select_expansion.restrictions == {}
@@ -619,7 +617,7 @@ class TestMapPlotSink:
     def test_expander_adds_parameters_restrictions(self, ekdsource_output: QubedOutput) -> None:
         expansions = plugin().expander(ekdsource_output)
         map_plot_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("mapPlotSink"))
-        assert map_plot_expansion.restrictions[PARAM_DIM].serialize() == "list[enumClosed[2t,msl]]"
+        assert map_plot_expansion.restrictions[PARAM].serialize() == "list[enumClosed[2t,msl]]"
 
     def test_expander_skips_restriction_for_non_string_axes(self) -> None:
         output = QubedOutput(dataqube=Qube.from_datacube({"param": [1, 2]}))

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -26,8 +26,10 @@ from fiab_core.fable import (
     BlockInstance as BlockInstanceBase,
 )
 from fiab_core.tools.blocks import BlockInstanceRich as BlockInstance
+from fiab_core.tools.blocks import QubedBlockBuilder
 from qubed import Qube
 
+from fiab_plugin_ecmwf import blocks as ecmwf_block_builders
 from fiab_plugin_ecmwf import plugin
 from fiab_plugin_ecmwf.anemoi.utils import get_checkpoint_enum_type
 from fiab_plugin_ecmwf.blocks import (
@@ -37,9 +39,7 @@ from fiab_plugin_ecmwf.blocks import (
     EkdSource,
     EnsembleStatistics,
     MapPlotSink,
-    SelectMembers,
-    SelectParameters,
-    SelectSteps,
+    SelectDimension,
     TemporalStatistics,
     ZarrSink,
 )
@@ -48,6 +48,28 @@ from fiab_plugin_ecmwf.qubed_utils import axes, collapse, contains
 
 def _config(values: dict[str, object]) -> dict[ConfigurationOptionId, object]:
     return {ConfigurationOptionId(key): value for key, value in values.items()}
+
+
+def _block_builder(factory_id: str) -> QubedBlockBuilder:
+    return ecmwf_block_builders[BlockFactoryId(factory_id)]
+
+
+def _select_parameters() -> SelectDimension:
+    block = _block_builder("selectParameters")
+    assert isinstance(block, SelectDimension)
+    return block
+
+
+def _select_steps() -> SelectDimension:
+    block = _block_builder("selectSteps")
+    assert isinstance(block, SelectDimension)
+    return block
+
+
+def _select_members() -> SelectDimension:
+    block = _block_builder("selectMembers")
+    assert isinstance(block, SelectDimension)
+    return block
 
 
 @pytest.fixture
@@ -140,7 +162,7 @@ def temporal_statistics_configuration() -> BlockInstance:
 def select_parameters_configuration() -> BlockInstance:
     return BlockInstance.from_block(
         BlockInstanceBase(
-            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="SelectParameters"),  # type: ignore
+            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="selectParameters"),  # type: ignore
             input_ids={"dataset": BlockInstanceId("source_output")},
             configuration_values=_config(
                 {
@@ -148,7 +170,7 @@ def select_parameters_configuration() -> BlockInstance:
                 }
             ),
         ),
-        SelectParameters.configuration_options,
+        _select_parameters().configuration_options,
     )
 
 
@@ -156,7 +178,7 @@ def select_parameters_configuration() -> BlockInstance:
 def select_steps_configuration() -> BlockInstance:
     return BlockInstance.from_block(
         BlockInstanceBase(
-            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="SelectSteps"),  # type: ignore
+            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="selectSteps"),  # type: ignore
             input_ids={"dataset": BlockInstanceId("source_output")},
             configuration_values=_config(
                 {
@@ -164,7 +186,7 @@ def select_steps_configuration() -> BlockInstance:
                 }
             ),
         ),
-        SelectSteps.configuration_options,
+        _select_steps().configuration_options,
     )
 
 
@@ -172,7 +194,7 @@ def select_steps_configuration() -> BlockInstance:
 def select_members_configuration() -> BlockInstance:
     return BlockInstance.from_block(
         BlockInstanceBase(
-            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="SelectMembers"),  # type: ignore
+            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="selectMembers"),  # type: ignore
             input_ids={"dataset": BlockInstanceId("source_output")},
             configuration_values=_config(
                 {
@@ -180,7 +202,7 @@ def select_members_configuration() -> BlockInstance:
                 }
             ),
         ),
-        SelectMembers.configuration_options,
+        _select_members().configuration_options,
     )
 
 
@@ -398,10 +420,10 @@ class TestZarrSink:
 
 class TestSelectParameters:
     def test_catalogue_value_type_is_canonical(self) -> None:
-        assert SelectParameters.configuration_options[PARAM].value_type == "list[str]"
+        assert _select_parameters().configuration_options[PARAM].value_type == "list[str]"
 
     def test_from_ekdsource(self, select_parameters_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
-        block = SelectParameters()
+        block = _select_parameters()
         assert block.intersect(other=ekdsource_output)  # type: ignore[arg-type]
         output = block.validate(block=select_parameters_configuration, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
         assert isinstance(output, QubedOutput)
@@ -411,21 +433,21 @@ class TestSelectParameters:
     def test_from_ekdsource_multiple_parameters(
         self, select_parameters_configuration: BlockInstance, ekdsource_output: QubedOutput
     ) -> None:
-        block = SelectParameters()
+        block = _select_parameters()
         config = select_parameters_configuration.model_copy(update={"configuration_values": _config({"param": ["2t", "msl"]})})
         output = block.validate(block=config, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
         assert isinstance(output, QubedOutput)
         assert axes(output)["param"] == {"2t", "msl"}
 
     def test_missing_parameters(self, select_parameters_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
-        block = SelectParameters()
+        block = _select_parameters()
         config = select_parameters_configuration.model_copy(update={"configuration_values": _config({"param": ["nonexistent"]})})
         result = block.validate(block=config, inputs={"dataset": ekdsource_output})  # type: ignore[dict-item]
         with pytest.raises(Exception, match="parameters \\['nonexistent'\\] are not in the input parameters"):
             result.get_or_raise()
 
     def test_compile_calls_select(self, select_parameters_configuration: BlockInstance) -> None:
-        block = SelectParameters()
+        block = _select_parameters()
         input_action = MagicMock()
         selected_action = MagicMock()
         input_action.select.return_value = selected_action
@@ -439,7 +461,7 @@ class TestSelectParameters:
         input_action.select.assert_called_once_with({ConfigurationOptionId("param"): "2t"})
 
     def test_compile_calls_select_with_multiple_parameters(self, select_parameters_configuration: BlockInstance) -> None:
-        block = SelectParameters()
+        block = _select_parameters()
         input_action = MagicMock()
         selected_action = MagicMock()
         input_action.select.return_value = selected_action
@@ -467,10 +489,10 @@ class TestSelectParameters:
 
 class TestSelectSteps:
     def test_catalogue_value_type_is_canonical(self) -> None:
-        assert SelectSteps.configuration_options[STEP].value_type == "list[int]"
+        assert _select_steps().configuration_options[STEP].value_type == "list[int]"
 
     def test_from_ekdsource(self, select_steps_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
-        block = SelectSteps()
+        block = _select_steps()
         assert block.intersect(other=ekdsource_output)  # type: ignore[arg-type]
         output = block.validate(block=select_steps_configuration, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
         assert isinstance(output, QubedOutput)
@@ -478,21 +500,21 @@ class TestSelectSteps:
         assert axes(output)[STEP] == {0}
 
     def test_from_ekdsource_multiple_steps(self, select_steps_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
-        block = SelectSteps()
+        block = _select_steps()
         config = select_steps_configuration.model_copy(update={"configuration_values": _config({"step": [0, 6]})})
         output = block.validate(block=config, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
         assert isinstance(output, QubedOutput)
         assert axes(output)[STEP] == {0, 6}
 
     def test_missing_steps(self, select_steps_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
-        block = SelectSteps()
+        block = _select_steps()
         config = select_steps_configuration.model_copy(update={"configuration_values": _config({"step": [999]})})
         result = block.validate(block=config, inputs={"dataset": ekdsource_output})  # type: ignore[dict-item]
         with pytest.raises(Exception, match="steps \\[999\\] are not in the input steps"):
             result.get_or_raise()
 
     def test_compile_calls_select(self, select_steps_configuration: BlockInstance) -> None:
-        block = SelectSteps()
+        block = _select_steps()
         input_action = MagicMock()
         selected_action = MagicMock()
         input_action.select.return_value = selected_action
@@ -506,7 +528,7 @@ class TestSelectSteps:
         input_action.select.assert_called_once_with({STEP: 0})
 
     def test_compile_calls_select_with_multiple_steps(self, select_steps_configuration: BlockInstance) -> None:
-        block = SelectSteps()
+        block = _select_steps()
         input_action = MagicMock()
         selected_action = MagicMock()
         input_action.select.return_value = selected_action
@@ -534,10 +556,10 @@ class TestSelectSteps:
 
 class TestSelectMembers:
     def test_catalogue_value_type_is_canonical(self) -> None:
-        assert SelectMembers.configuration_options[ENSEMBLE].value_type == "list[int]"
+        assert _select_members().configuration_options[ENSEMBLE].value_type == "list[int]"
 
     def test_from_ekdsource(self, select_members_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
-        block = SelectMembers()
+        block = _select_members()
         assert block.intersect(other=ekdsource_output)  # type: ignore[arg-type]
         output = block.validate(block=select_members_configuration, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
         assert isinstance(output, QubedOutput)
@@ -545,21 +567,21 @@ class TestSelectMembers:
         assert axes(output)[ENSEMBLE] == {1}
 
     def test_from_ekdsource_multiple_members(self, select_members_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
-        block = SelectMembers()
+        block = _select_members()
         config = select_members_configuration.model_copy(update={"configuration_values": _config({"number": [1, 2]})})
         output = block.validate(block=config, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
         assert isinstance(output, QubedOutput)
         assert axes(output)[ENSEMBLE] == {1, 2}
 
     def test_missing_members(self, select_members_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
-        block = SelectMembers()
+        block = _select_members()
         config = select_members_configuration.model_copy(update={"configuration_values": _config({"number": [999]})})
         result = block.validate(block=config, inputs={"dataset": ekdsource_output})  # type: ignore[dict-item]
         with pytest.raises(Exception, match="members \\[999\\] are not in the input members"):
             result.get_or_raise()
 
     def test_compile_calls_select(self, select_members_configuration: BlockInstance) -> None:
-        block = SelectMembers()
+        block = _select_members()
         input_action = MagicMock()
         selected_action = MagicMock()
         input_action.select.return_value = selected_action
@@ -573,7 +595,7 @@ class TestSelectMembers:
         input_action.select.assert_called_once_with({ENSEMBLE: 1})
 
     def test_compile_calls_select_with_multiple_members(self, select_members_configuration: BlockInstance) -> None:
-        block = SelectMembers()
+        block = _select_members()
         input_action = MagicMock()
         selected_action = MagicMock()
         input_action.select.return_value = selected_action

--- a/frontend/src/api/types/fable.types.ts
+++ b/frontend/src/api/types/fable.types.ts
@@ -305,6 +305,7 @@ export interface BlockValidationState {
   errors: Array<string>
   hasErrors: boolean
   possibleExpansions: Array<PluginBlockFactoryId>
+  possibleExpansionRestrictions: Record<string, Record<string, string>>
   /** Unknown glyph names per option, from /blueprint/expand. */
   missingGlyphs: Record<string, Array<string>>
 }
@@ -608,15 +609,16 @@ export function toValidationState(
     const missingErrors = missingRequiredByBlock[blockId] ?? []
     const errors = [...backendErrors, ...missingErrors]
     const missingGlyphs = expansion.missing_glyphs[blockId] ?? {}
+    const possibleExpansions = expansion.possible_expansions[blockId] ?? []
     const hasMissingGlyphs = Object.values(missingGlyphs).some(
       (names) => names.length > 0,
     )
     blockStates[blockId] = {
       errors,
       hasErrors: errors.length > 0 || hasMissingGlyphs,
-      possibleExpansions: toPluginFactoryIds(
-        expansion.possible_expansions[blockId] ?? [],
-      ),
+      possibleExpansions: toPluginFactoryIds(possibleExpansions),
+      possibleExpansionRestrictions:
+        toExpansionRestrictionMap(possibleExpansions),
       missingGlyphs,
     }
   }
@@ -643,8 +645,39 @@ function toPluginFactoryIds(
   }))
 }
 
+function toExpansionRestrictionMap(
+  expansions: ReadonlyArray<BlockExpansion>,
+): Record<string, Record<string, string>> {
+  const result: Record<string, Record<string, string>> = {}
+  for (const expansion of expansions) {
+    result[factoryIdToKey(expansion)] = expansion.restrictions
+  }
+  return result
+}
+
 function isOptionalValueType(valueType: string): boolean {
   return /^optional\[(.+)\]$/i.test(valueType.trim())
+}
+
+export function getBlockConfigurationRestrictions(
+  fable: FableBuilderV1,
+  validationState: FableValidationState | null,
+  blockId: BlockInstanceId,
+): Record<string, string> {
+  const block = fable.blocks[blockId]
+  if (!block || !validationState) return {}
+
+  const blockFactoryKey = factoryIdToKey(block.factory_id)
+  const restrictions: Record<string, string> = {}
+  for (const sourceId of Object.values(block.input_ids)) {
+    Object.assign(
+      restrictions,
+      validationState.blockStates[sourceId]?.possibleExpansionRestrictions[
+        blockFactoryKey
+      ] ?? {},
+    )
+  }
+  return restrictions
 }
 
 function toPythonStringSet(items: ReadonlyArray<string>): string {

--- a/frontend/src/api/types/fable.types.ts
+++ b/frontend/src/api/types/fable.types.ts
@@ -659,23 +659,33 @@ function isOptionalValueType(valueType: string): boolean {
   return /^optional\[(.+)\]$/i.test(valueType.trim())
 }
 
+function getRecordItem<T>(
+  record: Record<string, T>,
+  key: string,
+): T | undefined {
+  return Object.hasOwn(record, key) ? record[key] : undefined
+}
+
 export function getBlockConfigurationRestrictions(
   fable: FableBuilderV1,
   validationState: FableValidationState | null,
   blockId: BlockInstanceId,
 ): Record<string, string> {
-  const block = fable.blocks[blockId]
+  const block = getRecordItem(fable.blocks, blockId)
   if (!block || !validationState) return {}
 
   const blockFactoryKey = factoryIdToKey(block.factory_id)
   const restrictions: Record<string, string> = {}
   for (const sourceId of Object.values(block.input_ids)) {
-    Object.assign(
-      restrictions,
-      validationState.blockStates[sourceId]?.possibleExpansionRestrictions[
-        blockFactoryKey
-      ] ?? {},
-    )
+    const sourceState = getRecordItem(validationState.blockStates, sourceId)
+    const sourceRestrictions = sourceState
+      ? getRecordItem(
+          sourceState.possibleExpansionRestrictions,
+          blockFactoryKey,
+        )
+      : undefined
+
+    Object.assign(restrictions, sourceRestrictions)
   }
   return restrictions
 }

--- a/frontend/src/components/base/fields/FieldRenderer.tsx
+++ b/frontend/src/components/base/fields/FieldRenderer.tsx
@@ -11,6 +11,7 @@
 import { useMemo } from 'react'
 import { DateTimeField } from './fields/DateTimeField'
 import { EnumField } from './fields/EnumField'
+import { EnumListField } from './fields/EnumListField'
 import { ListField } from './fields/ListField'
 import { NumberField } from './fields/NumberField'
 import { StringField } from './fields/StringField'
@@ -181,6 +182,20 @@ function renderField(
           disabled={disabled}
           className={className}
           itemType={parsedType.itemType}
+        />
+      )
+
+    case 'enumList':
+      return (
+        <EnumListField
+          id={id}
+          configKey={configKey}
+          value={value}
+          onChange={onChange}
+          options={parsedType.options}
+          placeholder={placeholder}
+          disabled={disabled}
+          className={className}
         />
       )
   }

--- a/frontend/src/components/base/fields/fields/EnumListField.tsx
+++ b/frontend/src/components/base/fields/fields/EnumListField.tsx
@@ -1,0 +1,181 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { Check, ChevronDown, X } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { GlyphFieldWrapper } from './GlyphFieldWrapper'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { cn } from '@/lib/utils'
+
+export interface EnumListFieldProps {
+  id: string
+  configKey: string
+  value: string
+  onChange: (value: string) => void
+  options: Array<string>
+  placeholder?: string
+  disabled?: boolean
+  className?: string
+}
+
+function parseListValue(value: string): Array<string> {
+  if (!value.trim()) return []
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+function serializeListValue(items: Array<string>): string {
+  return items.join(',')
+}
+
+export function EnumListField({
+  id,
+  configKey,
+  value,
+  onChange,
+  options,
+  placeholder,
+  disabled,
+  className,
+}: EnumListFieldProps) {
+  const { t } = useTranslation('common')
+  const resolvedPlaceholder = placeholder ?? t('field.selectPlaceholder')
+
+  return (
+    <GlyphFieldWrapper
+      id={id}
+      configKey={configKey}
+      value={value}
+      onChange={onChange}
+      placeholder={resolvedPlaceholder}
+      disabled={disabled}
+      className={className}
+      allowGlyphMode={false}
+    >
+      <EnumListFieldConcrete
+        id={id}
+        value={value}
+        onChange={onChange}
+        options={options}
+        placeholder={resolvedPlaceholder}
+        disabled={disabled}
+        className={className}
+      />
+    </GlyphFieldWrapper>
+  )
+}
+
+function EnumListFieldConcrete({
+  id,
+  value,
+  onChange,
+  options,
+  placeholder,
+  disabled,
+  className,
+}: Omit<EnumListFieldProps, 'configKey'>) {
+  const { t } = useTranslation('common')
+  const selected = parseListValue(value)
+  const selectedSet = new Set(selected)
+  const resolvedPlaceholder = placeholder ?? t('field.selectPlaceholder')
+  const buttonText =
+    selected.length > 0 ? selected.join(', ') : resolvedPlaceholder
+
+  function toggleOption(option: string): void {
+    const nextSet = new Set(selectedSet)
+    if (nextSet.has(option)) {
+      nextSet.delete(option)
+    } else {
+      nextSet.add(option)
+    }
+    onChange(serializeListValue(options.filter((item) => nextSet.has(item))))
+  }
+
+  function removeOption(option: string): void {
+    onChange(serializeListValue(selected.filter((item) => item !== option)))
+  }
+
+  return (
+    <div className="min-w-0 space-y-2">
+      <Popover>
+        <PopoverTrigger
+          render={
+            <Button
+              id={id}
+              type="button"
+              variant="outline"
+              className={cn('h-9 w-full justify-between px-3', className)}
+              disabled={disabled}
+            />
+          }
+        >
+          <span
+            className={cn(
+              'truncate',
+              selected.length === 0 && 'text-muted-foreground',
+            )}
+          >
+            {buttonText}
+          </span>
+          <ChevronDown className="h-4 w-4 opacity-50" />
+        </PopoverTrigger>
+        <PopoverContent className="max-h-72 w-(--anchor-width) gap-1 overflow-y-auto p-1">
+          {options.map((option) => {
+            const checked = selectedSet.has(option)
+            return (
+              <button
+                key={option}
+                type="button"
+                className={cn(
+                  'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm',
+                  'outline-none hover:bg-accent hover:text-accent-foreground',
+                )}
+                onClick={() => toggleOption(option)}
+              >
+                <span className="flex h-4 w-4 items-center justify-center">
+                  {checked && <Check className="h-4 w-4" />}
+                </span>
+                <span className="min-w-0 flex-1 truncate">{option}</span>
+              </button>
+            )
+          })}
+        </PopoverContent>
+      </Popover>
+
+      {selected.length > 0 && (
+        <div className="flex min-w-0 flex-wrap gap-1.5">
+          {selected.map((item) => (
+            <Badge key={item} variant="secondary" className="gap-1 pr-1">
+              {item}
+              {!disabled && (
+                <button
+                  type="button"
+                  onClick={() => removeOption(item)}
+                  className="ml-1 rounded-full p-0.5 transition-colors hover:bg-muted-foreground/20"
+                  aria-label={t('removeTag', { tag: item })}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              )}
+            </Badge>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/base/fields/value-type-parser.ts
+++ b/frontend/src/components/base/fields/value-type-parser.ts
@@ -37,6 +37,7 @@ export type ParsedValueType =
   | { type: 'list'; itemType: 'string'; optional?: boolean }
   | { type: 'list'; itemType: 'int'; optional?: boolean }
   | { type: 'enum'; options: Array<string>; optional?: boolean }
+  | { type: 'enumList'; options: Array<string>; optional?: boolean }
   | { type: 'unknown'; raw: string; optional?: boolean }
 
 /**
@@ -80,18 +81,21 @@ export function parseValueType(valueType: string | undefined): ParsedValueType {
     return { type: 'date' }
   }
 
-  // List type: list[str] or list[int]
+  // List type: list[str], list[int], or list[enumClosed[...]]
   // Match the trimmed string so leading/trailing whitespace does not fall through.
-  const listMatch = trimmed.match(/^list\[(\w+)\]$/i)
+  const listMatch = trimmed.match(/^list\[(.+)\]$/i)
   if (listMatch) {
-    const itemType = listMatch[1].toLowerCase()
-    if (itemType === 'str' || itemType === 'string') {
+    const itemValueType = parseValueType(listMatch[1])
+    if (itemValueType.type === 'string') {
       return { type: 'list', itemType: 'string' }
     }
-    if (itemType === 'int' || itemType === 'integer') {
+    if (itemValueType.type === 'int') {
       return { type: 'list', itemType: 'int' }
     }
-    // For now, only support list[str] and list[int]
+    if (itemValueType.type === 'enum') {
+      return { type: 'enumList', options: itemValueType.options }
+    }
+    // For now, only support list[str], list[int], and list[enumClosed[...]]
     return { type: 'unknown', raw: trimmed }
   }
 
@@ -112,17 +116,20 @@ export function parseValueType(valueType: string | undefined): ParsedValueType {
  * Parse enum options from a string like "'a','b','c'" or '"a","b","c"'
  */
 function parseEnumOptions(optionsStr: string): Array<string> {
-  const options: Array<string> = []
-
-  // Match quoted strings (single or double quotes)
-  const regex = /['"]([^'"]+)['"]/g
-  let match
-
-  while ((match = regex.exec(optionsStr)) !== null) {
-    options.push(match[1])
-  }
-
-  return options
+  return optionsStr
+    .split(',')
+    .map((option) => option.trim())
+    .filter(Boolean)
+    .map((option) => {
+      if (
+        option.length >= 2 &&
+        option[0] === option[option.length - 1] &&
+        (option[0] === "'" || option[0] === '"')
+      ) {
+        return option.slice(1, -1)
+      }
+      return option
+    })
 }
 
 /**
@@ -146,6 +153,8 @@ export function getDefaultValueForType(parsedType: ParsedValueType): string {
       return ''
     case 'enum':
       return parsedType.options[0] ?? ''
+    case 'enumList':
+      return ''
     case 'unknown':
       return ''
   }

--- a/frontend/src/features/fable-builder/components/form-mode/BlockInstanceCard.tsx
+++ b/frontend/src/features/fable-builder/components/form-mode/BlockInstanceCard.tsx
@@ -109,7 +109,7 @@ export function BlockInstanceCard({
   const disconnectBlock = useFableBuilderStore((state) => state.disconnectBlock)
   const validationState = useFableBuilderStore((state) => state.validationState)
   const pendingRestrictions = useFableBuilderStore(
-    (state) => state.blockConfigurationRestrictions?.[instanceId],
+    (state) => state.blockConfigurationRestrictions[instanceId],
   )
   const resolvedConfigForBlock = useFableBuilderStore(
     (state) =>
@@ -120,7 +120,7 @@ export function BlockInstanceCard({
   const instance = fable.blocks[instanceId]
   const factory = getFactory(catalogue, instance.factory_id)
   const configRestrictions = {
-    ...(pendingRestrictions ?? {}),
+    ...pendingRestrictions,
     ...getBlockConfigurationRestrictions(fable, validationState, instanceId),
   }
 

--- a/frontend/src/features/fable-builder/components/form-mode/BlockInstanceCard.tsx
+++ b/frontend/src/features/fable-builder/components/form-mode/BlockInstanceCard.tsx
@@ -67,6 +67,7 @@ import {
 } from '@/components/ui/select'
 import {
   BLOCK_KIND_METADATA,
+  getBlockConfigurationRestrictions,
   getBlockKindIcon,
   getFactory,
 } from '@/api/types/fable.types'
@@ -106,6 +107,10 @@ export function BlockInstanceCard({
   )
   const connectBlocks = useFableBuilderStore((state) => state.connectBlocks)
   const disconnectBlock = useFableBuilderStore((state) => state.disconnectBlock)
+  const validationState = useFableBuilderStore((state) => state.validationState)
+  const pendingRestrictions = useFableBuilderStore(
+    (state) => state.blockConfigurationRestrictions?.[instanceId],
+  )
   const resolvedConfigForBlock = useFableBuilderStore(
     (state) =>
       state.validationState?.resolvedConfigurationOptions[instanceId] ?? null,
@@ -114,6 +119,10 @@ export function BlockInstanceCard({
 
   const instance = fable.blocks[instanceId]
   const factory = getFactory(catalogue, instance.factory_id)
+  const configRestrictions = {
+    ...(pendingRestrictions ?? {}),
+    ...getBlockConfigurationRestrictions(fable, validationState, instanceId),
+  }
 
   // Compute available sources that can be connected to this block's inputs
   const availableSources = useMemo(() => {
@@ -291,7 +300,9 @@ export function BlockInstanceCard({
                           key={key}
                           id={`${instanceId}-${key}`}
                           configKey={key}
-                          valueType={option.value_type}
+                          valueType={
+                            configRestrictions[key] ?? option.value_type
+                          }
                           value={instance.configuration_values[key] ?? ''}
                           onChange={(value) =>
                             updateBlockConfig(instanceId, key, value)

--- a/frontend/src/features/fable-builder/components/form-mode/FableFormCanvas.tsx
+++ b/frontend/src/features/fable-builder/components/form-mode/FableFormCanvas.tsx
@@ -58,6 +58,9 @@ export function FableFormCanvas({ catalogue }: FableFormCanvasProps) {
   const validationState = useFableBuilderStore((state) => state.validationState)
   const addBlock = useFableBuilderStore((state) => state.addBlock)
   const connectBlocks = useFableBuilderStore((state) => state.connectBlocks)
+  const setBlockConfigurationRestrictions = useFableBuilderStore(
+    (state) => state.setBlockConfigurationRestrictions,
+  )
   const selectedBlockId = useFableBuilderStore((state) => state.selectedBlockId)
   const selectBlock = useFableBuilderStore((state) => state.selectBlock)
 
@@ -185,6 +188,11 @@ export function FableFormCanvas({ catalogue }: FableFormCanvasProps) {
     if (!factory) return
 
     const newBlockId = addBlock(factoryId, factory)
+    const restrictions =
+      direction === 'parent'
+        ? {}
+        : (validationState?.blockStates[anchorBlockId]
+            ?.possibleExpansionRestrictions[factoryIdToKey(factoryId)] ?? {})
 
     if (direction === 'parent') {
       // New block is upstream: connect it into the anchor's first input.
@@ -200,6 +208,7 @@ export function FableFormCanvas({ catalogue }: FableFormCanvasProps) {
       // New block is downstream: connect the anchor into its first input.
       connectBlocks(newBlockId, factory.inputs[0], anchorBlockId)
     }
+    setBlockConfigurationRestrictions(newBlockId, restrictions)
 
     // Navigate to the new block's step
     setCurrentStep(factory.kind)

--- a/frontend/src/features/fable-builder/components/graph-mode/AddNodeButton.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/AddNodeButton.tsx
@@ -47,6 +47,9 @@ const POPOVER_SIDE: Record<string, 'top' | 'bottom' | 'left' | 'right'> = {
   RL: 'left',
 }
 
+const EMPTY_EXPANSION_RESTRICTIONS: Record<string, Record<string, string>> = {}
+const EMPTY_CONFIG_RESTRICTIONS: Record<string, string> = {}
+
 /** Wraps a block's output `<Handle>` with an add-downstream-block popover:
  *  clicking the handle opens the menu, dragging it still draws a connection. */
 export const AddNodeButton = memo(function ({
@@ -61,7 +64,15 @@ export const AddNodeButton = memo(function ({
 
   const addBlock = useFableBuilderStore((state) => state.addBlock)
   const connectBlocks = useFableBuilderStore((state) => state.connectBlocks)
+  const setBlockConfigurationRestrictions = useFableBuilderStore(
+    (state) => state.setBlockConfigurationRestrictions,
+  )
   const layoutDirection = useFableBuilderStore((state) => state.layoutDirection)
+  const expansionRestrictions = useFableBuilderStore(
+    (state) =>
+      state.validationState?.blockStates[sourceBlockId]
+        ?.possibleExpansionRestrictions ?? EMPTY_EXPANSION_RESTRICTIONS,
+  )
 
   // When the backend provides validated expansions, use them. Otherwise build
   // a fallback from the full catalogue (all factories that accept inputs) so
@@ -72,10 +83,18 @@ export const AddNodeButton = memo(function ({
         .map((id) => ({
           id,
           factory: getFactory(catalogue, id),
+          restrictions:
+            expansionRestrictions[factoryIdToKey(id)] ??
+            EMPTY_CONFIG_RESTRICTIONS,
         }))
         .filter(
-          (item): item is { id: PluginBlockFactoryId; factory: BlockFactory } =>
-            item.factory !== undefined,
+          (
+            item,
+          ): item is {
+            id: PluginBlockFactoryId
+            factory: BlockFactory
+            restrictions: Record<string, string>
+          } => item.factory !== undefined,
         )
     }
 
@@ -83,6 +102,7 @@ export const AddNodeButton = memo(function ({
     const fallback: Array<{
       id: PluginBlockFactoryId
       factory: BlockFactory
+      restrictions: Record<string, string>
     }> = []
     for (const [pluginKey, plugin] of Object.entries(catalogue)) {
       for (const [factoryKey, factory] of Object.entries(plugin.factories)) {
@@ -92,12 +112,13 @@ export const AddNodeButton = memo(function ({
           fallback.push({
             id: { plugin: { store, local }, factory: factoryKey },
             factory,
+            restrictions: {},
           })
         }
       }
     }
     return fallback
-  }, [possibleExpansions, catalogue])
+  }, [possibleExpansions, catalogue, expansionRestrictions])
 
   const filteredFactories = useMemo(() => {
     if (!search.trim()) return availableFactories
@@ -113,7 +134,11 @@ export const AddNodeButton = memo(function ({
   const groupedFactories = useMemo(() => {
     const groups: Record<
       string,
-      Array<{ id: PluginBlockFactoryId; factory: BlockFactory }>
+      Array<{
+        id: PluginBlockFactoryId
+        factory: BlockFactory
+        restrictions: Record<string, string>
+      }>
     > = {}
 
     for (const item of filteredFactories) {
@@ -128,12 +153,14 @@ export const AddNodeButton = memo(function ({
   const handleAddBlock = (
     factoryId: PluginBlockFactoryId,
     factory: BlockFactory,
+    restrictions: Record<string, string>,
   ) => {
     const newBlockId = addBlock(factoryId, factory)
 
     if (factory.inputs.length > 0) {
       connectBlocks(newBlockId, factory.inputs[0], sourceBlockId)
     }
+    setBlockConfigurationRestrictions(newBlockId, restrictions)
 
     setOpen(false)
     setSearch('')
@@ -175,7 +202,7 @@ export const AddNodeButton = memo(function ({
                     {metadata.label}
                   </div>
 
-                  {factories.map(({ id, factory }) => {
+                  {factories.map(({ id, factory, restrictions }) => {
                     const IconComponent = getBlockKindIcon(factory.kind)
                     const itemMetadata = BLOCK_KIND_METADATA[factory.kind]
 
@@ -187,7 +214,9 @@ export const AddNodeButton = memo(function ({
                           'text-left hover:bg-accent',
                           'transition-colors',
                         )}
-                        onClick={() => handleAddBlock(id, factory)}
+                        onClick={() =>
+                          handleAddBlock(id, factory, restrictions)
+                        }
                       >
                         <IconComponent
                           className={cn(

--- a/frontend/src/features/fable-builder/components/layout/ConfigPanel.tsx
+++ b/frontend/src/features/fable-builder/components/layout/ConfigPanel.tsx
@@ -89,7 +89,7 @@ export function ConfigPanel({ catalogue }: ConfigPanelProps): React.ReactNode {
   const validationState = useFableBuilderStore((state) => state.validationState)
   const pendingRestrictions = useFableBuilderStore((state) =>
     selectedBlockId
-      ? state.blockConfigurationRestrictions?.[selectedBlockId]
+      ? state.blockConfigurationRestrictions[selectedBlockId]
       : undefined,
   )
   const factory = selectedBlock

--- a/frontend/src/features/fable-builder/components/layout/ConfigPanel.tsx
+++ b/frontend/src/features/fable-builder/components/layout/ConfigPanel.tsx
@@ -16,6 +16,7 @@ import { useFieldErrorMessages } from '@/features/fable-builder/hooks/useFieldEr
 import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
 import {
   BLOCK_KIND_METADATA,
+  getBlockConfigurationRestrictions,
   getBlockKindIcon,
   getFactory,
 } from '@/api/types/fable.types'
@@ -85,6 +86,12 @@ export function ConfigPanel({ catalogue }: ConfigPanelProps): React.ReactNode {
   const disconnectBlock = useFableBuilderStore((state) => state.disconnectBlock)
 
   const selectedBlock = selectedBlockId ? fable.blocks[selectedBlockId] : null
+  const validationState = useFableBuilderStore((state) => state.validationState)
+  const pendingRestrictions = useFableBuilderStore((state) =>
+    selectedBlockId
+      ? state.blockConfigurationRestrictions?.[selectedBlockId]
+      : undefined,
+  )
   const factory = selectedBlock
     ? getFactory(catalogue, selectedBlock.factory_id)
     : null
@@ -153,6 +160,14 @@ export function ConfigPanel({ catalogue }: ConfigPanelProps): React.ReactNode {
 
   const metadata = BLOCK_KIND_METADATA[factory.kind]
   const IconComponent = getBlockKindIcon(factory.kind)
+  const configRestrictions = {
+    ...(pendingRestrictions ?? {}),
+    ...getBlockConfigurationRestrictions(
+      fable,
+      validationState,
+      selectedBlockId ?? '',
+    ),
+  }
   const configOptions = Object.entries(factory.configuration_options)
   const inputs = factory.inputs
 
@@ -225,7 +240,7 @@ export function ConfigPanel({ catalogue }: ConfigPanelProps): React.ReactNode {
                     key={key}
                     id={`config-${key}`}
                     configKey={key}
-                    valueType={option.value_type}
+                    valueType={configRestrictions[key] ?? option.value_type}
                     value={selectedBlock.configuration_values[key] || ''}
                     onChange={(value) => handleConfigChange(key, value)}
                     label={option.title || key}

--- a/frontend/src/features/fable-builder/stores/fableBuilderStore.ts
+++ b/frontend/src/features/fable-builder/stores/fableBuilderStore.ts
@@ -23,6 +23,7 @@ import { STORAGE_KEYS, STORE_VERSIONS } from '@/lib/storage-keys'
 import {
   createBlockInstance,
   createEmptyFable,
+  factoryIdToKey,
   generateBlockInstanceId,
 } from '@/api/types/fable.types'
 
@@ -93,6 +94,10 @@ interface FableBuilderState {
   layoutDirection: LayoutDirection
   nodesLocked: boolean
   validationState: FableValidationState | null
+  blockConfigurationRestrictions: Record<
+    BlockInstanceId,
+    Record<string, string>
+  >
   isValidating: boolean
   lastValidatedAt: number | null
   isDirty: boolean
@@ -152,6 +157,10 @@ interface FableBuilderState {
   setLocalGlyph: (key: string, value: string) => void
   removeLocalGlyph: (key: string) => void
   setValidationState: (state: FableValidationState | null) => void
+  setBlockConfigurationRestrictions: (
+    blockId: BlockInstanceId,
+    restrictions: Record<string, string>,
+  ) => void
   setIsValidating: (validating: boolean) => void
   setSubmitDialogOpen: (open: boolean) => void
   setDraggedFactory: (dragged: DraggedFactory | null) => void
@@ -192,6 +201,7 @@ function createInitialState() {
     layoutDirection: getDefaultLayoutDirection(),
     nodesLocked: true,
     validationState: null,
+    blockConfigurationRestrictions: {},
     isValidating: false,
     lastValidatedAt: null,
     isDirty: false,
@@ -219,6 +229,7 @@ export const useFableBuilderStore = create<FableBuilderState>()(
             isDirty: false,
             selectedBlockId: null,
             validationState: null,
+            blockConfigurationRestrictions: {},
             step: 'edit',
           }),
 
@@ -285,6 +296,10 @@ export const useFableBuilderStore = create<FableBuilderState>()(
         removeBlock: (instanceId) => {
           const { fable, selectedBlockId } = get()
           const { [instanceId]: _removed, ...remainingBlocks } = fable.blocks
+          const {
+            [instanceId]: _removedRestrictions,
+            ...remainingRestrictions
+          } = get().blockConfigurationRestrictions ?? {}
 
           const updatedBlocks: Record<BlockInstanceId, BlockInstance> = {}
           for (const [id, block] of Object.entries(remainingBlocks)) {
@@ -305,6 +320,7 @@ export const useFableBuilderStore = create<FableBuilderState>()(
               selectedBlockId === instanceId ? null : selectedBlockId,
             isDirty: true,
             validationState: null,
+            blockConfigurationRestrictions: remainingRestrictions,
           })
         },
 
@@ -318,6 +334,12 @@ export const useFableBuilderStore = create<FableBuilderState>()(
           const toRemove = new Set([instanceId, ...downstreamBlocks])
 
           const remainingBlocks: Record<BlockInstanceId, BlockInstance> = {}
+          const remainingRestrictions = {
+            ...(get().blockConfigurationRestrictions ?? {}),
+          }
+          for (const id of toRemove) {
+            delete remainingRestrictions[id]
+          }
           for (const [id, block] of Object.entries(fable.blocks)) {
             if (!toRemove.has(id)) {
               const cleanedInputIds: Record<string, string> = {}
@@ -339,12 +361,14 @@ export const useFableBuilderStore = create<FableBuilderState>()(
               : selectedBlockId,
             isDirty: true,
             validationState: null,
+            blockConfigurationRestrictions: remainingRestrictions,
           })
         },
 
         duplicateBlock: (instanceId) => {
           const { fable } = get()
           const block = fable.blocks[instanceId]
+          const restrictions = get().blockConfigurationRestrictions[instanceId]
           const newInstanceId = generateBlockInstanceId()
           const duplicatedBlock: BlockInstance = {
             factory_id: block.factory_id,
@@ -363,6 +387,12 @@ export const useFableBuilderStore = create<FableBuilderState>()(
             selectedBlockId: newInstanceId,
             isDirty: true,
             validationState: null,
+            blockConfigurationRestrictions: restrictions
+              ? {
+                  ...(state.blockConfigurationRestrictions ?? {}),
+                  [newInstanceId]: restrictions,
+                }
+              : state.blockConfigurationRestrictions,
           }))
 
           return newInstanceId
@@ -424,8 +454,18 @@ export const useFableBuilderStore = create<FableBuilderState>()(
         },
 
         connectBlocks: (targetBlockId, inputName, sourceBlockId) => {
-          const { fable } = get()
+          const { fable, validationState } = get()
           const block = fable.blocks[targetBlockId]
+          const restrictions =
+            validationState?.blockStates[sourceBlockId]
+              ?.possibleExpansionRestrictions[factoryIdToKey(block.factory_id)]
+          const nextRestrictions =
+            restrictions && Object.keys(restrictions).length > 0
+              ? {
+                  ...(get().blockConfigurationRestrictions ?? {}),
+                  [targetBlockId]: restrictions,
+                }
+              : get().blockConfigurationRestrictions
 
           set({
             fable: {
@@ -440,6 +480,7 @@ export const useFableBuilderStore = create<FableBuilderState>()(
             },
             isDirty: true,
             validationState: null,
+            blockConfigurationRestrictions: nextRestrictions,
           })
         },
 
@@ -458,6 +499,10 @@ export const useFableBuilderStore = create<FableBuilderState>()(
             },
             isDirty: true,
             validationState: null,
+            blockConfigurationRestrictions: {
+              ...(get().blockConfigurationRestrictions ?? {}),
+              [targetBlockId]: {},
+            },
           })
         },
 
@@ -519,6 +564,13 @@ export const useFableBuilderStore = create<FableBuilderState>()(
             validationState: state,
             lastValidatedAt: state ? Date.now() : null,
           }),
+        setBlockConfigurationRestrictions: (blockId, restrictions) =>
+          set((state) => ({
+            blockConfigurationRestrictions: {
+              ...(state.blockConfigurationRestrictions ?? {}),
+              [blockId]: restrictions,
+            },
+          })),
         setIsValidating: (validating) => set({ isValidating: validating }),
         setSubmitDialogOpen: (open) => set({ submitDialogOpen: open }),
         setDraggedFactory: (dragged) => set({ draggedFactory: dragged }),

--- a/frontend/src/features/fable-builder/stores/fableBuilderStore.ts
+++ b/frontend/src/features/fable-builder/stores/fableBuilderStore.ts
@@ -75,6 +75,20 @@ function findDownstreamBlocks(
   return downstream
 }
 
+function replaceBlockConfigurationRestrictions(
+  current: Record<BlockInstanceId, Record<string, string>>,
+  blockId: BlockInstanceId,
+  restrictions: Record<string, string> | undefined,
+): Record<BlockInstanceId, Record<string, string>> {
+  const next = { ...current }
+  if (restrictions && Object.keys(restrictions).length > 0) {
+    next[blockId] = restrictions
+  } else {
+    delete next[blockId]
+  }
+  return next
+}
+
 interface FableBuilderState {
   fable: FableBuilderV1
   fableId: string | null
@@ -299,7 +313,7 @@ export const useFableBuilderStore = create<FableBuilderState>()(
           const {
             [instanceId]: _removedRestrictions,
             ...remainingRestrictions
-          } = get().blockConfigurationRestrictions ?? {}
+          } = get().blockConfigurationRestrictions
 
           const updatedBlocks: Record<BlockInstanceId, BlockInstance> = {}
           for (const [id, block] of Object.entries(remainingBlocks)) {
@@ -335,7 +349,7 @@ export const useFableBuilderStore = create<FableBuilderState>()(
 
           const remainingBlocks: Record<BlockInstanceId, BlockInstance> = {}
           const remainingRestrictions = {
-            ...(get().blockConfigurationRestrictions ?? {}),
+            ...get().blockConfigurationRestrictions,
           }
           for (const id of toRemove) {
             delete remainingRestrictions[id]
@@ -368,7 +382,9 @@ export const useFableBuilderStore = create<FableBuilderState>()(
         duplicateBlock: (instanceId) => {
           const { fable } = get()
           const block = fable.blocks[instanceId]
-          const restrictions = get().blockConfigurationRestrictions[instanceId]
+          const restrictions = get().blockConfigurationRestrictions[
+            instanceId
+          ] as Record<string, string> | undefined
           const newInstanceId = generateBlockInstanceId()
           const duplicatedBlock: BlockInstance = {
             factory_id: block.factory_id,
@@ -387,12 +403,12 @@ export const useFableBuilderStore = create<FableBuilderState>()(
             selectedBlockId: newInstanceId,
             isDirty: true,
             validationState: null,
-            blockConfigurationRestrictions: restrictions
-              ? {
-                  ...(state.blockConfigurationRestrictions ?? {}),
-                  [newInstanceId]: restrictions,
-                }
-              : state.blockConfigurationRestrictions,
+            blockConfigurationRestrictions:
+              replaceBlockConfigurationRestrictions(
+                state.blockConfigurationRestrictions,
+                newInstanceId,
+                restrictions,
+              ),
           }))
 
           return newInstanceId
@@ -459,13 +475,11 @@ export const useFableBuilderStore = create<FableBuilderState>()(
           const restrictions =
             validationState?.blockStates[sourceBlockId]
               ?.possibleExpansionRestrictions[factoryIdToKey(block.factory_id)]
-          const nextRestrictions =
-            restrictions && Object.keys(restrictions).length > 0
-              ? {
-                  ...(get().blockConfigurationRestrictions ?? {}),
-                  [targetBlockId]: restrictions,
-                }
-              : get().blockConfigurationRestrictions
+          const nextRestrictions = replaceBlockConfigurationRestrictions(
+            get().blockConfigurationRestrictions,
+            targetBlockId,
+            restrictions,
+          )
 
           set({
             fable: {
@@ -499,10 +513,12 @@ export const useFableBuilderStore = create<FableBuilderState>()(
             },
             isDirty: true,
             validationState: null,
-            blockConfigurationRestrictions: {
-              ...(get().blockConfigurationRestrictions ?? {}),
-              [targetBlockId]: {},
-            },
+            blockConfigurationRestrictions:
+              replaceBlockConfigurationRestrictions(
+                get().blockConfigurationRestrictions,
+                targetBlockId,
+                undefined,
+              ),
           })
         },
 
@@ -563,13 +579,16 @@ export const useFableBuilderStore = create<FableBuilderState>()(
           set({
             validationState: state,
             lastValidatedAt: state ? Date.now() : null,
+            ...(state ? { blockConfigurationRestrictions: {} } : {}),
           }),
         setBlockConfigurationRestrictions: (blockId, restrictions) =>
           set((state) => ({
-            blockConfigurationRestrictions: {
-              ...(state.blockConfigurationRestrictions ?? {}),
-              [blockId]: restrictions,
-            },
+            blockConfigurationRestrictions:
+              replaceBlockConfigurationRestrictions(
+                state.blockConfigurationRestrictions,
+                blockId,
+                restrictions,
+              ),
           })),
         setIsValidating: (validating) => set({ isValidating: validating }),
         setSubmitDialogOpen: (open) => set({ submitDialogOpen: open }),

--- a/frontend/tests/unit/api/fable-types.test.ts
+++ b/frontend/tests/unit/api/fable-types.test.ts
@@ -149,5 +149,8 @@ describe('toValidationState', () => {
         factory: 'sink',
       },
     ])
+    expect(result.blockStates.b1.possibleExpansionRestrictions).toEqual({
+      'ecmwf/base:sink': { amount: 'enumClosed[1,2,3]' },
+    })
   })
 })

--- a/frontend/tests/unit/components/fields/value-type-parser.test.ts
+++ b/frontend/tests/unit/components/fields/value-type-parser.test.ts
@@ -79,6 +79,13 @@ describe('parseValueType', () => {
         itemType: 'int',
       })
     })
+
+    it('parses list with closed enum item type', () => {
+      expect(parseValueType('list[enumClosed[2t,msl]]')).toEqual({
+        type: 'enumList',
+        options: ['2t', 'msl'],
+      })
+    })
   })
 
   describe('enum types', () => {
@@ -107,6 +114,13 @@ describe('parseValueType', () => {
       expect(parseValueType("enumClosed['mars','ecmwf-open-data']")).toEqual({
         type: 'enum',
         options: ['mars', 'ecmwf-open-data'],
+      })
+    })
+
+    it('parses unquoted enumClosed options', () => {
+      expect(parseValueType('enumClosed[2t,msl]')).toEqual({
+        type: 'enum',
+        options: ['2t', 'msl'],
       })
     })
   })
@@ -257,6 +271,12 @@ describe('getDefaultValueForType', () => {
     expect(getDefaultValueForType({ type: 'list', itemType: 'string' })).toBe(
       '',
     )
+  })
+
+  it('returns empty string for enum list type', () => {
+    expect(
+      getDefaultValueForType({ type: 'enumList', options: ['2t', 'msl'] }),
+    ).toBe('')
   })
 
   it('returns first option for enum type', () => {

--- a/frontend/tests/unit/features/fable-builder/stores/fableBuilderStore.test.ts
+++ b/frontend/tests/unit/features/fable-builder/stores/fableBuilderStore.test.ts
@@ -10,7 +10,11 @@
 
 import { beforeEach, describe, expect, it } from 'vitest'
 import { act, renderHook } from '@testing-library/react'
-import type { BlockFactory, FableBuilderV1 } from '@/api/types/fable.types'
+import type {
+  BlockFactory,
+  FableBuilderV1,
+  FableValidationState,
+} from '@/api/types/fable.types'
 import {
   useFableBuilderStore,
   useHasBlocks,
@@ -50,6 +54,18 @@ const mockFable: FableBuilderV1 = {
       input_ids: { input: 'block-1' },
     },
   },
+}
+
+function makeValidationState(
+  blockStates: FableValidationState['blockStates'] = {},
+): FableValidationState {
+  return {
+    isValid: true,
+    globalErrors: [],
+    blockStates,
+    possibleSources: [],
+    resolvedConfigurationOptions: {},
+  }
 }
 
 describe('useFableBuilderStore', () => {
@@ -641,6 +657,94 @@ describe('useFableBuilderStore', () => {
           .new_input,
       ).toBe('block-1')
     })
+
+    it('replaces stale restrictions when reconnecting to an unrestricted source', () => {
+      const fable: FableBuilderV1 = {
+        blocks: {
+          restricted: {
+            factory_id: {
+              plugin: { store: 'ecmwf', local: 'test' },
+              factory: 'source',
+            },
+            configuration_values: {},
+            input_ids: {},
+          },
+          unrestricted: {
+            factory_id: {
+              plugin: { store: 'ecmwf', local: 'test' },
+              factory: 'source',
+            },
+            configuration_values: {},
+            input_ids: {},
+          },
+          target: {
+            factory_id: {
+              plugin: { store: 'ecmwf', local: 'test' },
+              factory: 'transform',
+            },
+            configuration_values: {},
+            input_ids: {},
+          },
+        },
+      }
+
+      act(() => useFableBuilderStore.getState().setFable(fable))
+      act(() =>
+        useFableBuilderStore.getState().setValidationState(
+          makeValidationState({
+            restricted: {
+              errors: [],
+              hasErrors: false,
+              possibleExpansions: [],
+              possibleExpansionRestrictions: {
+                'ecmwf/test:transform': {
+                  param: 'list[enumClosed[2t,msl]]',
+                },
+              },
+              missingGlyphs: {},
+            },
+            unrestricted: {
+              errors: [],
+              hasErrors: false,
+              possibleExpansions: [],
+              possibleExpansionRestrictions: {},
+              missingGlyphs: {},
+            },
+          }),
+        ),
+      )
+      act(() =>
+        useFableBuilderStore
+          .getState()
+          .connectBlocks('target', 'input', 'restricted'),
+      )
+      expect(
+        useFableBuilderStore.getState().blockConfigurationRestrictions.target,
+      ).toEqual({ param: 'list[enumClosed[2t,msl]]' })
+
+      act(() =>
+        useFableBuilderStore.getState().setValidationState(
+          makeValidationState({
+            unrestricted: {
+              errors: [],
+              hasErrors: false,
+              possibleExpansions: [],
+              possibleExpansionRestrictions: {},
+              missingGlyphs: {},
+            },
+          }),
+        ),
+      )
+      act(() =>
+        useFableBuilderStore
+          .getState()
+          .connectBlocks('target', 'input', 'unrestricted'),
+      )
+
+      expect(
+        useFableBuilderStore.getState().blockConfigurationRestrictions.target,
+      ).toBeUndefined()
+    })
   })
 
   describe('disconnectBlock', () => {
@@ -705,13 +809,9 @@ describe('useFableBuilderStore', () => {
 
   describe('validation', () => {
     it('sets validation state', () => {
-      const validationState = {
-        isValid: false,
-        globalErrors: ['Missing required block'],
-        blockStates: {},
-        possibleSources: [],
-        resolvedConfigurationOptions: {},
-      }
+      const validationState = makeValidationState()
+      validationState.isValid = false
+      validationState.globalErrors = ['Missing required block']
       act(() =>
         useFableBuilderStore.getState().setValidationState(validationState),
       )
@@ -723,18 +823,34 @@ describe('useFableBuilderStore', () => {
     it('sets lastValidatedAt when setting validation state', () => {
       const before = Date.now()
       act(() =>
-        useFableBuilderStore.getState().setValidationState({
-          isValid: true,
-          globalErrors: [],
-          blockStates: {},
-          possibleSources: [],
-          resolvedConfigurationOptions: {},
-        }),
+        useFableBuilderStore
+          .getState()
+          .setValidationState(makeValidationState()),
       )
       const after = Date.now()
       const lastValidatedAt = useFableBuilderStore.getState().lastValidatedAt
       expect(lastValidatedAt).toBeGreaterThanOrEqual(before)
       expect(lastValidatedAt).toBeLessThanOrEqual(after)
+    })
+
+    it('clears pending configuration restrictions when fresh validation arrives', () => {
+      act(() =>
+        useFableBuilderStore
+          .getState()
+          .setBlockConfigurationRestrictions('block-2', {
+            param: 'list[enumClosed[2t,msl]]',
+          }),
+      )
+
+      act(() =>
+        useFableBuilderStore
+          .getState()
+          .setValidationState(makeValidationState()),
+      )
+
+      expect(
+        useFableBuilderStore.getState().blockConfigurationRestrictions,
+      ).toEqual({})
     })
 
     it('sets isValidating', () => {


### PR DESCRIPTION
This pull request introduces improvements to the ECMWF plugin's parameter selection and typing system, as well as broader refactoring for clarity and extensibility. The most important changes include the introduction of a new `ClosedEnumListType` for enhanced type safety and its respective UI element (a multiple choice enum list), a major refactor of parameter/step/member selection blocks, and consistent renaming of configuration option identifiers throughout the ECMWF plugin codebase.

@liefra, I split the changes into two commits: backend changes and frontend. I did the frontend changes with an agent so it needs to be reviewed/updated.

@tmi, have a look at the new type and tell me if it makes sense to you.

### Type System Enhancements

* Added a new `ClosedEnumListType` to represent lists of closed enum values, updated the type parser to recognize `list[enumClosed[...]]`, and included tests for this new type. This improves type safety and expressiveness for list-based configuration options. [[1]](diffhunk://#diff-0db4b1c30e50c34a917816d81f3f4dad45a1fe781c484d01cf7545513fab5008R95-R96) [[2]](diffhunk://#diff-0db4b1c30e50c34a917816d81f3f4dad45a1fe781c484d01cf7545513fab5008R258-R265) [[3]](diffhunk://#diff-d03b28954ddb0f98cf5614d5adeb9706e8571a9fd0669d0fb7673dae247ac5aeR17) [[4]](diffhunk://#diff-d03b28954ddb0f98cf5614d5adeb9706e8571a9fd0669d0fb7673dae247ac5aeR289-R292)

### ECMWF Plugin Block Refactoring

* Refactored parameter, step, and ensemble member selection blocks: replaced the old `SelectVariable` block with new `SelectParameters`, `SelectSteps`, and `SelectMembers` blocks, each supporting selection of multiple values and improved validation. [[1]](diffhunk://#diff-c9403c8584dedb84b6580759eda4f5ec58297f78b31308c92b1a01293a0445ccL15-R32) [[2]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL308-R358) [[3]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL326-R373)

### Configuration Option Identifier Consistency

* Standardized configuration option identifiers across all ECMWF plugin blocks (e.g., using `PARAM`, `STEP`, `ENSEMBLE` instead of previous variants like `PARAM_DIM` or string literals), and updated all references accordingly for improved consistency and maintainability. [[1]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL29-R43) [[2]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL65-L66) [[3]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL96-R105) [[4]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL115-R123) [[5]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL136-R137) [[6]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL152-R169) [[7]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL183-R182) [[8]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL195-R198) [[9]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL211-R227) [[10]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL240-R242) [[11]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL255-R268)

### Validation and Restriction Improvements

* Enhanced validation logic in selection blocks to provide clearer error messages and stricter type checking, and added dynamic restriction generation based on available values in the dataset. [[1]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL308-R358) [[2]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL326-R373)

These changes collectively make the ECMWF plugin more robust, extensible, and easier to maintain.### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
