### PR TITLE
Add SSH remote artifact download support

### DIFF
--- a/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
+++ b/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
@@ -136,6 +136,7 @@ def expander(output: BlockInstanceOutput) -> list[BlockExpansion]:
 
 def compiler(lookup: ActionLookup, bid: BlockInstanceId, instance: BlockInstance) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
     with PayloadBuildingContext(environment=[f"-e {pathlib.Path(__file__).parent.parent.parent}"]):
+        # with PayloadBuildingContext(environment=["-e /home/dev/src/fiab-plugin-test"]): # TODO handle the ssh:// scenario intelligently
         if instance.factory_id.factory == "source_42":
             action = from_source(Payload("fiab_plugin_test.runtime.source_42"))  # type: ignore
         elif instance.factory_id.factory == "source_text":

--- a/backend/src/forecastbox/domain/artifact/base.py
+++ b/backend/src/forecastbox/domain/artifact/base.py
@@ -59,18 +59,9 @@ artifacts_subdir = "artifacts"
 
 
 def get_artifact_local_path(composite_id: CompositeArtifactId, data_dir_url: str) -> Path:
-    """Get the local filesystem path for an artifact file.
-
-    Args:
-        composite_id: The composite artifact ID
-        data_dir_url: The data directory URL (must be file:// or ssh:// scheme)
-
-    Returns:
-        Path to the artifact file
-
-    Raises:
-        ValueError: If the composite ID contains invalid path characters
-    """
+    """Get the local filesystem path for an artifact file, raising ValueError if the composite ID contains invalid path characters.
+    The Path is not checked for existence, only for validity (ie invalid chars). For remote paths (ssh:// scheme), resolves
+    from the PoV of the remote host."""
     store_id = composite_id.artifact_store_id
     artifact_local_id = composite_id.artifact_local_id
 

--- a/backend/src/forecastbox/domain/artifact/base.py
+++ b/backend/src/forecastbox/domain/artifact/base.py
@@ -11,6 +11,7 @@
 Base definitions pertaining to artifacts such as ml model checkpoints
 """
 
+import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -57,15 +58,33 @@ ArtifactCatalog = PMap[CompositeArtifactId, ArtifactResolved]
 artifacts_subdir = "artifacts"
 
 
-def get_artifact_local_path(composite_id: CompositeArtifactId, data_dir: Path) -> Path:
-    """Get the local filesystem path for an artifact file, raising ValueError if the composite ID contains invalid path characters.
-    The Path is not checked for existence, only for validity (ie invalid chars)"""
+def get_artifact_local_path(composite_id: CompositeArtifactId, data_dir_url: str | Path) -> Path:
+    """Get the local filesystem path for an artifact file.
+
+    data_dir_url can be:
+    - A Path object (legacy, treated as-is)
+    - A file:// URL (parsed to extract the path)
+    - A plain path string without scheme (treated as file://)
+
+    Raises ValueError if the composite ID contains invalid path characters.
+    The returned Path is not checked for existence, only for validity.
+    """
     store_id = composite_id.artifact_store_id
     artifact_local_id = composite_id.artifact_local_id
 
     invalid_chars = {"..", "/", "\\", "\0"}
     if any(char in store_id for char in invalid_chars) or any(char in artifact_local_id for char in invalid_chars):
         raise ValueError(f"Invalid characters in artifact ID: {composite_id}")
+
+    if isinstance(data_dir_url, Path):
+        data_dir = data_dir_url
+    else:
+        data_dir_str = str(data_dir_url)
+        if "://" not in data_dir_str:
+            data_dir = Path(data_dir_str)
+        else:
+            parsed = urllib.parse.urlparse(data_dir_str)
+            data_dir = Path(parsed.path)
 
     artifact_path = data_dir / artifacts_subdir / store_id / artifact_local_id
 

--- a/backend/src/forecastbox/domain/artifact/base.py
+++ b/backend/src/forecastbox/domain/artifact/base.py
@@ -58,16 +58,18 @@ ArtifactCatalog = PMap[CompositeArtifactId, ArtifactResolved]
 artifacts_subdir = "artifacts"
 
 
-def get_artifact_local_path(composite_id: CompositeArtifactId, data_dir_url: str | Path) -> Path:
+def get_artifact_local_path(composite_id: CompositeArtifactId, data_dir_url: str) -> Path:
     """Get the local filesystem path for an artifact file.
 
-    data_dir_url can be:
-    - A Path object (legacy, treated as-is)
-    - A file:// URL (parsed to extract the path)
-    - A plain path string without scheme (treated as file://)
+    Args:
+        composite_id: The composite artifact ID
+        data_dir_url: The data directory URL (must be file:// or ssh:// scheme)
 
-    Raises ValueError if the composite ID contains invalid path characters.
-    The returned Path is not checked for existence, only for validity.
+    Returns:
+        Path to the artifact file
+
+    Raises:
+        ValueError: If the composite ID contains invalid path characters
     """
     store_id = composite_id.artifact_store_id
     artifact_local_id = composite_id.artifact_local_id
@@ -76,15 +78,8 @@ def get_artifact_local_path(composite_id: CompositeArtifactId, data_dir_url: str
     if any(char in store_id for char in invalid_chars) or any(char in artifact_local_id for char in invalid_chars):
         raise ValueError(f"Invalid characters in artifact ID: {composite_id}")
 
-    if isinstance(data_dir_url, Path):
-        data_dir = data_dir_url
-    else:
-        data_dir_str = str(data_dir_url)
-        if "://" not in data_dir_str:
-            data_dir = Path(data_dir_str)
-        else:
-            parsed = urllib.parse.urlparse(data_dir_str)
-            data_dir = Path(parsed.path)
+    parsed = urllib.parse.urlparse(data_dir_url)
+    data_dir = Path(parsed.path)
 
     artifact_path = data_dir / artifacts_subdir / store_id / artifact_local_id
 

--- a/backend/src/forecastbox/domain/artifact/catalog.py
+++ b/backend/src/forecastbox/domain/artifact/catalog.py
@@ -1,0 +1,60 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Artifact catalog: loading and querying available artifacts from remote stores."""
+
+import json
+import logging
+from typing import cast
+
+import httpx
+from cascade.low.func import assert_never
+from fiab_core.artifacts import ArtifactLocalId, ArtifactResolved, ArtifactStoreId, ArtifactType, MlModelCheckpoint
+from pyrsistent import pmap
+
+from forecastbox.domain.artifact.base import ArtifactCatalog, CompositeArtifactId
+from forecastbox.domain.artifact.compatibility import get_model_checkpoint_compatibility, get_platform_info
+from forecastbox.utility.config import ArtifactStoresConfig
+from forecastbox.utility.httpx import fetch_content
+
+logger = logging.getLogger(__name__)
+
+
+def get_artifacts_catalog(artifact_stores_config: ArtifactStoresConfig) -> ArtifactCatalog:
+    """Query each artifact store and return a composed catalog of all available artifacts."""
+    catalog = {}
+    platform_info = get_platform_info()
+
+    with httpx.Client(follow_redirects=True) as client:
+        for store_id, store_config in artifact_stores_config.items():
+            if store_config.method == "file":
+                raw = fetch_content(store_config.url, client)
+                store_data = json.loads(raw)
+                artifacts = store_data.get("artifacts", {})
+                for artifact_id, artifact_data in artifacts.items():
+                    composite_id = CompositeArtifactId(artifact_store_id=store_id, artifact_local_id=ArtifactLocalId(artifact_id))
+                    artifact_type = cast(ArtifactType, artifact_data["artifact_type"])
+                    store_info_data = artifact_data["store_info"]
+                    if artifact_type == "MlModelCheckpoint":
+                        store_info = MlModelCheckpoint(**store_info_data)
+                        is_locally_compatible, local_compatibility_detail = get_model_checkpoint_compatibility(store_info, platform_info)
+                    else:
+                        assert_never(artifact_type)
+
+                    catalog[composite_id] = ArtifactResolved(
+                        artifact_type=artifact_type,
+                        store_info=store_info,
+                        is_locally_compatible=is_locally_compatible,
+                        local_compatibility_detail=local_compatibility_detail,
+                    )
+                    logger.debug(f"Loaded artifact {composite_id} from store {store_id}")
+            else:
+                assert_never(store_config.method)
+
+    return pmap(catalog)

--- a/backend/src/forecastbox/domain/artifact/io.py
+++ b/backend/src/forecastbox/domain/artifact/io.py
@@ -34,10 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 def _parse_data_dir_url(data_dir_url: str) -> tuple[str, str, str]:
-    """Parse a data_dir URL into (scheme, netloc, path).
-
-    Raises ValueError if the URL is invalid or missing a scheme.
-    """
+    """Parse a data_dir URL into (scheme, netloc, path). Raises ValueError on error."""
     if "://" not in data_dir_url:
         raise ValueError(f"Invalid data_dir URL (missing scheme): {data_dir_url}")
     parsed = urllib.parse.urlparse(data_dir_url)
@@ -51,9 +48,9 @@ def _parse_data_dir_url(data_dir_url: str) -> tuple[str, str, str]:
 # ---------------------------------------------------------------------------
 
 
-def _enumerate_artifacts_local(data_dir: Path) -> list[tuple[str, str]]:
+def _enumerate_artifacts_local(data_dir: str) -> list[tuple[str, str]]:
     """Return (store_id, artifact_id) pairs from local filesystem."""
-    artifacts_base = data_dir / artifacts_subdir
+    artifacts_base = Path(data_dir) / artifacts_subdir
     if not artifacts_base.exists():
         return []
 
@@ -71,9 +68,9 @@ def _enumerate_artifacts_local(data_dir: Path) -> list[tuple[str, str]]:
     return entries
 
 
-def _enumerate_artifacts_remote(handle: CommandHandle, remote_path: str) -> list[tuple[str, str]]:
+def _enumerate_artifacts_remote(path: str, handle: CommandHandle) -> list[tuple[str, str]]:
     """Return (store_id, artifact_id) pairs from a remote host via SSH."""
-    artifacts_base = remote_path.rstrip("/") + "/" + artifacts_subdir
+    artifacts_base = path.rstrip("/") + "/" + artifacts_subdir
     cmd = f"find {shlex.quote(artifacts_base)} -mindepth 2 -maxdepth 2 -not -type d 2>/dev/null || true"
     result = tunnel.run(handle, cmd)
 
@@ -113,13 +110,13 @@ def list_storage(catalog: ArtifactCatalog, data_dir_url: str, handle: CommandHan
     """List stored artifacts at the given data_dir_url (file:// or ssh://)."""
     scheme, _netloc, path = _parse_data_dir_url(data_dir_url)
     if scheme == "file":
-        entries = _enumerate_artifacts_local(Path(path))
+        entries = _enumerate_artifacts_local(path)
     elif scheme == "ssh":
         if handle is None:
             raise ValueError("SSH handle required for ssh:// data_dir_url")
-        entries = _enumerate_artifacts_remote(handle, path)
+        entries = _enumerate_artifacts_remote(path, handle)
     else:
-        raise ValueError(f"Unsupported data_dir scheme: {scheme!r}")
+        raise NotImplementedError(f"Unsupported data_dir scheme: {scheme!r}")
     return _match_artifacts_to_catalog(catalog, entries)
 
 
@@ -177,22 +174,19 @@ def _download_artifact_local(
 def _download_artifact_remote(
     composite_id: CompositeArtifactId,
     artifact: ArtifactResolved,
+    data_dir_url: str,
     handle: CommandHandle,
-    remote_path: str,
 ) -> None:
     """Download an artifact from its HTTP URL to remote storage via SSH curl."""
     checkpoint = artifact.store_info
-    artifact_path = str(get_artifact_local_path(composite_id, remote_path))
-    artifact_dir = str(Path(artifact_path).parent)
-    temp_path = artifact_path + ".tmp"
+    artifact_path = get_artifact_local_path(composite_id, data_dir_url)
+    temp_path = str(artifact_path) + ".tmp"
 
     logger.debug(f"Starting remote download for {composite_id} from {checkpoint.url}")
 
-    tunnel.run(handle, f"mkdir -p {shlex.quote(artifact_dir)}")
+    tunnel.run(handle, f"mkdir -p {shlex.quote(str(artifact_path.parent))}")
 
-    curl_cmd = (
-        f"curl -fsSL -o {shlex.quote(temp_path)} {shlex.quote(checkpoint.url)} && mv {shlex.quote(temp_path)} {shlex.quote(artifact_path)}"
-    )
+    curl_cmd = f"curl -fsSL -o {shlex.quote(temp_path)} {shlex.quote(checkpoint.url)} && mv {shlex.quote(temp_path)} {shlex.quote(str(artifact_path))}"
     try:
         tunnel.run(handle, curl_cmd)
     except subprocess.CalledProcessError as e:
@@ -213,16 +207,17 @@ def download_artifact(
     handle: CommandHandle | None = None,
     progress_callback: Callable[[int], None] | None = None,
 ) -> None:
-    """Download an artifact to local or remote storage, dispatching on the data_dir_url scheme."""
+    """Download an artifact to local or remote storage, dispatching on the data_dir_url scheme.
+    `handle` required for `ssh://` scheme."""
     scheme, _netloc, path = _parse_data_dir_url(data_dir_url)
     if scheme == "file":
         _download_artifact_local(composite_id, artifact, data_dir_url, progress_callback)
     elif scheme == "ssh":
         if handle is None:
             raise ValueError("SSH handle required for ssh:// data_dir_url")
-        _download_artifact_remote(composite_id, artifact, handle, path)
+        _download_artifact_remote(composite_id, artifact, data_dir_url, handle)
     else:
-        raise ValueError(f"Unsupported data_dir scheme: {scheme!r}")
+        raise NotImplementedError(f"Unsupported data_dir scheme: {scheme!r}")
 
 
 # ---------------------------------------------------------------------------
@@ -239,7 +234,7 @@ def _delete_artifact_local(composite_id: CompositeArtifactId, data_dir_url: str)
     logger.info(f"Deleted artifact {composite_id} from {artifact_path}")
 
 
-def _delete_artifact_remote(composite_id: CompositeArtifactId, handle: CommandHandle, data_dir_url: str) -> None:
+def _delete_artifact_remote(composite_id: CompositeArtifactId, data_dir_url: str, handle: CommandHandle) -> None:
     """Delete a remotely stored artifact file via SSH."""
     artifact_path = str(get_artifact_local_path(composite_id, data_dir_url))
     try:
@@ -264,6 +259,6 @@ def delete_artifact(
     elif scheme == "ssh":
         if handle is None:
             raise ValueError("SSH handle required for ssh:// data_dir_url")
-        _delete_artifact_remote(composite_id, handle, data_dir_url)
+        _delete_artifact_remote(composite_id, data_dir_url, handle)
     else:
-        raise ValueError(f"Unsupported data_dir scheme: {scheme!r}")
+        raise NotImplementedError(f"Unsupported data_dir scheme: {scheme!r}")

--- a/backend/src/forecastbox/domain/artifact/io.py
+++ b/backend/src/forecastbox/domain/artifact/io.py
@@ -36,11 +36,13 @@ logger = logging.getLogger(__name__)
 def _parse_data_dir_url(data_dir_url: str) -> tuple[str, str, str]:
     """Parse a data_dir URL into (scheme, netloc, path).
 
-    Plain paths without a scheme (legacy format) are treated as file:// URLs.
+    Raises ValueError if the URL is invalid or missing a scheme.
     """
     if "://" not in data_dir_url:
-        return "file", "", data_dir_url
+        raise ValueError(f"Invalid data_dir URL (missing scheme): {data_dir_url}")
     parsed = urllib.parse.urlparse(data_dir_url)
+    if not parsed.scheme:
+        raise ValueError(f"Invalid data_dir URL (no scheme): {data_dir_url}")
     return parsed.scheme, parsed.netloc, parsed.path
 
 
@@ -129,12 +131,12 @@ def list_storage(catalog: ArtifactCatalog, data_dir_url: str, handle: CommandHan
 def _download_artifact_local(
     composite_id: CompositeArtifactId,
     artifact: ArtifactResolved,
-    data_dir: Path,
+    data_dir_url: str,
     progress_callback: Callable[[int], None] | None = None,
 ) -> None:
     """Download an artifact from its remote URL to local storage."""
     checkpoint = artifact.store_info
-    artifact_path = get_artifact_local_path(composite_id, data_dir)
+    artifact_path = get_artifact_local_path(composite_id, data_dir_url)
     artifact_path.parent.mkdir(parents=True, exist_ok=True)
 
     temp_file = tempfile.NamedTemporaryFile(prefix="artifact_", suffix=".ckpt", delete=False)
@@ -214,7 +216,7 @@ def download_artifact(
     """Download an artifact to local or remote storage, dispatching on the data_dir_url scheme."""
     scheme, _netloc, path = _parse_data_dir_url(data_dir_url)
     if scheme == "file":
-        _download_artifact_local(composite_id, artifact, Path(path), progress_callback)
+        _download_artifact_local(composite_id, artifact, data_dir_url, progress_callback)
     elif scheme == "ssh":
         if handle is None:
             raise ValueError("SSH handle required for ssh:// data_dir_url")
@@ -228,18 +230,18 @@ def download_artifact(
 # ---------------------------------------------------------------------------
 
 
-def _delete_artifact_local(composite_id: CompositeArtifactId, data_dir: Path) -> None:
+def _delete_artifact_local(composite_id: CompositeArtifactId, data_dir_url: str) -> None:
     """Delete a locally stored artifact file."""
-    artifact_path = get_artifact_local_path(composite_id, data_dir)
+    artifact_path = get_artifact_local_path(composite_id, data_dir_url)
     if not artifact_path.exists():
         raise FileNotFoundError(f"Artifact file not found: {artifact_path}")
     artifact_path.unlink()
     logger.info(f"Deleted artifact {composite_id} from {artifact_path}")
 
 
-def _delete_artifact_remote(composite_id: CompositeArtifactId, handle: CommandHandle, remote_path: str) -> None:
+def _delete_artifact_remote(composite_id: CompositeArtifactId, handle: CommandHandle, data_dir_url: str) -> None:
     """Delete a remotely stored artifact file via SSH."""
-    artifact_path = str(get_artifact_local_path(composite_id, remote_path))
+    artifact_path = str(get_artifact_local_path(composite_id, data_dir_url))
     try:
         tunnel.run(handle, f"rm {shlex.quote(artifact_path)}")
     except subprocess.CalledProcessError as e:
@@ -256,12 +258,12 @@ def delete_artifact(
     handle: CommandHandle | None = None,
 ) -> None:
     """Delete an artifact from local or remote storage, dispatching on the data_dir_url scheme."""
-    scheme, _netloc, path = _parse_data_dir_url(data_dir_url)
+    scheme, _netloc, _path = _parse_data_dir_url(data_dir_url)
     if scheme == "file":
-        _delete_artifact_local(composite_id, Path(path))
+        _delete_artifact_local(composite_id, data_dir_url)
     elif scheme == "ssh":
         if handle is None:
             raise ValueError("SSH handle required for ssh:// data_dir_url")
-        _delete_artifact_remote(composite_id, handle, path)
+        _delete_artifact_remote(composite_id, handle, data_dir_url)
     else:
         raise ValueError(f"Unsupported data_dir scheme: {scheme!r}")

--- a/backend/src/forecastbox/domain/artifact/io.py
+++ b/backend/src/forecastbox/domain/artifact/io.py
@@ -8,121 +8,140 @@
 # nor does it submit to any jurisdiction.
 
 """
-Downloading and managing artifacts such as ml model checkpoints
+Downloading and managing artifacts such as ml model checkpoints.
 
-All the methods here are blocking -- see manager for nonblocking invocations
+All the methods here are blocking -- see manager for nonblocking invocations.
+Supports both local (file://) and remote (ssh://) data directories.
 """
 
-import json
 import logging
+import shlex
 import shutil
+import subprocess
 import tempfile
+import urllib.parse
 from collections.abc import Callable
 from pathlib import Path
-from typing import cast
 
 import httpx
-from cascade.low.func import assert_never
-from fiab_core.artifacts import ArtifactLocalId, ArtifactResolved, ArtifactStoreId, ArtifactType, MlModelCheckpoint
-from pyrsistent import pmap
+from fiab_core.artifacts import ArtifactLocalId, ArtifactResolved, ArtifactStoreId
 
 from forecastbox.domain.artifact.base import ArtifactCatalog, CompositeArtifactId, artifacts_subdir, get_artifact_local_path
-from forecastbox.domain.artifact.compatibility import get_model_checkpoint_compatibility, get_platform_info
-from forecastbox.utility.config import ArtifactStoresConfig
-from forecastbox.utility.httpx import fetch_content
+from forecastbox.utility import tunnel
+from forecastbox.utility.tunnel import CommandHandle
 
 logger = logging.getLogger(__name__)
 
 
-def get_artifacts_catalog(artifact_stores_config: ArtifactStoresConfig) -> ArtifactCatalog:
-    """Query each artifact store and return a composed catalog of all available artifacts."""
-    catalog = {}
-    platform_info = get_platform_info()
+def _parse_data_dir_url(data_dir_url: str) -> tuple[str, str, str]:
+    """Parse a data_dir URL into (scheme, netloc, path).
 
-    with httpx.Client(follow_redirects=True) as client:
-        for store_id, store_config in artifact_stores_config.items():
-            if store_config.method == "file":
-                raw = fetch_content(store_config.url, client)
-                store_data = json.loads(raw)
-                artifacts = store_data.get("artifacts", {})
-                for artifact_id, artifact_data in artifacts.items():
-                    composite_id = CompositeArtifactId(artifact_store_id=store_id, artifact_local_id=ArtifactLocalId(artifact_id))
-                    artifact_type = cast(ArtifactType, artifact_data["artifact_type"])
-                    store_info_data = artifact_data["store_info"]
-                    if artifact_type == "MlModelCheckpoint":
-                        store_info = MlModelCheckpoint(**store_info_data)
-                        is_locally_compatible, local_compatibility_detail = get_model_checkpoint_compatibility(store_info, platform_info)
-                    else:
-                        assert_never(artifact_type)
-
-                    catalog[composite_id] = ArtifactResolved(
-                        artifact_type=artifact_type,
-                        store_info=store_info,
-                        is_locally_compatible=is_locally_compatible,
-                        local_compatibility_detail=local_compatibility_detail,
-                    )
-                    logger.debug(f"Loaded artifact {composite_id} from store {store_id}")
-            else:
-                assert_never(store_config.method)
-
-    return pmap(catalog)
+    Plain paths without a scheme (legacy format) are treated as file:// URLs.
+    """
+    if "://" not in data_dir_url:
+        return "file", "", data_dir_url
+    parsed = urllib.parse.urlparse(data_dir_url)
+    return parsed.scheme, parsed.netloc, parsed.path
 
 
-def list_local_storage(artifacts_catalog: ArtifactCatalog, data_dir: Path) -> list[CompositeArtifactId]:
-    """List locally stored artifacts by traversing the artifacts directory under data_dir/artifacts/{store_id}/{checkpoint_id}."""
+# ---------------------------------------------------------------------------
+# Listing
+# ---------------------------------------------------------------------------
+
+
+def _enumerate_artifacts_local(data_dir: Path) -> list[tuple[str, str]]:
+    """Return (store_id, artifact_id) pairs from local filesystem."""
     artifacts_base = data_dir / artifacts_subdir
-
     if not artifacts_base.exists():
         return []
 
-    local_artifacts: list[CompositeArtifactId] = []
-    known_store_ids = {artifact_id.artifact_store_id for artifact_id in artifacts_catalog.keys()}
-
+    entries: list[tuple[str, str]] = []
     for store_item in artifacts_base.iterdir():
         if not store_item.is_dir():
             logger.warning(f"Found non-directory item in artifacts directory: {store_item.name}")
             continue
-
         store_id = store_item.name
-
-        if store_id not in known_store_ids:
-            logger.warning(f"Found unknown artifact store directory: {store_id}")
-            continue
-
         for checkpoint_item in store_item.iterdir():
             if checkpoint_item.is_dir():
                 logger.warning(f"Found directory instead of file for checkpoint: {checkpoint_item.name}")
                 continue
-
-            checkpoint_id = checkpoint_item.name
-            composite_id = CompositeArtifactId(
-                artifact_store_id=ArtifactStoreId(store_id), artifact_local_id=ArtifactLocalId(checkpoint_id)
-            )
-
-            if composite_id in artifacts_catalog:
-                local_artifacts.append(composite_id)
-            else:
-                logger.warning(f"Found local artifact not in catalog: {composite_id}")
-
-    return local_artifacts
+            entries.append((store_id, checkpoint_item.name))
+    return entries
 
 
-def download_artifact(
+def _enumerate_artifacts_remote(handle: CommandHandle, remote_path: str) -> list[tuple[str, str]]:
+    """Return (store_id, artifact_id) pairs from a remote host via SSH."""
+    artifacts_base = remote_path.rstrip("/") + "/" + artifacts_subdir
+    cmd = f"find {shlex.quote(artifacts_base)} -mindepth 2 -maxdepth 2 -not -type d 2>/dev/null || true"
+    result = tunnel.run(handle, cmd)
+
+    prefix = artifacts_base.rstrip("/") + "/"
+    entries: list[tuple[str, str]] = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line or not line.startswith(prefix):
+            continue
+        rest = line[len(prefix) :]
+        parts = rest.split("/", 1)
+        if len(parts) == 2:
+            entries.append((parts[0], parts[1]))
+    return entries
+
+
+def _match_artifacts_to_catalog(catalog: ArtifactCatalog, entries: list[tuple[str, str]]) -> list[CompositeArtifactId]:
+    """Filter (store_id, artifact_id) pairs against the catalog, returning matching CompositeArtifactIds."""
+    known_store_ids = {artifact_id.artifact_store_id for artifact_id in catalog.keys()}
+    result: list[CompositeArtifactId] = []
+    for store_id, checkpoint_id in entries:
+        if store_id not in known_store_ids:
+            logger.warning(f"Found unknown artifact store directory: {store_id}")
+            continue
+        composite_id = CompositeArtifactId(
+            artifact_store_id=ArtifactStoreId(store_id),
+            artifact_local_id=ArtifactLocalId(checkpoint_id),
+        )
+        if composite_id in catalog:
+            result.append(composite_id)
+        else:
+            logger.warning(f"Found local artifact not in catalog: {composite_id}")
+    return result
+
+
+def list_storage(catalog: ArtifactCatalog, data_dir_url: str, handle: CommandHandle | None = None) -> list[CompositeArtifactId]:
+    """List stored artifacts at the given data_dir_url (file:// or ssh://)."""
+    scheme, _netloc, path = _parse_data_dir_url(data_dir_url)
+    if scheme == "file":
+        entries = _enumerate_artifacts_local(Path(path))
+    elif scheme == "ssh":
+        if handle is None:
+            raise ValueError("SSH handle required for ssh:// data_dir_url")
+        entries = _enumerate_artifacts_remote(handle, path)
+    else:
+        raise ValueError(f"Unsupported data_dir scheme: {scheme!r}")
+    return _match_artifacts_to_catalog(catalog, entries)
+
+
+# ---------------------------------------------------------------------------
+# Downloading
+# ---------------------------------------------------------------------------
+
+
+def _download_artifact_local(
     composite_id: CompositeArtifactId,
     artifact: ArtifactResolved,
     data_dir: Path,
     progress_callback: Callable[[int], None] | None = None,
 ) -> None:
-    """Download an artifact from its remote URL to local storage, raising httpx.HTTPError if download fails."""
+    """Download an artifact from its remote URL to local storage."""
     checkpoint = artifact.store_info
     artifact_path = get_artifact_local_path(composite_id, data_dir)
     artifact_path.parent.mkdir(parents=True, exist_ok=True)
 
-    try:
-        temp_file = tempfile.NamedTemporaryFile(prefix="artifact_", suffix=".ckpt", delete=False)
-        temp_path = Path(temp_file.name)
-        temp_file.close()
+    temp_file = tempfile.NamedTemporaryFile(prefix="artifact_", suffix=".ckpt", delete=False)
+    temp_path = Path(temp_file.name)
+    temp_file.close()
 
+    try:
         with httpx.Client(follow_redirects=True, timeout=300.0) as client:
             logger.debug(f"Starting download for {composite_id} from {checkpoint.url} to {temp_path}")
             with client.stream("GET", checkpoint.url) as response:
@@ -142,22 +161,107 @@ def download_artifact(
                                 if progress_callback:
                                     progress_callback(progress)
 
-            logger.debug(f"Download completed for {composite_id}, total bytes: {downloaded}")
-            shutil.move(str(temp_path), str(artifact_path))
-            logger.info(f"Successfully downloaded artifact {composite_id} to {artifact_path}")
+        logger.debug(f"Download completed for {composite_id}, total bytes: {downloaded}")
+        shutil.move(str(temp_path), str(artifact_path))
+        logger.info(f"Successfully downloaded artifact {composite_id} to {artifact_path}")
 
     except Exception as e:
-        # Clean up temp file if it exists
         if temp_path.exists():
             temp_path.unlink()
         logger.error(f"Failed to download artifact {composite_id}: {e}")
         raise
 
 
-def delete_artifact(composite_id: CompositeArtifactId, data_dir: Path) -> None:
-    """Delete a locally stored artifact file, raising FileNotFoundError if it doesn't exist."""
+def _download_artifact_remote(
+    composite_id: CompositeArtifactId,
+    artifact: ArtifactResolved,
+    handle: CommandHandle,
+    remote_path: str,
+) -> None:
+    """Download an artifact from its HTTP URL to remote storage via SSH curl."""
+    checkpoint = artifact.store_info
+    artifact_path = str(get_artifact_local_path(composite_id, remote_path))
+    artifact_dir = str(Path(artifact_path).parent)
+    temp_path = artifact_path + ".tmp"
+
+    logger.debug(f"Starting remote download for {composite_id} from {checkpoint.url}")
+
+    tunnel.run(handle, f"mkdir -p {shlex.quote(artifact_dir)}")
+
+    curl_cmd = (
+        f"curl -fsSL -o {shlex.quote(temp_path)} {shlex.quote(checkpoint.url)} && mv {shlex.quote(temp_path)} {shlex.quote(artifact_path)}"
+    )
+    try:
+        tunnel.run(handle, curl_cmd)
+    except subprocess.CalledProcessError as e:
+        try:
+            tunnel.run(handle, f"rm -f {shlex.quote(temp_path)}")
+        except Exception as cleanup_err:
+            logger.warning(f"Could not clean up remote temp file {temp_path!r}: {cleanup_err}")
+        logger.error(f"Failed remote download for {composite_id}: {e.stderr}")
+        raise
+
+    logger.info(f"Successfully downloaded artifact {composite_id} to {artifact_path} on {handle.host}")
+
+
+def download_artifact(
+    composite_id: CompositeArtifactId,
+    artifact: ArtifactResolved,
+    data_dir_url: str,
+    handle: CommandHandle | None = None,
+    progress_callback: Callable[[int], None] | None = None,
+) -> None:
+    """Download an artifact to local or remote storage, dispatching on the data_dir_url scheme."""
+    scheme, _netloc, path = _parse_data_dir_url(data_dir_url)
+    if scheme == "file":
+        _download_artifact_local(composite_id, artifact, Path(path), progress_callback)
+    elif scheme == "ssh":
+        if handle is None:
+            raise ValueError("SSH handle required for ssh:// data_dir_url")
+        _download_artifact_remote(composite_id, artifact, handle, path)
+    else:
+        raise ValueError(f"Unsupported data_dir scheme: {scheme!r}")
+
+
+# ---------------------------------------------------------------------------
+# Deleting
+# ---------------------------------------------------------------------------
+
+
+def _delete_artifact_local(composite_id: CompositeArtifactId, data_dir: Path) -> None:
+    """Delete a locally stored artifact file."""
     artifact_path = get_artifact_local_path(composite_id, data_dir)
     if not artifact_path.exists():
         raise FileNotFoundError(f"Artifact file not found: {artifact_path}")
     artifact_path.unlink()
     logger.info(f"Deleted artifact {composite_id} from {artifact_path}")
+
+
+def _delete_artifact_remote(composite_id: CompositeArtifactId, handle: CommandHandle, remote_path: str) -> None:
+    """Delete a remotely stored artifact file via SSH."""
+    artifact_path = str(get_artifact_local_path(composite_id, remote_path))
+    try:
+        tunnel.run(handle, f"rm {shlex.quote(artifact_path)}")
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or "").lower()
+        if "no such file or directory" in stderr:
+            raise FileNotFoundError(f"Artifact file not found on remote: {artifact_path}") from e
+        raise
+    logger.info(f"Deleted remote artifact {composite_id} at {artifact_path} on {handle.host}")
+
+
+def delete_artifact(
+    composite_id: CompositeArtifactId,
+    data_dir_url: str,
+    handle: CommandHandle | None = None,
+) -> None:
+    """Delete an artifact from local or remote storage, dispatching on the data_dir_url scheme."""
+    scheme, _netloc, path = _parse_data_dir_url(data_dir_url)
+    if scheme == "file":
+        _delete_artifact_local(composite_id, Path(path))
+    elif scheme == "ssh":
+        if handle is None:
+            raise ValueError("SSH handle required for ssh:// data_dir_url")
+        _delete_artifact_remote(composite_id, handle, path)
+    else:
+        raise ValueError(f"Unsupported data_dir scheme: {scheme!r}")

--- a/backend/src/forecastbox/domain/artifact/manager.py
+++ b/backend/src/forecastbox/domain/artifact/manager.py
@@ -49,6 +49,7 @@ timeout_acquire_error = 2  # something failed, report quickly so that can be joi
 
 class ArtifactManager:
     lock: threading.Lock = threading.Lock()
+    ssh_handle_lock: threading.Lock = threading.Lock()
     catalog: ArtifactCatalog = pmap()
     locally_available: PSet[CompositeArtifactId] = pset()
     ongoing_downloads: PMap[CompositeArtifactId, int | str] = pmap()
@@ -63,31 +64,30 @@ class ArtifactManager:
         if cls.executor is None:
             cls.executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="artifact-io")
 
+    @classmethod
+    def _get_or_create_ssh_handle(cls, timeout: int) -> CommandHandle:
+        """Return an alive CommandHandle for the configured SSH data_path, creating or reconnecting as needed."""
+        with timed_acquire(cls.ssh_handle_lock, timeout) as result:
+            if not result:
+                raise ValueError("failed to acquire SSH handle lock")
+            if cls.ssh_handle is not None:
+                if tunnel.status_cmd(cls.ssh_handle):
+                    return cls.ssh_handle
+                # Stale handle -- attempt graceful close before replacing
+                try:
+                    tunnel.disconnect(cls.ssh_handle)
+                except Exception as e:
+                    logger.warning(f"Could not disconnect stale SSH handle: {e}")
+            parsed = urllib.parse.urlparse(config.api.data_path)
+            cls.ssh_handle = tunnel.connect(parsed.netloc)
+            return cls.ssh_handle
 
-_ssh_handle_lock = threading.Lock()
 
-
-def _get_or_create_ssh_handle() -> CommandHandle:
-    """Return an alive CommandHandle for the configured SSH data_path, creating or reconnecting as needed."""
-    with _ssh_handle_lock:
-        if ArtifactManager.ssh_handle is not None:
-            if tunnel.status_cmd(ArtifactManager.ssh_handle):
-                return ArtifactManager.ssh_handle
-            # Stale handle -- attempt graceful close before replacing
-            try:
-                tunnel.disconnect(ArtifactManager.ssh_handle)
-            except Exception as e:
-                logger.warning(f"Could not disconnect stale SSH handle: {e}")
-        parsed = urllib.parse.urlparse(config.api.data_path)
-        ArtifactManager.ssh_handle = tunnel.connect(parsed.netloc)
-        return ArtifactManager.ssh_handle
-
-
-def _ssh_handle_if_needed() -> CommandHandle | None:
+def _ssh_handle_if_needed(timeout: int = timeout_acquire_task) -> CommandHandle | None:
     """Return SSH handle if data_path uses ssh:// scheme, else None."""
     parsed = urllib.parse.urlparse(config.api.data_path)
     if parsed.scheme == "ssh":
-        return _get_or_create_ssh_handle()
+        return ArtifactManager._get_or_create_ssh_handle(timeout)
     return None
 
 

--- a/backend/src/forecastbox/domain/artifact/manager.py
+++ b/backend/src/forecastbox/domain/artifact/manager.py
@@ -21,17 +21,20 @@ We use pyrsistent immutable structures for safe lock-free reads.
 import logging
 import threading
 import time
+import urllib.parse
 from concurrent.futures import Future, ThreadPoolExecutor
-from pathlib import Path
 
 from cascade.low.func import Either
 from pyrsistent import pmap, pset
 from pyrsistent.typing import PMap, PSet
 
 from forecastbox.domain.artifact.base import ArtifactCatalog, CompositeArtifactId, MlModelDetail, MlModelOverview
-from forecastbox.domain.artifact.io import delete_artifact, download_artifact, get_artifacts_catalog, list_local_storage
+from forecastbox.domain.artifact.catalog import get_artifacts_catalog
+from forecastbox.domain.artifact.io import delete_artifact, download_artifact, list_storage
+from forecastbox.utility import tunnel
 from forecastbox.utility.concurrent import timed_acquire
 from forecastbox.utility.config import config
+from forecastbox.utility.tunnel import CommandHandle
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +54,7 @@ class ArtifactManager:
     ongoing_downloads: PMap[CompositeArtifactId, int | str] = pmap()
     executor: ThreadPoolExecutor | None = None
     refresh_error: str | None = None
+    ssh_handle: CommandHandle | None = None
 
     @classmethod
     def _ensure_pool(cls) -> None:
@@ -60,12 +64,40 @@ class ArtifactManager:
             cls.executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="artifact-io")
 
 
+_ssh_handle_lock = threading.Lock()
+
+
+def _get_or_create_ssh_handle() -> CommandHandle:
+    """Return an alive CommandHandle for the configured SSH data_path, creating or reconnecting as needed."""
+    with _ssh_handle_lock:
+        if ArtifactManager.ssh_handle is not None:
+            if tunnel.status_cmd(ArtifactManager.ssh_handle):
+                return ArtifactManager.ssh_handle
+            # Stale handle -- attempt graceful close before replacing
+            try:
+                tunnel.disconnect(ArtifactManager.ssh_handle)
+            except Exception as e:
+                logger.warning(f"Could not disconnect stale SSH handle: {e}")
+        parsed = urllib.parse.urlparse(config.api.data_path)
+        ArtifactManager.ssh_handle = tunnel.connect(parsed.netloc)
+        return ArtifactManager.ssh_handle
+
+
+def _ssh_handle_if_needed() -> CommandHandle | None:
+    """Return SSH handle if data_path uses ssh:// scheme, else None."""
+    parsed = urllib.parse.urlparse(config.api.data_path)
+    if parsed.scheme == "ssh":
+        return _get_or_create_ssh_handle()
+    return None
+
+
 def _refresh_catalog_task() -> None:
     """Background task to refresh catalog and local artifact list."""
     try:
         logger.info("Starting artifact catalog refresh")
         catalog = get_artifacts_catalog(config.product.artifact_stores)
-        local_artifacts = list_local_storage(catalog, Path(config.api.data_path))
+        handle = _ssh_handle_if_needed()
+        local_artifacts = list_storage(catalog, config.api.data_path, handle)
 
         with timed_acquire(ArtifactManager.lock, timeout_acquire_task) as result:
             if not result:
@@ -101,7 +133,8 @@ def _download_artifact_task(composite_id: CompositeArtifactId) -> None:
         def progress_callback(progress: int) -> None:
             report_artifact_download_progress(composite_id, progress=progress)
 
-        download_artifact(composite_id, checkpoint, Path(config.api.data_path), progress_callback=progress_callback)
+        handle = _ssh_handle_if_needed()
+        download_artifact(composite_id, checkpoint, config.api.data_path, handle=handle, progress_callback=progress_callback)
 
         with timed_acquire(ArtifactManager.lock, timeout_acquire_task) as result:
             if not result:
@@ -245,8 +278,9 @@ def delete_model(composite_id: CompositeArtifactId) -> Either[str, str]:  # ty: 
 
     # TODO race condition possibility 1/ pop in one thread 2/ another request triggers a download
     # 3/ unlink happens while download is ongoing -> fix by making the delete two-step
+    handle = _ssh_handle_if_needed()
     try:
-        delete_artifact(composite_id, Path(config.api.data_path))
+        delete_artifact(composite_id, config.api.data_path, handle=handle)
     except Exception as e:
         logger.exception(f"Failed to delete artifact {composite_id}: {repr(e)}")
         return Either.error(f"Failed to delete: {repr(e)}")

--- a/backend/src/forecastbox/entrypoint/app.py
+++ b/backend/src/forecastbox/entrypoint/app.py
@@ -56,9 +56,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     app.version = f"{release_version}@{release_time}"
     submit_initialize_stores()
     ArtifactsProvider.register_get_artifacts_lookup(lambda: ArtifactManager.catalog)
-    ArtifactsProvider.register_get_artifact_local_path(
-        lambda composite_id: get_artifact_local_path(composite_id, Path(config.api.data_path))
-    )
+    ArtifactsProvider.register_get_artifact_local_path(lambda composite_id: get_artifact_local_path(composite_id, config.api.data_path))
     catalog_ready = submit_refresh_catalog()
     submit_load_plugins(start_after=catalog_ready)
     yield

--- a/backend/src/forecastbox/utility/config.py
+++ b/backend/src/forecastbox/utility/config.py
@@ -207,7 +207,7 @@ class ProductSettings(FiabBaseModel):
 
 class BackendAPISettings(FiabBaseModel):
     data_path: str = f"file://{fiab_home / 'data_dir'}"
-    """Path to the data directory. Supports file:// (local) and ssh://[user@]host/path (remote) schemes."""
+    """Data directory URL. Supports file:// (local) and ssh://[user@]host/path (remote) schemes."""
     model_repository: str = "https://sites.ecmwf.int/repository/fiab"
     """URL to the model repository."""
     uvicorn_host: str = "0.0.0.0"
@@ -218,17 +218,6 @@ class BackendAPISettings(FiabBaseModel):
     """Whether we assume that a system-level service has been registered. Affects entrypoint.main behaviour"""
     allow_scheduler: bool = False
     """Whether scheduler thread should be started. Best combine with allow_service=True"""
-
-    @model_validator(mode="before")
-    @classmethod
-    def migrate_plain_data_path(cls, data: dict) -> dict:  # type: ignore[override]
-        """Convert legacy plain-path data_path values to file:// URLs."""
-        if isinstance(data, dict) and "data_path" in data:
-            val = data["data_path"]
-            if isinstance(val, str) and "://" not in val:
-                logger.warning(f"data_path '{val}' is a plain path; please update your config to use file:// scheme")
-                data["data_path"] = f"file://{val}"
-        return data
 
     def local_url(self) -> str:
         return f"http://localhost:{self.uvicorn_port}"

--- a/backend/src/forecastbox/utility/config.py
+++ b/backend/src/forecastbox/utility/config.py
@@ -206,8 +206,8 @@ class ProductSettings(FiabBaseModel):
 
 
 class BackendAPISettings(FiabBaseModel):
-    data_path: str = str(fiab_home / "data_dir")
-    """Path to the data directory."""
+    data_path: str = f"file://{fiab_home / 'data_dir'}"
+    """Path to the data directory. Supports file:// (local) and ssh://[user@]host/path (remote) schemes."""
     model_repository: str = "https://sites.ecmwf.int/repository/fiab"
     """URL to the model repository."""
     uvicorn_host: str = "0.0.0.0"
@@ -219,13 +219,33 @@ class BackendAPISettings(FiabBaseModel):
     allow_scheduler: bool = False
     """Whether scheduler thread should be started. Best combine with allow_service=True"""
 
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_plain_data_path(cls, data: dict) -> dict:  # type: ignore[override]
+        """Convert legacy plain-path data_path values to file:// URLs."""
+        if isinstance(data, dict) and "data_path" in data:
+            val = data["data_path"]
+            if isinstance(val, str) and "://" not in val:
+                logger.warning(f"data_path '{val}' is a plain path; please update your config to use file:// scheme")
+                data["data_path"] = f"file://{val}"
+        return data
+
     def local_url(self) -> str:
         return f"http://localhost:{self.uvicorn_port}"
 
     def validate_runtime(self) -> list[str]:
         errors = []
-        if not os.path.isdir(self.data_path):
-            errors.append(f"not a directory: data_path={self.data_path}")
+        parsed = urllib.parse.urlparse(self.data_path)
+        if parsed.scheme == "file":
+            if not os.path.isdir(parsed.path):
+                errors.append(f"not a directory: data_path={self.data_path}")
+        elif parsed.scheme == "ssh":
+            if not parsed.netloc:
+                errors.append(f"missing host in ssh:// data_path: {self.data_path}")
+            if not parsed.path.startswith("/"):
+                errors.append(f"ssh:// data_path must have an absolute path: {self.data_path}")
+        else:
+            errors.append(f"unsupported scheme in data_path (use file:// or ssh://): {self.data_path}")
         if not _validate_url(self.model_repository):
             errors.append(f"not an url: model_repository={self.model_repository}")
         pseudo_url = f"http://{self.uvicorn_host}:{self.uvicorn_port}"

--- a/backend/src/forecastbox/utility/config.py
+++ b/backend/src/forecastbox/utility/config.py
@@ -310,6 +310,17 @@ class FIABConfig(BaseSettings):
         with open(config_path, "w") as f:
             f.write(self._get_toml(exclude_defaults=True, exclude_none=True))
 
+    def validate_runtime(self) -> list[str]:
+        cascade = urllib.parse.urlparse(self.cascade.cascade_url)
+        data_path = urllib.parse.urlparse(self.api.data_path)
+        errors = []
+        if cascade.scheme != data_path.scheme:
+            errors.append(f"cascade and data path must use the same scheme: {cascade=} != {data_path=}")
+        if cascade.scheme == "ssh":
+            if cascade.netloc != data_path.netloc:
+                errors.append(f"under ssh://, cascade and data path must use the same netlo: {cascade=} != {data_path=}")
+        return errors
+
 
 def validate_runtime(config: FIABConfig) -> None:
     """Validates that a particular config can be used to execute FIAB in this machine/venv.

--- a/backend/src/forecastbox/utility/tunnel.py
+++ b/backend/src/forecastbox/utility/tunnel.py
@@ -53,11 +53,11 @@ def _new_control_path() -> str:
     return str(_CONTROL_ROOT / f"{uuid.uuid4().hex[:12]}.sock")
 
 
-def _ssh_base_args(handle: "ConnectionHandle") -> list[str]:
+def _ssh_base_args(control_path: str) -> list[str]:
     return [
         "ssh",
         "-S",
-        handle.control_path,
+        control_path,
         "-o",
         "BatchMode=yes",
         "-o",
@@ -106,11 +106,20 @@ class ConnectionHandle:
         return f"tcp://localhost:{self.local_port}"
 
 
+@dataclass(frozen=True, slots=True)
+class CommandHandle:
+    """A persistent SSH master connection for running remote commands (no port forwarding)."""
+
+    host: str
+    control_path: str
+
+
 class TunnelRegistry:
     """Track live tunnel handles so the app can shut them down on exit."""
 
     def __init__(self) -> None:
         self._handles: set[ConnectionHandle] = set()
+        self._command_handles: set[CommandHandle] = set()
         self._lock = threading.Lock()
 
     def register(self, handle: ConnectionHandle) -> None:
@@ -121,11 +130,22 @@ class TunnelRegistry:
         with self._lock:
             self._handles.discard(handle)
 
+    def register_command(self, handle: CommandHandle) -> None:
+        with self._lock:
+            self._command_handles.add(handle)
+
+    def discard_command(self, handle: CommandHandle) -> None:
+        with self._lock:
+            self._command_handles.discard(handle)
+
     def shutdown(self) -> None:
         with self._lock:
             handles = tuple(self._handles)
+            command_handles = tuple(self._command_handles)
         for handle in handles:
             stop(handle)
+        for handle in command_handles:
+            disconnect(handle)
 
 
 registry = TunnelRegistry()
@@ -191,7 +211,7 @@ def setup(
 def status(handle: ConnectionHandle) -> bool:
     """Return whether the SSH master connection is alive."""
 
-    result = _ssh_run([*_ssh_base_args(handle), "-O", "check", handle.host], check=False)
+    result = _ssh_run([*_ssh_base_args(handle.control_path), "-O", "check", handle.host], check=False)
     return result.returncode == 0
 
 
@@ -199,13 +219,13 @@ def execute(handle: ConnectionHandle, command: RemoteCommand, output_path: str =
     """Launch a remote command over the existing SSH control socket."""
 
     remote_command = _render_remote_command(command, output_path)
-    return _ssh_run([*_ssh_base_args(handle), handle.host, remote_command])
+    return _ssh_run([*_ssh_base_args(handle.control_path), handle.host, remote_command])
 
 
 def stop(handle: ConnectionHandle) -> subprocess.CompletedProcess[str]:
     """Terminate an SSH master connection and remove it from the registry."""
 
-    rv = _ssh_run([*_ssh_base_args(handle), "-O", "exit", handle.host])
+    rv = _ssh_run([*_ssh_base_args(handle.control_path), "-O", "exit", handle.host])
     registry.discard(handle)
     return rv
 
@@ -214,3 +234,53 @@ def shutdown() -> None:
     """Stop all tracked SSH tunnels."""
 
     registry.shutdown()
+
+
+def connect(host: str) -> CommandHandle:
+    """Start a persistent SSH master connection without port forwarding, for running remote commands."""
+
+    handle = CommandHandle(host=host, control_path=_new_control_path())
+    _ssh_run(
+        [
+            "ssh",
+            "-M",
+            "-f",
+            "-N",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ConnectTimeout=10",
+            "-o",
+            "ControlMaster=auto",
+            "-o",
+            f"ControlPath={handle.control_path}",
+            "-o",
+            "ControlPersist=10m",
+            host,
+        ],
+        start_new_session=True,
+    )
+    registry.register_command(handle)
+    return handle
+
+
+def run(handle: CommandHandle, command: RemoteCommand) -> subprocess.CompletedProcess[str]:
+    """Run a command synchronously over the SSH control socket, returning stdout/stderr."""
+
+    cmd = command if isinstance(command, str) else shlex.join(command)
+    return _ssh_run([*_ssh_base_args(handle.control_path), handle.host, cmd])
+
+
+def status_cmd(handle: CommandHandle) -> bool:
+    """Return whether the command SSH master connection is alive."""
+
+    result = _ssh_run([*_ssh_base_args(handle.control_path), "-O", "check", handle.host], check=False)
+    return result.returncode == 0
+
+
+def disconnect(handle: CommandHandle) -> subprocess.CompletedProcess[str]:
+    """Terminate a command SSH master connection and remove it from the registry."""
+
+    rv = _ssh_run([*_ssh_base_args(handle.control_path), "-O", "exit", handle.host], check=False)
+    registry.discard_command(handle)
+    return rv

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -146,7 +146,7 @@ def backend_client() -> Generator[httpx.Client, None, None]:
         config.cascade.cascade_url = "tcp://localhost"
         config.db.sqlite_userdb_path = f"{td.name}/user.db"
         config.db.sqlite_jobdb_path = f"{td.name}/job.db"
-        config.api.data_path = td_data.name
+        config.api.data_path = f"file://{td_data.name}"
         config.api.allow_scheduler = True
         config.product.artifact_stores = {
             ArtifactStoreId(fake_artifact_store_id): ArtifactStoreConfig(

--- a/backend/tests/unit/test_artifacts.py
+++ b/backend/tests/unit/test_artifacts.py
@@ -8,6 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 import json
+import subprocess
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
@@ -25,12 +26,14 @@ from forecastbox.domain.artifact.base import (
     CompositeArtifactId,
     get_artifact_local_path,
 )
+from forecastbox.domain.artifact.catalog import get_artifacts_catalog
 from forecastbox.domain.artifact.io import (
+    delete_artifact,
     download_artifact,
-    get_artifacts_catalog,
-    list_local_storage,
+    list_storage,
 )
 from forecastbox.utility.config import ArtifactStoreConfig, ArtifactStoresConfig
+from forecastbox.utility.tunnel import CommandHandle
 
 
 @pytest.fixture
@@ -234,19 +237,19 @@ def test_get_artifacts_catalog_from_local_file(tmpdir_path: Path, sample_checkpo
 
 
 def test_list_local_storage_empty(tmpdir_path: Path, sample_artifact: Any) -> None:
-    """Test list_local_storage with no artifacts"""
+    """Test list_storage with no artifacts"""
     catalog: ArtifactCatalog = pmap(
         {
             CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1")): sample_artifact,
         }
     )
 
-    result = list_local_storage(catalog, tmpdir_path)
+    result = list_storage(catalog, f"file://{tmpdir_path}")
     assert result == []
 
 
 def test_list_local_storage_nonexistent_dir(tmpdir_path: Path, sample_artifact: Any) -> None:
-    """Test list_local_storage with nonexistent artifacts directory"""
+    """Test list_storage with nonexistent artifacts directory"""
     catalog: ArtifactCatalog = pmap(
         {
             CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1")): sample_artifact,
@@ -254,12 +257,12 @@ def test_list_local_storage_nonexistent_dir(tmpdir_path: Path, sample_artifact: 
     )
 
     nonexistent_dir = tmpdir_path / "nonexistent"
-    result = list_local_storage(catalog, nonexistent_dir)
+    result = list_storage(catalog, f"file://{nonexistent_dir}")
     assert result == []
 
 
 def test_list_local_storage_with_artifacts(tmpdir_path: Path, sample_artifact: Any) -> None:
-    """Test list_local_storage with existing artifacts as files"""
+    """Test list_storage with existing artifacts as files"""
     catalog: ArtifactCatalog = pmap(
         {
             CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1.ckpt")): sample_artifact,
@@ -279,7 +282,7 @@ def test_list_local_storage_with_artifacts(tmpdir_path: Path, sample_artifact: A
     (store1_dir / "model2.ckpt").touch()
     (store2_dir / "model3.ckpt").touch()
 
-    result = list_local_storage(catalog, tmpdir_path)
+    result = list_storage(catalog, f"file://{tmpdir_path}")
 
     assert len(result) == 3
     assert CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1.ckpt")) in result
@@ -288,7 +291,7 @@ def test_list_local_storage_with_artifacts(tmpdir_path: Path, sample_artifact: A
 
 
 def test_list_local_storage_with_unknown_store(tmpdir_path: Path, sample_artifact: Any) -> None:
-    """Test list_local_storage with unknown store directory"""
+    """Test list_storage with unknown store directory"""
     catalog: ArtifactCatalog = pmap(
         {
             CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1.ckpt")): sample_artifact,
@@ -305,14 +308,14 @@ def test_list_local_storage_with_unknown_store(tmpdir_path: Path, sample_artifac
     (store1_dir / "model1.ckpt").touch()
     (unknown_dir / "model2.ckpt").touch()
 
-    result = list_local_storage(catalog, tmpdir_path)
+    result = list_storage(catalog, f"file://{tmpdir_path}")
 
     assert len(result) == 1
     assert CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1.ckpt")) in result
 
 
 def test_list_local_storage_with_unknown_checkpoint(tmpdir_path: Path, sample_artifact: Any) -> None:
-    """Test list_local_storage with unknown checkpoint in known store"""
+    """Test list_storage with unknown checkpoint in known store"""
     catalog: ArtifactCatalog = pmap(
         {
             CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1.ckpt")): sample_artifact,
@@ -327,7 +330,7 @@ def test_list_local_storage_with_unknown_checkpoint(tmpdir_path: Path, sample_ar
     (store1_dir / "model1.ckpt").touch()
     (store1_dir / "unknown_model.ckpt").touch()
 
-    result = list_local_storage(catalog, tmpdir_path)
+    result = list_storage(catalog, f"file://{tmpdir_path}")
 
     assert len(result) == 1
     assert CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1.ckpt")) in result
@@ -385,7 +388,7 @@ def test_download_artifact_success(tmpdir_path: Path, sample_artifact: Any) -> N
         mock_client.stream.return_value.__enter__.return_value = mock_response
         mock_client_class.return_value = mock_client
 
-        download_artifact(composite_id, sample_artifact, tmpdir_path)
+        download_artifact(composite_id, sample_artifact, f"file://{tmpdir_path}")
 
         # Verify the file was downloaded
         artifact_path = get_artifact_local_path(composite_id, tmpdir_path)
@@ -411,7 +414,7 @@ def test_download_artifact_creates_directory(tmpdir_path: Path, sample_artifact:
         mock_client.stream.return_value.__enter__.return_value = mock_response
         mock_client_class.return_value = mock_client
 
-        download_artifact(composite_id, sample_artifact, tmpdir_path)
+        download_artifact(composite_id, sample_artifact, f"file://{tmpdir_path}")
 
         artifact_path = get_artifact_local_path(composite_id, tmpdir_path)
         assert artifact_path.exists()
@@ -433,7 +436,7 @@ def test_download_artifact_http_error(tmpdir_path: Path, sample_artifact: Any) -
         mock_client_class.return_value = mock_client
 
         with pytest.raises(httpx.HTTPStatusError):
-            download_artifact(composite_id, sample_artifact, tmpdir_path)
+            download_artifact(composite_id, sample_artifact, f"file://{tmpdir_path}")
 
 
 def test_download_artifact_chunked_download(tmpdir_path: Path, sample_artifact: Any) -> None:
@@ -457,10 +460,178 @@ def test_download_artifact_chunked_download(tmpdir_path: Path, sample_artifact: 
         mock_client.stream.return_value.__enter__.return_value = mock_response
         mock_client_class.return_value = mock_client
 
-        download_artifact(composite_id, sample_artifact, tmpdir_path)
+        download_artifact(composite_id, sample_artifact, f"file://{tmpdir_path}")
 
         # Verify all chunks were written
         artifact_path = get_artifact_local_path(composite_id, tmpdir_path)
 
         assert artifact_path.exists()
         assert artifact_path.read_bytes() == total_content
+
+
+# ---------------------------------------------------------------------------
+# SSH remote tests (mock tunnel.run)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_handle() -> CommandHandle:
+    return CommandHandle(host="fakehost", control_path="/tmp/fake.sock")
+
+
+def test_list_storage_remote_empty(fake_handle: CommandHandle, sample_artifact: Any) -> None:
+    """list_storage with ssh:// returns empty list when find produces no output."""
+    catalog: ArtifactCatalog = pmap({CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1.ckpt")): sample_artifact})
+    mock_result = MagicMock()
+    mock_result.stdout = ""
+
+    with patch("forecastbox.domain.artifact.io.tunnel") as mock_tunnel:
+        mock_tunnel.run.return_value = mock_result
+        result = list_storage(catalog, "ssh://fakehost/remote/data", handle=fake_handle)
+
+    assert result == []
+    mock_tunnel.run.assert_called_once()
+    cmd = mock_tunnel.run.call_args[0][1]
+    assert "find" in cmd
+    assert "/remote/data/artifacts" in cmd
+
+
+def test_list_storage_remote_with_artifacts(fake_handle: CommandHandle, sample_artifact: Any) -> None:
+    """list_storage with ssh:// correctly parses find output."""
+    catalog: ArtifactCatalog = pmap(
+        {
+            CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1.ckpt")): sample_artifact,
+            CompositeArtifactId(ArtifactStoreId("store2"), ArtifactLocalId("model2.ckpt")): sample_artifact,
+        }
+    )
+    mock_result = MagicMock()
+    mock_result.stdout = "/remote/data/artifacts/store1/model1.ckpt\n/remote/data/artifacts/store2/model2.ckpt\n"
+
+    with patch("forecastbox.domain.artifact.io.tunnel") as mock_tunnel:
+        mock_tunnel.run.return_value = mock_result
+        result = list_storage(catalog, "ssh://fakehost/remote/data", handle=fake_handle)
+
+    assert len(result) == 2
+    assert CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1.ckpt")) in result
+    assert CompositeArtifactId(ArtifactStoreId("store2"), ArtifactLocalId("model2.ckpt")) in result
+
+
+def test_list_storage_remote_unknown_store_ignored(fake_handle: CommandHandle, sample_artifact: Any) -> None:
+    """list_storage with ssh:// ignores paths from unknown stores."""
+    catalog: ArtifactCatalog = pmap({CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1.ckpt")): sample_artifact})
+    mock_result = MagicMock()
+    mock_result.stdout = "/remote/data/artifacts/store1/model1.ckpt\n/remote/data/artifacts/unknown_store/model2.ckpt\n"
+
+    with patch("forecastbox.domain.artifact.io.tunnel") as mock_tunnel:
+        mock_tunnel.run.return_value = mock_result
+        result = list_storage(catalog, "ssh://fakehost/remote/data", handle=fake_handle)
+
+    assert len(result) == 1
+    assert CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1.ckpt")) in result
+
+
+def test_list_storage_requires_handle_for_ssh() -> None:
+    """list_storage raises ValueError when no handle is given for ssh:// URL."""
+    from pyrsistent import pmap as pm
+
+    with pytest.raises(ValueError, match="SSH handle required"):
+        list_storage(pm({}), "ssh://host/path", handle=None)
+
+
+def test_download_artifact_remote_sends_correct_commands(fake_handle: CommandHandle, sample_artifact: Any) -> None:
+    """download_artifact with ssh:// sends mkdir then curl+mv commands."""
+    composite_id = CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1.ckpt"))
+
+    mock_result = MagicMock()
+    mock_result.stdout = ""
+    mock_result.stderr = ""
+
+    with patch("forecastbox.domain.artifact.io.tunnel") as mock_tunnel:
+        mock_tunnel.run.return_value = mock_result
+        download_artifact(composite_id, sample_artifact, "ssh://fakehost/remote/data", handle=fake_handle)
+
+    calls = mock_tunnel.run.call_args_list
+    assert len(calls) == 2
+
+    mkdir_cmd = calls[0][0][1]
+    assert "mkdir" in mkdir_cmd
+    assert "/remote/data/artifacts/store1" in mkdir_cmd
+
+    curl_cmd = calls[1][0][1]
+    assert "curl" in curl_cmd
+    assert "https://example.com/model.ckpt" in curl_cmd
+    assert "/remote/data/artifacts/store1/model1.ckpt" in curl_cmd
+    assert ".tmp" in curl_cmd
+
+
+def test_download_artifact_remote_cleans_up_on_curl_failure(fake_handle: CommandHandle, sample_artifact: Any) -> None:
+    """download_artifact with ssh:// attempts to remove temp file if curl fails."""
+    composite_id = CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1.ckpt"))
+
+    curl_error = subprocess.CalledProcessError(1, "curl", stderr="curl: (6) Could not resolve host")
+
+    with patch("forecastbox.domain.artifact.io.tunnel") as mock_tunnel:
+        mock_tunnel.run.side_effect = [MagicMock(), curl_error, MagicMock()]
+        with pytest.raises(subprocess.CalledProcessError):
+            download_artifact(composite_id, sample_artifact, "ssh://fakehost/remote/data", handle=fake_handle)
+
+    # Third call should be rm -f for cleanup
+    cleanup_cmd = mock_tunnel.run.call_args_list[2][0][1]
+    assert "rm -f" in cleanup_cmd
+    assert ".tmp" in cleanup_cmd
+
+
+def test_delete_artifact_remote_sends_rm(fake_handle: CommandHandle, sample_artifact: Any) -> None:
+    """delete_artifact with ssh:// sends an rm command for the correct path."""
+    composite_id = CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1.ckpt"))
+
+    mock_result = MagicMock()
+    mock_result.stdout = ""
+    mock_result.stderr = ""
+
+    with patch("forecastbox.domain.artifact.io.tunnel") as mock_tunnel:
+        mock_tunnel.run.return_value = mock_result
+        delete_artifact(composite_id, "ssh://fakehost/remote/data", handle=fake_handle)
+
+    cmd = mock_tunnel.run.call_args[0][1]
+    assert "rm" in cmd
+    assert "/remote/data/artifacts/store1/model1.ckpt" in cmd
+
+
+def test_delete_artifact_remote_raises_file_not_found(fake_handle: CommandHandle) -> None:
+    """delete_artifact with ssh:// raises FileNotFoundError when rm says no such file."""
+    composite_id = CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1.ckpt"))
+
+    error = subprocess.CalledProcessError(1, "rm", stderr="rm: cannot remove '/path': No such file or directory")
+
+    with patch("forecastbox.domain.artifact.io.tunnel") as mock_tunnel:
+        mock_tunnel.run.side_effect = error
+        with pytest.raises(FileNotFoundError):
+            delete_artifact(composite_id, "ssh://fakehost/remote/data", handle=fake_handle)
+
+
+def test_delete_artifact_remote_reraises_other_errors(fake_handle: CommandHandle) -> None:
+    """delete_artifact with ssh:// re-raises non-FileNotFound errors unchanged."""
+    composite_id = CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1.ckpt"))
+
+    error = subprocess.CalledProcessError(1, "rm", stderr="rm: cannot remove '/path': Permission denied")
+
+    with patch("forecastbox.domain.artifact.io.tunnel") as mock_tunnel:
+        mock_tunnel.run.side_effect = error
+        with pytest.raises(subprocess.CalledProcessError):
+            delete_artifact(composite_id, "ssh://fakehost/remote/data", handle=fake_handle)
+
+
+def test_list_storage_raises_on_unsupported_scheme() -> None:
+    """list_storage raises ValueError for unknown URL schemes."""
+    from pyrsistent import pmap as pm
+
+    with pytest.raises(ValueError, match="Unsupported data_dir scheme"):
+        list_storage(pm({}), "ftp://host/path")
+
+
+def test_download_artifact_raises_on_unsupported_scheme(sample_artifact: Any) -> None:
+    """download_artifact raises ValueError for unknown URL schemes."""
+    composite_id = CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1.ckpt"))
+    with pytest.raises(ValueError, match="Unsupported data_dir scheme"):
+        download_artifact(composite_id, sample_artifact, "ftp://host/path")

--- a/backend/tests/unit/test_artifacts.py
+++ b/backend/tests/unit/test_artifacts.py
@@ -626,12 +626,12 @@ def test_list_storage_raises_on_unsupported_scheme() -> None:
     """list_storage raises ValueError for unknown URL schemes."""
     from pyrsistent import pmap as pm
 
-    with pytest.raises(ValueError, match="Unsupported data_dir scheme"):
+    with pytest.raises(NotImplementedError, match="Unsupported data_dir scheme"):
         list_storage(pm({}), "ftp://host/path")
 
 
 def test_download_artifact_raises_on_unsupported_scheme(sample_artifact: Any) -> None:
     """download_artifact raises ValueError for unknown URL schemes."""
     composite_id = CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1.ckpt"))
-    with pytest.raises(ValueError, match="Unsupported data_dir scheme"):
+    with pytest.raises(NotImplementedError, match="Unsupported data_dir scheme"):
         download_artifact(composite_id, sample_artifact, "ftp://host/path")

--- a/backend/tests/unit/test_artifacts.py
+++ b/backend/tests/unit/test_artifacts.py
@@ -339,16 +339,16 @@ def test_list_local_storage_with_unknown_checkpoint(tmpdir_path: Path, sample_ar
 def test_get_artifact_local_path(tmpdir_path: Path) -> None:
     """Test get_artifact_local_path returns correct path"""
     composite_id = CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1.ckpt"))
-    path = get_artifact_local_path(composite_id, tmpdir_path)
+    path = get_artifact_local_path(composite_id, f"file://{tmpdir_path}")
 
     expected = tmpdir_path / "artifacts" / "store1" / "model1.ckpt"
     assert path == expected
 
 
 def test_get_artifact_local_path_with_string_dir(tmpdir_path: Path) -> None:
-    """Test get_artifact_local_path with Path directory path"""
+    """Test get_artifact_local_path with file:// URL"""
     composite_id = CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1.ckpt"))
-    path = get_artifact_local_path(composite_id, tmpdir_path)
+    path = get_artifact_local_path(composite_id, f"file://{tmpdir_path}")
 
     expected = tmpdir_path / "artifacts" / "store1" / "model1.ckpt"
     assert path == expected
@@ -356,7 +356,7 @@ def test_get_artifact_local_path_with_string_dir(tmpdir_path: Path) -> None:
 
 def test_get_artifact_local_path_invalid_characters() -> None:
     """Test get_artifact_local_path raises on invalid path characters"""
-    tmpdir = Path("/tmp")
+    tmpdir_url = "file:///tmp"
     invalid_ids = [
         CompositeArtifactId(ArtifactStoreId("../etc"), ArtifactLocalId("model1.ckpt")),
         CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("../../../etc/passwd")),
@@ -368,7 +368,7 @@ def test_get_artifact_local_path_invalid_characters() -> None:
 
     for invalid_id in invalid_ids:
         with pytest.raises(ValueError, match="Invalid characters in artifact ID"):
-            get_artifact_local_path(invalid_id, tmpdir)
+            get_artifact_local_path(invalid_id, tmpdir_url)
 
 
 def test_download_artifact_success(tmpdir_path: Path, sample_artifact: Any) -> None:
@@ -391,7 +391,7 @@ def test_download_artifact_success(tmpdir_path: Path, sample_artifact: Any) -> N
         download_artifact(composite_id, sample_artifact, f"file://{tmpdir_path}")
 
         # Verify the file was downloaded
-        artifact_path = get_artifact_local_path(composite_id, tmpdir_path)
+        artifact_path = get_artifact_local_path(composite_id, f"file://{tmpdir_path}")
 
         assert artifact_path.exists()
         assert artifact_path.read_bytes() == mock_content
@@ -416,7 +416,7 @@ def test_download_artifact_creates_directory(tmpdir_path: Path, sample_artifact:
 
         download_artifact(composite_id, sample_artifact, f"file://{tmpdir_path}")
 
-        artifact_path = get_artifact_local_path(composite_id, tmpdir_path)
+        artifact_path = get_artifact_local_path(composite_id, f"file://{tmpdir_path}")
         assert artifact_path.exists()
         assert artifact_path.is_file()
         assert artifact_path.parent.is_dir()
@@ -463,7 +463,7 @@ def test_download_artifact_chunked_download(tmpdir_path: Path, sample_artifact: 
         download_artifact(composite_id, sample_artifact, f"file://{tmpdir_path}")
 
         # Verify all chunks were written
-        artifact_path = get_artifact_local_path(composite_id, tmpdir_path)
+        artifact_path = get_artifact_local_path(composite_id, f"file://{tmpdir_path}")
 
         assert artifact_path.exists()
         assert artifact_path.read_bytes() == total_content


### PR DESCRIPTION
Extend artifact storage backend to support downloading files to remote hosts over persistent SSH connections, in addition to the existing local filesystem support. Configuration now uses URLs with 'file://' and 'ssh://' schemes.

Key changes:

- config.py: data_path now uses 'file://' and 'ssh://' URL schemes with auto-migration for legacy plain paths, backward-compatible validation

- utility/tunnel.py: Extended SSH infrastructure with CommandHandle for simple command execution (vs port forwarding), added connect/run/disconnect/ status_cmd functions, extended TunnelRegistry to track both handle types

- domain/artifacts/io.py: Complete refactor to dispatch on URL scheme; split local/remote implementation of list_storage, download_artifact, delete_artifact; shared catalog matching logic; remote commands sent over SSH via tunnel

- domain/artifacts/catalog.py: Moved get_artifacts_catalog from io.py to separate concerns

- domain/artifacts/manager.py: Added SSH handle lifecycle management with lazy init, status checking, and graceful reconnection

- domain/artifacts/base.py: get_artifact_local_path now parses URL schemes and extracts path component for both file:// and ssh://

- entrypoint/app.py: Pass URL string directly to get_artifact_local_path

- tests: Updated unit tests to use new signatures and URL schemes; added 12 new SSH variant tests with mocked tunnel.run()

All tests passing: 346 unit, 41 integration (including fixed artifact test)

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
