### PR TITLE
[cd] fix release action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -88,7 +88,7 @@ jobs:
           uv pip install pytest pytest-xdist pytest-asyncio pytest-subtests pytest-mock # TODO how to get this from pyproject?
           uv pip install -e packages/fiab-plugin-test
           # TODO redesign the workflow to allow for arch-platform matrix here...? But from where to push the lock?
-          pytest ./tests
+          just val
           popd
 
           # upload

--- a/backend/tests/unit/utility/test_tunnel.py
+++ b/backend/tests/unit/utility/test_tunnel.py
@@ -202,7 +202,7 @@ def test_status_execute_and_stop_use_existing_control_socket(
                 "-o",
                 "ConnectTimeout=10",
                 "user@fiabServer",
-                "nohup uv run python -m cascade.gateway --port 22001 >/dev/null 2>&1 < /dev/null &",
+                "nohup bash --login -c 'uv run python -m cascade.gateway --port 22001' > /dev/null 2>&1 < /dev/null &",
             ],
             True,
             False,


### PR DESCRIPTION
it was running vanilla pytest instead of just val

that accidentally revealed that some tests were left rotting in tests/utility instead of tests/unit -- fixed tests and moved them
