### PR TITLE
Grib MIME

### DIFF
--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -77,6 +77,8 @@ GRIB_ALIASES = {
     "level": "levelist",
 }
 
+GRIB_MIME = "text/plain; fiab-format=gribdir"
+
 logger = logging.getLogger(__name__)
 
 PLOT_FORMAT_TO_MIME: dict[str, str] = {
@@ -433,7 +435,7 @@ class GribSink(Sink):
         dirname = os.path.dirname(path)
         if len(self._find_template_values(dirname)) != 0:
             return Either.error(f"Invalid filepath: directory path can not contain template values")
-        return Either.ok(RawOutput(type_fqn="bytes", mime_type="text/plain"))
+        return Either.ok(RawOutput(type_fqn="bytes", mime_type=GRIB_MIME))
 
     def compile(
         self,

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/runtime/sinks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/runtime/sinks.py
@@ -15,4 +15,5 @@ def write_grib(fieldlist: earthkit.data.SimpleFieldList, path: str) -> bytes:
     p.parent.mkdir(parents=True, exist_ok=True)
     formatted_path = path.replace("[", "{").replace("]", "}")
     fieldlist.to_target("file-pattern", formatted_path)
-    return path.encode("ascii")
+    # Returning the parent directory as file-pattern may write multiple files
+    return str(p.parent).encode("ascii")


### PR DESCRIPTION
### Description

This pull request updates the handling of GRIB output files in the ECMWF plugin to better reflect the output format and file structure. The main improvements include introducing a custom MIME type for GRIB directory outputs and ensuring that the output path returned for file-pattern writes is the parent directory rather than a single file.

**GRIB output handling improvements:**

* Introduced a new `GRIB_MIME` constant (`text/plain; fiab-format=gribdir`) to accurately describe the MIME type for GRIB directory outputs in `blocks.py`.
* Updated the `validate` method in `blocks.py` to use the new `GRIB_MIME` constant when returning the output type, ensuring downstream consumers are aware of the output format.
* Modified the `write_grib` function in `runtime/sinks.py` to return the parent directory path (as a byte string) instead of the file path, since the file-pattern write may produce multiple files.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
