### PR TITLE
[plugin] feat: add GRIB sink block

### DIFF
--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/__init__.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/__init__.py
@@ -18,11 +18,11 @@ from fiab_plugin_ecmwf.blocks import (
     STEP,
     EkdSource,
     EnsembleStatistics,
+    GribSink,
     MapPlotSink,
     SelectDimension,
     TemporalStatistics,
     ZarrSink,
-    GribSink,
 )
 
 blocks: dict[BlockFactoryId, QubedBlockBuilder] = {

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/__init__.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/__init__.py
@@ -22,6 +22,7 @@ from fiab_plugin_ecmwf.blocks import (
     SelectDimension,
     TemporalStatistics,
     ZarrSink,
+    GribSink,
 )
 
 blocks: dict[BlockFactoryId, QubedBlockBuilder] = {
@@ -44,6 +45,7 @@ blocks: dict[BlockFactoryId, QubedBlockBuilder] = {
         selection_label="members",
     ),
     BlockFactoryId("zarrSink"): ZarrSink(),
+    BlockFactoryId("gribSink"): GribSink(),
     BlockFactoryId("anemoiSource"): AnemoiSource(),
     BlockFactoryId("anemoiTransform"): AnemoiTransform(),
     BlockFactoryId("mapPlotSink"): MapPlotSink(),

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -9,6 +9,8 @@
 
 import logging
 from typing import Any, cast
+import os
+import re
 
 import numpy as np
 from cascade.low.func import Either
@@ -63,6 +65,13 @@ IFS_REQUEST = {
     "step": list(range(0, 61, 6)),
     "type": "pf",
     "number": list(range(1, 6)),
+}
+
+GRIB_ALIASES = {
+    "shortName": PARAM_DIM,
+    "paramId": PARAM_DIM,
+    "stepRange": "step",
+    "level": "levelist",
 }
 
 logger = logging.getLogger(__name__)
@@ -292,11 +301,17 @@ class ZarrSink(Sink):
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         input_task = block.input_ids["dataset"]
 
-        action = inputs[input_task].map(
-            Payload(
-                "fiab_plugin_ecmwf.runtime.sinks.write_zarr",
-                kwargs={"path": block.config_as_str(PATH)},
-                metadata={"environment": ["zarr"]},
+        action = (
+            inputs[input_task]
+            .combine_branches(dim=PARAM_DIM, force=True)
+            .flatten(new_dim="**temp**", reset_coords=True)
+            .concatenate(dim="**temp**")
+            .map(
+                Payload(
+                    "fiab_plugin_ecmwf.runtime.sinks.write_zarr",
+                    kwargs={"path": block.config_as_str(PATH)},
+                    metadata={"environment": ["zarr"]},
+                )
             )
         )
         return Either.ok(action)
@@ -392,8 +407,8 @@ class SelectDimension(Transform):
 class GribSink(Sink):
     title: str = "GRIB Sink"
     description: str = "Write dataset to a GRIB file on the local filesystem"
-    configuration_options: dict[str, BlockConfigurationOption] = {
-        "path": BlockConfigurationOption(
+    configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {
+        PATH: BlockConfigurationOption(
             title="GRIB Path",
             description="Filesystem path where the GRIB file should be written",
             value_type="str",
@@ -401,7 +416,23 @@ class GribSink(Sink):
     }
     inputs: list[str] = ["dataset"]
 
+    def _find_template_values(cls, path: str) -> list[str]:
+        return re.findall(r"\{(.*?)\}", path)
+
     def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
+        input_dataset = inputs.get("dataset")
+        if not isinstance(input_dataset, QubedOutput):
+            actual_type = type(input_dataset).__name__ if input_dataset is not None else "None"
+            return Either.error(f"Unsupported input type for 'dataset': expected QubedOutput, got {actual_type}")
+        path = block.config_as_str(PATH)
+        dirname = os.path.dirname(path)
+        if len(self._find_template_values(dirname)) != 0:
+            return Either.error(f"Invalid filepath: directory path can not contain template values")
+        path_dims = self._find_template_values(path)
+        if not all([contains(input_dataset, GRIB_ALIASES.get(dim, dim)) for dim in path_dims]):
+            return Either.error(
+                f"Invalid filename: template values in filename must be one of {set(GRIB_ALIASES.keys()).union(dimensions(input_dataset))}"
+            )
         return Either.ok(NoOutput())
 
     def compile(
@@ -411,11 +442,25 @@ class GribSink(Sink):
         block: BlockInstance,
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         input_task = block.input_ids["dataset"]
+        path_dims = self._find_template_values(block.config_as_str(PATH))
+        keep_dims = []
+        for dim in path_dims:
+            mapped_dim = GRIB_ALIASES.get(dim, dim)
+            if mapped_dim not in keep_dims:
+                keep_dims.append(mapped_dim)
+        action = inputs[input_task].flatten(new_dim="**temp**", keep_dims=keep_dims, reset_coords=True).concatenate(dim="**temp**")
+        try:
+            if PARAM_DIM in keep_dims:
+                action = action.combine_branches(dim=PARAM_DIM)
+            else:
+                action = action.combine_branches(dim="**temp**").concatenate(dim="**temp**")
+        except:
+            pass
 
-        action = inputs[input_task].map(
+        action = action.map(
             Payload(
                 "fiab_plugin_ecmwf.runtime.sinks.write_grib",
-                kwargs={"path": block.configuration_values["path"]},
+                kwargs={"path": block.config_as_str(PATH)},
             )
         )
         return Either.ok(action)

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -303,9 +303,9 @@ class ZarrSink(Sink):
 
         action = (
             inputs[input_task]
-            .combine_branches(dim=PARAM_DIM, force=True)
-            .flatten(new_dim="**temp**", reset_coords=True)
-            .concatenate(dim="**temp**")
+            .flatten(new_dim="**temp1**", reset_coords=True)
+            .combine_branches(dim="**temp1**")
+            .concatenate(dim="**temp1**")
             .map(
                 Payload(
                     "fiab_plugin_ecmwf.runtime.sinks.write_zarr",
@@ -428,11 +428,12 @@ class GribSink(Sink):
         dirname = os.path.dirname(path)
         if len(self._find_template_values(dirname)) != 0:
             return Either.error(f"Invalid filepath: directory path can not contain template values")
-        path_dims = self._find_template_values(path)
-        if not all([contains(input_dataset, GRIB_ALIASES.get(dim, dim)) for dim in path_dims]):
-            return Either.error(
-                f"Invalid filename: template values in filename must be one of {set(GRIB_ALIASES.keys()).union(dimensions(input_dataset))}"
-            )
+        path_templates = self._find_template_values(path)
+        allowed_templates = dimensions(input_dataset).union(
+            set([alias for alias, dim in GRIB_ALIASES.items() if contains(input_dataset, dim)])
+        )
+        if not all([dim in allowed_templates for dim in path_templates]):
+            return Either.error(f"Invalid filename: template values in filename must be one of {allowed_templates}")
         return Either.ok(NoOutput())
 
     def compile(

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -15,6 +15,7 @@ from typing import Any, cast
 import numpy as np
 from cascade.low.func import Either
 from earthkit.workflows.fluent import Action, Payload, from_source
+from earthkit.workflows.nodetree import nodetree_dimensions, nodetree_new_dimension
 from fiab_core.fable import (
     ActionLookup,
     BlockConfigurationOption,
@@ -301,7 +302,7 @@ class ZarrSink(Sink):
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         input_task = block.input_ids["dataset"]
 
-        temp_dim = inputs[input_task]._temp_dim()
+        temp_dim = nodetree_new_dimension(inputs[input_task].nodes)
         action = (
             inputs[input_task]
             .flatten(new_dim=temp_dim, reset_coords=True)
@@ -419,7 +420,7 @@ class GribSink(Sink):
     inputs: list[str] = ["dataset"]
 
     def _find_template_values(cls, path: str) -> list[str]:
-        return re.findall(r"\{[.*?]\}", path)
+        return re.findall(r"\[(.*?)\]", path)
 
     def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
         input_dataset = inputs.get("dataset")
@@ -430,12 +431,6 @@ class GribSink(Sink):
         dirname = os.path.dirname(path)
         if len(self._find_template_values(dirname)) != 0:
             return Either.error(f"Invalid filepath: directory path can not contain template values")
-        path_templates = self._find_template_values(path)
-        allowed_templates = dimensions(input_dataset).union(
-            set([alias for alias, dim in GRIB_ALIASES.items() if contains(input_dataset, dim)])
-        )
-        if not all([dim in allowed_templates for dim in path_templates]):
-            return Either.error(f"Invalid filename: template values in filename must be one of {allowed_templates}")
         return Either.ok(RawOutput(type_fqn="bytes", mime_type="text/plain"))
 
     def compile(
@@ -446,12 +441,13 @@ class GribSink(Sink):
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         input_task = block.input_ids["dataset"]
         path_dims = self._find_template_values(block.config_as_str(PATH))
+        action_dims = nodetree_dimensions(inputs[input_task].nodes)
         keep_dims = []
         for dim in path_dims:
             mapped_dim = GRIB_ALIASES.get(dim, dim)
-            if mapped_dim not in keep_dims:
+            if mapped_dim in action_dims and mapped_dim not in keep_dims:
                 keep_dims.append(mapped_dim)
-        temp_dim = inputs[input_task]._temp_dim()
+        temp_dim = nodetree_new_dimension(inputs[input_task].nodes)
         action = inputs[input_task].flatten(new_dim=temp_dim, keep_dims=keep_dims, reset_coords=True).concatenate(dim=temp_dim)
         try:
             if PARAM in keep_dims:

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -301,11 +301,12 @@ class ZarrSink(Sink):
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         input_task = block.input_ids["dataset"]
 
+        temp_dim = inputs[input_task]._temp_dim()
         action = (
             inputs[input_task]
-            .flatten(new_dim="**temp1**", reset_coords=True)
-            .combine_branches(dim="**temp1**")
-            .concatenate(dim="**temp1**")
+            .flatten(new_dim=temp_dim, reset_coords=True)
+            .combine_branches(dim=temp_dim)
+            .concatenate(dim=temp_dim)
             .map(
                 Payload(
                     "fiab_plugin_ecmwf.runtime.sinks.write_zarr",
@@ -450,12 +451,13 @@ class GribSink(Sink):
             mapped_dim = GRIB_ALIASES.get(dim, dim)
             if mapped_dim not in keep_dims:
                 keep_dims.append(mapped_dim)
-        action = inputs[input_task].flatten(new_dim="**temp**", keep_dims=keep_dims, reset_coords=True).concatenate(dim="**temp**")
+        temp_dim = inputs[input_task]._temp_dim()
+        action = inputs[input_task].flatten(new_dim=temp_dim, keep_dims=keep_dims, reset_coords=True).concatenate(dim=temp_dim)
         try:
             if PARAM_DIM in keep_dims:
                 action = action.combine_branches(dim=PARAM_DIM)
             else:
-                action = action.combine_branches(dim="**temp**").concatenate(dim="**temp**")
+                action = action.combine_branches(dim=temp_dim).concatenate(dim=temp_dim)
         except:
             pass
 

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -412,14 +412,14 @@ class GribSink(Sink):
     configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {
         PATH: BlockConfigurationOption(
             title="GRIB Path",
-            description="Filesystem path where the GRIB file should be written",
+            description="Filesystem path where the GRIB file should be written. Filename can contain template values from metadata in [] brackets.",
             value_type="str",
         )
     }
     inputs: list[str] = ["dataset"]
 
     def _find_template_values(cls, path: str) -> list[str]:
-        return re.findall(r"\{(.*?)\}", path)
+        return re.findall(r"\{[.*?]\}", path)
 
     def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
         input_dataset = inputs.get("dataset")

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -8,9 +8,9 @@
 # nor does it submit to any jurisdiction.
 
 import logging
-from typing import Any, cast
 import os
 import re
+from typing import Any, cast
 
 import numpy as np
 from cascade.low.func import Either
@@ -68,8 +68,8 @@ IFS_REQUEST = {
 }
 
 GRIB_ALIASES = {
-    "shortName": PARAM_DIM,
-    "paramId": PARAM_DIM,
+    "shortName": PARAM,
+    "paramId": PARAM,
     "stepRange": "step",
     "level": "levelist",
 }
@@ -454,8 +454,8 @@ class GribSink(Sink):
         temp_dim = inputs[input_task]._temp_dim()
         action = inputs[input_task].flatten(new_dim=temp_dim, keep_dims=keep_dims, reset_coords=True).concatenate(dim=temp_dim)
         try:
-            if PARAM_DIM in keep_dims:
-                action = action.combine_branches(dim=PARAM_DIM)
+            if PARAM in keep_dims:
+                action = action.combine_branches(dim=PARAM)
             else:
                 action = action.combine_branches(dim=temp_dim).concatenate(dim=temp_dim)
         except:

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -389,6 +389,40 @@ class SelectDimension(Transform):
     def intersect(self, other: QubedOutput) -> bool:
         return contains(other, self.option_id)
 
+class GribSink(Sink):
+    title: str = "GRIB Sink"
+    description: str = "Write dataset to a GRIB file on the local filesystem"
+    configuration_options: dict[str, BlockConfigurationOption] = {
+        "path": BlockConfigurationOption(
+            title="GRIB Path",
+            description="Filesystem path where the GRIB file should be written",
+            value_type="str",
+        )
+    }
+    inputs: list[str] = ["dataset"]
+
+    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
+        return Either.ok(NoOutput())
+
+    def compile(
+        self,
+        inputs: ActionLookup,
+        block_id: BlockInstanceId,
+        block: BlockInstance,
+    ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
+        input_task = block.input_ids["dataset"]
+
+        action = inputs[input_task].map(
+            Payload(
+                "fiab_plugin_ecmwf.runtime.sinks.write_grib",
+                kwargs={"path": block.configuration_values["path"]},
+            )
+        )
+        return Either.ok(action)
+
+    def intersect(self, other: QubedOutput) -> bool:
+        return bool(dimensions(other))
+
 
 class MapPlotSink(Sink):
     title: str = "Map Plot"

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -291,7 +291,7 @@ class ZarrSink(Sink):
     inputs: list[str] = ["dataset"]
 
     def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
-        return Either.ok(NoOutput())
+        return Either.ok(RawOutput(type_fqn="bytes", mime_type="text/plain"))
 
     def compile(
         self,
@@ -404,6 +404,7 @@ class SelectDimension(Transform):
     def intersect(self, other: QubedOutput) -> bool:
         return contains(other, self.option_id)
 
+
 class GribSink(Sink):
     title: str = "GRIB Sink"
     description: str = "Write dataset to a GRIB file on the local filesystem"
@@ -434,7 +435,7 @@ class GribSink(Sink):
         )
         if not all([dim in allowed_templates for dim in path_templates]):
             return Either.error(f"Invalid filename: template values in filename must be one of {allowed_templates}")
-        return Either.ok(NoOutput())
+        return Either.ok(RawOutput(type_fqn="bytes", mime_type="text/plain"))
 
     def compile(
         self,

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/runtime/sinks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/runtime/sinks.py
@@ -3,13 +3,15 @@ import pathlib
 import earthkit.data
 
 
-def write_zarr(fieldlist: earthkit.data.SimpleFieldList, path: str) -> str:
+def write_zarr(fieldlist: earthkit.data.SimpleFieldList, path: str) -> bytes:
+    p = pathlib.Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
     fieldlist.to_target("zarr", xarray_to_zarr_kwargs={"store": path, "mode": "w"})
-    return path
+    return path.encode("ascii")
 
 
-def write_grib(fieldlist: earthkit.data.SimpleFieldList, path: str) -> str:
+def write_grib(fieldlist: earthkit.data.SimpleFieldList, path: str) -> bytes:
     p = pathlib.Path(path)
     p.parent.mkdir(parents=True, exist_ok=True)
     fieldlist.to_target("file-pattern", path)
-    return str(p.parent)
+    return str(p.parent).encode("ascii")

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/runtime/sinks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/runtime/sinks.py
@@ -13,5 +13,6 @@ def write_zarr(fieldlist: earthkit.data.SimpleFieldList, path: str) -> bytes:
 def write_grib(fieldlist: earthkit.data.SimpleFieldList, path: str) -> bytes:
     p = pathlib.Path(path)
     p.parent.mkdir(parents=True, exist_ok=True)
-    fieldlist.to_target("file-pattern", path)
-    return str(p.parent).encode("ascii")
+    formatted_path = path.replace("{", "[").replace("}", "]")
+    fieldlist.to_target("file-pattern", formatted_path)
+    return path.encode("ascii")

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/runtime/sinks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/runtime/sinks.py
@@ -13,6 +13,6 @@ def write_zarr(fieldlist: earthkit.data.SimpleFieldList, path: str) -> bytes:
 def write_grib(fieldlist: earthkit.data.SimpleFieldList, path: str) -> bytes:
     p = pathlib.Path(path)
     p.parent.mkdir(parents=True, exist_ok=True)
-    formatted_path = path.replace("{", "[").replace("}", "]")
+    formatted_path = path.replace("[", "{").replace("]", "}")
     fieldlist.to_target("file-pattern", formatted_path)
     return path.encode("ascii")

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/runtime/sinks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/runtime/sinks.py
@@ -1,6 +1,25 @@
+import fcntl
+import pathlib
+
 import earthkit.data
 
 
 def write_zarr(fieldlist: earthkit.data.SimpleFieldList, path: str) -> str:
     fieldlist.to_target("zarr", xarray_to_zarr_kwargs={"store": path, "mode": "w"})
     return path
+
+
+def write_grib(fieldlist: earthkit.data.SimpleFieldList, path: str) -> str:
+    # Cascade fans out, so multiple workers can call this concurrently.
+    p = pathlib.Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with open(p, "ab") as fh:
+        # Acquire an exclusive lock
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        try:
+            # Let earthkit handle the actual data I/O natively
+            fieldlist.to_target("file", str(p), append=True)
+        finally:
+            # Explicitly release the lock
+            fcntl.flock(fh, fcntl.LOCK_UN)
+    return str(p)

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/runtime/sinks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/runtime/sinks.py
@@ -1,4 +1,3 @@
-import fcntl
 import pathlib
 
 import earthkit.data
@@ -10,16 +9,7 @@ def write_zarr(fieldlist: earthkit.data.SimpleFieldList, path: str) -> str:
 
 
 def write_grib(fieldlist: earthkit.data.SimpleFieldList, path: str) -> str:
-    # Cascade fans out, so multiple workers can call this concurrently.
     p = pathlib.Path(path)
     p.parent.mkdir(parents=True, exist_ok=True)
-    with open(p, "ab") as fh:
-        # Acquire an exclusive lock
-        fcntl.flock(fh, fcntl.LOCK_EX)
-        try:
-            # Let earthkit handle the actual data I/O natively
-            fieldlist.to_target("file", str(p), append=True)
-        finally:
-            # Explicitly release the lock
-            fcntl.flock(fh, fcntl.LOCK_UN)
-    return str(p)
+    fieldlist.to_target("file-pattern", path)
+    return str(p.parent)

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -38,6 +38,7 @@ from fiab_plugin_ecmwf.blocks import (
     STEP,
     EkdSource,
     EnsembleStatistics,
+    GribSink,
     MapPlotSink,
     SelectDimension,
     TemporalStatistics,
@@ -219,6 +220,17 @@ def zarr_sink_configuration() -> BlockInstance:
             ),
         ),
         ZarrSink.configuration_options,
+    )
+
+
+@pytest.fixture
+def grib_sink_configuration() -> BlockInstance:
+    return BlockInstance(
+        factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="GribSink"),  # type: ignore
+        input_ids={"dataset": BlockInstanceId("source_output")},
+        configuration_values={
+            "path": "/path/to/output.grib2",
+        },
     )
 
 
@@ -623,6 +635,59 @@ class TestSelectMembers:
 
 def test_anemoi_catalogue_value_types_are_canonical(registered_provider: None) -> None:
     assert get_checkpoint_enum_type() == "enumClosed['dummy_store:dummy_ckpt']"
+
+class TestGribSink:
+    def test_from_ekdsource(self, grib_sink_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:
+        block = GribSink()
+
+        assert block.intersect(other=ekdsource_output)  # type: ignore[arg-type]
+        output = block.validate(  # type: ignore[assignment]
+            block=grib_sink_configuration,
+            inputs={"dataset": ekdsource_output},  # type: ignore[dict-item]
+        ).get_or_raise()
+        assert isinstance(output, NoOutput)
+
+    def test_from_ensemble_statistics(
+        self,
+        grib_sink_configuration: BlockInstance,
+        ensemble_statistics_configuration: BlockInstance,
+        ekdsource_output: QubedOutput,
+    ) -> None:
+        ensemble_block = EnsembleStatistics()
+        ensemble_output = ensemble_block.validate(  # type: ignore[assignment]
+            block=ensemble_statistics_configuration,
+            inputs={"dataset": ekdsource_output},  # type: ignore[dict-item]
+        ).get_or_raise()
+
+        block = GribSink()
+
+        assert block.intersect(other=ensemble_output)  # type: ignore[arg-type]
+        output = block.validate(  # type: ignore[assignment]
+            block=grib_sink_configuration,
+            inputs={"dataset": ensemble_output},  # type: ignore[dict-item]
+        ).get_or_raise()
+        assert isinstance(output, NoOutput)
+
+    def test_from_temporal_statistics(
+        self,
+        grib_sink_configuration: BlockInstance,
+        temporal_statistics_configuration: BlockInstance,
+        ekdsource_output: QubedOutput,
+    ) -> None:
+        temporal_block = TemporalStatistics()
+        temporal_output = temporal_block.validate(  # type: ignore[assignment]
+            block=temporal_statistics_configuration,
+            inputs={"dataset": ekdsource_output},  # type: ignore[dict-item]
+        ).get_or_raise()
+
+        block = GribSink()
+
+        assert block.intersect(other=temporal_output)  # type: ignore[arg-type]
+        output = block.validate(  # type: ignore[assignment]
+            block=grib_sink_configuration,
+            inputs={"dataset": temporal_output},  # type: ignore[dict-item]
+        ).get_or_raise()
+        assert isinstance(output, NoOutput)
 
 
 class TestMapPlotSink:

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -228,9 +228,11 @@ def grib_sink_configuration() -> BlockInstance:
     return BlockInstance(
         factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="GribSink"),  # type: ignore
         input_ids={"dataset": BlockInstanceId("source_output")},
-        configuration_values={
-            "path": "/path/to/output.grib2",
-        },
+        configuration_values=_config(
+            {
+                "path": "/path/to/output.grib2",
+            }
+        ),
     )
 
 
@@ -635,6 +637,7 @@ class TestSelectMembers:
 
 def test_anemoi_catalogue_value_types_are_canonical(registered_provider: None) -> None:
     assert get_checkpoint_enum_type() == "enumClosed['dummy_store:dummy_ckpt']"
+
 
 class TestGribSink:
     def test_from_ekdsource(self, grib_sink_configuration: BlockInstance, ekdsource_output: QubedOutput) -> None:

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -738,15 +738,7 @@ class TestGribSink:
         ).get_or_raise()
         assert isinstance(output, RawOutput)
 
-    @pytest.mark.parametrize(
-        "filepath, error",
-        [
-            ["/path/to/[unknown].grib2", "Invalid filename: template values in filename must be one of"],
-            ["/path/to/[levelist].grib2", "Invalid filename: template values in filename must be one of"],
-            ["/path/to/[param]/[step].grib", "Invalid filepath: directory path can not contain template values"],
-        ],
-    )
-    def test_invalid_path(self, ekdsource_output: QubedOutput, filepath: str, error: str) -> None:
+    def test_invalid_path(self, ekdsource_output: QubedOutput) -> None:
         block = GribSink()
         config = BlockInstance.from_block(
             BlockInstanceBase(
@@ -754,7 +746,7 @@ class TestGribSink:
                 input_ids={"dataset": BlockInstanceId("source_output")},
                 configuration_values=_config(
                     {
-                        "path": filepath,
+                        "path": "/path/to/[param]/[step].grib",
                     }
                 ),
             ),
@@ -764,7 +756,7 @@ class TestGribSink:
             block=config,
             inputs={"dataset": ekdsource_output},  # type: ignore[dict-item]
         )
-        with pytest.raises(Exception, match=error):
+        with pytest.raises(Exception, match="Invalid filepath: directory path can not contain template values"):
             output.get_or_raise()
 
     @pytest.mark.parametrize(
@@ -773,7 +765,7 @@ class TestGribSink:
             ["/path/to/output.grib", {}],
             ["/path/to/[param].grib", {"param": 2}],
             ["/path/to/[param]_[shortName]_[step].grib", {"param": 2, "step": 3}],
-            ["/path/to/[stepRange]_[number].grib", {"step": 3, "number": 5}],
+            ["/path/to/[stepRange]_[number]_[non_dim].grib", {"step": 3, "number": 5}],
         ],
     )
     def test_compile(self, ekdsource_output: QubedOutput, ekdsource_action: Action, filepath: str, dims: dict[str, int]) -> None:

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -396,7 +396,7 @@ class TestZarrSink:
             block=zarr_sink_configuration,
             inputs={"dataset": ekdsource_output},  # type: ignore[dict-item]
         ).get_or_raise()
-        assert isinstance(output, NoOutput)
+        assert isinstance(output, RawOutput)
 
     def test_from_ensemble_statistics(
         self,
@@ -417,7 +417,7 @@ class TestZarrSink:
             block=zarr_sink_configuration,
             inputs={"dataset": ensemble_output},  # type: ignore[dict-item]
         ).get_or_raise()
-        assert isinstance(output, NoOutput)
+        assert isinstance(output, RawOutput)
 
     def test_from_temporal_statistics(
         self,
@@ -438,7 +438,7 @@ class TestZarrSink:
             block=zarr_sink_configuration,
             inputs={"dataset": temporal_output},  # type: ignore[dict-item]
         ).get_or_raise()
-        assert isinstance(output, NoOutput)
+        assert isinstance(output, RawOutput)
 
     def test_compile(self, ekdsource_output: QubedOutput, ekdsource_action: Action, zarr_sink_configuration: BlockInstance) -> None:
         block = ZarrSink()
@@ -665,7 +665,7 @@ class TestGribSink:
             block=grib_sink_configuration,
             inputs={"dataset": ekdsource_output},  # type: ignore[dict-item]
         ).get_or_raise()
-        assert isinstance(output, NoOutput)
+        assert isinstance(output, RawOutput)
 
     def test_from_ensemble_statistics(
         self,
@@ -686,7 +686,7 @@ class TestGribSink:
             block=grib_sink_configuration,
             inputs={"dataset": ensemble_output},  # type: ignore[dict-item]
         ).get_or_raise()
-        assert isinstance(output, NoOutput)
+        assert isinstance(output, RawOutput)
 
     def test_from_temporal_statistics(
         self,
@@ -707,7 +707,7 @@ class TestGribSink:
             block=grib_sink_configuration,
             inputs={"dataset": temporal_output},  # type: ignore[dict-item]
         ).get_or_raise()
-        assert isinstance(output, NoOutput)
+        assert isinstance(output, RawOutput)
 
     @pytest.mark.parametrize(
         "filepath",
@@ -736,7 +736,7 @@ class TestGribSink:
             block=config,
             inputs={"dataset": ekdsource_output},  # type: ignore[dict-item]
         ).get_or_raise()
-        assert isinstance(output, NoOutput)
+        assert isinstance(output, RawOutput)
 
     @pytest.mark.parametrize(
         "filepath, error",

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -741,7 +741,8 @@ class TestGribSink:
     @pytest.mark.parametrize(
         "filepath, error",
         [
-            ["/path/to/{unkwown}.grib2", "Invalid filename: template values in filename must be one of"],
+            ["/path/to/{unknown}.grib2", "Invalid filename: template values in filename must be one of"],
+            ["/path/to/{levelist}.grib2", "Invalid filename: template values in filename must be one of"],
             ["/path/to/{param}/{step}.grib", "Invalid filepath: directory path can not contain template values"],
         ],
     )

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -12,6 +12,7 @@ from datetime import date
 from unittest.mock import MagicMock
 
 import pytest
+from earthkit.workflows.fluent import Action
 from fiab_core.fable import (
     BlockFactoryId,
     BlockInstanceId,
@@ -126,6 +127,11 @@ def ekdsource_output(dummy_blockinstance: BlockInstance) -> QubedOutput:
 
 
 @pytest.fixture
+def ekdsource_action(dummy_blockinstance: BlockInstance) -> Action:
+    return EkdSource().compile(inputs={}, block_id=BlockInstanceId("source_output"), block=dummy_blockinstance).get_or_raise()
+
+
+@pytest.fixture
 def ensemble_statistics_configuration() -> BlockInstance:
     return BlockInstance.from_block(
         BlockInstanceBase(
@@ -225,14 +231,17 @@ def zarr_sink_configuration() -> BlockInstance:
 
 @pytest.fixture
 def grib_sink_configuration() -> BlockInstance:
-    return BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="GribSink"),  # type: ignore
-        input_ids={"dataset": BlockInstanceId("source_output")},
-        configuration_values=_config(
-            {
-                "path": "/path/to/output.grib2",
-            }
+    return BlockInstance.from_block(
+        BlockInstanceBase(
+            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="GribSink"),  # type: ignore
+            input_ids={"dataset": BlockInstanceId("source_output")},
+            configuration_values=_config(
+                {
+                    "path": "/path/to/output.grib2",
+                }
+            ),
         ),
+        GribSink.configuration_options,
     )
 
 
@@ -430,6 +439,14 @@ class TestZarrSink:
             inputs={"dataset": temporal_output},  # type: ignore[dict-item]
         ).get_or_raise()
         assert isinstance(output, NoOutput)
+
+    def test_compile(self, ekdsource_output: QubedOutput, ekdsource_action: Action, zarr_sink_configuration: BlockInstance) -> None:
+        block = ZarrSink()
+        block.validate(block=zarr_sink_configuration, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
+        action = block.compile(
+            inputs={BlockInstanceId("source_output"): ekdsource_action}, block_id=BlockInstanceId("grib"), block=zarr_sink_configuration
+        ).get_or_raise()
+        assert action.nodes.dims == {}
 
 
 class TestSelectParameters:
@@ -691,6 +708,92 @@ class TestGribSink:
             inputs={"dataset": temporal_output},  # type: ignore[dict-item]
         ).get_or_raise()
         assert isinstance(output, NoOutput)
+
+    @pytest.mark.parametrize(
+        "filepath",
+        [
+            "/path/to/output.grib",
+            "/path/to/{param}.grib",
+            "/path/to/{shortName}.grib",
+            "/path/to/{param}_{shortName}_{step}.grib",
+        ],
+    )
+    def test_validate_template_values(self, ekdsource_output: QubedOutput, filepath: str) -> None:
+        block = GribSink()
+        config = BlockInstance.from_block(
+            BlockInstanceBase(
+                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="GribSink"),  # type: ignore
+                input_ids={"dataset": BlockInstanceId("source_output")},
+                configuration_values=_config(
+                    {
+                        "path": filepath,
+                    }
+                ),
+            ),
+            GribSink.configuration_options,
+        )
+        output = block.validate(  # type: ignore[assignment]
+            block=config,
+            inputs={"dataset": ekdsource_output},  # type: ignore[dict-item]
+        ).get_or_raise()
+        assert isinstance(output, NoOutput)
+
+    @pytest.mark.parametrize(
+        "filepath, error",
+        [
+            ["/path/to/{unkwown}.grib2", "Invalid filename: template values in filename must be one of"],
+            ["/path/to/{param}/{step}.grib", "Invalid filepath: directory path can not contain template values"],
+        ],
+    )
+    def test_invalid_path(self, ekdsource_output: QubedOutput, filepath: str, error: str) -> None:
+        block = GribSink()
+        config = BlockInstance.from_block(
+            BlockInstanceBase(
+                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="GribSink"),  # type: ignore
+                input_ids={"dataset": BlockInstanceId("source_output")},
+                configuration_values=_config(
+                    {
+                        "path": filepath,
+                    }
+                ),
+            ),
+            GribSink.configuration_options,
+        )
+        output = block.validate(  # type: ignore[assignment]
+            block=config,
+            inputs={"dataset": ekdsource_output},  # type: ignore[dict-item]
+        )
+        with pytest.raises(Exception, match=error):
+            output.get_or_raise()
+
+    @pytest.mark.parametrize(
+        "filepath, dims",
+        [
+            ["/path/to/output.grib", {}],
+            ["/path/to/{param}.grib", {"param": 2}],
+            ["/path/to/{param}_{shortName}_{step}.grib", {"param": 2, "step": 3}],
+            ["/path/to/{stepRange}_{number}.grib", {"step": 3, "number": 5}],
+        ],
+    )
+    def test_compile(self, ekdsource_output: QubedOutput, ekdsource_action: Action, filepath: str, dims: dict[str, int]) -> None:
+        block = GribSink()
+        config = BlockInstance.from_block(
+            BlockInstanceBase(
+                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="GribSink"),  # type: ignore
+                input_ids={"dataset": BlockInstanceId("source_output")},
+                configuration_values=_config(
+                    {
+                        "path": filepath,
+                    }
+                ),
+            ),
+            GribSink.configuration_options,
+        )
+        block.validate(block=config, inputs={"dataset": ekdsource_output}).get_or_raise()  # type: ignore[dict-item]
+        action = block.compile(
+            inputs={BlockInstanceId("source_output"): ekdsource_action}, block_id=BlockInstanceId("grib"), block=config
+        ).get_or_raise()
+        assert action.nodes.dims == dims
 
 
 class TestMapPlotSink:

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -741,9 +741,9 @@ class TestGribSink:
     @pytest.mark.parametrize(
         "filepath, error",
         [
-            ["/path/to/{unknown}.grib2", "Invalid filename: template values in filename must be one of"],
-            ["/path/to/{levelist}.grib2", "Invalid filename: template values in filename must be one of"],
-            ["/path/to/{param}/{step}.grib", "Invalid filepath: directory path can not contain template values"],
+            ["/path/to/[unknown].grib2", "Invalid filename: template values in filename must be one of"],
+            ["/path/to/[levelist].grib2", "Invalid filename: template values in filename must be one of"],
+            ["/path/to/[param]/[step].grib", "Invalid filepath: directory path can not contain template values"],
         ],
     )
     def test_invalid_path(self, ekdsource_output: QubedOutput, filepath: str, error: str) -> None:
@@ -771,9 +771,9 @@ class TestGribSink:
         "filepath, dims",
         [
             ["/path/to/output.grib", {}],
-            ["/path/to/{param}.grib", {"param": 2}],
-            ["/path/to/{param}_{shortName}_{step}.grib", {"param": 2, "step": 3}],
-            ["/path/to/{stepRange}_{number}.grib", {"step": 3, "number": 5}],
+            ["/path/to/[param].grib", {"param": 2}],
+            ["/path/to/[param]_[shortName]_[step].grib", {"param": 2, "step": 3}],
+            ["/path/to/[stepRange]_[number].grib", {"step": 3, "number": 5}],
         ],
     )
     def test_compile(self, ekdsource_output: QubedOutput, ekdsource_action: Action, filepath: str, dims: dict[str, int]) -> None:


### PR DESCRIPTION
### Description
Adds a GribSink block: A Sink block that writes a SimpleFieldList to a GRIB file via earthkit-data's file target. Squashes dimensions in the input Action that aren't declared as template values in the filepath. Functionality requires earthkit-workflows release with https://github.com/ecmwf/earthkit-workflows/pull/209 and https://github.com/ecmwf/earthkit-workflows/pull/210. Also modifies ZarrSink to reduce combine all nodes in Action into one node before writing.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
