### PR TITLE
Fix block metadata mapping

### DIFF
--- a/backend/src/forecastbox/domain/run/compile.py
+++ b/backend/src/forecastbox/domain/run/compile.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from cascade.low.core import DatasetId, TaskId
 from cascade.low.func import assert_never
 from earthkit.workflows.compilers import graph2job
+from earthkit.workflows.fluent import PayloadBuildingContext
 from earthkit.workflows.graph import Graph, deduplicate_nodes
 from fiab_core.artifacts import CompositeArtifactId
 from fiab_core.fable import BlockInstanceId, BlockInstanceOutput, NoOutput, RawOutput
@@ -108,7 +109,8 @@ def compile_builder(
         if converted_values.t is None:
             raise ValueError(f"compile failed at {blockId=} with {converted_values.e}")
         blockInstance.configuration_values = converted_values.t
-        result = plugin.compiler(action_lookup, blockId, blockInstance)
+        with PayloadBuildingContext(blockId=blockId):
+            result = plugin.compiler(action_lookup, blockId, blockInstance)
         if result.t is None:
             raise ValueError(f"compile failed at {blockId=} with {result.e}")
         action_lookup[blockId] = result.t
@@ -127,15 +129,9 @@ def compile_builder(
         except Exception as e:
             raise ValueError(f"compile failed at {blockId=} with {e}")
 
-        # TODO this is inefficient -- every task in a source block gets traversed as
-        # many times as there are sinks. Instead, we should utilize the Context for
-        # metadata enrichment during compilation to inject BlockId, and retrieve that
-        # at the end. Sinks should also be collected from the cascade graph presumably
         if block_factory.kind == "sink":
             block_graph = action_lookup[blockId].graph()
-            for node in block_graph.nodes():
-                task_id, detail = fluentNode_to_detail(node, blockId)
-                task_detail[task_id] = detail
+
             sink_tasks.update(
                 _fluentName_to_taskId(node.name)
                 for node in block_graph.sinks
@@ -149,6 +145,13 @@ def compile_builder(
             graph += block_graph
 
     graph = deduplicate_nodes(graph)
+    for node in graph.nodes():
+        metadata = getattr(node.payload, "metadata", None)
+        if not isinstance(metadata, dict) or "blockId" not in metadata:
+            raise ValueError(f"compile failed: missing blockId metadata on task {node.name}")
+        task_block_id = metadata["blockId"]
+        task_id, detail = fluentNode_to_detail(node, task_block_id)
+        task_detail[task_id] = detail
     job_instance = graph2job(graph)
 
     job_instance.ext_outputs = [dataset_id for task_id in sink_tasks for dataset_id in job_instance.outputs_of(task_id)]

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -969,8 +969,17 @@ def test_blueprint_composite_glyph_execute(tmpdir: Any, backend_client_with_auth
         configuration_values=_config({"fname": f"{tmpdir}/composite_exec_output.txt"}),
         input_ids={"data": BlockInstanceId("source_text")},
     )
+    sink_file_2 = BlockInstance(
+        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("sink_file")),
+        configuration_values=_config({"fname": f"{tmpdir}/composite_exec_output_2.txt"}),
+        input_ids={"data": BlockInstanceId("source_text")},
+    )
     builder = BlueprintBuilder(
-        blocks={BlockInstanceId("source_text"): source_text, BlockInstanceId("sink_file"): sink_file},
+        blocks={
+            BlockInstanceId("source_text"): source_text,
+            BlockInstanceId("sink_file"): sink_file,
+            BlockInstanceId("sink_file_2"): sink_file_2,
+        },
         local_glyphs={"compositeLocalGlyphExec": "${compositeExecGlobalPart}/${runId}"},
     )
     save_resp = backend_client_with_auth.post("/blueprint/create", json=BlueprintSaveCommand(builder=builder).model_dump())
@@ -987,13 +996,23 @@ def test_blueprint_composite_glyph_execute(tmpdir: Any, backend_client_with_auth
     detail_resp = backend_client_with_auth.get("/run/getCompilationDetail", params={"run_id": run_id})
     assert detail_resp.is_success, detail_resp.text
     detail = CompilationDetailResponse.model_validate(detail_resp.json())
-    assert len(detail.tasks) == 2, f"Expected 2 tasks, got {len(detail.tasks)}: {detail.tasks}"
+    assert len(detail.tasks) == 3, f"Expected 3 tasks, got {len(detail.tasks)}: {detail.tasks}"
+    assert {task.block for task in detail.tasks} == {
+        BlockInstanceId("source_text"),
+        BlockInstanceId("sink_file"),
+        BlockInstanceId("sink_file_2"),
+    }
 
     output = pathlib.Path(f"{tmpdir}/composite_exec_output.txt")
     content = output.read_text()
     # Content must be "exec_global/<run_id>"
     assert content == f"exec_global/{run_id}", f"Unexpected output: {content!r}"
     output.unlink()
+
+    output_2 = pathlib.Path(f"{tmpdir}/composite_exec_output_2.txt")
+    content_2 = output_2.read_text()
+    assert content_2 == f"exec_global/{run_id}", f"Unexpected output: {content_2!r}"
+    output_2.unlink()
 
     # Clean up the global glyph created in this test
     del_resp = backend_client_with_auth.post(


### PR DESCRIPTION
Switches taskId2blockId derivation from graph traversal to metadata tagging

Addresses a certain frontend-visible bug for graphs with more than two nodes -- cc @liefra 