### PR TITLE
[plugin]:  pre-fill Map Plot block configuration defaults

### DIFF
--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -479,7 +479,7 @@ class MapPlotSink(Sink):
             title="Parameters",
             description="Parameters to select and plot (e.g. '2t', 'msl')",
             value_type="list[str]",
-            default_value="2t",
+            default_value="2t,msl",
         ),
         DOMAIN: BlockConfigurationOption(
             title="Domain",
@@ -497,7 +497,7 @@ class MapPlotSink(Sink):
             title="Group By",
             description="Dimension to create subplots over",
             value_type="enumClosed['valid_datetime', 'step', 'number', 'none']",
-            default_value="none",
+            default_value="step",
         ),
         SPLITBY: BlockConfigurationOption(
             title="Split By",

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -479,16 +479,19 @@ class MapPlotSink(Sink):
             title="Parameters",
             description="Parameters to select and plot (e.g. '2t', 'msl')",
             value_type="list[str]",
+            default_value="2t",
         ),
         DOMAIN: BlockConfigurationOption(
             title="Domain",
             description="Geographic domain: global, europe, or a named region",
             value_type="str",
+            default_value="global",
         ),
         FORMAT: BlockConfigurationOption(
             title="Format",
             description="Output image format",
             value_type="enumClosed['png', 'pdf', 'svg']",
+            default_value="png",
         ),
         GROUPBY: BlockConfigurationOption(
             title="Group By",
@@ -500,6 +503,7 @@ class MapPlotSink(Sink):
             title="Split By",
             description="Dimensions to separate plots by",
             value_type="list[str]",
+            default_value="none",
         ),
         # ConfigurationOptionId("style_schema"): BlockConfigurationOption(
         #     title="Style Schema",


### PR DESCRIPTION
Adds `default_value`s to the Map Plot (`mapPlotSink`) block options so a freshly-added block is valid out of the box instead of showing "Missing required value" on every field. 

The frontend already seeds fields from the backend's `default_value` on add (`createBlockInstance`), so no frontend change is needed.

### Changes (`mapPlotSink`)
- `param` → `2t`, `domain` → `global`, `format` → `png`, `splitby` → `none` (`groupby` already `none`).

@HCookie : Please recheck if these defaults make sense or amend if required.

### Notes
- Defaults apply only on first add, stay overridable, and a cleared field stays blank.
- `param='2t'` is near-universal and bootstraps the dynamic Parameters combobox — the per-source restriction only flows once the block validates.
### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
