### PR TITLE
Add SSH tunnel utility

### DIFF
--- a/backend/src/forecastbox/domain/gateway/__init__.py
+++ b/backend/src/forecastbox/domain/gateway/__init__.py
@@ -1,0 +1,16 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""
+Manages the Gateway domain -- process lifecycle and connection URL used by
+other domains to execute and inspect workflow jobs.
+
+Depends on utility config and Cascade runtime bindings.
+Depended on by Run domain and gateway/status routes.
+"""

--- a/backend/src/forecastbox/domain/gateway/exceptions.py
+++ b/backend/src/forecastbox/domain/gateway/exceptions.py
@@ -1,0 +1,38 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Domain exceptions for gateway lifecycle and connectivity."""
+
+
+class GatewayError(Exception):
+    """Base class for gateway domain errors."""
+
+
+class GatewayManagerNotInitialized(GatewayError):
+    """Raised when gateway manager singleton was not initialized."""
+
+
+class GatewayAlreadyRunning(GatewayError):
+    """Raised when attempting to start an already tracked gateway process."""
+
+
+class GatewayNotRunning(GatewayError):
+    """Raised when attempting to stop or use a non-running gateway process."""
+
+
+class GatewayNotStarted(GatewayError):
+    """Raised when status is requested but no process was started yet."""
+
+
+class GatewayExited(GatewayError):
+    """Raised when status is requested and process already exited."""
+
+    def __init__(self, exitcode: int) -> None:
+        self.exitcode = exitcode
+        super().__init__(f"Gateway exited with code {exitcode}")

--- a/backend/src/forecastbox/domain/gateway/exceptions.py
+++ b/backend/src/forecastbox/domain/gateway/exceptions.py
@@ -14,10 +14,6 @@ class GatewayError(Exception):
     """Base class for gateway domain errors."""
 
 
-class GatewayManagerNotInitialized(GatewayError):
-    """Raised when gateway manager singleton was not initialized."""
-
-
 class GatewayAlreadyRunning(GatewayError):
     """Raised when attempting to start an already tracked gateway process."""
 

--- a/backend/src/forecastbox/domain/gateway/service.py
+++ b/backend/src/forecastbox/domain/gateway/service.py
@@ -1,0 +1,158 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Gateway lifecycle and URL management for the backend."""
+
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from multiprocessing.process import BaseProcess
+from tempfile import TemporaryDirectory
+
+from cascade.deployment.logging import LoggingConfig
+from cascade.executor import platform
+from cascade.gateway import api, client
+from cascade.gateway.server import main_enp
+
+from forecastbox.domain.gateway.exceptions import (
+    GatewayAlreadyRunning,
+    GatewayExited,
+    GatewayManagerNotInitialized,
+    GatewayNotRunning,
+    GatewayNotStarted,
+)
+from forecastbox.utility.config import StatusMessage, config
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, eq=True, slots=True)
+class GatewayProcess:
+    logs_directory: TemporaryDirectory
+    process: BaseProcess
+
+
+@dataclass(eq=False, slots=True)
+class GatewayConnectionManager:
+    lock: threading.Lock
+    gateway_process: GatewayProcess | None = None
+
+
+_manager: GatewayConnectionManager | None = None
+
+
+def _require_manager() -> GatewayConnectionManager:
+    if _manager is None:
+        raise GatewayManagerNotInitialized("Gateway manager is not initialized")
+    return _manager
+
+
+def init_manager() -> None:
+    global _manager
+    if _manager is not None:
+        raise ValueError("Gateway manager is already initialized")
+    _manager = GatewayConnectionManager(lock=threading.Lock())
+
+
+def _reset_manager() -> None:
+    global _manager
+    _manager = None
+
+
+def launch_cascade(cascade_url: str, log_base: str | None, max_concurrent_jobs: int | None) -> None:
+    logging_config = LoggingConfig(path_base=log_base, formatter="line")
+    try:
+        main_enp(url=cascade_url, loggingConfig=logging_config, max_concurrent_jobs=max_concurrent_jobs)
+    except KeyboardInterrupt:
+        pass
+
+
+def launch_gateway() -> None:
+    manager = _require_manager()
+    with manager.lock:
+        if manager.gateway_process is not None:
+            raise GatewayAlreadyRunning("Process already running.")
+        logs_directory = TemporaryDirectory(prefix="fiabLogs")
+        logger.debug(f"logging base is at {logs_directory.name}")
+        logs_base = None if os.getenv("FIAB_LOGSTDOUT", "nay") == "yea" else logs_directory.name + os.sep
+        max_concurrent_jobs = config.cascade.max_concurrent_jobs
+        process = platform.get_mp_ctx("gateway").Process(
+            target=launch_cascade,
+            args=(config.cascade.cascade_url, logs_base, max_concurrent_jobs),
+        )  # type: ignore[unresolved-attribute] # context
+        process.start()
+        logger.debug(f"spawned new gateway process with pid {process.pid}")
+        manager.gateway_process = GatewayProcess(logs_directory=logs_directory, process=process)
+
+
+def get_gateway_url() -> str:
+    manager = _require_manager()
+    if manager.gateway_process is None:
+        raise GatewayNotRunning("Gateway is not running")
+    return config.cascade.cascade_url
+
+
+def get_logs_directory() -> TemporaryDirectory | None:
+    manager = _require_manager()
+    gateway_process = manager.gateway_process
+    if gateway_process is None:
+        return None
+    return gateway_process.logs_directory
+
+
+def status_gateway() -> str:
+    manager = _require_manager()
+    gateway_process = manager.gateway_process
+    if gateway_process is None:
+        raise GatewayNotStarted("Gateway was not started")
+    if gateway_process.process.exitcode is not None:
+        raise GatewayExited(gateway_process.process.exitcode)
+    return StatusMessage.gateway_running
+
+
+def stop_gateway() -> None:
+    manager = _require_manager()
+    with manager.lock:
+        gateway_process = manager.gateway_process
+        if gateway_process is None or gateway_process.process.exitcode is not None:
+            raise GatewayNotRunning("Gateway is not running")
+
+        logger.debug("gateway shutdown message")
+        m = api.ShutdownRequest()
+        client.request_response(m, get_gateway_url(), 4_000)
+        logger.debug("gateway terminate and join")
+
+        process = gateway_process.process
+        process.terminate()
+        process.join(1)
+        if process.exitcode is None:
+            logger.debug("gateway kill")
+            process.kill()
+        manager.gateway_process = None
+
+
+async def shutdown_processes() -> None:
+    """Terminate all running gateway processes on app shutdown."""
+    logger.debug("initiating graceful gateway shutdown")
+    if _manager is None:
+        return
+    manager = _require_manager()
+    gateway_process = manager.gateway_process
+    if gateway_process is None:
+        _reset_manager()
+        return
+    if gateway_process.process.exitcode is None:
+        try:
+            stop_gateway()
+        except GatewayNotRunning:
+            pass
+    else:
+        manager.gateway_process = None
+    _reset_manager()

--- a/backend/src/forecastbox/domain/gateway/service.py
+++ b/backend/src/forecastbox/domain/gateway/service.py
@@ -11,7 +11,6 @@
 
 import logging
 import os
-import socket
 import threading
 import urllib.parse
 from dataclasses import dataclass
@@ -22,6 +21,7 @@ from cascade.deployment.logging import LoggingConfig
 from cascade.executor import platform
 from cascade.gateway import api, client
 from cascade.gateway.server import main_enp
+from cascade.low.func import assert_never
 
 from forecastbox.domain.gateway.exceptions import (
     GatewayAlreadyRunning,
@@ -57,11 +57,6 @@ GatewayConnection = LocalProcess | RemoteTunnel | RemoteUrl
 GatewayConnectionType = type[LocalProcess] | type[RemoteTunnel] | type[RemoteUrl]
 
 
-class GatewayConnectionManager:
-    lock: threading.Lock = threading.Lock()
-    gateway_connection: GatewayConnection | None = None
-
-
 def config2gatewayMethod() -> GatewayConnectionType:
     parsed_url = urllib.parse.urlparse(config.cascade.cascade_url)
     if not config.cascade.spawn_gateway:
@@ -78,6 +73,11 @@ def _initial_connection() -> GatewayConnection | None:
     return None
 
 
+class GatewayConnectionManager:
+    lock: threading.Lock = threading.Lock()
+    gateway_connection: GatewayConnection | None = _initial_connection()
+
+
 def _remote_tunnel_target_and_port() -> tuple[str, int]:
     parsed_url = urllib.parse.urlparse(config.cascade.cascade_url)
     if parsed_url.hostname is None or parsed_url.port is None:
@@ -86,17 +86,7 @@ def _remote_tunnel_target_and_port() -> tuple[str, int]:
     return host, parsed_url.port
 
 
-def _random_local_gateway_url() -> str:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        port = int(sock.getsockname()[1])
-    return f"tcp://localhost:{port}"
-
-
-GatewayConnectionManager.gateway_connection = _initial_connection()
-
-
-def launch_cascade(cascade_url: str, log_base: str | None, max_concurrent_jobs: int | None) -> None:
+def _local_process_entrypoint(cascade_url: str, log_base: str | None, max_concurrent_jobs: int | None) -> None:
     logging_config = LoggingConfig(path_base=log_base, formatter="line")
     try:
         main_enp(url=cascade_url, loggingConfig=logging_config, max_concurrent_jobs=max_concurrent_jobs)
@@ -114,9 +104,9 @@ def launch_gateway() -> None:
             logs_directory = TemporaryDirectory(prefix="fiabLogs")
             logger.debug(f"logging base is at {logs_directory.name}")
             logs_base = None if os.getenv("FIAB_LOGSTDOUT", "nay") == "yea" else logs_directory.name + os.sep
-            gateway_url = _random_local_gateway_url()
+            gateway_url = f"tcp://localhost:{tunnel.claim_free_port()}"
             process = platform.get_mp_ctx("gateway").Process(
-                target=launch_cascade,
+                target=_local_process_entrypoint,
                 args=(gateway_url, logs_base, max_concurrent_jobs),
             )  # type: ignore[unresolved-attribute] # context
             process.start()
@@ -127,7 +117,7 @@ def launch_gateway() -> None:
                 gateway_url=gateway_url,
             )
             return
-        if gateway_method is RemoteTunnel:
+        elif gateway_method is RemoteTunnel:
             host, remote_port = _remote_tunnel_target_and_port()
             handle = tunnel.setup(host=host, remote_port=remote_port)
             remote_gateway_url = f"tcp://localhost:{handle.remote_port}"
@@ -136,8 +126,10 @@ def launch_gateway() -> None:
                 cmd.extend(["--max_concurrent_jobs", str(max_concurrent_jobs)])
             tunnel.execute(handle, cmd)
             GatewayConnectionManager.gateway_connection = RemoteTunnel(handle=handle)
-            return
-        raise NotImplementedError("RemoteUrl gateway cannot be launched by backend")
+        elif gateway_method is RemoteUrl:
+            raise NotImplementedError("RemoteUrl gateway cannot be launched by backend")
+        else:
+            assert_never(gateway_method)
 
 
 def get_gateway_url() -> str:
@@ -146,9 +138,12 @@ def get_gateway_url() -> str:
         raise GatewayNotRunning("Gateway is not running")
     if isinstance(gateway_connection, LocalProcess):
         return gateway_connection.gateway_url
-    if isinstance(gateway_connection, RemoteTunnel):
+    elif isinstance(gateway_connection, RemoteTunnel):
         return gateway_connection.handle.as_local_url()
-    return config.cascade.cascade_url
+    elif isinstance(gateway_connection, RemoteUrl):
+        return config.cascade.cascade_url
+    else:
+        assert_never(gateway_connection)
 
 
 def get_logs_directory() -> TemporaryDirectory | None:
@@ -157,7 +152,12 @@ def get_logs_directory() -> TemporaryDirectory | None:
         return None
     if isinstance(gateway_connection, LocalProcess):
         return gateway_connection.logs_directory
-    raise NotImplementedError("Logs directory is available only for local gateway process")
+    elif isinstance(gateway_connection, RemoteTunnel):
+        raise NotImplementedError("Logs directory is available only for local gateway process")
+    elif isinstance(gateway_connection, RemoteUrl):
+        raise NotImplementedError("Logs directory is available only for local gateway process")
+    else:
+        assert_never(gateway_connection)
 
 
 def status_gateway() -> str:
@@ -168,13 +168,16 @@ def status_gateway() -> str:
         if gateway_connection.process.exitcode is not None:
             raise GatewayExited(gateway_connection.process.exitcode)
         return StatusMessage.gateway_running
-    if isinstance(gateway_connection, RemoteTunnel):
+    elif isinstance(gateway_connection, RemoteTunnel):
         # TODO -- call gw status api once available, on fallback run command to check the proc status?
         if tunnel.status(gateway_connection.handle):
             return StatusMessage.gateway_running
         raise GatewayExited(255)
-    # TODO -- actually attempt resolving the url, then call gw status api once its available.
-    return StatusMessage.gateway_running
+    elif isinstance(gateway_connection, RemoteUrl):
+        # TODO -- actually attempt resolving the url, then call gw status api once its available.
+        return StatusMessage.gateway_running
+    else:
+        assert_never(gateway_connection)
 
 
 def stop_gateway() -> None:
@@ -198,7 +201,7 @@ def stop_gateway() -> None:
                 process.kill()
             GatewayConnectionManager.gateway_connection = None
             return
-        if isinstance(gateway_connection, RemoteTunnel):
+        elif isinstance(gateway_connection, RemoteTunnel):
             logger.debug("remote gateway shutdown message")
             m = api.ShutdownRequest()
             client.request_response(m, gateway_connection.handle.as_local_url(), 4_000)
@@ -206,14 +209,17 @@ def stop_gateway() -> None:
             tunnel.stop(gateway_connection.handle)
             GatewayConnectionManager.gateway_connection = None
             return
-        raise NotImplementedError("RemoteUrl gateway cannot be stopped by backend")
+        elif isinstance(gateway_connection, RemoteUrl):
+            raise NotImplementedError("RemoteUrl gateway cannot be stopped by backend")
+        else:
+            assert_never(gateway_connection)
 
 
 async def shutdown_processes() -> None:
     """Terminate all running gateway processes on app shutdown."""
     logger.debug("initiating graceful gateway shutdown")
     gateway_connection = GatewayConnectionManager.gateway_connection
-    if gateway_connection is None or isinstance(gateway_connection, RemoteUrl):
+    if gateway_connection is None:
         return
     if isinstance(gateway_connection, LocalProcess):
         if gateway_connection.process.exitcode is None:
@@ -222,15 +228,20 @@ async def shutdown_processes() -> None:
             except GatewayNotRunning:
                 pass
         else:
-            GatewayConnectionManager.gateway_connection = None
+            with GatewayConnectionManager.lock:
+                GatewayConnectionManager.gateway_connection = None
         return
-    if isinstance(gateway_connection, RemoteTunnel):
+    elif isinstance(gateway_connection, RemoteTunnel):
         if tunnel.status(gateway_connection.handle):
             try:
                 stop_gateway()
             except GatewayNotRunning:
                 pass
         else:
-            GatewayConnectionManager.gateway_connection = None
+            with GatewayConnectionManager.lock:
+                GatewayConnectionManager.gateway_connection = None
         return
-    raise NotImplementedError("Unknown gateway connection type")
+    elif isinstance(gateway_connection, RemoteUrl):
+        return
+    else:
+        assert_never(gateway_connection)

--- a/backend/src/forecastbox/domain/gateway/service.py
+++ b/backend/src/forecastbox/domain/gateway/service.py
@@ -11,7 +11,9 @@
 
 import logging
 import os
+import socket
 import threading
+import urllib.parse
 from dataclasses import dataclass
 from multiprocessing.process import BaseProcess
 from tempfile import TemporaryDirectory
@@ -27,20 +29,71 @@ from forecastbox.domain.gateway.exceptions import (
     GatewayNotRunning,
     GatewayNotStarted,
 )
+from forecastbox.utility import tunnel
 from forecastbox.utility.config import StatusMessage, config
 
 logger = logging.getLogger(__name__)
+_LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1"}
 
 
 @dataclass(frozen=True, eq=True, slots=True)
-class GatewayProcess:
+class LocalProcess:
     logs_directory: TemporaryDirectory
     process: BaseProcess
+    gateway_url: str
+
+
+@dataclass(frozen=True, eq=True, slots=True)
+class RemoteTunnel:
+    handle: tunnel.ConnectionHandle
+
+
+@dataclass(frozen=True, eq=True, slots=True)
+class RemoteUrl:
+    pass
+
+
+GatewayConnection = LocalProcess | RemoteTunnel | RemoteUrl
+GatewayConnectionType = type[LocalProcess] | type[RemoteTunnel] | type[RemoteUrl]
 
 
 class GatewayConnectionManager:
     lock: threading.Lock = threading.Lock()
-    gateway_process: GatewayProcess | None = None
+    gateway_connection: GatewayConnection | None = None
+
+
+def config2gatewayMethod() -> GatewayConnectionType:
+    parsed_url = urllib.parse.urlparse(config.cascade.cascade_url)
+    if not config.cascade.spawn_gateway:
+        return RemoteUrl
+    if parsed_url.hostname in _LOCAL_HOSTS:
+        return LocalProcess
+    return RemoteTunnel
+
+
+def _initial_connection() -> GatewayConnection | None:
+    gateway_method = config2gatewayMethod()
+    if gateway_method is RemoteUrl:
+        return RemoteUrl()
+    return None
+
+
+def _remote_tunnel_target_and_port() -> tuple[str, int]:
+    parsed_url = urllib.parse.urlparse(config.cascade.cascade_url)
+    if parsed_url.hostname is None or parsed_url.port is None:
+        raise ValueError(f"Invalid cascade_url for remote tunnel mode: {config.cascade.cascade_url!r}")
+    host = f"{parsed_url.username}@{parsed_url.hostname}" if parsed_url.username else parsed_url.hostname
+    return host, parsed_url.port
+
+
+def _random_local_gateway_url() -> str:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = int(sock.getsockname()[1])
+    return f"tcp://localhost:{port}"
+
+
+GatewayConnectionManager.gateway_connection = _initial_connection()
 
 
 def launch_cascade(cascade_url: str, log_base: str | None, max_concurrent_jobs: int | None) -> None:
@@ -53,73 +106,131 @@ def launch_cascade(cascade_url: str, log_base: str | None, max_concurrent_jobs: 
 
 def launch_gateway() -> None:
     with GatewayConnectionManager.lock:
-        if GatewayConnectionManager.gateway_process is not None:
+        if GatewayConnectionManager.gateway_connection is not None:
             raise GatewayAlreadyRunning("Process already running.")
-        logs_directory = TemporaryDirectory(prefix="fiabLogs")
-        logger.debug(f"logging base is at {logs_directory.name}")
-        logs_base = None if os.getenv("FIAB_LOGSTDOUT", "nay") == "yea" else logs_directory.name + os.sep
+        gateway_method = config2gatewayMethod()
         max_concurrent_jobs = config.cascade.max_concurrent_jobs
-        process = platform.get_mp_ctx("gateway").Process(
-            target=launch_cascade,
-            args=(config.cascade.cascade_url, logs_base, max_concurrent_jobs),
-        )  # type: ignore[unresolved-attribute] # context
-        process.start()
-        logger.debug(f"spawned new gateway process with pid {process.pid}")
-        GatewayConnectionManager.gateway_process = GatewayProcess(logs_directory=logs_directory, process=process)
+        if gateway_method is LocalProcess:
+            logs_directory = TemporaryDirectory(prefix="fiabLogs")
+            logger.debug(f"logging base is at {logs_directory.name}")
+            logs_base = None if os.getenv("FIAB_LOGSTDOUT", "nay") == "yea" else logs_directory.name + os.sep
+            gateway_url = _random_local_gateway_url()
+            process = platform.get_mp_ctx("gateway").Process(
+                target=launch_cascade,
+                args=(gateway_url, logs_base, max_concurrent_jobs),
+            )  # type: ignore[unresolved-attribute] # context
+            process.start()
+            logger.debug(f"spawned new gateway process with pid {process.pid}")
+            GatewayConnectionManager.gateway_connection = LocalProcess(
+                logs_directory=logs_directory,
+                process=process,
+                gateway_url=gateway_url,
+            )
+            return
+        if gateway_method is RemoteTunnel:
+            host, remote_port = _remote_tunnel_target_and_port()
+            handle = tunnel.setup(host=host, remote_port=remote_port)
+            remote_gateway_url = f"tcp://localhost:{handle.remote_port}"
+            cmd = ["uv", "run", "python", "-m", "cascade.gateway", "--url", remote_gateway_url]
+            if max_concurrent_jobs is not None:
+                cmd.extend(["--max_concurrent_jobs", str(max_concurrent_jobs)])
+            tunnel.execute(handle, cmd)
+            GatewayConnectionManager.gateway_connection = RemoteTunnel(handle=handle)
+            return
+        raise NotImplementedError("RemoteUrl gateway cannot be launched by backend")
 
 
 def get_gateway_url() -> str:
-    if GatewayConnectionManager.gateway_process is None:
+    gateway_connection = GatewayConnectionManager.gateway_connection
+    if gateway_connection is None:
         raise GatewayNotRunning("Gateway is not running")
+    if isinstance(gateway_connection, LocalProcess):
+        return gateway_connection.gateway_url
+    if isinstance(gateway_connection, RemoteTunnel):
+        return gateway_connection.handle.as_local_url()
     return config.cascade.cascade_url
 
 
 def get_logs_directory() -> TemporaryDirectory | None:
-    gateway_process = GatewayConnectionManager.gateway_process
-    if gateway_process is None:
+    gateway_connection = GatewayConnectionManager.gateway_connection
+    if gateway_connection is None:
         return None
-    return gateway_process.logs_directory
+    if isinstance(gateway_connection, LocalProcess):
+        return gateway_connection.logs_directory
+    raise NotImplementedError("Logs directory is available only for local gateway process")
 
 
 def status_gateway() -> str:
-    gateway_process = GatewayConnectionManager.gateway_process
-    if gateway_process is None:
+    gateway_connection = GatewayConnectionManager.gateway_connection
+    if gateway_connection is None:
         raise GatewayNotStarted("Gateway was not started")
-    if gateway_process.process.exitcode is not None:
-        raise GatewayExited(gateway_process.process.exitcode)
+    if isinstance(gateway_connection, LocalProcess):
+        if gateway_connection.process.exitcode is not None:
+            raise GatewayExited(gateway_connection.process.exitcode)
+        return StatusMessage.gateway_running
+    if isinstance(gateway_connection, RemoteTunnel):
+        # TODO -- call gw status api once available, on fallback run command to check the proc status?
+        if tunnel.status(gateway_connection.handle):
+            return StatusMessage.gateway_running
+        raise GatewayExited(255)
+    # TODO -- actually attempt resolving the url, then call gw status api once its available.
     return StatusMessage.gateway_running
 
 
 def stop_gateway() -> None:
     with GatewayConnectionManager.lock:
-        gateway_process = GatewayConnectionManager.gateway_process
-        if gateway_process is None or gateway_process.process.exitcode is not None:
+        gateway_connection = GatewayConnectionManager.gateway_connection
+        if gateway_connection is None:
             raise GatewayNotRunning("Gateway is not running")
+        if isinstance(gateway_connection, LocalProcess):
+            if gateway_connection.process.exitcode is not None:
+                raise GatewayNotRunning("Gateway is not running")
+            logger.debug("gateway shutdown message")
+            m = api.ShutdownRequest()
+            client.request_response(m, gateway_connection.gateway_url, 4_000)
+            logger.debug("gateway terminate and join")
 
-        logger.debug("gateway shutdown message")
-        m = api.ShutdownRequest()
-        client.request_response(m, get_gateway_url(), 4_000)
-        logger.debug("gateway terminate and join")
-
-        process = gateway_process.process
-        process.terminate()
-        process.join(1)
-        if process.exitcode is None:
-            logger.debug("gateway kill")
-            process.kill()
-        GatewayConnectionManager.gateway_process = None
+            process = gateway_connection.process
+            process.terminate()
+            process.join(1)
+            if process.exitcode is None:
+                logger.debug("gateway kill")
+                process.kill()
+            GatewayConnectionManager.gateway_connection = None
+            return
+        if isinstance(gateway_connection, RemoteTunnel):
+            logger.debug("remote gateway shutdown message")
+            m = api.ShutdownRequest()
+            client.request_response(m, gateway_connection.handle.as_local_url(), 4_000)
+            # TODO -- if shutdown via gateway API fails, the nohup-launched process may outlive the tunnel.
+            tunnel.stop(gateway_connection.handle)
+            GatewayConnectionManager.gateway_connection = None
+            return
+        raise NotImplementedError("RemoteUrl gateway cannot be stopped by backend")
 
 
 async def shutdown_processes() -> None:
     """Terminate all running gateway processes on app shutdown."""
     logger.debug("initiating graceful gateway shutdown")
-    gateway_process = GatewayConnectionManager.gateway_process
-    if gateway_process is None:
+    gateway_connection = GatewayConnectionManager.gateway_connection
+    if gateway_connection is None or isinstance(gateway_connection, RemoteUrl):
         return
-    if gateway_process.process.exitcode is None:
-        try:
-            stop_gateway()
-        except GatewayNotRunning:
-            pass
-    else:
-        GatewayConnectionManager.gateway_process = None
+    if isinstance(gateway_connection, LocalProcess):
+        if gateway_connection.process.exitcode is None:
+            try:
+                stop_gateway()
+            except GatewayNotRunning:
+                pass
+        else:
+            GatewayConnectionManager.gateway_connection = None
+        return
+    if isinstance(gateway_connection, RemoteTunnel):
+        if tunnel.status(gateway_connection.handle):
+            try:
+                stop_gateway()
+            except GatewayNotRunning:
+                pass
+        else:
+            GatewayConnectionManager.gateway_connection = None
+        return
+    raise NotImplementedError("Unknown gateway connection type")

--- a/backend/src/forecastbox/domain/gateway/service.py
+++ b/backend/src/forecastbox/domain/gateway/service.py
@@ -13,6 +13,7 @@ import logging
 import os
 import threading
 import urllib.parse
+import uuid
 from dataclasses import dataclass
 from multiprocessing.process import BaseProcess
 from tempfile import TemporaryDirectory
@@ -21,7 +22,7 @@ from cascade.deployment.logging import LoggingConfig
 from cascade.executor import platform
 from cascade.gateway import api, client
 from cascade.gateway.server import main_enp
-from cascade.low.func import assert_never
+from cascade.low.func import Either, assert_never
 
 from forecastbox.domain.gateway.exceptions import (
     GatewayAlreadyRunning,
@@ -58,12 +59,17 @@ GatewayConnectionType = type[LocalProcess] | type[RemoteTunnel] | type[RemoteUrl
 
 
 def config2gatewayMethod() -> GatewayConnectionType:
-    parsed_url = urllib.parse.urlparse(config.cascade.cascade_url)
     if not config.cascade.spawn_gateway:
         return RemoteUrl
-    if parsed_url.hostname in _LOCAL_HOSTS:
+    parsed_url = urllib.parse.urlparse(config.cascade.cascade_url)
+    if parsed_url.scheme not in ("tcp", "ssh"):
+        raise ValueError("unsupported protocol: {parsed_url.scheme}. Use tcp for local, ssh for remote")
+    if parsed_url.hostname in _LOCAL_HOSTS and parsed_url.scheme == "tcp":
         return LocalProcess
-    return RemoteTunnel
+    elif parsed_url.scheme == "ssh":
+        return RemoteTunnel
+    else:
+        raise ValueError("tcp protocol but not a local host! Gateway spawning not supported!")
 
 
 def _initial_connection() -> GatewayConnection | None:
@@ -78,9 +84,9 @@ class GatewayConnectionManager:
     gateway_connection: GatewayConnection | None = _initial_connection()
 
 
-def _remote_tunnel_target_and_port() -> tuple[str, int]:
+def _remote_tunnel_target() -> tuple[str, int | None]:
     parsed_url = urllib.parse.urlparse(config.cascade.cascade_url)
-    if parsed_url.hostname is None or parsed_url.port is None:
+    if parsed_url.hostname is None:
         raise ValueError(f"Invalid cascade_url for remote tunnel mode: {config.cascade.cascade_url!r}")
     host = f"{parsed_url.username}@{parsed_url.hostname}" if parsed_url.username else parsed_url.hostname
     return host, parsed_url.port
@@ -101,7 +107,7 @@ def launch_gateway() -> None:
         gateway_method = config2gatewayMethod()
         max_concurrent_jobs = config.cascade.max_concurrent_jobs
         if gateway_method is LocalProcess:
-            logs_directory = TemporaryDirectory(prefix="fiabLogs")
+            logs_directory = TemporaryDirectory(prefix="fiabLogs", dir=config.cascade.cascade_logging_base)
             logger.debug(f"logging base is at {logs_directory.name}")
             logs_base = None if os.getenv("FIAB_LOGSTDOUT", "nay") == "yea" else logs_directory.name + os.sep
             gateway_url = f"tcp://localhost:{tunnel.claim_free_port()}"
@@ -116,15 +122,29 @@ def launch_gateway() -> None:
                 process=process,
                 gateway_url=gateway_url,
             )
-            return
         elif gateway_method is RemoteTunnel:
-            host, remote_port = _remote_tunnel_target_and_port()
+            host, remote_port = _remote_tunnel_target()
             handle = tunnel.setup(host=host, remote_port=remote_port)
+            log_base = f"{config.cascade.cascade_logging_base or '/tmp/'}fiabLogs{uuid.uuid4()}."
+            logger.debug(f"logging base for tunnel gateway is {log_base}")
             remote_gateway_url = f"tcp://localhost:{handle.remote_port}"
-            cmd = ["uv", "run", "python", "-m", "cascade.gateway", "--url", remote_gateway_url]
+            logging_config = LoggingConfig(path_base=log_base, formatter="line")
+            cmd = [
+                "uv",
+                "run",
+                "--with",
+                "earthkit.workflows",
+                "python",
+                "-m",
+                "cascade.gateway",
+                "--url",
+                remote_gateway_url,
+                "--loggingConfigSer",
+                logging_config.ser_cliparam(),
+            ]
             if max_concurrent_jobs is not None:
                 cmd.extend(["--max_concurrent_jobs", str(max_concurrent_jobs)])
-            tunnel.execute(handle, cmd)
+            tunnel.execute(handle, cmd, output_path=log_base + "gwstdouterr")
             GatewayConnectionManager.gateway_connection = RemoteTunnel(handle=handle)
         elif gateway_method is RemoteUrl:
             raise NotImplementedError("RemoteUrl gateway cannot be launched by backend")
@@ -146,16 +166,16 @@ def get_gateway_url() -> str:
         assert_never(gateway_connection)
 
 
-def get_logs_directory() -> TemporaryDirectory | None:
+def get_logs_directory() -> Either[TemporaryDirectory, str]:  # ty: ignore[invalid-type-arguments]
     gateway_connection = GatewayConnectionManager.gateway_connection
     if gateway_connection is None:
-        return None
+        return Either.error("gateway connection not initialized")
     if isinstance(gateway_connection, LocalProcess):
-        return gateway_connection.logs_directory
+        return Either.ok(gateway_connection.logs_directory)
     elif isinstance(gateway_connection, RemoteTunnel):
-        raise NotImplementedError("Logs directory is available only for local gateway process")
+        return Either.error("Logs directory is available only for local gateway process")
     elif isinstance(gateway_connection, RemoteUrl):
-        raise NotImplementedError("Logs directory is available only for local gateway process")
+        return Either.error("Logs directory is available only for local gateway process")
     else:
         assert_never(gateway_connection)
 
@@ -200,7 +220,6 @@ def stop_gateway() -> None:
                 logger.debug("gateway kill")
                 process.kill()
             GatewayConnectionManager.gateway_connection = None
-            return
         elif isinstance(gateway_connection, RemoteTunnel):
             logger.debug("remote gateway shutdown message")
             m = api.ShutdownRequest()
@@ -208,7 +227,6 @@ def stop_gateway() -> None:
             # TODO -- if shutdown via gateway API fails, the nohup-launched process may outlive the tunnel.
             tunnel.stop(gateway_connection.handle)
             GatewayConnectionManager.gateway_connection = None
-            return
         elif isinstance(gateway_connection, RemoteUrl):
             raise NotImplementedError("RemoteUrl gateway cannot be stopped by backend")
         else:
@@ -217,8 +235,8 @@ def stop_gateway() -> None:
 
 async def shutdown_processes() -> None:
     """Terminate all running gateway processes on app shutdown."""
-    logger.debug("initiating graceful gateway shutdown")
     gateway_connection = GatewayConnectionManager.gateway_connection
+    logger.debug(f"initiating graceful gateway shutdown of {gateway_connection}")
     if gateway_connection is None:
         return
     if isinstance(gateway_connection, LocalProcess):
@@ -230,7 +248,6 @@ async def shutdown_processes() -> None:
         else:
             with GatewayConnectionManager.lock:
                 GatewayConnectionManager.gateway_connection = None
-        return
     elif isinstance(gateway_connection, RemoteTunnel):
         if tunnel.status(gateway_connection.handle):
             try:
@@ -240,8 +257,7 @@ async def shutdown_processes() -> None:
         else:
             with GatewayConnectionManager.lock:
                 GatewayConnectionManager.gateway_connection = None
-        return
     elif isinstance(gateway_connection, RemoteUrl):
-        return
+        pass
     else:
         assert_never(gateway_connection)

--- a/backend/src/forecastbox/domain/gateway/service.py
+++ b/backend/src/forecastbox/domain/gateway/service.py
@@ -24,7 +24,6 @@ from cascade.gateway.server import main_enp
 from forecastbox.domain.gateway.exceptions import (
     GatewayAlreadyRunning,
     GatewayExited,
-    GatewayManagerNotInitialized,
     GatewayNotRunning,
     GatewayNotStarted,
 )
@@ -39,31 +38,9 @@ class GatewayProcess:
     process: BaseProcess
 
 
-@dataclass(eq=False, slots=True)
 class GatewayConnectionManager:
-    lock: threading.Lock
+    lock: threading.Lock = threading.Lock()
     gateway_process: GatewayProcess | None = None
-
-
-_manager: GatewayConnectionManager | None = None
-
-
-def _require_manager() -> GatewayConnectionManager:
-    if _manager is None:
-        raise GatewayManagerNotInitialized("Gateway manager is not initialized")
-    return _manager
-
-
-def init_manager() -> None:
-    global _manager
-    if _manager is not None:
-        raise ValueError("Gateway manager is already initialized")
-    _manager = GatewayConnectionManager(lock=threading.Lock())
-
-
-def _reset_manager() -> None:
-    global _manager
-    _manager = None
 
 
 def launch_cascade(cascade_url: str, log_base: str | None, max_concurrent_jobs: int | None) -> None:
@@ -75,9 +52,8 @@ def launch_cascade(cascade_url: str, log_base: str | None, max_concurrent_jobs: 
 
 
 def launch_gateway() -> None:
-    manager = _require_manager()
-    with manager.lock:
-        if manager.gateway_process is not None:
+    with GatewayConnectionManager.lock:
+        if GatewayConnectionManager.gateway_process is not None:
             raise GatewayAlreadyRunning("Process already running.")
         logs_directory = TemporaryDirectory(prefix="fiabLogs")
         logger.debug(f"logging base is at {logs_directory.name}")
@@ -89,27 +65,24 @@ def launch_gateway() -> None:
         )  # type: ignore[unresolved-attribute] # context
         process.start()
         logger.debug(f"spawned new gateway process with pid {process.pid}")
-        manager.gateway_process = GatewayProcess(logs_directory=logs_directory, process=process)
+        GatewayConnectionManager.gateway_process = GatewayProcess(logs_directory=logs_directory, process=process)
 
 
 def get_gateway_url() -> str:
-    manager = _require_manager()
-    if manager.gateway_process is None:
+    if GatewayConnectionManager.gateway_process is None:
         raise GatewayNotRunning("Gateway is not running")
     return config.cascade.cascade_url
 
 
 def get_logs_directory() -> TemporaryDirectory | None:
-    manager = _require_manager()
-    gateway_process = manager.gateway_process
+    gateway_process = GatewayConnectionManager.gateway_process
     if gateway_process is None:
         return None
     return gateway_process.logs_directory
 
 
 def status_gateway() -> str:
-    manager = _require_manager()
-    gateway_process = manager.gateway_process
+    gateway_process = GatewayConnectionManager.gateway_process
     if gateway_process is None:
         raise GatewayNotStarted("Gateway was not started")
     if gateway_process.process.exitcode is not None:
@@ -118,9 +91,8 @@ def status_gateway() -> str:
 
 
 def stop_gateway() -> None:
-    manager = _require_manager()
-    with manager.lock:
-        gateway_process = manager.gateway_process
+    with GatewayConnectionManager.lock:
+        gateway_process = GatewayConnectionManager.gateway_process
         if gateway_process is None or gateway_process.process.exitcode is not None:
             raise GatewayNotRunning("Gateway is not running")
 
@@ -135,18 +107,14 @@ def stop_gateway() -> None:
         if process.exitcode is None:
             logger.debug("gateway kill")
             process.kill()
-        manager.gateway_process = None
+        GatewayConnectionManager.gateway_process = None
 
 
 async def shutdown_processes() -> None:
     """Terminate all running gateway processes on app shutdown."""
     logger.debug("initiating graceful gateway shutdown")
-    if _manager is None:
-        return
-    manager = _require_manager()
-    gateway_process = manager.gateway_process
+    gateway_process = GatewayConnectionManager.gateway_process
     if gateway_process is None:
-        _reset_manager()
         return
     if gateway_process.process.exitcode is None:
         try:
@@ -154,5 +122,4 @@ async def shutdown_processes() -> None:
         except GatewayNotRunning:
             pass
     else:
-        manager.gateway_process = None
-    _reset_manager()
+        GatewayConnectionManager.gateway_process = None

--- a/backend/src/forecastbox/domain/run/__init__.py
+++ b/backend/src/forecastbox/domain/run/__init__.py
@@ -11,6 +11,7 @@
 Manages the Run domain -- execution of python workflows using the `cascade`
 execution engine, based on a Blueprint.
 
-Depends on Blueprint, Glyph and Plugin domains -- all are used when compiling a Run.
+Depends on Blueprint, Glyph, Plugin and Gateway domains -- all are used when
+compiling and submitting a Run.
 Depended on by Experiment domain (which spawns Runs).
 """

--- a/backend/src/forecastbox/domain/run/cascade.py
+++ b/backend/src/forecastbox/domain/run/cascade.py
@@ -20,6 +20,7 @@ from pydantic import Field
 
 from forecastbox.domain.artifact.manager import ArtifactManager, submit_artifact_download
 from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
+from forecastbox.domain.gateway.service import get_gateway_url
 from forecastbox.utility.config import config
 from forecastbox.utility.pydantic import FiabBaseModel
 
@@ -100,7 +101,7 @@ def execute_cascade(spec: ExecutionSpecification) -> SubmitJobResponse:
         )
     )
     try:
-        submit_job_response: SubmitJobResponse = request_response(r, f"{config.cascade.cascade_url}")  # type: ignore
+        submit_job_response: SubmitJobResponse = request_response(r, get_gateway_url())  # type: ignore
     except Exception as e:
         return SubmitJobResponse(job_id=None, error=repr(e))
 

--- a/backend/src/forecastbox/domain/run/cascade.py
+++ b/backend/src/forecastbox/domain/run/cascade.py
@@ -89,7 +89,6 @@ def execute_cascade(spec: ExecutionSpecification) -> SubmitJobResponse:
     environment = spec.environment
     hosts = min(config.cascade.max_hosts, environment.hosts or config.cascade.default_hosts)
     workers_per_host = min(config.cascade.max_workers_per_host, environment.workers_per_host or config.cascade.default_workers_per_host)
-    env_vars = {"TMPDIR": config.cascade.venv_temp_dir}
 
     r = SubmitJobRequest(
         job=JobSpec(

--- a/backend/src/forecastbox/domain/run/cascade.py
+++ b/backend/src/forecastbox/domain/run/cascade.py
@@ -8,6 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 import logging
+import tempfile
 import time
 from pathlib import Path
 from typing import Literal
@@ -94,7 +95,7 @@ def execute_cascade(spec: ExecutionSpecification) -> SubmitJobResponse:
         job=JobSpec(
             workers_per_host=workers_per_host,
             hosts=hosts,
-            envvars=env_vars,
+            envvars={},
             use_slurm=False,
             job_instance=JobInstanceRich(jobInstance=job, checkpointSpec=None),
         )

--- a/backend/src/forecastbox/domain/run/service.py
+++ b/backend/src/forecastbox/domain/run/service.py
@@ -38,6 +38,7 @@ import forecastbox.domain.blueprint.db as blueprint_db
 import forecastbox.domain.run.db as run_db
 from forecastbox.domain.blueprint.types import BlueprintId
 from forecastbox.domain.experiment.types import ExperimentDefinitionId
+from forecastbox.domain.gateway.service import get_gateway_url
 from forecastbox.domain.run.background import execute_background
 from forecastbox.domain.run.cascade import RunOutputs
 from forecastbox.domain.run.db import CompilerRuntimeContext
@@ -46,7 +47,6 @@ from forecastbox.domain.run.exceptions import CompilationDetailCorrupted, Compil
 from forecastbox.domain.run.types import RunId
 from forecastbox.schemata.jobs import Blueprint, Run
 from forecastbox.utility.auth import AuthContext
-from forecastbox.utility.config import config
 from forecastbox.utility.memcache import pop as pop_memcache
 from forecastbox.utility.pydantic import FiabBaseModel
 from forecastbox.utility.time import value_dt2str
@@ -253,7 +253,7 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
         try:
             response = client.request_response(
                 api.JobProgressRequest(job_ids=[job_id], detailed_report=detailed_report),
-                f"{config.cascade.cascade_url}",
+                get_gateway_url(),
             )
             response = cast(api.JobProgressResponse, response)
         except TimeoutError:

--- a/backend/src/forecastbox/entrypoint/app.py
+++ b/backend/src/forecastbox/entrypoint/app.py
@@ -38,6 +38,7 @@ from forecastbox.domain.plugin.manager import join_updater_thread, submit_load_p
 from forecastbox.domain.plugin.store import join_stores_thread, submit_initialize_stores
 from forecastbox.routes.gateway import shutdown_processes
 from forecastbox.utility.config import config
+from forecastbox.utility.tunnel import shutdown as shutdown_tunnels
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +66,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         stop_scheduler()
     shutdown_all_lens_instances()
     await shutdown_processes()
+    shutdown_tunnels()
     join_updater_thread(timeout_sec=10)
     join_stores_thread(timeout_sec=10)
     join_artifact_manager(timeout_sec=10)

--- a/backend/src/forecastbox/entrypoint/app.py
+++ b/backend/src/forecastbox/entrypoint/app.py
@@ -33,10 +33,10 @@ from forecastbox.domain.admin import get_local_release
 from forecastbox.domain.artifact.base import get_artifact_local_path
 from forecastbox.domain.artifact.manager import ArtifactManager, join_artifact_manager, submit_refresh_catalog
 from forecastbox.domain.experiment.scheduling.background import start_scheduler, stop_scheduler
+from forecastbox.domain.gateway.service import init_manager, shutdown_processes
 from forecastbox.domain.lens.manager import shutdown_all_lens_instances
 from forecastbox.domain.plugin.manager import join_updater_thread, submit_load_plugins
 from forecastbox.domain.plugin.store import join_stores_thread, submit_initialize_stores
-from forecastbox.routes.gateway import shutdown_processes
 from forecastbox.utility.config import config
 from forecastbox.utility.tunnel import shutdown as shutdown_tunnels
 
@@ -46,6 +46,7 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     logger.debug(f"Starting FIAB with config: {config}")
+    init_manager()
     for module_info in pkgutil.iter_modules(forecastbox.schemata.__path__):
         module = importlib.import_module(f"forecastbox.schemata.{module_info.name}")
         if hasattr(module, "create_db_and_tables"):

--- a/backend/src/forecastbox/entrypoint/app.py
+++ b/backend/src/forecastbox/entrypoint/app.py
@@ -33,7 +33,7 @@ from forecastbox.domain.admin import get_local_release
 from forecastbox.domain.artifact.base import get_artifact_local_path
 from forecastbox.domain.artifact.manager import ArtifactManager, join_artifact_manager, submit_refresh_catalog
 from forecastbox.domain.experiment.scheduling.background import start_scheduler, stop_scheduler
-from forecastbox.domain.gateway.service import init_manager, shutdown_processes
+from forecastbox.domain.gateway.service import shutdown_processes
 from forecastbox.domain.lens.manager import shutdown_all_lens_instances
 from forecastbox.domain.plugin.manager import join_updater_thread, submit_load_plugins
 from forecastbox.domain.plugin.store import join_stores_thread, submit_initialize_stores
@@ -46,7 +46,6 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     logger.debug(f"Starting FIAB with config: {config}")
-    init_manager()
     for module_info in pkgutil.iter_modules(forecastbox.schemata.__path__):
         module = importlib.import_module(f"forecastbox.schemata.{module_info.name}")
         if hasattr(module, "create_db_and_tables"):

--- a/backend/src/forecastbox/routes/gateway.py
+++ b/backend/src/forecastbox/routes/gateway.py
@@ -8,78 +8,25 @@
 # nor does it submit to any jurisdiction.
 
 """
-Gateway operations routes — /gateway/*. Corresponds to no domain entity.
+Gateway operations routes — /gateway/*. Corresponds to operational functions in
+`domain.gateway`, not a persisted user-managed entity.
 
-All routes are purely operational, no ids -- gateway start, status, kill."""
+All routes are purely operational, no ids -- gateway start, status, kill.
+"""
 
-import asyncio
-import logging
-import os
-import select
-import subprocess
-from dataclasses import dataclass
-from multiprocessing.process import BaseProcess
-from tempfile import TemporaryDirectory
-from typing import NewType
+from fastapi import APIRouter, HTTPException
 
-from cascade.deployment.logging import LoggingConfig
-from cascade.executor import platform
-from cascade.gateway import api, client
-from cascade.gateway.server import main_enp
-from fastapi import APIRouter, HTTPException, Request
-from sse_starlette.sse import EventSourceResponse
-
-from forecastbox.utility.config import StatusMessage, config
+from forecastbox.domain.gateway.exceptions import (
+    GatewayAlreadyRunning,
+    GatewayExited,
+    GatewayManagerNotInitialized,
+    GatewayNotRunning,
+    GatewayNotStarted,
+)
+from forecastbox.domain.gateway.service import launch_gateway, status_gateway, stop_gateway
+from forecastbox.utility.config import config
 
 PREFIX = "/api/v1/gateway"
-
-logger = logging.getLogger(__name__)
-
-GatewayProcess = NewType("GatewayProcess", BaseProcess)
-
-
-def cleanup_gw(process: GatewayProcess) -> None:
-    pass
-
-
-def kill_gw(process: GatewayProcess) -> None:
-    logger.debug("gateway shutdown message")
-    m = api.ShutdownRequest()
-    client.request_response(m, config.cascade.cascade_url, 4_000)
-    logger.debug("gateway terminate and join")
-
-    process.terminate()
-    process.join(1)
-    if process.exitcode is None:
-        logger.debug("gateway kill")
-        process.kill()
-
-
-def launch_cascade(cascade_url: str, log_base: str | None, max_concurrent_jobs: int | None) -> None:
-    loggingConfig = LoggingConfig(path_base=log_base, formatter="line")
-
-    try:
-        main_enp(url=cascade_url, loggingConfig=loggingConfig, max_concurrent_jobs=max_concurrent_jobs)
-    except KeyboardInterrupt:
-        pass  # no need to spew stacktrace to log
-
-
-class Globals:
-    # NOTE we cant have them at top level due to imports from other modules
-    # TODO refactor the above dataclass into classmethods here, its singletons anyway
-    logs_directory: TemporaryDirectory | None = None
-    gateway: GatewayProcess | None = None
-
-
-async def shutdown_processes() -> None:
-    """Terminate all running processes on shutdown."""
-    logger.debug("initiating graceful gateway shutdown")
-    if Globals.gateway is not None:
-        if Globals.gateway.exitcode is None:
-            kill_gw(Globals.gateway)
-        cleanup_gw(Globals.gateway)
-        Globals.gateway = None
-
 
 router = APIRouter(
     tags=["gateway"],
@@ -91,27 +38,12 @@ router = APIRouter(
 async def start_gateway() -> str:
     if not config.cascade.spawn_gateway:
         raise HTTPException(400, "This instance does not manage the gateway")
-    if Globals.logs_directory is None:
-        Globals.logs_directory = TemporaryDirectory(prefix="fiabLogs")
-        logger.debug(f"logging base is at {Globals.logs_directory.name}")
-    if Globals.gateway is not None:
-        if Globals.gateway.exitcode is None:
-            # TODO add an explicit restart option
-            raise HTTPException(400, "Process already running.")
-        else:
-            logger.warning(f"restarting gateway as it exited with {Globals.gateway.exitcode}")
-            # TODO spawn as async task? This blocks... but we'd need to lock
-            cleanup_gw(Globals.gateway)
-            Globals.gateway = None
-
-    logs_directory = None if os.getenv("FIAB_LOGSTDOUT", "nay") == "yea" else Globals.logs_directory.name + os.sep
-    max_concurrent_jobs = config.cascade.max_concurrent_jobs
-    process = platform.get_mp_ctx("gateway").Process(
-        target=launch_cascade, args=(config.cascade.cascade_url, logs_directory, max_concurrent_jobs)
-    )  # type: ignore[unresolved-attribute] # context
-    process.start()
-    Globals.gateway = GatewayProcess(process)
-    logger.debug(f"spawned new gateway process with pid {process.pid}")
+    try:
+        launch_gateway()
+    except GatewayAlreadyRunning:
+        raise HTTPException(400, "Process already running.")
+    except GatewayManagerNotInitialized:
+        raise HTTPException(500, "Gateway manager is not initialized")
     return "started"
 
 
@@ -120,23 +52,24 @@ async def get_status() -> str:
     """Get the status of the Cascade Gateway process."""
     if not config.cascade.spawn_gateway:
         return "not managed"
-    elif Globals.gateway is None:
+    try:
+        return status_gateway()
+    except GatewayNotStarted:
         return "not started"
-    elif Globals.gateway.exitcode is not None:
-        return f"exited with {Globals.gateway.exitcode}"
-    else:
-        return StatusMessage.gateway_running
+    except GatewayExited as e:
+        return f"exited with {e.exitcode}"
+    except GatewayManagerNotInitialized:
+        raise HTTPException(500, "Gateway manager is not initialized")
 
 
 @router.post("/kill")
 async def kill_gateway() -> str:
     if not config.cascade.spawn_gateway:
         raise HTTPException(400, "This instance does not manage the gateway")
-    if Globals.gateway is None or Globals.gateway.exitcode is not None:
+    try:
+        stop_gateway()
+    except GatewayNotRunning:
         raise HTTPException(400, "Gateway is not running")
-    else:
-        # TODO spawn as async task? This blocks... but we'd need to lock
-        kill_gw(Globals.gateway)
-        cleanup_gw(Globals.gateway)
-        Globals.gateway = None
-        return "killed"
+    except GatewayManagerNotInitialized:
+        raise HTTPException(500, "Gateway manager is not initialized")
+    return "killed"

--- a/backend/src/forecastbox/routes/gateway.py
+++ b/backend/src/forecastbox/routes/gateway.py
@@ -19,7 +19,6 @@ from fastapi import APIRouter, HTTPException
 from forecastbox.domain.gateway.exceptions import (
     GatewayAlreadyRunning,
     GatewayExited,
-    GatewayManagerNotInitialized,
     GatewayNotRunning,
     GatewayNotStarted,
 )
@@ -42,8 +41,6 @@ async def start_gateway() -> str:
         launch_gateway()
     except GatewayAlreadyRunning:
         raise HTTPException(400, "Process already running.")
-    except GatewayManagerNotInitialized:
-        raise HTTPException(500, "Gateway manager is not initialized")
     return "started"
 
 
@@ -58,8 +55,6 @@ async def get_status() -> str:
         return "not started"
     except GatewayExited as e:
         return f"exited with {e.exitcode}"
-    except GatewayManagerNotInitialized:
-        raise HTTPException(500, "Gateway manager is not initialized")
 
 
 @router.post("/kill")
@@ -70,6 +65,4 @@ async def kill_gateway() -> str:
         stop_gateway()
     except GatewayNotRunning:
         raise HTTPException(400, "Gateway is not running")
-    except GatewayManagerNotInitialized:
-        raise HTTPException(500, "Gateway manager is not initialized")
     return "killed"

--- a/backend/src/forecastbox/routes/run.py
+++ b/backend/src/forecastbox/routes/run.py
@@ -33,14 +33,13 @@ from fiab_core.fable import BlockInstanceId
 
 from forecastbox.domain.auth.users import get_auth_context
 from forecastbox.domain.blueprint.types import BlueprintId
+from forecastbox.domain.gateway.service import get_gateway_url, get_logs_directory
 from forecastbox.domain.run import db, service
 from forecastbox.domain.run.cascade import RunOutputs
 from forecastbox.domain.run.detail import retrieve_compilation_detail
 from forecastbox.domain.run.exceptions import CompilationDetailCorrupted, CompilationDetailNotFound, RunAccessDenied, RunNotFound
 from forecastbox.domain.run.types import RunId
-from forecastbox.routes.gateway import Globals
 from forecastbox.utility.auth import AuthContext
-from forecastbox.utility.config import config
 from forecastbox.utility.pagination import PaginationSpec
 from forecastbox.utility.pydantic import FiabBaseModel
 
@@ -209,7 +208,7 @@ async def _resolve_run_with_cascade(
 async def _build_run_logs_response(cascade_job_id: str, db_entity_ser: bytes) -> Response:
     try:
         request = api.JobProgressRequest(job_ids=[JobId(cascade_job_id)])
-        gw_state = client.request_response(request, f"{config.cascade.cascade_url}").model_dump()
+        gw_state = client.request_response(request, get_gateway_url()).model_dump()
     except TimeoutError:
         gw_state = {"progresses": {}, "datasets": {}, "error": "TimeoutError"}
     except Exception as e:
@@ -221,10 +220,11 @@ async def _build_run_logs_response(cascade_job_id: str, db_entity_ser: bytes) ->
             with zipfile.ZipFile(buffer, "a", zipfile.ZIP_DEFLATED) as zf:
                 zf.writestr("db_entity.json", db_entity_ser)
                 zf.writestr("gw_state.json", orjson.dumps(gw_state))
-                if not Globals.logs_directory:
+                logs_directory = get_logs_directory()
+                if not logs_directory:
                     zf.writestr("logs_directory.error.txt", "logs directory missing")
                 else:
-                    p = pathlib.Path(Globals.logs_directory.name)
+                    p = pathlib.Path(logs_directory.name)
                     f = ""
                     try:
                         for f in os.listdir(p):
@@ -366,7 +366,7 @@ async def delete_run(
     try:
         client.request_response(
             api.ResultDeletionRequest(datasets={cascade_job_id: []}),  # type: ignore[invalid-argument-type]
-            f"{config.cascade.cascade_url}",
+            get_gateway_url(),
         )
     except Exception as e:
         raise HTTPException(500, f"Job deletion failed: {e}")
@@ -431,7 +431,7 @@ async def get_run_output_content(
         raise HTTPException(500, f"Result mime lookup failed: {mime_result.e}")
     response = client.request_response(
         api.ResultRetrievalRequest(job_id=JobId(cascade_job_id), dataset_id=dataset),
-        f"{config.cascade.cascade_url}",
+        get_gateway_url(),
     )
     response = cast(api.ResultRetrievalResponse, response)
     if response.error:

--- a/backend/src/forecastbox/routes/run.py
+++ b/backend/src/forecastbox/routes/run.py
@@ -220,11 +220,11 @@ async def _build_run_logs_response(cascade_job_id: str, db_entity_ser: bytes) ->
             with zipfile.ZipFile(buffer, "a", zipfile.ZIP_DEFLATED) as zf:
                 zf.writestr("db_entity.json", db_entity_ser)
                 zf.writestr("gw_state.json", orjson.dumps(gw_state))
-                logs_directory = get_logs_directory()
-                if not logs_directory:
-                    zf.writestr("logs_directory.error.txt", "logs directory missing")
+                maybe_logs_directory = get_logs_directory()
+                if maybe_logs_directory.t is None:
+                    zf.writestr("logs_directory.error.txt", "logs directory missing: {maybe_logs_directory.e}")
                 else:
-                    p = pathlib.Path(logs_directory.name)
+                    p = pathlib.Path(maybe_logs_directory.t.name)
                     f = ""
                     try:
                         for f in os.listdir(p):

--- a/backend/src/forecastbox/routes/status.py
+++ b/backend/src/forecastbox/routes/status.py
@@ -17,6 +17,7 @@ from cascade.gateway import api, client
 from fastapi import APIRouter, Request
 
 from forecastbox.domain.experiment.scheduling.background import status_scheduler
+from forecastbox.domain.gateway.service import get_gateway_url
 from forecastbox.domain.plugin.manager import status_brief
 from forecastbox.utility.config import config
 
@@ -44,7 +45,7 @@ def get_status(request: Request) -> StatusResponse:
     status: dict[str, str] = {"api": "up", "cascade": "up", "ecmwf": "up", "scheduler": "up", "version": request.app.version}
 
     try:
-        client.request_response(api.JobProgressRequest(job_ids=[]), config.cascade.cascade_url, timeout_ms=1000)
+        client.request_response(api.JobProgressRequest(job_ids=[]), get_gateway_url(), timeout_ms=1000)
         status["cascade"] = "up"
     except Exception as e:
         logger.warning(f"Error connecting to Cascade: {repr(e)}")

--- a/backend/src/forecastbox/utility/config.py
+++ b/backend/src/forecastbox/utility/config.py
@@ -243,24 +243,17 @@ class CascadeSettings(FiabBaseModel):
     """Default number of workers per hosts for Cascade if unspecified in a job."""
     max_workers_per_host: int = 8
     """Max number of workers per host for Cascade."""
-    cascade_url: str = "tcp://localhost:8067"
-    """Base URL for the Cascade API."""
+    cascade_url: str = "tcp://localhost"
+    """Base URL for the Cascade API in case of unmanaged gateway, otherwise localhost or sshable [<user>@]<hostname>."""
+    cascade_logging_base: str | None = None
+    """Where to store logs of cascade gw and jobs. Use eg /home/<user>/fiabLogs or /tmp/fiabLogs"""
     spawn_gateway: bool = True
     """Whether the backend should spawn a gateway or assume it is provided externally"""
-    # TODO remove the spawn_gateway setting -- instead, base it on whether cascade_url is provided.
-    # But that needs refactoring of the code to provide the cascade_url dynamically in case of a local spawn,
-    # and utilization of the FreePortsManager etc
-    log_collection_max_size: int = 1000
-    """Maximum size of the log collection for Cascade."""
-    venv_temp_dir: str = "/tmp"
-    """Temporary directory for virtual environments."""
     max_concurrent_jobs: int | None = 1
     """If more jobs submitted at a given time, all but this many wait in a queue"""
 
     def validate_runtime(self) -> list[str]:
         errors = []
-        if not os.path.isdir(self.venv_temp_dir):
-            errors.append(f"not a directory: venv_temp_dir={self.venv_temp_dir}")
         if not _validate_url(self.cascade_url):
             errors.append(f"not an url: cascade_url={self.cascade_url}")
         return errors

--- a/backend/src/forecastbox/utility/tunnel.py
+++ b/backend/src/forecastbox/utility/tunnel.py
@@ -65,8 +65,17 @@ def _ssh_base_args(handle: "ConnectionHandle") -> list[str]:
     ]
 
 
-def _ssh_run(args: Sequence[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(list(args), check=check, capture_output=True, text=True)
+def _ssh_run(
+    args: Sequence[str],
+    *,
+    check: bool = True,
+    start_new_session: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    """The start_new_session prevents interrupt / Ctrl-C stopping the command
+    too early -- we use this when we setup a long running ssh tunnel, because
+    those we want to explicitly exit ourselves, after we have sent a gateway
+    termination command over it."""
+    return subprocess.run(list(args), check=check, capture_output=True, text=True, start_new_session=start_new_session)
 
 
 def _is_bind_failure(exc: subprocess.CalledProcessError) -> bool:
@@ -166,7 +175,8 @@ def setup(
                     "-o",
                     "ExitOnForwardFailure=yes",
                     host,
-                ]
+                ],
+                start_new_session=True,  # NOTE detaching to prevent early interrupt
             )
         except subprocess.CalledProcessError as exc:
             last_error = exc

--- a/backend/src/forecastbox/utility/tunnel.py
+++ b/backend/src/forecastbox/utility/tunnel.py
@@ -33,7 +33,7 @@ def _ensure_control_root() -> None:
     _CONTROL_ROOT.mkdir(mode=0o700, parents=True, exist_ok=True)
 
 
-def _claim_free_port() -> int:
+def claim_free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 0))
         return int(sock.getsockname()[1])
@@ -136,7 +136,7 @@ def setup(
     last_error: subprocess.CalledProcessError | None = None
     attempts = 1 if remote_port is not None else _SETUP_ATTEMPTS
     for _ in range(attempts):
-        resolved_local_port = local_port if local_port is not None else _claim_free_port()
+        resolved_local_port = local_port if local_port is not None else claim_free_port()
         resolved_remote_port = remote_port if remote_port is not None else _claim_remote_port()
         handle = ConnectionHandle(
             host=host,

--- a/backend/src/forecastbox/utility/tunnel.py
+++ b/backend/src/forecastbox/utility/tunnel.py
@@ -10,14 +10,14 @@
 """Helpers for SSH multiplexing tunnels."""
 
 import os
-import secrets
+import random
 import shlex
 import socket
 import subprocess
 import tempfile
 import threading
 import uuid
-from collections.abc import Iterable, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -40,7 +40,7 @@ def _claim_free_port() -> int:
 
 
 def _claim_remote_port() -> int:
-    return _REMOTE_PORT_MIN + secrets.randbelow(_REMOTE_PORT_MAX - _REMOTE_PORT_MIN + 1)
+    return random.randint(_REMOTE_PORT_MIN, _REMOTE_PORT_MAX)
 
 
 def _validate_port(port: int, name: str) -> None:
@@ -91,9 +91,8 @@ class ConnectionHandle:
     local_port: int
     remote_port: int
 
-    @property
-    def cascade_url(self) -> str:
-        """Return the local Cascade URL exposed through the tunnel."""
+    def as_local_url(self) -> str:
+        """Return the local URL for the service forwarded through the tunnel."""
 
         return f"tcp://localhost:{self.local_port}"
 
@@ -118,18 +117,6 @@ class TunnelRegistry:
             handles = tuple(self._handles)
         for handle in handles:
             stop(handle)
-
-    def __contains__(self, handle: ConnectionHandle) -> bool:
-        with self._lock:
-            return handle in self._handles
-
-    def __len__(self) -> int:
-        with self._lock:
-            return len(self._handles)
-
-    def __iter__(self) -> Iterable[ConnectionHandle]:
-        with self._lock:
-            return iter(tuple(self._handles))
 
 
 registry = TunnelRegistry()

--- a/backend/src/forecastbox/utility/tunnel.py
+++ b/backend/src/forecastbox/utility/tunnel.py
@@ -74,12 +74,12 @@ def _is_bind_failure(exc: subprocess.CalledProcessError) -> bool:
     return "cannot listen to port" in stderr or "address already in use" in stderr
 
 
-def _render_remote_command(command: RemoteCommand) -> str:
+def _render_remote_command(command: RemoteCommand, output_path: str = "/dev/null") -> str:
     if isinstance(command, str):
         rendered = command
     else:
         rendered = shlex.join(command)
-    return f"nohup {rendered} >/dev/null 2>&1 < /dev/null &"
+    return f"nohup bash --login -c '{rendered}' > {output_path} 2>&1 < /dev/null &"
 
 
 @dataclass(frozen=True, slots=True)
@@ -185,18 +185,19 @@ def status(handle: ConnectionHandle) -> bool:
     return result.returncode == 0
 
 
-def execute(handle: ConnectionHandle, command: RemoteCommand) -> None:
+def execute(handle: ConnectionHandle, command: RemoteCommand, output_path: str = "/dev/null") -> subprocess.CompletedProcess[str]:
     """Launch a remote command over the existing SSH control socket."""
 
-    remote_command = _render_remote_command(command)
-    _ssh_run([*_ssh_base_args(handle), handle.host, remote_command])
+    remote_command = _render_remote_command(command, output_path)
+    return _ssh_run([*_ssh_base_args(handle), handle.host, remote_command])
 
 
-def stop(handle: ConnectionHandle) -> None:
+def stop(handle: ConnectionHandle) -> subprocess.CompletedProcess[str]:
     """Terminate an SSH master connection and remove it from the registry."""
 
-    _ssh_run([*_ssh_base_args(handle), "-O", "exit", handle.host])
+    rv = _ssh_run([*_ssh_base_args(handle), "-O", "exit", handle.host])
     registry.discard(handle)
+    return rv
 
 
 def shutdown() -> None:

--- a/backend/src/forecastbox/utility/tunnel.py
+++ b/backend/src/forecastbox/utility/tunnel.py
@@ -1,0 +1,218 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Helpers for SSH multiplexing tunnels."""
+
+import os
+import secrets
+import shlex
+import socket
+import subprocess
+import tempfile
+import threading
+import uuid
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+_CONTROL_ROOT = Path(tempfile.gettempdir()) / f"forecastbox-ssh-{os.getpid()}"
+_REMOTE_PORT_MIN = 20_000
+_REMOTE_PORT_MAX = 60_000
+_SETUP_ATTEMPTS = 8
+
+RemoteCommand = str | Sequence[str]
+
+
+def _ensure_control_root() -> None:
+    _CONTROL_ROOT.mkdir(mode=0o700, parents=True, exist_ok=True)
+
+
+def _claim_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _claim_remote_port() -> int:
+    return _REMOTE_PORT_MIN + secrets.randbelow(_REMOTE_PORT_MAX - _REMOTE_PORT_MIN + 1)
+
+
+def _validate_port(port: int, name: str) -> None:
+    if port < 1 or port > 65535:
+        raise ValueError(f"{name} must be a valid TCP port: {port}")
+
+
+def _new_control_path() -> str:
+    _ensure_control_root()
+    return str(_CONTROL_ROOT / f"{uuid.uuid4().hex[:12]}.sock")
+
+
+def _ssh_base_args(handle: "ConnectionHandle") -> list[str]:
+    return [
+        "ssh",
+        "-S",
+        handle.control_path,
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ConnectTimeout=10",
+    ]
+
+
+def _ssh_run(args: Sequence[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(list(args), check=check, capture_output=True, text=True)
+
+
+def _is_bind_failure(exc: subprocess.CalledProcessError) -> bool:
+    stderr = (exc.stderr or "").lower()
+    return "cannot listen to port" in stderr or "address already in use" in stderr
+
+
+def _render_remote_command(command: RemoteCommand) -> str:
+    if isinstance(command, str):
+        rendered = command
+    else:
+        rendered = shlex.join(command)
+    return f"nohup {rendered} >/dev/null 2>&1 < /dev/null &"
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectionHandle:
+    """A persisted SSH tunnel connection."""
+
+    host: str
+    control_path: str
+    local_port: int
+    remote_port: int
+
+    @property
+    def cascade_url(self) -> str:
+        """Return the local Cascade URL exposed through the tunnel."""
+
+        return f"tcp://localhost:{self.local_port}"
+
+
+class TunnelRegistry:
+    """Track live tunnel handles so the app can shut them down on exit."""
+
+    def __init__(self) -> None:
+        self._handles: set[ConnectionHandle] = set()
+        self._lock = threading.Lock()
+
+    def register(self, handle: ConnectionHandle) -> None:
+        with self._lock:
+            self._handles.add(handle)
+
+    def discard(self, handle: ConnectionHandle) -> None:
+        with self._lock:
+            self._handles.discard(handle)
+
+    def shutdown(self) -> None:
+        with self._lock:
+            handles = tuple(self._handles)
+        for handle in handles:
+            stop(handle)
+
+    def __contains__(self, handle: ConnectionHandle) -> bool:
+        with self._lock:
+            return handle in self._handles
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._handles)
+
+    def __iter__(self) -> Iterable[ConnectionHandle]:
+        with self._lock:
+            return iter(tuple(self._handles))
+
+
+registry = TunnelRegistry()
+
+
+def setup(
+    host: str,
+    local_port: int | None = None,
+    remote_port: int | None = None,
+) -> ConnectionHandle:
+    """Start an SSH master connection with a localhost port forward."""
+
+    if local_port is not None:
+        _validate_port(local_port, "local_port")
+    if remote_port is not None:
+        _validate_port(remote_port, "remote_port")
+    last_error: subprocess.CalledProcessError | None = None
+    attempts = 1 if remote_port is not None else _SETUP_ATTEMPTS
+    for _ in range(attempts):
+        resolved_local_port = local_port if local_port is not None else _claim_free_port()
+        resolved_remote_port = remote_port if remote_port is not None else _claim_remote_port()
+        handle = ConnectionHandle(
+            host=host,
+            control_path=_new_control_path(),
+            local_port=resolved_local_port,
+            remote_port=resolved_remote_port,
+        )
+        try:
+            _ssh_run(
+                [
+                    "ssh",
+                    "-M",
+                    "-f",
+                    "-N",
+                    "-L",
+                    f"{handle.local_port}:localhost:{handle.remote_port}",
+                    "-o",
+                    "BatchMode=yes",
+                    "-o",
+                    "ConnectTimeout=10",
+                    "-o",
+                    "ControlMaster=auto",
+                    "-o",
+                    f"ControlPath={handle.control_path}",
+                    "-o",
+                    "ControlPersist=10m",
+                    "-o",
+                    "ExitOnForwardFailure=yes",
+                    host,
+                ]
+            )
+        except subprocess.CalledProcessError as exc:
+            last_error = exc
+            if remote_port is not None or not _is_bind_failure(exc):
+                raise
+            continue
+        registry.register(handle)
+        return handle
+    raise RuntimeError("failed to establish ssh tunnel after retries") from last_error
+
+
+def status(handle: ConnectionHandle) -> bool:
+    """Return whether the SSH master connection is alive."""
+
+    result = _ssh_run([*_ssh_base_args(handle), "-O", "check", handle.host], check=False)
+    return result.returncode == 0
+
+
+def execute(handle: ConnectionHandle, command: RemoteCommand) -> None:
+    """Launch a remote command over the existing SSH control socket."""
+
+    remote_command = _render_remote_command(command)
+    _ssh_run([*_ssh_base_args(handle), handle.host, remote_command])
+
+
+def stop(handle: ConnectionHandle) -> None:
+    """Terminate an SSH master connection and remove it from the registry."""
+
+    _ssh_run([*_ssh_base_args(handle), "-O", "exit", handle.host])
+    registry.discard(handle)
+
+
+def shutdown() -> None:
+    """Stop all tracked SSH tunnels."""
+
+    registry.shutdown()

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -143,7 +143,7 @@ def backend_client() -> Generator[httpx.Client, None, None]:
         config = FIABConfig()
         config.auth.jwt_secret = SecretStr("x" * 32)
         config.api.uvicorn_port = 30645
-        config.cascade.cascade_url = "tcp://localhost:30644"
+        config.cascade.cascade_url = "tcp://localhost"
         config.db.sqlite_userdb_path = f"{td.name}/user.db"
         config.db.sqlite_jobdb_path = f"{td.name}/job.db"
         config.api.data_path = td_data.name

--- a/backend/tests/unit/domain/run/test_run_detailed_report.py
+++ b/backend/tests/unit/domain/run/test_run_detailed_report.py
@@ -73,6 +73,7 @@ async def test_poll_and_update_requests_detailed_report_and_translates_to_block_
     with (
         patch("forecastbox.domain.run.service.client.request_response", return_value=response) as mock_request,
         patch("forecastbox.domain.run.service.retrieve_compilation_detail", return_value=compilation_detail) as mock_retrieve,
+        patch("forecastbox.domain.run.service.get_gateway_url", return_value="tcp://localhost:8067"),
         patch("forecastbox.domain.run.service.run_db.update_run_runtime", new=AsyncMock()),
     ):
         detail = await run_service.poll_and_update(cast(Run, execution), detailed_report=True)
@@ -112,6 +113,7 @@ async def test_poll_and_update_disables_detailed_report_when_cache_misses() -> N
         patch(
             "forecastbox.domain.run.service.retrieve_compilation_detail", side_effect=CompilationDetailNotFound("missing")
         ) as mock_retrieve,
+        patch("forecastbox.domain.run.service.get_gateway_url", return_value="tcp://localhost:8067"),
         patch("forecastbox.domain.run.service.run_db.update_run_runtime", new=AsyncMock()),
     ):
         detail = await run_service.poll_and_update(cast(Run, execution), detailed_report=True)

--- a/backend/tests/utility/test_tunnel.py
+++ b/backend/tests/utility/test_tunnel.py
@@ -44,8 +44,8 @@ def test_setup_registers_tunnel_and_builds_master_command(
         local_port=21001,
         remote_port=31001,
     )
-    assert handle.cascade_url == "tcp://localhost:21001"
-    assert handle in fresh_registry
+    assert handle.as_local_url() == "tcp://localhost:21001"
+    assert handle in fresh_registry._handles
     assert ssh_calls == [
         (
             [
@@ -102,7 +102,7 @@ def test_setup_retries_on_bind_failure(
     handle = tunnel.setup("fiabServer")
 
     assert handle.remote_port == 31002
-    assert handle in fresh_registry
+    assert handle in fresh_registry._handles
     assert ssh_calls == [
         [
             "ssh",
@@ -165,7 +165,7 @@ def test_status_execute_and_stop_use_existing_control_socket(
     tunnel.execute(handle, ["uv", "run", "python", "-m", "cascade.gateway", "--port", "22001"])
     tunnel.stop(handle)
 
-    assert handle not in fresh_registry
+    assert handle not in fresh_registry._handles
     assert ssh_calls == [
         (
             [
@@ -236,4 +236,4 @@ def test_shutdown_stops_all_tracked_handles(
     tunnel.shutdown()
 
     assert set(seen) == set(handles)
-    assert len(fresh_registry) == 0
+    assert len(fresh_registry._handles) == 0

--- a/backend/tests/utility/test_tunnel.py
+++ b/backend/tests/utility/test_tunnel.py
@@ -32,7 +32,7 @@ def test_setup_registers_tunnel_and_builds_master_command(
     monkeypatch: pytest.MonkeyPatch,
     ssh_calls: list[tuple[list[str], bool]],
 ) -> None:
-    monkeypatch.setattr(tunnel, "_claim_free_port", lambda: 21001)
+    monkeypatch.setattr(tunnel, "claim_free_port", lambda: 21001)
     monkeypatch.setattr(tunnel, "_claim_remote_port", lambda: 31001)
     monkeypatch.setattr(tunnel, "_new_control_path", lambda: "/tmp/forecastbox-ssh/test.sock")
 
@@ -83,7 +83,7 @@ def test_setup_retries_on_bind_failure(
     control_paths = iter(["/tmp/forecastbox-ssh/a.sock", "/tmp/forecastbox-ssh/b.sock"])
     ssh_calls: list[list[str]] = []
 
-    monkeypatch.setattr(tunnel, "_claim_free_port", lambda: next(local_ports))
+    monkeypatch.setattr(tunnel, "claim_free_port", lambda: next(local_ports))
     monkeypatch.setattr(tunnel, "_claim_remote_port", lambda: next(remote_ports))
     monkeypatch.setattr(tunnel, "_new_control_path", lambda: next(control_paths))
 

--- a/backend/tests/utility/test_tunnel.py
+++ b/backend/tests/utility/test_tunnel.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+import forecastbox.utility.tunnel as tunnel
+from forecastbox.utility.tunnel import ConnectionHandle, TunnelRegistry
+
+
+@pytest.fixture
+def fresh_registry(monkeypatch: pytest.MonkeyPatch) -> TunnelRegistry:
+    registry = TunnelRegistry()
+    monkeypatch.setattr(tunnel, "registry", registry)
+    return registry
+
+
+@pytest.fixture
+def ssh_calls(monkeypatch: pytest.MonkeyPatch) -> list[tuple[list[str], bool]]:
+    calls: list[tuple[list[str], bool]] = []
+
+    def fake_run(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+        calls.append((args, check))
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(tunnel, "_ssh_run", fake_run)
+    return calls
+
+
+def test_setup_registers_tunnel_and_builds_master_command(
+    fresh_registry: TunnelRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+    ssh_calls: list[tuple[list[str], bool]],
+) -> None:
+    monkeypatch.setattr(tunnel, "_claim_free_port", lambda: 21001)
+    monkeypatch.setattr(tunnel, "_claim_remote_port", lambda: 31001)
+    monkeypatch.setattr(tunnel, "_new_control_path", lambda: "/tmp/forecastbox-ssh/test.sock")
+
+    handle = tunnel.setup("fiabServer")
+
+    assert handle == ConnectionHandle(
+        host="fiabServer",
+        control_path="/tmp/forecastbox-ssh/test.sock",
+        local_port=21001,
+        remote_port=31001,
+    )
+    assert handle.cascade_url == "tcp://localhost:21001"
+    assert handle in fresh_registry
+    assert ssh_calls == [
+        (
+            [
+                "ssh",
+                "-M",
+                "-f",
+                "-N",
+                "-L",
+                "21001:localhost:31001",
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "ConnectTimeout=10",
+                "-o",
+                "ControlMaster=auto",
+                "-o",
+                "ControlPath=/tmp/forecastbox-ssh/test.sock",
+                "-o",
+                "ControlPersist=10m",
+                "-o",
+                "ExitOnForwardFailure=yes",
+                "fiabServer",
+            ],
+            True,
+        )
+    ]
+
+
+def test_setup_retries_on_bind_failure(
+    fresh_registry: TunnelRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    local_ports = iter([21001, 21001])
+    remote_ports = iter([31001, 31002])
+    control_paths = iter(["/tmp/forecastbox-ssh/a.sock", "/tmp/forecastbox-ssh/b.sock"])
+    ssh_calls: list[list[str]] = []
+
+    monkeypatch.setattr(tunnel, "_claim_free_port", lambda: next(local_ports))
+    monkeypatch.setattr(tunnel, "_claim_remote_port", lambda: next(remote_ports))
+    monkeypatch.setattr(tunnel, "_new_control_path", lambda: next(control_paths))
+
+    def fake_run(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+        ssh_calls.append(args)
+        if len(ssh_calls) == 1:
+            raise subprocess.CalledProcessError(
+                returncode=255,
+                cmd=args,
+                stderr="channel_setup_fwd_listener_tcpip: cannot listen to port: Address already in use",
+            )
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(tunnel, "_ssh_run", fake_run)
+
+    handle = tunnel.setup("fiabServer")
+
+    assert handle.remote_port == 31002
+    assert handle in fresh_registry
+    assert ssh_calls == [
+        [
+            "ssh",
+            "-M",
+            "-f",
+            "-N",
+            "-L",
+            "21001:localhost:31001",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ConnectTimeout=10",
+            "-o",
+            "ControlMaster=auto",
+            "-o",
+            "ControlPath=/tmp/forecastbox-ssh/a.sock",
+            "-o",
+            "ControlPersist=10m",
+            "-o",
+            "ExitOnForwardFailure=yes",
+            "fiabServer",
+        ],
+        [
+            "ssh",
+            "-M",
+            "-f",
+            "-N",
+            "-L",
+            "21001:localhost:31002",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ConnectTimeout=10",
+            "-o",
+            "ControlMaster=auto",
+            "-o",
+            "ControlPath=/tmp/forecastbox-ssh/b.sock",
+            "-o",
+            "ControlPersist=10m",
+            "-o",
+            "ExitOnForwardFailure=yes",
+            "fiabServer",
+        ],
+    ]
+
+
+def test_status_execute_and_stop_use_existing_control_socket(
+    fresh_registry: TunnelRegistry,
+    ssh_calls: list[tuple[list[str], bool]],
+) -> None:
+    handle = ConnectionHandle(
+        host="user@fiabServer",
+        control_path="/tmp/forecastbox-ssh/test.sock",
+        local_port=21001,
+        remote_port=22001,
+    )
+    fresh_registry.register(handle)
+
+    assert tunnel.status(handle) is True
+    tunnel.execute(handle, ["uv", "run", "python", "-m", "cascade.gateway", "--port", "22001"])
+    tunnel.stop(handle)
+
+    assert handle not in fresh_registry
+    assert ssh_calls == [
+        (
+            [
+                "ssh",
+                "-S",
+                "/tmp/forecastbox-ssh/test.sock",
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "ConnectTimeout=10",
+                "-O",
+                "check",
+                "user@fiabServer",
+            ],
+            False,
+        ),
+        (
+            [
+                "ssh",
+                "-S",
+                "/tmp/forecastbox-ssh/test.sock",
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "ConnectTimeout=10",
+                "user@fiabServer",
+                "nohup uv run python -m cascade.gateway --port 22001 >/dev/null 2>&1 < /dev/null &",
+            ],
+            True,
+        ),
+        (
+            [
+                "ssh",
+                "-S",
+                "/tmp/forecastbox-ssh/test.sock",
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "ConnectTimeout=10",
+                "-O",
+                "exit",
+                "user@fiabServer",
+            ],
+            True,
+        ),
+    ]
+
+
+def test_shutdown_stops_all_tracked_handles(
+    fresh_registry: TunnelRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handles = [
+        ConnectionHandle("host-a", "/tmp/forecastbox-ssh/a.sock", 21001, 22001),
+        ConnectionHandle("host-b", "/tmp/forecastbox-ssh/b.sock", 21002, 22002),
+    ]
+    for handle in handles:
+        fresh_registry.register(handle)
+
+    seen: list[ConnectionHandle] = []
+
+    def fake_stop(handle: ConnectionHandle) -> None:
+        seen.append(handle)
+        fresh_registry.discard(handle)
+
+    monkeypatch.setattr(tunnel, "stop", fake_stop)
+
+    tunnel.shutdown()
+
+    assert set(seen) == set(handles)
+    assert len(fresh_registry) == 0

--- a/backend/tests/utility/test_tunnel.py
+++ b/backend/tests/utility/test_tunnel.py
@@ -16,11 +16,11 @@ def fresh_registry(monkeypatch: pytest.MonkeyPatch) -> TunnelRegistry:
 
 
 @pytest.fixture
-def ssh_calls(monkeypatch: pytest.MonkeyPatch) -> list[tuple[list[str], bool]]:
-    calls: list[tuple[list[str], bool]] = []
+def ssh_calls(monkeypatch: pytest.MonkeyPatch) -> list[tuple[list[str], bool, bool]]:
+    calls: list[tuple[list[str], bool, bool]] = []
 
-    def fake_run(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
-        calls.append((args, check))
+    def fake_run(args: list[str], *, check: bool = True, start_new_session: bool = False) -> subprocess.CompletedProcess[str]:
+        calls.append((args, check, start_new_session))
         return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(tunnel, "_ssh_run", fake_run)
@@ -30,7 +30,7 @@ def ssh_calls(monkeypatch: pytest.MonkeyPatch) -> list[tuple[list[str], bool]]:
 def test_setup_registers_tunnel_and_builds_master_command(
     fresh_registry: TunnelRegistry,
     monkeypatch: pytest.MonkeyPatch,
-    ssh_calls: list[tuple[list[str], bool]],
+    ssh_calls: list[tuple[list[str], bool, bool]],
 ) -> None:
     monkeypatch.setattr(tunnel, "claim_free_port", lambda: 21001)
     monkeypatch.setattr(tunnel, "_claim_remote_port", lambda: 31001)
@@ -70,6 +70,7 @@ def test_setup_registers_tunnel_and_builds_master_command(
                 "fiabServer",
             ],
             True,
+            True,
         )
     ]
 
@@ -81,14 +82,14 @@ def test_setup_retries_on_bind_failure(
     local_ports = iter([21001, 21001])
     remote_ports = iter([31001, 31002])
     control_paths = iter(["/tmp/forecastbox-ssh/a.sock", "/tmp/forecastbox-ssh/b.sock"])
-    ssh_calls: list[list[str]] = []
+    ssh_calls: list[tuple[list[str], bool, bool]] = []
 
     monkeypatch.setattr(tunnel, "claim_free_port", lambda: next(local_ports))
     monkeypatch.setattr(tunnel, "_claim_remote_port", lambda: next(remote_ports))
     monkeypatch.setattr(tunnel, "_new_control_path", lambda: next(control_paths))
 
-    def fake_run(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
-        ssh_calls.append(args)
+    def fake_run(args: list[str], *, check: bool = True, start_new_session: bool = False) -> subprocess.CompletedProcess[str]:
+        ssh_calls.append((args, check, start_new_session))
         if len(ssh_calls) == 1:
             raise subprocess.CalledProcessError(
                 returncode=255,
@@ -104,54 +105,62 @@ def test_setup_retries_on_bind_failure(
     assert handle.remote_port == 31002
     assert handle in fresh_registry._handles
     assert ssh_calls == [
-        [
-            "ssh",
-            "-M",
-            "-f",
-            "-N",
-            "-L",
-            "21001:localhost:31001",
-            "-o",
-            "BatchMode=yes",
-            "-o",
-            "ConnectTimeout=10",
-            "-o",
-            "ControlMaster=auto",
-            "-o",
-            "ControlPath=/tmp/forecastbox-ssh/a.sock",
-            "-o",
-            "ControlPersist=10m",
-            "-o",
-            "ExitOnForwardFailure=yes",
-            "fiabServer",
-        ],
-        [
-            "ssh",
-            "-M",
-            "-f",
-            "-N",
-            "-L",
-            "21001:localhost:31002",
-            "-o",
-            "BatchMode=yes",
-            "-o",
-            "ConnectTimeout=10",
-            "-o",
-            "ControlMaster=auto",
-            "-o",
-            "ControlPath=/tmp/forecastbox-ssh/b.sock",
-            "-o",
-            "ControlPersist=10m",
-            "-o",
-            "ExitOnForwardFailure=yes",
-            "fiabServer",
-        ],
+        (
+            [
+                "ssh",
+                "-M",
+                "-f",
+                "-N",
+                "-L",
+                "21001:localhost:31001",
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "ConnectTimeout=10",
+                "-o",
+                "ControlMaster=auto",
+                "-o",
+                "ControlPath=/tmp/forecastbox-ssh/a.sock",
+                "-o",
+                "ControlPersist=10m",
+                "-o",
+                "ExitOnForwardFailure=yes",
+                "fiabServer",
+            ],
+            True,
+            True,
+        ),
+        (
+            [
+                "ssh",
+                "-M",
+                "-f",
+                "-N",
+                "-L",
+                "21001:localhost:31002",
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "ConnectTimeout=10",
+                "-o",
+                "ControlMaster=auto",
+                "-o",
+                "ControlPath=/tmp/forecastbox-ssh/b.sock",
+                "-o",
+                "ControlPersist=10m",
+                "-o",
+                "ExitOnForwardFailure=yes",
+                "fiabServer",
+            ],
+            True,
+            True,
+        ),
     ]
 
 
 def test_status_execute_and_stop_use_existing_control_socket(
     fresh_registry: TunnelRegistry,
-    ssh_calls: list[tuple[list[str], bool]],
+    ssh_calls: list[tuple[list[str], bool, bool]],
 ) -> None:
     handle = ConnectionHandle(
         host="user@fiabServer",
@@ -181,6 +190,7 @@ def test_status_execute_and_stop_use_existing_control_socket(
                 "user@fiabServer",
             ],
             False,
+            False,
         ),
         (
             [
@@ -195,6 +205,7 @@ def test_status_execute_and_stop_use_existing_control_socket(
                 "nohup uv run python -m cascade.gateway --port 22001 >/dev/null 2>&1 < /dev/null &",
             ],
             True,
+            False,
         ),
         (
             [
@@ -210,6 +221,7 @@ def test_status_execute_and_stop_use_existing_control_socket(
                 "user@fiabServer",
             ],
             True,
+            False,
         ),
     ]
 


### PR DESCRIPTION
1/ Introduces a utility for setting up and managing ssh connexions
2/ Refactors the gateway management to distinguish between RemoteUrl, RemoteTunnel, and LocalProcess:
  - RemoteUrl does not manage gateway at all, no logs (yet) or restarts supported
    provide full url of cascade gateway `tcp://<hostname>:<port>` and set spawn: False
  - RemoteTunnel supports spawning/restart, but no logs (yet)
    provide url `ssh://[<username>@]<hostname>` and set spawn: True
  - LocalProcess supports spawning/restart and logs
    provide url `tcp://localhost` and set spawn: True

Changes to config:
  - local gateway does not require port in its url -- we always choose a random one
  - dropped unused config options related to cascade (log size, venv dir)
  - introduced a new config for logging base (use like /tmp/cascadeLogs or /home/<hpcLogin>/fiabLogs). Default behaviour is the original one
 
Notes:
  - artifacts are _not_ supported correctly
  - beware on hpc -- if you ssh to hpc in parallel to observe/troubleshoot, you may be on a different node! You will not `ps` see the process, you will not see the same `/tmp`, etc. I was using `fiab__cascade__cascade_logging_base=/home/ecme7737/fl fiab__cascade__cascade_url="ssh://hpc-login" FIAB_ROOT=.fiab uv run --no-sync python -m forecastbox.entrypoint.main` to execute it
  - we *assume* `uv` to be installed and available, but we always run `uv run --with earthkit-workflows`, meaning you dont need to install it, but you also override it to eg editable via config
  - slurm submissions are *not* supported yet -- so basically dont run anything :)