### PR TITLE
Cascade-Gateway Improvements

### DIFF
--- a/backend/justfile
+++ b/backend/justfile
@@ -1,7 +1,7 @@
 val:
     uv run ty check
-    uv run pytest -n4 tests/unit
-    uv run pytest tests/integration
+    FIAB_IGNORE_CONFIG_SOURCES=1 uv run pytest -n4 tests/unit
+    FIAB_IGNORE_CONFIG_SOURCES=1 uv run pytest tests/integration
 
 dev:
     #!/usr/bin/env bash

--- a/backend/src/forecastbox/domain/artifact/manager.py
+++ b/backend/src/forecastbox/domain/artifact/manager.py
@@ -78,14 +78,14 @@ class ArtifactManager:
                     tunnel.disconnect(cls.ssh_handle)
                 except Exception as e:
                     logger.warning(f"Could not disconnect stale SSH handle: {e}")
-            parsed = urllib.parse.urlparse(config.api.data_path)
+            parsed = urllib.parse.urlparse(config.backend.data_path)
             cls.ssh_handle = tunnel.connect(parsed.netloc)
             return cls.ssh_handle
 
 
 def _ssh_handle_if_needed(timeout: int = timeout_acquire_task) -> CommandHandle | None:
     """Return SSH handle if data_path uses ssh:// scheme, else None."""
-    parsed = urllib.parse.urlparse(config.api.data_path)
+    parsed = urllib.parse.urlparse(config.backend.data_path)
     if parsed.scheme == "ssh":
         return ArtifactManager._get_or_create_ssh_handle(timeout)
     return None
@@ -95,9 +95,9 @@ def _refresh_catalog_task() -> None:
     """Background task to refresh catalog and local artifact list."""
     try:
         logger.info("Starting artifact catalog refresh")
-        catalog = get_artifacts_catalog(config.product.artifact_stores)
+        catalog = get_artifacts_catalog(config.external.artifact_stores)
         handle = _ssh_handle_if_needed()
-        local_artifacts = list_storage(catalog, config.api.data_path, handle)
+        local_artifacts = list_storage(catalog, config.backend.data_path, handle)
 
         with timed_acquire(ArtifactManager.lock, timeout_acquire_task) as result:
             if not result:
@@ -134,7 +134,7 @@ def _download_artifact_task(composite_id: CompositeArtifactId) -> None:
             report_artifact_download_progress(composite_id, progress=progress)
 
         handle = _ssh_handle_if_needed()
-        download_artifact(composite_id, checkpoint, config.api.data_path, handle=handle, progress_callback=progress_callback)
+        download_artifact(composite_id, checkpoint, config.backend.data_path, handle=handle, progress_callback=progress_callback)
 
         with timed_acquire(ArtifactManager.lock, timeout_acquire_task) as result:
             if not result:
@@ -281,7 +281,7 @@ def delete_model(composite_id: CompositeArtifactId) -> Either[str, str]:  # ty: 
     # 3/ unlink happens while download is ongoing -> fix by making the delete two-step
     handle = _ssh_handle_if_needed()
     try:
-        delete_artifact(composite_id, config.api.data_path, handle=handle)
+        delete_artifact(composite_id, config.backend.data_path, handle=handle)
     except Exception as e:
         logger.exception(f"Failed to delete artifact {composite_id}: {repr(e)}")
         return Either.error(f"Failed to delete: {repr(e)}")

--- a/backend/src/forecastbox/domain/blueprint/cascade.py
+++ b/backend/src/forecastbox/domain/blueprint/cascade.py
@@ -7,7 +7,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-"""Cascade execution data models: environment specification."""
+from typing import Literal
 
 from fiab_core.artifacts import CompositeArtifactId
 from pydantic import Field, PositiveInt
@@ -17,6 +17,7 @@ from forecastbox.utility.pydantic import FiabBaseModel
 
 class EnvironmentSpecification(FiabBaseModel):
     # NOTE warning -- this class is used by the web api. Be careful about changes here
+    cascade_infra: Literal["localProcess", "slurm", "sshCluster"] = Field(default="localProcess")
     hosts: PositiveInt | None = Field(default=None)
     workers_per_host: PositiveInt | None = Field(default=None)
     environment_variables: dict[str, str] = Field(default_factory=dict)

--- a/backend/src/forecastbox/domain/blueprint/cascade.py
+++ b/backend/src/forecastbox/domain/blueprint/cascade.py
@@ -7,6 +7,8 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+"""Cascade execution data models: environment specification."""
+
 from typing import Literal
 
 from fiab_core.artifacts import CompositeArtifactId

--- a/backend/src/forecastbox/domain/experiment/scheduling/background.py
+++ b/backend/src/forecastbox/domain/experiment/scheduling/background.py
@@ -200,7 +200,7 @@ def prod_scheduler() -> None:
 
 
 def status_scheduler() -> str:
-    if not config.api.allow_scheduler:
+    if not config.backend.allow_scheduler:
         return "off"
     if Globals.scheduler is None:
         logger.warning("scheduler reported down due to being None")

--- a/backend/src/forecastbox/domain/gateway/service.py
+++ b/backend/src/forecastbox/domain/gateway/service.py
@@ -31,7 +31,7 @@ from forecastbox.domain.gateway.exceptions import (
     GatewayNotStarted,
 )
 from forecastbox.utility import tunnel
-from forecastbox.utility.config import StatusMessage, config
+from forecastbox.utility.config import LocalGateway, RemoteGateway, StatusMessage, UnmanagedGateway, config
 
 logger = logging.getLogger(__name__)
 _LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1"}
@@ -59,17 +59,18 @@ GatewayConnectionType = type[LocalProcess] | type[RemoteTunnel] | type[RemoteUrl
 
 
 def config2gatewayMethod() -> GatewayConnectionType:
-    if not config.cascade.spawn_gateway:
+    if isinstance(config.cascade.gateway, UnmanagedGateway):
         return RemoteUrl
-    parsed_url = urllib.parse.urlparse(config.cascade.cascade_url)
-    if parsed_url.scheme not in ("tcp", "ssh"):
-        raise ValueError("unsupported protocol: {parsed_url.scheme}. Use tcp for local, ssh for remote")
-    if parsed_url.hostname in _LOCAL_HOSTS and parsed_url.scheme == "tcp":
+    gateway = config.cascade.gateway
+    if isinstance(gateway, LocalGateway):
         return LocalProcess
-    elif parsed_url.scheme == "ssh":
+    elif isinstance(gateway, RemoteGateway):
+        parsed_url = urllib.parse.urlparse(gateway.cascade_url)
+        if parsed_url.scheme != "ssh":
+            raise ValueError(f"unsupported protocol for RemoteGateway: {parsed_url.scheme}. Use ssh")
         return RemoteTunnel
     else:
-        raise ValueError("tcp protocol but not a local host! Gateway spawning not supported!")
+        assert_never(gateway)
 
 
 def _initial_connection() -> GatewayConnection | None:
@@ -85,9 +86,11 @@ class GatewayConnectionManager:
 
 
 def _remote_tunnel_target() -> tuple[str, int | None]:
-    parsed_url = urllib.parse.urlparse(config.cascade.cascade_url)
+    if not isinstance(config.cascade.gateway, RemoteGateway):
+        raise ValueError("_remote_tunnel_target called but gateway is not RemoteGateway")
+    parsed_url = urllib.parse.urlparse(config.cascade.gateway.cascade_url)
     if parsed_url.hostname is None:
-        raise ValueError(f"Invalid cascade_url for remote tunnel mode: {config.cascade.cascade_url!r}")
+        raise ValueError(f"Invalid cascade_url for remote tunnel mode: {config.cascade.gateway.cascade_url!r}")
     host = f"{parsed_url.username}@{parsed_url.hostname}" if parsed_url.username else parsed_url.hostname
     return host, parsed_url.port
 
@@ -105,9 +108,14 @@ def launch_gateway() -> None:
         if GatewayConnectionManager.gateway_connection is not None:
             raise GatewayAlreadyRunning("Process already running.")
         gateway_method = config2gatewayMethod()
-        max_concurrent_jobs = config.cascade.max_concurrent_jobs
         if gateway_method is LocalProcess:
-            logs_directory = TemporaryDirectory(prefix="fiabLogs", dir=config.cascade.cascade_logging_base)
+            gateway = config.cascade.gateway
+            if not isinstance(gateway, LocalGateway):
+                raise ValueError("Expected LocalGateway when gateway_method is LocalProcess")
+            startup_params = gateway.startup_params
+            max_concurrent_jobs = startup_params.max_concurrent_jobs
+            cascade_logging_base = startup_params.cascade_logging_base
+            logs_directory = TemporaryDirectory(prefix="fiabLogs", dir=cascade_logging_base)
             logger.debug(f"logging base is at {logs_directory.name}")
             logs_base = None if os.getenv("FIAB_LOGSTDOUT", "nay") == "yea" else logs_directory.name + os.sep
             gateway_url = f"tcp://localhost:{tunnel.claim_free_port()}"
@@ -123,9 +131,15 @@ def launch_gateway() -> None:
                 gateway_url=gateway_url,
             )
         elif gateway_method is RemoteTunnel:
+            gateway = config.cascade.gateway
+            if not isinstance(gateway, RemoteGateway):
+                raise ValueError("Expected RemoteGateway when gateway_method is RemoteTunnel")
+            startup_params = gateway.startup_params
+            max_concurrent_jobs = startup_params.max_concurrent_jobs
+            cascade_logging_base = startup_params.cascade_logging_base
             host, remote_port = _remote_tunnel_target()
             handle = tunnel.setup(host=host, remote_port=remote_port)
-            log_base = f"{config.cascade.cascade_logging_base or '/tmp/'}fiabLogs{uuid.uuid4()}."
+            log_base = f"{cascade_logging_base or '/tmp/'}fiabLogs{uuid.uuid4()}."
             logger.debug(f"logging base for tunnel gateway is {log_base}")
             remote_gateway_url = f"tcp://localhost:{handle.remote_port}"
             logging_config = LoggingConfig(path_base=log_base, formatter="line")
@@ -161,7 +175,10 @@ def get_gateway_url() -> str:
     elif isinstance(gateway_connection, RemoteTunnel):
         return gateway_connection.handle.as_local_url()
     elif isinstance(gateway_connection, RemoteUrl):
-        return config.cascade.cascade_url
+        if isinstance(config.cascade.gateway, UnmanagedGateway):
+            return config.cascade.gateway.cascade_url
+        else:
+            raise ValueError("RemoteUrl gateway connection but gateway is not UnmanagedGateway")
     else:
         assert_never(gateway_connection)
 

--- a/backend/src/forecastbox/domain/gateway/service.py
+++ b/backend/src/forecastbox/domain/gateway/service.py
@@ -77,10 +77,15 @@ def _remote_tunnel_target() -> tuple[str, int | None]:
     return host, parsed_url.port
 
 
-def _local_process_entrypoint(cascade_url: str, log_base: str | None, max_concurrent_jobs: int | None) -> None:
+def _local_process_entrypoint(cascade_url: str, log_base: str | None, max_concurrent_jobs: int | None, shared_path: str | None) -> None:
     loggingConfigSer = LoggingConfig(path_base=log_base, formatter="line").ser_cliparam()
     try:
-        serve(url=cascade_url, loggingConfigSer=loggingConfigSer, max_concurrent_jobs=max_concurrent_jobs)
+        serve(
+            url=cascade_url,
+            loggingConfigSer=loggingConfigSer,
+            max_concurrent_jobs=max_concurrent_jobs,
+            shared_path=shared_path,
+        )
     except KeyboardInterrupt:
         pass
 
@@ -94,13 +99,14 @@ def launch_gateway() -> None:
             startup_params = gateway.startup_params
             max_concurrent_jobs = startup_params.max_concurrent_jobs
             cascade_logging_base = startup_params.cascade_logging_base
+            shared_path = startup_params.shared_path
             logs_directory = TemporaryDirectory(prefix="fiabLogs", dir=cascade_logging_base)
             logger.debug(f"logging base is at {logs_directory.name}")
             logs_base = None if os.getenv("FIAB_LOGSTDOUT", "nay") == "yea" else logs_directory.name + os.sep
             gateway_url = f"tcp://localhost:{tunnel.claim_free_port()}"
             process = platform.get_mp_ctx("gateway").Process(
                 target=_local_process_entrypoint,
-                args=(gateway_url, logs_base, max_concurrent_jobs),
+                args=(gateway_url, logs_base, max_concurrent_jobs, shared_path),
             )  # type: ignore[unresolved-attribute] # context
             process.start()
             logger.debug(f"spawned new gateway process with pid {process.pid}")
@@ -113,6 +119,7 @@ def launch_gateway() -> None:
             startup_params = gateway.startup_params
             max_concurrent_jobs = startup_params.max_concurrent_jobs
             cascade_logging_base = startup_params.cascade_logging_base
+            shared_path = startup_params.shared_path
             host, remote_port = _remote_tunnel_target()
             handle = tunnel.setup(host=host, remote_port=remote_port)
             log_base = f"{cascade_logging_base or '/tmp/'}fiabLogs{uuid.uuid4()}."
@@ -134,6 +141,8 @@ def launch_gateway() -> None:
             ]
             if max_concurrent_jobs is not None:
                 cmd.extend(["--max_concurrent_jobs", str(max_concurrent_jobs)])
+            if shared_path is not None:
+                cmd.extend(["--shared_path", shared_path])
             tunnel.execute(handle, cmd, output_path=log_base + "gwstdouterr")
             GatewayConnectionManager.gateway_connection = RemoteTunnel(handle=handle)
         elif isinstance(gateway, UnmanagedGateway):

--- a/backend/src/forecastbox/domain/gateway/service.py
+++ b/backend/src/forecastbox/domain/gateway/service.py
@@ -34,7 +34,6 @@ from forecastbox.utility import tunnel
 from forecastbox.utility.config import LocalGateway, RemoteGateway, StatusMessage, UnmanagedGateway, config
 
 logger = logging.getLogger(__name__)
-_LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1"}
 
 
 @dataclass(frozen=True, eq=True, slots=True)
@@ -55,27 +54,10 @@ class RemoteUrl:
 
 
 GatewayConnection = LocalProcess | RemoteTunnel | RemoteUrl
-GatewayConnectionType = type[LocalProcess] | type[RemoteTunnel] | type[RemoteUrl]
-
-
-def config2gatewayMethod() -> GatewayConnectionType:
-    if isinstance(config.cascade.gateway, UnmanagedGateway):
-        return RemoteUrl
-    gateway = config.cascade.gateway
-    if isinstance(gateway, LocalGateway):
-        return LocalProcess
-    elif isinstance(gateway, RemoteGateway):
-        parsed_url = urllib.parse.urlparse(gateway.cascade_url)
-        if parsed_url.scheme != "ssh":
-            raise ValueError(f"unsupported protocol for RemoteGateway: {parsed_url.scheme}. Use ssh")
-        return RemoteTunnel
-    else:
-        assert_never(gateway)
 
 
 def _initial_connection() -> GatewayConnection | None:
-    gateway_method = config2gatewayMethod()
-    if gateway_method is RemoteUrl:
+    if isinstance(config.cascade.gateway, UnmanagedGateway):
         return RemoteUrl()
     return None
 
@@ -107,11 +89,8 @@ def launch_gateway() -> None:
     with GatewayConnectionManager.lock:
         if GatewayConnectionManager.gateway_connection is not None:
             raise GatewayAlreadyRunning("Process already running.")
-        gateway_method = config2gatewayMethod()
-        if gateway_method is LocalProcess:
-            gateway = config.cascade.gateway
-            if not isinstance(gateway, LocalGateway):
-                raise ValueError("Expected LocalGateway when gateway_method is LocalProcess")
+        gateway = config.cascade.gateway
+        if isinstance(gateway, LocalGateway):
             startup_params = gateway.startup_params
             max_concurrent_jobs = startup_params.max_concurrent_jobs
             cascade_logging_base = startup_params.cascade_logging_base
@@ -130,10 +109,7 @@ def launch_gateway() -> None:
                 process=process,
                 gateway_url=gateway_url,
             )
-        elif gateway_method is RemoteTunnel:
-            gateway = config.cascade.gateway
-            if not isinstance(gateway, RemoteGateway):
-                raise ValueError("Expected RemoteGateway when gateway_method is RemoteTunnel")
+        elif isinstance(gateway, RemoteGateway):
             startup_params = gateway.startup_params
             max_concurrent_jobs = startup_params.max_concurrent_jobs
             cascade_logging_base = startup_params.cascade_logging_base
@@ -160,10 +136,10 @@ def launch_gateway() -> None:
                 cmd.extend(["--max_concurrent_jobs", str(max_concurrent_jobs)])
             tunnel.execute(handle, cmd, output_path=log_base + "gwstdouterr")
             GatewayConnectionManager.gateway_connection = RemoteTunnel(handle=handle)
-        elif gateway_method is RemoteUrl:
+        elif isinstance(gateway, UnmanagedGateway):
             raise NotImplementedError("RemoteUrl gateway cannot be launched by backend")
         else:
-            assert_never(gateway_method)
+            assert_never(gateway)
 
 
 def get_gateway_url() -> str:

--- a/backend/src/forecastbox/domain/gateway/service.py
+++ b/backend/src/forecastbox/domain/gateway/service.py
@@ -143,6 +143,7 @@ def launch_gateway() -> None:
                 cmd.extend(["--max_concurrent_jobs", str(max_concurrent_jobs)])
             if shared_path is not None:
                 cmd.extend(["--shared_path", shared_path])
+            tunnel.execute(handle, ["mkdir", "-p", log_base])
             tunnel.execute(handle, cmd, output_path=log_base + "gwstdouterr")
             GatewayConnectionManager.gateway_connection = RemoteTunnel(handle=handle)
         elif isinstance(gateway, UnmanagedGateway):

--- a/backend/src/forecastbox/domain/gateway/service.py
+++ b/backend/src/forecastbox/domain/gateway/service.py
@@ -21,7 +21,7 @@ from tempfile import TemporaryDirectory
 from cascade.deployment.logging import LoggingConfig
 from cascade.executor import platform
 from cascade.gateway import api, client
-from cascade.gateway.server import main_enp
+from cascade.gateway.server import serve
 from cascade.low.func import Either, assert_never
 
 from forecastbox.domain.gateway.exceptions import (
@@ -78,9 +78,9 @@ def _remote_tunnel_target() -> tuple[str, int | None]:
 
 
 def _local_process_entrypoint(cascade_url: str, log_base: str | None, max_concurrent_jobs: int | None) -> None:
-    logging_config = LoggingConfig(path_base=log_base, formatter="line")
+    loggingConfigSer = LoggingConfig(path_base=log_base, formatter="line").ser_cliparam()
     try:
-        main_enp(url=cascade_url, loggingConfig=logging_config, max_concurrent_jobs=max_concurrent_jobs)
+        serve(url=cascade_url, loggingConfigSer=loggingConfigSer, max_concurrent_jobs=max_concurrent_jobs)
     except KeyboardInterrupt:
         pass
 

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -226,7 +226,7 @@ def submit_load_plugins(start_after: Future[None]) -> None:
         elif PluginManager.updater is not None:
             raise TypeError("attempted to submit load_plugins but updater is already in progress")
         else:
-            PluginManager.updater = delayed_thread(start_after, load_plugins, (config.product.plugins,))
+            PluginManager.updater = delayed_thread(start_after, load_plugins, (config.external.plugins,))
             PluginManager.updater.start()
 
 
@@ -281,7 +281,7 @@ def catalogue_view() -> dict[PluginCompositeId, BlockFactoryCatalogue] | bool:
 
 
 def submit_update_single(pluginId: PluginCompositeId, isUpdate: bool) -> str:
-    pluginSettings = config.product.plugins.get(pluginId, None)
+    pluginSettings = config.external.plugins.get(pluginId, None)
     if pluginSettings is None:
         return f"plugin {pluginId} not configured"
     else:
@@ -303,12 +303,12 @@ def submit_update_single(pluginId: PluginCompositeId, isUpdate: bool) -> str:
 
 
 def uninstall_plugin(pluginId: PluginCompositeId) -> None:
-    if pluginId not in config.product.plugins:
+    if pluginId not in config.external.plugins:
         raise ValueError(f"plugin {pluginId} not installed")
     with timed_acquire(config_edit_lock, 5) as result:
         if not result:
             raise ValueError("failed to acquire the shared lock")
-        config.product.plugins.pop(pluginId)
+        config.external.plugins.pop(pluginId)
         config.save_to_file()
     unload_single(pluginId)
 
@@ -317,7 +317,7 @@ def modify_enabled(pluginId: PluginCompositeId, isEnabled: bool) -> None:
     with timed_acquire(config_edit_lock, 5) as result:
         if not result:
             raise ValueError("failed to acquire the shared lock")
-        config.product.plugins[pluginId].enabled = isEnabled
+        config.external.plugins[pluginId].enabled = isEnabled
         config.save_to_file()
     if not isEnabled:
         unload_single(pluginId)

--- a/backend/src/forecastbox/domain/plugin/store.py
+++ b/backend/src/forecastbox/domain/plugin/store.py
@@ -139,7 +139,7 @@ def submit_initialize_stores() -> None:
         if not result:
             logger.error("failed to initialize stores")
             return
-        StoresManager.stores_updater = threading.Thread(target=initialize_stores, args=(config.product.plugin_stores,))
+        StoresManager.stores_updater = threading.Thread(target=initialize_stores, args=(config.external.plugin_stores,))
         StoresManager.stores_updater.start()
 
 
@@ -155,11 +155,11 @@ def submit_install_plugin(plugin_composite_key: PluginCompositeId) -> None:
     if pluginStoreEntry is None:
         raise ValueError(f"plugin with id {pluginId} not known to store {storeId}")
 
-    if plugin_composite_key not in config.product.plugins:
+    if plugin_composite_key not in config.external.plugins:
         with timed_acquire(config_edit_lock, 5) as result:
             if not result:
                 raise ValueError("failed to acquire the shared lock")
-            config.product.plugins[plugin_composite_key] = PluginSettings(
+            config.external.plugins[plugin_composite_key] = PluginSettings(
                 pip_source=pluginStoreEntry.pip_source,
                 module_name=pluginStoreEntry.module_name,
                 update_strategy="manual",

--- a/backend/src/forecastbox/domain/run/cascade.py
+++ b/backend/src/forecastbox/domain/run/cascade.py
@@ -88,8 +88,10 @@ def execute_cascade(spec: ExecutionSpecification) -> SubmitJobResponse:
     job = spec.job.job_instance
 
     environment = spec.environment
-    hosts = min(config.cascade.max_hosts, environment.hosts or config.cascade.default_hosts)
-    workers_per_host = min(config.cascade.max_workers_per_host, environment.workers_per_host or config.cascade.default_workers_per_host)
+    hosts = min(config.cascade.constraints.max_hosts, environment.hosts or config.cascade.constraints.default_hosts)
+    workers_per_host = min(
+        config.cascade.constraints.max_workers_per_host, environment.workers_per_host or config.cascade.constraints.default_workers_per_host
+    )
 
     r = SubmitJobRequest(
         job=JobSpec(

--- a/backend/src/forecastbox/domain/run/cascade.py
+++ b/backend/src/forecastbox/domain/run/cascade.py
@@ -13,7 +13,7 @@ import time
 from pathlib import Path
 from typing import Literal
 
-from cascade.gateway.api import JobSpec, LocalProcesses, SubmitJobRequest, SubmitJobResponse
+from cascade.gateway.api import JobSpec, LocalProcesses, SlurmCluster, SshCluster, SubmitJobRequest, SubmitJobResponse
 from cascade.gateway.client import request_response
 from cascade.low.core import JobInstance, JobInstanceRich, TaskId
 from fiab_core.fable import BlockInstanceId
@@ -22,10 +22,44 @@ from pydantic import Field
 from forecastbox.domain.artifact.manager import ArtifactManager, submit_artifact_download
 from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
 from forecastbox.domain.gateway.service import get_gateway_url
-from forecastbox.utility.config import config
+from forecastbox.utility.config import UnmanagedGateway, config
 from forecastbox.utility.pydantic import FiabBaseModel
 
 logger = logging.getLogger(__name__)
+
+
+def _select_cascade_infra(environment: EnvironmentSpecification) -> Literal["localProcess", "slurm", "sshCluster"]:
+    if "cascade_infra" in environment.model_fields_set:
+        return environment.cascade_infra
+    return config.cascade.constraints.default_cascade_infra
+
+
+def _build_infra_spec(
+    environment: EnvironmentSpecification, workers_per_host: int, hosts: int
+) -> LocalProcesses | SlurmCluster | SshCluster:
+    requested_infra = _select_cascade_infra(environment)
+    gateway = config.cascade.gateway
+
+    if requested_infra == "localProcess":
+        return LocalProcesses(workers_per_host=workers_per_host, hosts=hosts)
+
+    if requested_infra == "slurm":
+        if not isinstance(gateway, UnmanagedGateway):
+            if not gateway.startup_params.shared_path:
+                raise ValueError("slurm submissions with managed gateway require cascade.gateway.startup_params.shared_path")
+        return SlurmCluster(workers_per_host=workers_per_host, hosts=hosts)
+
+    if requested_infra == "sshCluster":
+        ssh_cluster_spec = gateway.startup_params.ssh_cluster_spec
+        if ssh_cluster_spec is None:
+            raise ValueError("sshCluster submissions require cascade.gateway.startup_params.ssh_cluster_spec")
+        return SshCluster(
+            controller_url=ssh_cluster_spec.controller_url,
+            worker_urls=ssh_cluster_spec.worker_urls,
+            workers_per_host=workers_per_host,
+        )
+
+    raise ValueError(f"Unsupported cascade infrastructure: {requested_infra}")
 
 
 class RawCascadeJob(FiabBaseModel):
@@ -93,9 +127,11 @@ def execute_cascade(spec: ExecutionSpecification) -> SubmitJobResponse:
         config.cascade.constraints.max_workers_per_host, environment.workers_per_host or config.cascade.constraints.default_workers_per_host
     )
 
+    infra_spec = _build_infra_spec(environment, workers_per_host=workers_per_host, hosts=hosts)
+
     r = SubmitJobRequest(
         job=JobSpec(
-            infra_spec=LocalProcesses(workers_per_host=workers_per_host, hosts=hosts),
+            infra_spec=infra_spec,
             envvars={},
             job_instance=JobInstanceRich(jobInstance=job, checkpointSpec=None),
         )

--- a/backend/src/forecastbox/domain/run/cascade.py
+++ b/backend/src/forecastbox/domain/run/cascade.py
@@ -22,13 +22,13 @@ from pydantic import Field
 from forecastbox.domain.artifact.manager import ArtifactManager, submit_artifact_download
 from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
 from forecastbox.domain.gateway.service import get_gateway_url
-from forecastbox.utility.config import UnmanagedGateway, config
+from forecastbox.utility.config import CascadeInfrastructureType, UnmanagedGateway, config
 from forecastbox.utility.pydantic import FiabBaseModel
 
 logger = logging.getLogger(__name__)
 
 
-def _select_cascade_infra(environment: EnvironmentSpecification) -> Literal["localProcess", "slurm", "sshCluster"]:
+def _select_cascade_infra(environment: EnvironmentSpecification) -> CascadeInfrastructureType:
     if "cascade_infra" in environment.model_fields_set:
         return environment.cascade_infra
     return config.cascade.constraints.default_cascade_infra
@@ -43,23 +43,28 @@ def _build_infra_spec(
     if requested_infra == "localProcess":
         return LocalProcesses(workers_per_host=workers_per_host, hosts=hosts)
 
-    if requested_infra == "slurm":
+    elif requested_infra == "slurm":
         if not isinstance(gateway, UnmanagedGateway):
             if not gateway.startup_params.shared_path:
-                raise ValueError("slurm submissions with managed gateway require cascade.gateway.startup_params.shared_path")
+                raise ValueError(
+                    "slurm submissions with managed gateway require setting config value of cascade.gateway.startup_params.shared_path"
+                )
         return SlurmCluster(workers_per_host=workers_per_host, hosts=hosts)
 
-    if requested_infra == "sshCluster":
+    elif requested_infra == "sshCluster":
+        if isinstance(gateway, UnmanagedGateway):
+            raise ValueError("sshCluster submission currently not supported for unmanaged gateway")
         ssh_cluster_spec = gateway.startup_params.ssh_cluster_spec
         if ssh_cluster_spec is None:
-            raise ValueError("sshCluster submissions require cascade.gateway.startup_params.ssh_cluster_spec")
+            raise ValueError("sshCluster submissions require setting config value of cascade.gateway.startup_params.ssh_cluster_spec")
         return SshCluster(
             controller_url=ssh_cluster_spec.controller_url,
             worker_urls=ssh_cluster_spec.worker_urls,
             workers_per_host=workers_per_host,
         )
 
-    raise ValueError(f"Unsupported cascade infrastructure: {requested_infra}")
+    else:
+        assert_never(request_infra)
 
 
 class RawCascadeJob(FiabBaseModel):

--- a/backend/src/forecastbox/domain/run/cascade.py
+++ b/backend/src/forecastbox/domain/run/cascade.py
@@ -13,7 +13,7 @@ import time
 from pathlib import Path
 from typing import Literal
 
-from cascade.gateway.api import JobSpec, SubmitJobRequest, SubmitJobResponse
+from cascade.gateway.api import JobSpec, LocalProcesses, SubmitJobRequest, SubmitJobResponse
 from cascade.gateway.client import request_response
 from cascade.low.core import JobInstance, JobInstanceRich, TaskId
 from fiab_core.fable import BlockInstanceId
@@ -95,10 +95,8 @@ def execute_cascade(spec: ExecutionSpecification) -> SubmitJobResponse:
 
     r = SubmitJobRequest(
         job=JobSpec(
-            workers_per_host=workers_per_host,
-            hosts=hosts,
+            infra_spec=LocalProcesses(workers_per_host=workers_per_host, hosts=hosts),
             envvars={},
-            use_slurm=False,
             job_instance=JobInstanceRich(jobInstance=job, checkpointSpec=None),
         )
     )

--- a/backend/src/forecastbox/entrypoint/app.py
+++ b/backend/src/forecastbox/entrypoint/app.py
@@ -50,17 +50,17 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         module = importlib.import_module(f"forecastbox.schemata.{module_info.name}")
         if hasattr(module, "create_db_and_tables"):
             await module.create_db_and_tables()  # type: ignore[call-non-callable] # NOTE no module protocol
-    if config.api.allow_scheduler:
+    if config.backend.allow_scheduler:
         start_scheduler()
     release_time, release_version = get_local_release()
     app.version = f"{release_version}@{release_time}"
     submit_initialize_stores()
     ArtifactsProvider.register_get_artifacts_lookup(lambda: ArtifactManager.catalog)
-    ArtifactsProvider.register_get_artifact_local_path(lambda composite_id: get_artifact_local_path(composite_id, config.api.data_path))
+    ArtifactsProvider.register_get_artifact_local_path(lambda composite_id: get_artifact_local_path(composite_id, config.backend.data_path))
     catalog_ready = submit_refresh_catalog()
     submit_load_plugins(start_after=catalog_ready)
     yield
-    if config.api.allow_scheduler:
+    if config.backend.allow_scheduler:
         stop_scheduler()
     shutdown_all_lens_instances()
     await shutdown_processes()

--- a/backend/src/forecastbox/entrypoint/bootstrap/checks.py
+++ b/backend/src/forecastbox/entrypoint/bootstrap/checks.py
@@ -57,11 +57,11 @@ def check_backend_ready(
 ) -> None:
     try:
         with httpx.Client() as client:
-            _wait_for(client, config.api.local_url() + "/api/v1/status", attempts, _call_succ)
+            _wait_for(client, config.backend.local_url() + "/api/v1/status", attempts, _call_succ)
             if spawn_gateway:
-                client.post(config.api.local_url() + "/api/v1/gateway/start").raise_for_status()
+                client.post(config.backend.local_url() + "/api/v1/gateway/start").raise_for_status()
             gw_check = lambda resp, _: resp.raise_for_status().text == f'"{StatusMessage.gateway_running}"'
-            _wait_for(client, config.api.local_url() + "/api/v1/gateway/status", attempts, gw_check)
+            _wait_for(client, config.backend.local_url() + "/api/v1/gateway/status", attempts, gw_check)
     except StartupError as e:
         logger.error(f"failed to start the backend: {e}")
         if handles is not None:
@@ -74,7 +74,7 @@ def install_default_plugins(config: FIABConfig) -> None:
     try:
         with httpx.Client(follow_redirects=True) as client:
             for pluginId in _default_plugins().keys():
-                url = config.api.local_url() + "/api/v1/plugin/install"
+                url = config.backend.local_url() + "/api/v1/plugin/install"
                 try:
                     client.post(url, json=pluginId.model_dump()).raise_for_status()
                 except Exception:

--- a/backend/src/forecastbox/entrypoint/bootstrap/launchers.py
+++ b/backend/src/forecastbox/entrypoint/bootstrap/launchers.py
@@ -47,8 +47,8 @@ def launch_backend() -> None:
 
     setup_process()
     logger.debug(f"logging initialized post-{forecastbox.entrypoint.app.__name__} import")
-    port = config.api.uvicorn_port
-    host = config.api.uvicorn_host
+    port = config.backend.uvicorn_port
+    host = config.backend.uvicorn_host
     task = _uvicorn_run("forecastbox.entrypoint.app:app", host, port)
     try:
         asyncio.run(task)

--- a/backend/src/forecastbox/entrypoint/bootstrap/service.py
+++ b/backend/src/forecastbox/entrypoint/bootstrap/service.py
@@ -9,7 +9,7 @@ from forecastbox.entrypoint.bootstrap.checks import check_backend_ready
 from forecastbox.entrypoint.bootstrap.config import export_recursive, setup_process
 from forecastbox.entrypoint.bootstrap.launchers import launch_backend
 from forecastbox.entrypoint.bootstrap.procs import ChildProcessGroup, previous_cleanup
-from forecastbox.utility.config import FIABConfig, fiab_home, validate_runtime
+from forecastbox.utility.config import FIABConfig, UnmanagedGateway, fiab_home, validate_runtime
 
 logger = logging.getLogger(__name__ if __name__ != "__main__" else __package__)
 
@@ -41,7 +41,7 @@ if __name__ == "__main__":
     freeze_support()
     setup_process()
 
-    if not config.api.allow_service:
+    if not config.backend.allow_service:
         raise TypeError("launched as a service but config incompatible")
 
     previous_cleanup()
@@ -58,4 +58,4 @@ if __name__ == "__main__":
     else:
         raise ValueError(f"start failure: {backend.exitcode}")
 
-    check_backend_ready(config, handle, config.cascade.spawn_gateway)
+    check_backend_ready(config, handle, not isinstance(config.cascade.gateway, UnmanagedGateway))

--- a/backend/src/forecastbox/entrypoint/main.py
+++ b/backend/src/forecastbox/entrypoint/main.py
@@ -27,7 +27,7 @@ from forecastbox.entrypoint.bootstrap.checks import check_backend_ready, install
 from forecastbox.entrypoint.bootstrap.config import export_recursive, setup_process
 from forecastbox.entrypoint.bootstrap.launchers import launch_backend
 from forecastbox.entrypoint.bootstrap.procs import ChildProcessGroup, previous_cleanup
-from forecastbox.utility.config import FIABConfig, validate_runtime
+from forecastbox.utility.config import FIABConfig, UnmanagedGateway, validate_runtime
 
 logger = logging.getLogger(__name__ if __name__ != "__main__" else __package__)
 
@@ -37,7 +37,7 @@ def launch_all(config: FIABConfig, attempts: int = 20) -> ChildProcessGroup:
     logger.info("main process starting")
     logger.debug(f"loaded config {config.model_dump()}")
 
-    if not config.api.allow_service:
+    if not config.backend.allow_service:
         previous_cleanup()
         export_recursive(
             config.model_dump(exclude_defaults=True),
@@ -48,7 +48,7 @@ def launch_all(config: FIABConfig, attempts: int = 20) -> ChildProcessGroup:
         backend = get_context("forkserver").Process(target=launch_backend)
         backend.start()
         handle = ChildProcessGroup([backend])
-        spawn_gateway = config.cascade.spawn_gateway
+        spawn_gateway = not isinstance(config.cascade.gateway, UnmanagedGateway)
     else:
         if not forecastbox.entrypoint.bootstrap.service.is_running():
             raise ValueError("configured to use service, but is not running!")
@@ -59,8 +59,8 @@ def launch_all(config: FIABConfig, attempts: int = 20) -> ChildProcessGroup:
     if should_install_default_plugin():
         install_default_plugins(config)
 
-    if config.general.launch_browser:
-        webbrowser.open(config.api.local_url())
+    if config.backend.launch_browser:
+        webbrowser.open(config.backend.local_url())
 
     return handle
 

--- a/backend/src/forecastbox/routes/admin.py
+++ b/backend/src/forecastbox/routes/admin.py
@@ -25,7 +25,7 @@ from pydantic import UUID4
 from forecastbox.domain.admin import Release, get_local_release, get_most_recent_release, get_pylock, mark_release, save_pylock
 from forecastbox.domain.auth.db import delete_user_by_id, get_user_by_id, list_users, patch_user_by_id, update_user_by_id
 from forecastbox.domain.auth.users import UserRead, UserUpdate, current_active_user
-from forecastbox.utility.config import BackendAPISettings, CascadeSettings, ProductSettings, config
+from forecastbox.utility.config import BackendSettings, CascadeSettings, ExternalServicesSettings, config
 from forecastbox.utility.pydantic import FiabBaseModel
 from forecastbox.utility.rsjf import ExportedSchemas, FormDefinition, from_pydantic
 
@@ -52,9 +52,9 @@ router = APIRouter(
 class ExposedSettings(FiabBaseModel):
     """Exposed settings for modification"""
 
-    product: ProductSettings = config.product
+    external: ExternalServicesSettings = config.external
 
-    api: BackendAPISettings = config.api
+    backend: BackendSettings = config.backend
     cascade: CascadeSettings = config.cascade
 
     def to_rjsf(self) -> FormDefinition:
@@ -126,8 +126,8 @@ async def update_settings(settings: ExposedSettings, admin: UserRead | None = De
             setattr(old, key, val)
 
     try:
-        update(config.api, settings.api)
-        update(config.product, settings.product)
+        update(config.backend, settings.backend)
+        update(config.external, settings.external)
         update(config.cascade, settings.cascade)
     except Exception as e:
         return HTMLResponse(content=str(e), status_code=500)

--- a/backend/src/forecastbox/routes/gateway.py
+++ b/backend/src/forecastbox/routes/gateway.py
@@ -23,7 +23,7 @@ from forecastbox.domain.gateway.exceptions import (
     GatewayNotStarted,
 )
 from forecastbox.domain.gateway.service import launch_gateway, status_gateway, stop_gateway
-from forecastbox.utility.config import config
+from forecastbox.utility.config import UnmanagedGateway, config
 
 PREFIX = "/api/v1/gateway"
 
@@ -35,7 +35,7 @@ router = APIRouter(
 
 @router.post("/start")
 async def start_gateway() -> str:
-    if not config.cascade.spawn_gateway:
+    if isinstance(config.cascade.gateway, UnmanagedGateway):
         raise HTTPException(400, "This instance does not manage the gateway")
     try:
         launch_gateway()
@@ -47,7 +47,7 @@ async def start_gateway() -> str:
 @router.get("/status")
 async def get_status() -> str:
     """Get the status of the Cascade Gateway process."""
-    if not config.cascade.spawn_gateway:
+    if isinstance(config.cascade.gateway, UnmanagedGateway):
         return "not managed"
     try:
         return status_gateway()
@@ -59,7 +59,7 @@ async def get_status() -> str:
 
 @router.post("/kill")
 async def kill_gateway() -> str:
-    if not config.cascade.spawn_gateway:
+    if isinstance(config.cascade.gateway, UnmanagedGateway):
         raise HTTPException(400, "This instance does not manage the gateway")
     try:
         stop_gateway()

--- a/backend/src/forecastbox/routes/plugins.py
+++ b/backend/src/forecastbox/routes/plugins.py
@@ -76,7 +76,7 @@ def get_plugin_details(forceRefresh: bool = False) -> PluginListing:
         raise NotImplementedError
     rv = {}
     statuses = status_full()
-    disabled = {pluginCompositeId for pluginCompositeId, pluginSettings in config.product.plugins.items() if not pluginSettings.enabled}
+    disabled = {pluginCompositeId for pluginCompositeId, pluginSettings in config.external.plugins.items() if not pluginSettings.enabled}
     errored = set(statuses.plugin_errors.keys())
     loaded = set(statuses.plugin_versions.keys())
     installed = errored.union(loaded).union(disabled)

--- a/backend/src/forecastbox/routes/status.py
+++ b/backend/src/forecastbox/routes/status.py
@@ -64,7 +64,7 @@ def get_status(request: Request) -> StatusResponse:
         status["plugins"] = f"failure getting status"
 
     try:
-        response = requests.get(f"{config.api.model_repository}/MANIFEST", timeout=5)
+        response = requests.get(f"{config.external.model_repository}/MANIFEST", timeout=5)
         if response.status_code == 200:
             status["ecmwf"] = "up"
         else:

--- a/backend/src/forecastbox/utility/config.py
+++ b/backend/src/forecastbox/utility/config.py
@@ -347,13 +347,20 @@ class FIABConfig(BaseSettings):
         dotenv_settings: PydanticBaseSettingsSource,
         file_secret_settings: PydanticBaseSettingsSource,
     ) -> tuple[PydanticBaseSettingsSource, ...]:
-        return (
-            env_settings,
-            file_secret_settings,
-            dotenv_settings,
-            TomlConfigSettingsSource(settings_cls, fiab_home / "config.toml"),
-            init_settings,
-        )
+        # for tests in particular, we dont want user's ~/.fiab or .env to mess up
+        if os.environ.get("FIAB_IGNORE_CONFIG_SOURCES", "0") == "1":
+            return (
+                env_settings,
+                init_settings,
+            )
+        else:
+            return (
+                env_settings,
+                file_secret_settings,
+                dotenv_settings,
+                TomlConfigSettingsSource(settings_cls, fiab_home / "config.toml"),
+                init_settings,
+            )
 
     def _get_toml(self, **k: Any) -> str:
         json_config = self.model_dump(mode="json", **k)

--- a/backend/src/forecastbox/utility/config.py
+++ b/backend/src/forecastbox/utility/config.py
@@ -202,6 +202,12 @@ class ExternalServicesSettings(FiabBaseModel):
     model_repository: str = "https://sites.ecmwf.int/repository/fiab"
     """URL to the model repository."""
 
+    def validate_runtime(self) -> list[str]:
+        errors = []
+        if not _validate_url(self.model_repository):
+            errors.append(f"not an url: model_repository={self.model_repository}")
+        return errors
+
 
 class BackendSettings(FiabBaseModel):
     data_path: str = f"file://{fiab_home.absolute() / 'data_dir'}"
@@ -257,6 +263,12 @@ class RemoteGateway(FiabBaseModel):
     startup_params: GatewayStartupParams = Field(default_factory=GatewayStartupParams)
     cascade_url: str
     """Sshable url like 'ssh://[<user>@]<hostname>:<port>'"""
+
+    def validate_runtime(self) -> list[str]:
+        parsed = urllib.parse.urlparse(self.cascade_url)
+        if parsed.scheme != "ssh":
+            return [f"unsupported protocol for RemoteGateway cascade_url: {parsed.scheme!r}. Use ssh://"]
+        return []
 
 
 class UnmanagedGateway(FiabBaseModel):

--- a/backend/src/forecastbox/utility/config.py
+++ b/backend/src/forecastbox/utility/config.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Annotated, Any, Literal, Self
 
 import toml
-from cascade.low.func import pydantic_recursive_collect
+from cascade.low.func import assert_never, pydantic_recursive_collect
 from fiab_core.artifacts import ArtifactStoreId
 from fiab_core.fable import PluginCompositeId, PluginId, PluginStoreId
 from pydantic import BeforeValidator, Field, PlainSerializer, SecretStr, model_validator
@@ -100,12 +100,6 @@ class AuthSettings(FiabBaseModel):
         if self.public_url is not None and not _validate_url(self.public_url):
             errors.append(f"not an url: public_url={self.public_url}")
         return errors
-
-
-class GeneralSettings(FiabBaseModel):
-    launch_browser: bool = True
-    """Whether a browser window should be opened after start. Used only when
-    entrypoint.main.launch_all module is used"""
 
 
 PluginRefreshStrategy = Literal["automatic", "manual"]
@@ -194,10 +188,6 @@ class ProductSettings(FiabBaseModel):
     default_input_source: str = "opendata"
     """Default input source for models, if not specified otherwise"""
 
-    plugins: PluginsSettings = Field(default_factory=_default_plugins)
-    plugin_stores: PluginStoresConfig = Field(default_factory=_default_plugin_stores)
-    artifact_stores: ArtifactStoresConfig = Field(default_factory=_default_artifact_stores)
-
     def validate_runtime(self) -> list[str]:
         if self.pproc_schema_dir and not os.path.isdir(self.pproc_schema_dir):
             return ["not a directory: pproc_schema_dir={self.pproc_schema_dir}"]
@@ -205,11 +195,17 @@ class ProductSettings(FiabBaseModel):
             return []
 
 
-class BackendAPISettings(FiabBaseModel):
-    data_path: str = f"file://{fiab_home.absolute() / 'data_dir'}"
-    """Data directory URL. Supports file:// (local) and ssh://[user@]host/path (remote) schemes."""
+class ExternalServicesSettings(FiabBaseModel):
+    plugins: PluginsSettings = Field(default_factory=_default_plugins)
+    plugin_stores: PluginStoresConfig = Field(default_factory=_default_plugin_stores)
+    artifact_stores: ArtifactStoresConfig = Field(default_factory=_default_artifact_stores)
     model_repository: str = "https://sites.ecmwf.int/repository/fiab"
     """URL to the model repository."""
+
+
+class BackendSettings(FiabBaseModel):
+    data_path: str = f"file://{fiab_home.absolute() / 'data_dir'}"
+    """Data directory URL. Supports file:// (local) and ssh://[user@]host/path (remote) schemes."""
     uvicorn_host: str = "0.0.0.0"
     """Listening host of the whole server."""
     uvicorn_port: int = 8000
@@ -218,6 +214,9 @@ class BackendAPISettings(FiabBaseModel):
     """Whether we assume that a system-level service has been registered. Affects entrypoint.main behaviour"""
     allow_scheduler: bool = False
     """Whether scheduler thread should be started. Best combine with allow_service=True"""
+    launch_browser: bool = True
+    """Whether a browser window should be opened after start. Used only when
+    entrypoint.main.launch_all module is used"""
 
     def local_url(self) -> str:
         return f"http://localhost:{self.uvicorn_port}"
@@ -235,15 +234,38 @@ class BackendAPISettings(FiabBaseModel):
                 errors.append(f"ssh:// data_path must have an absolute path: {self.data_path}")
         else:
             errors.append(f"unsupported scheme in data_path (use file:// or ssh://): {self.data_path}")
-        if not _validate_url(self.model_repository):
-            errors.append(f"not an url: model_repository={self.model_repository}")
         pseudo_url = f"http://{self.uvicorn_host}:{self.uvicorn_port}"
         if not _validate_url(pseudo_url) or (self.uvicorn_port < 0) or (self.uvicorn_port > 2**16):
             errors.append(f"not a valid uvicorn config: {pseudo_url}")
         return errors
 
 
-class CascadeSettings(FiabBaseModel):
+class GatewayStartupParams(FiabBaseModel):
+    max_concurrent_jobs: int | None = 1
+    """If more jobs submitted at a given time, all but this many wait in a queue"""
+    cascade_logging_base: str | None = None
+    """Where to store logs of cascade gw and jobs. Use eg /home/<user>/fiabLogs or /tmp/fiabLogs"""
+
+
+class LocalGateway(FiabBaseModel):
+    gateway_type: Literal["local"]
+    startup_params: GatewayStartupParams = Field(default_factory=GatewayStartupParams)
+
+
+class RemoteGateway(FiabBaseModel):
+    gateway_type: Literal["remote"]
+    startup_params: GatewayStartupParams = Field(default_factory=GatewayStartupParams)
+    cascade_url: str
+    """Sshable url like 'ssh://[<user>@]<hostname>:<port>'"""
+
+
+class UnmanagedGateway(FiabBaseModel):
+    gateway_type: Literal["unmanaged"]
+    cascade_url: str
+    """Base URL for the Cascade API, eg tcp://<hostname>:<port>"""
+
+
+class CascadeConstraints(FiabBaseModel):
     default_hosts: int = 1
     """Default number of hosts for Cascade if unspecified in a job."""
     max_hosts: int = 1
@@ -252,32 +274,42 @@ class CascadeSettings(FiabBaseModel):
     """Default number of workers per hosts for Cascade if unspecified in a job."""
     max_workers_per_host: int = 8
     """Max number of workers per host for Cascade."""
-    cascade_url: str = "tcp://localhost"
-    """Base URL for the Cascade API in case of unmanaged gateway, otherwise localhost or sshable [<user>@]<hostname>."""
-    cascade_logging_base: str | None = None
-    """Where to store logs of cascade gw and jobs. Use eg /home/<user>/fiabLogs or /tmp/fiabLogs"""
-    spawn_gateway: bool = True
-    """Whether the backend should spawn a gateway or assume it is provided externally"""
-    max_concurrent_jobs: int | None = 1
-    """If more jobs submitted at a given time, all but this many wait in a queue"""
+
+
+class CascadeSettings(FiabBaseModel):
+    gateway: UnmanagedGateway | LocalGateway | RemoteGateway = Field(
+        discriminator="gateway_type", default_factory=lambda: LocalGateway(gateway_type="local")
+    )
+    constraints: CascadeConstraints = Field(default_factory=CascadeConstraints)
 
     def validate_runtime(self) -> list[str]:
         errors = []
-        if not _validate_url(self.cascade_url):
-            errors.append(f"not an url: cascade_url={self.cascade_url}")
+        cascade_url = self._get_cascade_url()
+        if not _validate_url(cascade_url):
+            errors.append(f"not an url: cascade_url={cascade_url}")
         return errors
+
+    def _get_cascade_url(self) -> str:
+        if isinstance(self.gateway, LocalGateway):
+            return "tcp://localhost"
+        elif isinstance(self.gateway, RemoteGateway):
+            return self.gateway.cascade_url
+        elif isinstance(self.gateway, UnmanagedGateway):
+            return self.gateway.cascade_url
+        else:
+            assert_never(self.gateway)
 
 
 class FIABConfig(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", env_nested_delimiter="__", env_prefix="fiab__", case_sensitive=True)
 
-    general: GeneralSettings = Field(default_factory=GeneralSettings)
     product: ProductSettings = Field(default_factory=ProductSettings, description="Product specific settings")
 
     auth: AuthSettings = Field(default_factory=AuthSettings)
 
     db: DatabaseSettings = Field(default_factory=DatabaseSettings)
-    api: BackendAPISettings = Field(default_factory=BackendAPISettings)
+    external: ExternalServicesSettings = Field(default_factory=ExternalServicesSettings)
+    backend: BackendSettings = Field(default_factory=BackendSettings)
     cascade: CascadeSettings = Field(default_factory=CascadeSettings)
 
     @classmethod
@@ -311,8 +343,9 @@ class FIABConfig(BaseSettings):
             f.write(self._get_toml(exclude_defaults=True, exclude_none=True))
 
     def validate_runtime(self) -> list[str]:
-        cascade = urllib.parse.urlparse(self.cascade.cascade_url)
-        data_path = urllib.parse.urlparse(self.api.data_path)
+        cascade_url = self.cascade._get_cascade_url()
+        cascade = urllib.parse.urlparse(cascade_url)
+        data_path = urllib.parse.urlparse(self.backend.data_path)
         errors = []
         compatible_scheme_pairs = {
             ("tcp", "file"),
@@ -322,7 +355,7 @@ class FIABConfig(BaseSettings):
             errors.append(f"cascade and data path must use a compatible scheme: {cascade=} != {data_path=}")
         if cascade.scheme == "ssh":
             if cascade.netloc != data_path.netloc:
-                errors.append(f"under ssh://, cascade and data path must use the same netlo: {cascade=} != {data_path=}")
+                errors.append(f"under ssh://, cascade and data path must use the same netloc: {cascade=} != {data_path=}")
         return errors
 
 

--- a/backend/src/forecastbox/utility/config.py
+++ b/backend/src/forecastbox/utility/config.py
@@ -257,7 +257,7 @@ class GatewayStartupParams(FiabBaseModel):
     cascade_logging_base: str | None = None
     """Where to store logs of cascade gw and jobs. Use eg /home/<user>/fiabLogs or /tmp/fiabLogs"""
     shared_path: str | None = None
-    """Shared filesystem path visible to all workers, required for managed Slurm submissions."""
+    """Shared filesystem path visible to all workers, required for Slurm submissions."""
     ssh_cluster_spec: SshClusterSpec | None = None
     """SSH cluster description for sshCluster submissions."""
 
@@ -284,11 +284,13 @@ class UnmanagedGateway(FiabBaseModel):
     gateway_type: Literal["unmanaged"]
     cascade_url: str
     """Base URL for the Cascade API, eg tcp://<hostname>:<port>"""
-    startup_params: GatewayStartupParams = Field(default_factory=GatewayStartupParams)
+
+
+CascadeInfrastructureType = Literal["localProcess", "slurm", "sshCluster"]
 
 
 class CascadeConstraints(FiabBaseModel):
-    default_cascade_infra: Literal["localProcess", "slurm", "sshCluster"] = "localProcess"
+    default_cascade_infra: CascadeInfrastructureType = "localProcess"
     """Default execution infrastructure for jobs if unspecified in a job."""
     default_hosts: int = 1
     """Default number of hosts for Cascade if unspecified in a job."""

--- a/backend/src/forecastbox/utility/config.py
+++ b/backend/src/forecastbox/utility/config.py
@@ -246,11 +246,20 @@ class BackendSettings(FiabBaseModel):
         return errors
 
 
+class SshClusterSpec(FiabBaseModel):
+    controller_url: str
+    worker_urls: list[str]
+
+
 class GatewayStartupParams(FiabBaseModel):
     max_concurrent_jobs: int | None = 1
     """If more jobs submitted at a given time, all but this many wait in a queue"""
     cascade_logging_base: str | None = None
     """Where to store logs of cascade gw and jobs. Use eg /home/<user>/fiabLogs or /tmp/fiabLogs"""
+    shared_path: str | None = None
+    """Shared filesystem path visible to all workers, required for managed Slurm submissions."""
+    ssh_cluster_spec: SshClusterSpec | None = None
+    """SSH cluster description for sshCluster submissions."""
 
 
 class LocalGateway(FiabBaseModel):
@@ -275,9 +284,12 @@ class UnmanagedGateway(FiabBaseModel):
     gateway_type: Literal["unmanaged"]
     cascade_url: str
     """Base URL for the Cascade API, eg tcp://<hostname>:<port>"""
+    startup_params: GatewayStartupParams = Field(default_factory=GatewayStartupParams)
 
 
 class CascadeConstraints(FiabBaseModel):
+    default_cascade_infra: Literal["localProcess", "slurm", "sshCluster"] = "localProcess"
+    """Default execution infrastructure for jobs if unspecified in a job."""
     default_hosts: int = 1
     """Default number of hosts for Cascade if unspecified in a job."""
     max_hosts: int = 1

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -19,6 +19,8 @@ from forecastbox.entrypoint.main import launch_all
 from forecastbox.utility.config import (
     ArtifactStoreConfig,
     FIABConfig,
+    GatewayStartupParams,
+    LocalGateway,
     PluginCompositeIdReadable,
     PluginSettings,
     PluginStoreConfig,
@@ -151,32 +153,32 @@ def backend_client() -> Generator[httpx.Client, None, None]:
 
         config = FIABConfig()
         config.auth.jwt_secret = SecretStr("x" * 32)
-        config.api.uvicorn_port = 30645
-        config.cascade.cascade_url = "tcp://localhost"
+        config.backend.uvicorn_port = 30645
+        config.cascade.gateway = LocalGateway(gateway_type="local", startup_params=GatewayStartupParams())
         config.db.sqlite_userdb_path = f"{td.name}/user.db"
         config.db.sqlite_jobdb_path = f"{td.name}/job.db"
-        config.api.data_path = f"file://{td_data.name}"
-        config.api.allow_scheduler = True
-        config.product.artifact_stores = {
+        config.backend.data_path = f"file://{td_data.name}"
+        config.backend.allow_scheduler = True
+        config.external.artifact_stores = {
             ArtifactStoreId(fake_artifact_store_id): ArtifactStoreConfig(
                 url=f"http://localhost:{fake_artifact_registry_port}/artifacts.json",
                 method="file",
             )
         }
-        config.product.plugin_stores = {
+        config.external.plugin_stores = {
             PluginStoreId("localTest"): PluginStoreConfig(
                 url="file://../../packages/fiab-plugin-test",
                 method="localSingle",
             ),
         }
-        config.product.plugins = {
+        config.external.plugins = {
             testPluginId: PluginSettings(
                 pip_source="-e file://../../packages/fiab-plugin-test",
                 module_name="fiab_plugin_test",
             ),
         }
 
-        config.general.launch_browser = False
+        config.backend.launch_browser = False
         config.auth.domain_allowlist_registry = ["somewhere.org"]
         config.auth.passthrough = False
         validate_runtime(config)
@@ -188,7 +190,7 @@ def backend_client() -> Generator[httpx.Client, None, None]:
 
         validate_runtime(config)
         handles = launch_all(config)
-        client = httpx.Client(base_url=config.api.local_url() + "/api/v1", follow_redirects=True)
+        client = httpx.Client(base_url=config.backend.local_url() + "/api/v1", follow_redirects=True)
         yield client
     finally:
         if client is not None:

--- a/backend/tests/largeE2E/bigtest.py
+++ b/backend/tests/largeE2E/bigtest.py
@@ -13,7 +13,7 @@ import time
 import httpx
 
 from forecastbox.entrypoint.main import launch_all
-from forecastbox.utility.config import FIABConfig, config
+from forecastbox.utility.config import FIABConfig, UnmanagedGateway, config
 
 logger = logging.getLogger("forecastbox.bigtest")
 
@@ -67,19 +67,19 @@ if __name__ == "__main__":
     dataDir = None
     try:
         config = FIABConfig()
-        config.api.uvicorn_port = 30645
+        config.backend.uvicorn_port = 30645
         config.auth.passthrough = True
-        config.cascade.cascade_url = "tcp://localhost:30644"
-        config.general.launch_browser = False
+        config.cascade.gateway = UnmanagedGateway(gateway_type="unmanaged", cascade_url="tcp://localhost:30644")
+        config.backend.launch_browser = False
         if os.environ.get("UNCLEAN", "") != "yea":
             dbDir = tempfile.TemporaryDirectory()
             config.db.sqlite_userdb_path = f"{dbDir.name}/user.db"
             config.db.sqlite_jobdb_path = f"{dbDir.name}/job.db"
             dataDir = tempfile.TemporaryDirectory()
-            config.api.data_path = dataDir.name
+            config.backend.data_path = dataDir.name
 
         handles = launch_all(config, attempts=50)
-        client = httpx.Client(base_url=config.api.local_url() + "/api/v1", follow_redirects=True)
+        client = httpx.Client(base_url=config.backend.local_url() + "/api/v1", follow_redirects=True)
 
         # download model
         client.post(f"/model/{model_id}/download").raise_for_status()

--- a/backend/tests/largeE2E/blueprint.py
+++ b/backend/tests/largeE2E/blueprint.py
@@ -19,7 +19,7 @@ from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
 from forecastbox.domain.blueprint.service import BlueprintBuilder
 from forecastbox.domain.run.cascade import ExecutionSpecification, RawCascadeJob
 from forecastbox.entrypoint.main import launch_all
-from forecastbox.utility.config import FIABConfig
+from forecastbox.utility.config import FIABConfig, UnmanagedGateway
 
 
 def _config(values: dict[str, str]) -> dict[ConfigurationOptionId, str]:
@@ -50,19 +50,19 @@ if __name__ == "__main__":
     try:
         with tempfile.TemporaryDirectory() as tmpdir:
             config = FIABConfig()
-            config.api.uvicorn_port = 30645
+            config.backend.uvicorn_port = 30645
             config.auth.passthrough = True
-            config.cascade.cascade_url = "tcp://localhost:30644"
-            config.general.launch_browser = False
+            config.cascade.gateway = UnmanagedGateway(gateway_type="unmanaged", cascade_url="tcp://localhost:30644")
+            config.backend.launch_browser = False
             if os.environ.get("UNCLEAN", "") != "yea":
                 dbDir = tempfile.TemporaryDirectory()
                 config.db.sqlite_userdb_path = f"{dbDir.name}/user.db"
                 config.db.sqlite_jobdb_path = f"{dbDir.name}/job.db"
                 dataDir = tempfile.TemporaryDirectory()
-                config.api.data_path = dataDir.name
+                config.backend.data_path = dataDir.name
 
             handles = launch_all(config, attempts=50)
-            client = httpx.Client(base_url=config.api.local_url() + "/api/v1", follow_redirects=True)
+            client = httpx.Client(base_url=config.backend.local_url() + "/api/v1", follow_redirects=True)
 
             response = client.get("/blueprint/catalogue").raise_for_status()
             assert len(response.json()) > 0

--- a/backend/tests/unit/domain/gateway/test_service.py
+++ b/backend/tests/unit/domain/gateway/test_service.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+import forecastbox.domain.gateway.service as gateway_service
+from forecastbox.utility.config import GatewayStartupParams, LocalGateway, RemoteGateway, config
+
+
+def test_local_process_entrypoint_passes_shared_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_serve(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(gateway_service, "serve", _fake_serve)
+
+    gateway_service._local_process_entrypoint("tcp://localhost:1234", "/tmp/logs", 2, "/mnt/shared")
+
+    assert captured["url"] == "tcp://localhost:1234"
+    assert captured["shared_path"] == "/mnt/shared"
+    assert captured["max_concurrent_jobs"] == 2
+
+
+@dataclass(frozen=True, slots=True)
+class _FakeHandle:
+    remote_port: int
+
+    def as_local_url(self) -> str:
+        return "tcp://localhost:7777"
+
+
+def test_launch_gateway_remote_passes_shared_path_to_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+    monkeypatch.setattr(
+        config.cascade,
+        "gateway",
+        RemoteGateway(
+            gateway_type="remote",
+            startup_params=GatewayStartupParams(shared_path="/mnt/shared"),
+            cascade_url="ssh://user@example.com:2222",
+        ),
+    )
+    monkeypatch.setattr(gateway_service.tunnel, "setup", lambda host, remote_port: _FakeHandle(remote_port=34567))
+    monkeypatch.setattr(gateway_service.tunnel, "execute", lambda handle, cmd, output_path: captured.update({"cmd": cmd}))
+    monkeypatch.setattr(gateway_service.uuid, "uuid4", lambda: "abc")
+    monkeypatch.setattr(gateway_service.GatewayConnectionManager, "gateway_connection", None)
+
+    gateway_service.launch_gateway()
+
+    cmd = captured["cmd"]
+    assert "--shared_path" in cmd
+    assert cmd[cmd.index("--shared_path") + 1] == "/mnt/shared"
+    gateway_service.GatewayConnectionManager.gateway_connection = None
+
+
+def test_launch_gateway_local_forwards_shared_path_to_process_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    class _FakeProcess:
+        def __init__(self, target: Any, args: tuple[Any, ...]) -> None:
+            captured["target"] = target
+            captured["args"] = args
+            self.pid = 42
+            self.exitcode = None
+
+        def start(self) -> None:
+            return None
+
+    class _FakeCtx:
+        def Process(self, target: Any, args: tuple[Any, ...]) -> _FakeProcess:  # noqa: N802
+            return _FakeProcess(target=target, args=args)
+
+    monkeypatch.setattr(
+        config.cascade,
+        "gateway",
+        LocalGateway(
+            gateway_type="local",
+            startup_params=GatewayStartupParams(shared_path="/mnt/shared"),
+        ),
+    )
+    monkeypatch.setattr(gateway_service, "TemporaryDirectory", lambda *a, **k: type("TD", (), {"name": "/tmp/fiab"})())
+    monkeypatch.setattr(gateway_service.tunnel, "claim_free_port", lambda: 45678)
+    monkeypatch.setattr(gateway_service.platform, "get_mp_ctx", lambda _: _FakeCtx())
+    monkeypatch.setattr(gateway_service.GatewayConnectionManager, "gateway_connection", None)
+
+    gateway_service.launch_gateway()
+
+    assert captured["target"] is gateway_service._local_process_entrypoint
+    assert captured["args"][3] == "/mnt/shared"
+    gateway_service.GatewayConnectionManager.gateway_connection = None

--- a/backend/tests/unit/domain/gateway/test_service.py
+++ b/backend/tests/unit/domain/gateway/test_service.py
@@ -32,30 +32,6 @@ class _FakeHandle:
         return "tcp://localhost:7777"
 
 
-def test_launch_gateway_remote_passes_shared_path_to_command(monkeypatch: pytest.MonkeyPatch) -> None:
-    captured: dict[str, Any] = {}
-    monkeypatch.setattr(
-        config.cascade,
-        "gateway",
-        RemoteGateway(
-            gateway_type="remote",
-            startup_params=GatewayStartupParams(shared_path="/mnt/shared"),
-            cascade_url="ssh://user@example.com:2222",
-        ),
-    )
-    monkeypatch.setattr(gateway_service.tunnel, "setup", lambda host, remote_port: _FakeHandle(remote_port=34567))
-    monkeypatch.setattr(gateway_service.tunnel, "execute", lambda handle, cmd, output_path: captured.update({"cmd": cmd}))
-    monkeypatch.setattr(gateway_service.uuid, "uuid4", lambda: "abc")
-    monkeypatch.setattr(gateway_service.GatewayConnectionManager, "gateway_connection", None)
-
-    gateway_service.launch_gateway()
-
-    cmd = captured["cmd"]
-    assert "--shared_path" in cmd
-    assert cmd[cmd.index("--shared_path") + 1] == "/mnt/shared"
-    gateway_service.GatewayConnectionManager.gateway_connection = None
-
-
 def test_launch_gateway_local_forwards_shared_path_to_process_args(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, Any] = {}
 

--- a/backend/tests/unit/domain/run/test_cascade.py
+++ b/backend/tests/unit/domain/run/test_cascade.py
@@ -161,7 +161,7 @@ def test_execute_cascade_slurm_does_not_require_shared_path_for_unmanaged_gatewa
 
 def test_execute_cascade_ssh_cluster_requires_spec(patch_submit_stack: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(config.cascade, "constraints", CascadeConstraints(default_cascade_infra="localProcess"))
-    monkeypatch.setattr(config.cascade, "gateway", UnmanagedGateway(gateway_type="unmanaged", cascade_url="tcp://gw"))
+    monkeypatch.setattr(config.cascade, "gateway", LocalGateway(gateway_type="local"))
     environment = EnvironmentSpecification(cascade_infra="sshCluster")
 
     with pytest.raises(ValueError, match="ssh_cluster_spec"):

--- a/backend/tests/unit/domain/run/test_cascade.py
+++ b/backend/tests/unit/domain/run/test_cascade.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+import forecastbox.domain.run.cascade as run_cascade
+from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
+from forecastbox.utility.config import (
+    CascadeConstraints,
+    GatewayStartupParams,
+    LocalGateway,
+    SshClusterSpec,
+    UnmanagedGateway,
+    config,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _FakeLocalProcesses:
+    workers_per_host: int
+    hosts: int
+
+
+@dataclass(frozen=True, slots=True)
+class _FakeSlurmCluster:
+    workers_per_host: int
+    hosts: int
+
+
+@dataclass(frozen=True, slots=True)
+class _FakeSshCluster:
+    controller_url: str
+    worker_urls: list[str]
+    workers_per_host: int
+
+
+@dataclass(frozen=True, slots=True)
+class _FakeJobSpec:
+    infra_spec: Any
+    envvars: dict[str, str]
+    job_instance: Any
+
+
+@dataclass(frozen=True, slots=True)
+class _FakeSubmitJobRequest:
+    job: _FakeJobSpec
+
+
+@dataclass(frozen=True, slots=True)
+class _FakeJobInstanceRich:
+    jobInstance: Any
+    checkpointSpec: Any
+
+
+def _spec_with_environment(environment: EnvironmentSpecification) -> run_cascade.ExecutionSpecification:
+    return run_cascade.ExecutionSpecification.model_construct(
+        job=run_cascade.RawCascadeJob.model_construct(job_type="raw_cascade_job", job_instance=object()),
+        environment=environment,
+        shared=False,
+    )
+
+
+@pytest.fixture
+def patch_submit_stack(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    captures: dict[str, Any] = {}
+
+    def _fake_request_response(request: _FakeSubmitJobRequest, url: str) -> str:
+        captures["request"] = request
+        captures["url"] = url
+        return "ok"
+
+    monkeypatch.setattr(run_cascade, "LocalProcesses", _FakeLocalProcesses)
+    monkeypatch.setattr(run_cascade, "SlurmCluster", _FakeSlurmCluster)
+    monkeypatch.setattr(run_cascade, "SshCluster", _FakeSshCluster)
+    monkeypatch.setattr(run_cascade, "JobSpec", _FakeJobSpec)
+    monkeypatch.setattr(run_cascade, "SubmitJobRequest", _FakeSubmitJobRequest)
+    monkeypatch.setattr(run_cascade, "JobInstanceRich", _FakeJobInstanceRich)
+    monkeypatch.setattr(run_cascade, "request_response", _fake_request_response)
+    monkeypatch.setattr(run_cascade, "get_gateway_url", lambda: "tcp://gateway")
+
+    return captures
+
+
+def test_execute_cascade_uses_config_default_infra_when_unset(patch_submit_stack: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config.cascade, "constraints", CascadeConstraints(default_cascade_infra="slurm"))
+    monkeypatch.setattr(config.cascade, "gateway", UnmanagedGateway(gateway_type="unmanaged", cascade_url="tcp://gw"))
+
+    response = run_cascade.execute_cascade(_spec_with_environment(EnvironmentSpecification()))
+
+    assert response == "ok"
+    request = patch_submit_stack["request"]
+    assert isinstance(request.job.infra_spec, _FakeSlurmCluster)
+
+
+def test_execute_cascade_explicit_env_infra_overrides_default(patch_submit_stack: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config.cascade, "constraints", CascadeConstraints(default_cascade_infra="slurm"))
+    monkeypatch.setattr(config.cascade, "gateway", UnmanagedGateway(gateway_type="unmanaged", cascade_url="tcp://gw"))
+    environment = EnvironmentSpecification(cascade_infra="localProcess")
+
+    response = run_cascade.execute_cascade(_spec_with_environment(environment))
+
+    assert response == "ok"
+    request = patch_submit_stack["request"]
+    assert isinstance(request.job.infra_spec, _FakeLocalProcesses)
+
+
+def test_execute_cascade_slurm_requires_shared_path_for_managed_gateway(
+    patch_submit_stack: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(config.cascade, "constraints", CascadeConstraints(default_cascade_infra="localProcess"))
+    monkeypatch.setattr(
+        config.cascade,
+        "gateway",
+        LocalGateway(
+            gateway_type="local",
+            startup_params=GatewayStartupParams(shared_path=None),
+        ),
+    )
+    environment = EnvironmentSpecification(cascade_infra="slurm")
+
+    with pytest.raises(ValueError, match="shared_path"):
+        run_cascade.execute_cascade(_spec_with_environment(environment))
+
+
+def test_execute_cascade_slurm_allows_managed_gateway_when_shared_path_set(
+    patch_submit_stack: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(config.cascade, "constraints", CascadeConstraints(default_cascade_infra="localProcess"))
+    monkeypatch.setattr(
+        config.cascade,
+        "gateway",
+        LocalGateway(
+            gateway_type="local",
+            startup_params=GatewayStartupParams(shared_path="/mnt/shared"),
+        ),
+    )
+    environment = EnvironmentSpecification(cascade_infra="slurm")
+
+    response = run_cascade.execute_cascade(_spec_with_environment(environment))
+
+    assert response == "ok"
+    request = patch_submit_stack["request"]
+    assert isinstance(request.job.infra_spec, _FakeSlurmCluster)
+
+
+def test_execute_cascade_slurm_does_not_require_shared_path_for_unmanaged_gateway(
+    patch_submit_stack: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(config.cascade, "constraints", CascadeConstraints(default_cascade_infra="localProcess"))
+    monkeypatch.setattr(config.cascade, "gateway", UnmanagedGateway(gateway_type="unmanaged", cascade_url="tcp://gw"))
+    environment = EnvironmentSpecification(cascade_infra="slurm")
+
+    response = run_cascade.execute_cascade(_spec_with_environment(environment))
+
+    assert response == "ok"
+    request = patch_submit_stack["request"]
+    assert isinstance(request.job.infra_spec, _FakeSlurmCluster)
+
+
+def test_execute_cascade_ssh_cluster_requires_spec(patch_submit_stack: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config.cascade, "constraints", CascadeConstraints(default_cascade_infra="localProcess"))
+    monkeypatch.setattr(config.cascade, "gateway", UnmanagedGateway(gateway_type="unmanaged", cascade_url="tcp://gw"))
+    environment = EnvironmentSpecification(cascade_infra="sshCluster")
+
+    with pytest.raises(ValueError, match="ssh_cluster_spec"):
+        run_cascade.execute_cascade(_spec_with_environment(environment))
+
+
+def test_execute_cascade_ssh_cluster_uses_gateway_spec(patch_submit_stack: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config.cascade, "constraints", CascadeConstraints(default_cascade_infra="localProcess"))
+    monkeypatch.setattr(
+        config.cascade,
+        "gateway",
+        LocalGateway(
+            gateway_type="local",
+            startup_params=GatewayStartupParams(
+                ssh_cluster_spec=SshClusterSpec(
+                    controller_url="ssh://controller",
+                    worker_urls=["ssh://worker-1", "ssh://worker-2"],
+                )
+            ),
+        ),
+    )
+    environment = EnvironmentSpecification(cascade_infra="sshCluster", workers_per_host=3)
+
+    response = run_cascade.execute_cascade(_spec_with_environment(environment))
+
+    assert response == "ok"
+    request = patch_submit_stack["request"]
+    assert isinstance(request.job.infra_spec, _FakeSshCluster)
+    assert request.job.infra_spec.controller_url == "ssh://controller"
+    assert request.job.infra_spec.worker_urls == ["ssh://worker-1", "ssh://worker-2"]
+    assert request.job.infra_spec.workers_per_host == 3

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1298,7 +1298,7 @@ wheels = [
 
 [[package]]
 name = "earthkit-workflows"
-version = "0.13.0"
+version = "0.13.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "array-api-compat", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -1318,9 +1318,9 @@ dependencies = [
     { name = "sortedcontainers", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "xarray", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/c2/7c8a45b308a9974a1ecc73d0c4efcd6f0bbb4f20dd3ea3889f9c580b7926/earthkit_workflows-0.13.0.tar.gz", hash = "sha256:ec3ffc4fb9f5bef6d26451ba81da622ed1dea76664e57336ec7d1d60207e0f10", size = 10849662, upload-time = "2026-05-28T11:25:26.104Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/57/7da60df4b80cc62cd4cd301a11cba94d616bea03e4ab9a9a9dd2868d9122/earthkit_workflows-0.13.1.tar.gz", hash = "sha256:4ec5ab4c74a5565f7491f7c0c11bb7805c79845288637a1bbdac9965b10ceb3c", size = 10849570, upload-time = "2026-05-29T08:34:56.762Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/03/725120dd43344218efcb6e7458c29205defb56644944924999b8edfff8cc/earthkit_workflows-0.13.0-py3-none-any.whl", hash = "sha256:472c653cb88cb17b70c2aded8981d4abe2ddca12dc40bc89fcd8d0bae26835d1", size = 203801, upload-time = "2026-05-28T11:25:24.626Z" },
+    { url = "https://files.pythonhosted.org/packages/27/8f/ad87fe653a7f7b777674d78305df7953497393920527d7cbbfde214aafa0/earthkit_workflows-0.13.1-py3-none-any.whl", hash = "sha256:0e14fb583cbaac8068d0b9cdd489dec4c6c2c334608a1f27b36164f510597178", size = 203510, upload-time = "2026-05-29T08:34:55.302Z" },
 ]
 
 [[package]]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1298,7 +1298,7 @@ wheels = [
 
 [[package]]
 name = "earthkit-workflows"
-version = "0.12.0"
+version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "array-api-compat", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -1318,9 +1318,9 @@ dependencies = [
     { name = "sortedcontainers", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "xarray", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/64/8e631e881a9b1a4e3cfc29bbc4a41561656650a530dc8b1ef2c5fa82f6c1/earthkit_workflows-0.12.0.tar.gz", hash = "sha256:d37f175e365070e26a26f1221208f9f0956a6f3c307c7c63915a5db3c5ff906d", size = 10838197, upload-time = "2026-05-22T14:52:06.669Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/c2/7c8a45b308a9974a1ecc73d0c4efcd6f0bbb4f20dd3ea3889f9c580b7926/earthkit_workflows-0.13.0.tar.gz", hash = "sha256:ec3ffc4fb9f5bef6d26451ba81da622ed1dea76664e57336ec7d1d60207e0f10", size = 10849662, upload-time = "2026-05-28T11:25:26.104Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/86/866c218e902bf70b080b1e9f717487b3bd77756d86673963857cb4da6291/earthkit_workflows-0.12.0-py3-none-any.whl", hash = "sha256:c7ecc07104c115df27d11a30d373e75a7bae584282e40b05d46b0865d80059e7", size = 198669, upload-time = "2026-05-22T14:52:05.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/03/725120dd43344218efcb6e7458c29205defb56644944924999b8edfff8cc/earthkit_workflows-0.13.0-py3-none-any.whl", hash = "sha256:472c653cb88cb17b70c2aded8981d4abe2ddca12dc40bc89fcd8d0bae26835d1", size = 203801, upload-time = "2026-05-28T11:25:24.626Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description
1/ general config changes for more clarity and coherence (backwards incompatible, see below for "migration guide")
2/ bump of ewk & corresponding api adaptation
3/ fix unit and integration tests to not be affected by .env files and .fiab homes
4/ extend the config and job submission to support slurm/sshCluster submissions


# Config Migration Guide
1. Field name changes:
   - config.api → config.backend (BackendAPISettings → BackendSettings)
   - config.product (artifact_stores, plugin_stores, plugins) → config.external (ExternalServicesSettings)
   - config.product.model_repository moved to config.external.model_repository

2. Gateway settings restructuring:
   - Replaced single spawn_gateway boolean with discriminated union of three gateway types
   - LocalGateway for local testing (no cascade_url needed, defaults to tcp://localhost)
   - RemoteGateway for remote SSH-based gateway management
   - UnmanagedGateway for externally managed gateway instances
   - Use isinstance() checks instead of spawn_gateway boolean
   - Gateway-specific startup parameters (max_concurrent_jobs, cascade_logging_base) are now in startup_params

3. Cascade constraints:
   - Moved max_hosts, default_hosts, default_workers_per_host, max_workers_per_host to config.cascade.constraints

