### PR TITLE
[ci] disable broken rust action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,7 @@ jobs:
         working-directory: cli
     steps:
       - uses: actions/checkout@v6
-      - uses: moonrepo/setup-rust@v1
+      # TODO this needs to be fixed -- the setup rust action *fails* on cleanup due to cache command not being there, and even though there should be cargo install on runners, it was not at the time I tried that
+      # - uses: moonrepo/setup-rust@v1
       - name: Cargo tests
-        run: cargo test # TODO we actually have no tests, neither unit nor integration!
+        run: echo "disabled until cargo fixed" # cargo test # TODO we actually have no tests, neither unit nor integration!


### PR DESCRIPTION
broken cargo setup -- disabling so that `main` runs of CI dont always fail