### PR TITLE
[backend] finegrain ty check

### DIFF
--- a/backend/justfile
+++ b/backend/justfile
@@ -1,5 +1,5 @@
 val:
-    uv run ty check
+    uv run ty check src/
     FIAB_IGNORE_CONFIG_SOURCES=1 uv run pytest -n4 tests/unit
     FIAB_IGNORE_CONFIG_SOURCES=1 uv run pytest tests/integration
 

--- a/backend/packages/fiab-core/justfile
+++ b/backend/packages/fiab-core/justfile
@@ -1,5 +1,5 @@
 val:
-    uv run ty check
+    uv run ty check src/
     uv run pytest
 
 build:

--- a/backend/packages/fiab-mcp-server/justfile
+++ b/backend/packages/fiab-mcp-server/justfile
@@ -1,5 +1,5 @@
 val:
-    uv run ty check
+    uv run ty check src/
     uv run pytest
 
 build:

--- a/backend/packages/fiab-plugin-demo/justfile
+++ b/backend/packages/fiab-plugin-demo/justfile
@@ -1,5 +1,5 @@
 val:
-    uv run ty check
+    uv run ty check src/
     uv run pytest
 
 build:

--- a/backend/packages/fiab-plugin-test/justfile
+++ b/backend/packages/fiab-plugin-test/justfile
@@ -1,5 +1,5 @@
 val:
-    uv run ty check
+    uv run ty check src/
     uv run pytest
 
 build:

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1623,7 +1623,6 @@ dev = [{ name = "ty", specifier = "==0.0.2" }]
 
 [[package]]
 name = "fiab-plugin-test"
-version = "0.1.0"
 source = { editable = "packages/fiab-plugin-test" }
 dependencies = [
     { name = "fiab-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },


### PR DESCRIPTION
was causing just val on cd to fail because of missing pkgs -- we dont want the full workspace there