### PR TITLE
Implement c-tag publishing flow

### DIFF
--- a/.github/workflows/cd-artifacts_update.yml
+++ b/.github/workflows/cd-artifacts_update.yml
@@ -1,0 +1,65 @@
+name: cd artifacts update
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Base tag. Use cX.Y.Z
+        type: string
+        required: true
+
+jobs:
+  update:
+    name: "Validate and tag artifacts"
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: astral-sh/setup-uv@v7
+      - run: |
+          set -euo pipefail
+          BASE_TAG="${{ inputs.tag }}"
+          echo "$BASE_TAG" | grep -Eq '^c[0-9]+\.[0-9]+\.[0-9]+$' || {
+            echo "expected tag in the form cX.Y.Z" >&2
+            exit 1
+          }
+
+          git fetch --tags origin
+
+          VERSION="${BASE_TAG#c}"
+          HIGHEST_TAG=$(
+            git tag -l "${BASE_TAG}.*" \
+            | grep -E "^${BASE_TAG}\.[0-9]+$" \
+            | sort -V \
+            | tail -n1
+          )
+          if [ -z "$HIGHEST_TAG" ] ; then
+            HIGHEST_TAG="${BASE_TAG}.0"
+          fi
+
+          CHANGED_FILES=$(git diff --name-only "$HIGHEST_TAG" HEAD)
+          if [ -z "$CHANGED_FILES" ] ; then
+            echo "expected at least artifacts.json to differ from $HIGHEST_TAG" >&2
+            exit 1
+          fi
+          if printf '%s\n' "$CHANGED_FILES" | grep -vx 'install/artifacts.json' >/dev/null ; then
+            echo "unexpected files changed relative to $HIGHEST_TAG" >&2
+            printf '%s\n' "$CHANGED_FILES" >&2
+            exit 1
+          fi
+          if ! printf '%s\n' "$CHANGED_FILES" | grep -qx 'install/artifacts.json' ; then
+            echo "artifacts.json must be part of the changes relative to $HIGHEST_TAG" >&2
+            exit 1
+          fi
+
+          uv run --no-project --with "fiab-core==${VERSION}" python backend/packages/fiab-core/scripts/parse_artifacts_catalog.py install/artifacts.json
+
+          IFS='.' read -r MAJOR MINOR PATCH BUILD <<< "${HIGHEST_TAG#c}"
+          NEW_TAG="c${MAJOR}.${MINOR}.${PATCH}.$((BUILD + 1))"
+          git tag "$NEW_TAG"
+          git push origin "$NEW_TAG"

--- a/.github/workflows/cd-plugins.yaml
+++ b/.github/workflows/cd-plugins.yaml
@@ -8,7 +8,7 @@ on:
       tag:
         description: Explicit tag. Use cX.Y.Z, make sure its free on pypi
         type: string
-        required: true
+        required: false
       testpypi:
         description: Whether to upload to testpypi instead of pypi.
         type: boolean
@@ -32,12 +32,31 @@ jobs:
           if [ "${{ inputs.testpypi }}" = "true" ] ; then
             set -x
           fi
+          git fetch --tags origin
+
           TAG_PREF="c"
           TAG_FULL="${{ inputs.tag }}"
-          case "$TAG_FULL" in
-            c*) ;;
-            *) echo "expected tag in the form cX.Y.Z" >&2; exit 1 ;;
-          esac
+          if [ -n "$TAG_FULL" ] ; then
+            echo "$TAG_FULL" | grep -Eq '^c[0-9]+\.[0-9]+\.[0-9]+$' || {
+              echo "expected tag in the form cX.Y.Z" >&2
+              exit 1
+            }
+          else
+            LATEST_BASE=$(
+              git tag -l 'c*' \
+              | sed -nE 's/^c([0-9]+\.[0-9]+\.[0-9]+)(\.[0-9]+)?$/\1/p' \
+              | sort -V \
+              | tail -n1
+            )
+            if [ -z "$LATEST_BASE" ] ; then
+              LATEST_BASE="0.0.0"
+            fi
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$LATEST_BASE"
+            NEW_PATCH=$((PATCH + 1))
+            TAG_FULL="${TAG_PREF}${MAJOR}.${MINOR}.${NEW_PATCH}"
+            echo "determined tag = $TAG_FULL"
+          fi
+
           TAG="${TAG_FULL}.0"
           export SETUPTOOLS_SCM_PRETEND_VERSION=${TAG_FULL#$TAG_PREF}
 

--- a/.github/workflows/cd-plugins.yaml
+++ b/.github/workflows/cd-plugins.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Explicit tag. Use vX.Y.Z, make sure its free on pypi
+        description: Explicit tag. Use cX.Y.Z, make sure its free on pypi
         type: string
         required: true
       testpypi:
@@ -21,6 +21,8 @@ jobs:
     name: "Build and upload"
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v7
@@ -30,8 +32,13 @@ jobs:
           if [ "${{ inputs.testpypi }}" = "true" ] ; then
             set -x
           fi
-          TAG_PREF="v"
+          TAG_PREF="c"
           TAG_FULL="${{ inputs.tag }}"
+          case "$TAG_FULL" in
+            c*) ;;
+            *) echo "expected tag in the form cX.Y.Z" >&2; exit 1 ;;
+          esac
+          TAG="${TAG_FULL}.0"
           export SETUPTOOLS_SCM_PRETEND_VERSION=${TAG_FULL#$TAG_PREF}
 
           cd backend
@@ -56,7 +63,9 @@ jobs:
             TARGET=""
           fi
           twine upload --verbose $TARGET packagesDist/*
+
+          git tag "$TAG"
+          git push origin "$TAG"
         env:
           TWINE_PASSWORD_PROD: ${{ secrets.PYPI_API_TOKEN }}
           TWINE_PASSWORD_TEST: ${{ secrets.PYPI_TEST_API_TOKEN }}
-

--- a/backend/packages/fiab-core/justfile
+++ b/backend/packages/fiab-core/justfile
@@ -1,6 +1,7 @@
 val:
     uv run ty check src/
     uv run pytest
+    uv run python scripts/parse_artifacts_catalog.py ../../../install/artifacts.json
 
 build:
     python -m build --installer uv .

--- a/backend/packages/fiab-core/scripts/parse_artifacts_catalog.py
+++ b/backend/packages/fiab-core/scripts/parse_artifacts_catalog.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+#
+# (C) Copyright 2026- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from collections.abc import Sequence
+from pathlib import Path
+
+from fiab_core.artifacts import ArtifactStoreId, parse_json
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("path", type=Path)
+    args = parser.parse_args(argv)
+
+    data = args.path.read_text()
+    dict(parse_json(ArtifactStoreId("validation"), data, lambda _checkpoint: (True, None)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/packages/fiab-core/scripts/parse_artifacts_catalog.py
+++ b/backend/packages/fiab-core/scripts/parse_artifacts_catalog.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from fiab_core.artifacts import ArtifactStoreId, parse_json
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Sequence[str] | None = None) -> None:
     import argparse
 
     parser = argparse.ArgumentParser()
@@ -24,8 +24,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     data = args.path.read_text()
     dict(parse_json(ArtifactStoreId("validation"), data, lambda _checkpoint: (True, None)))
-    return 0
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    main()

--- a/backend/packages/fiab-core/src/fiab_core/artifacts.py
+++ b/backend/packages/fiab-core/src/fiab_core/artifacts.py
@@ -11,10 +11,11 @@
 Declarations related to Artifacts such as ML Model Checkpoints.
 """
 
-from collections.abc import Callable, Mapping
+import json
+from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal, NewType, Self
+from typing import Any, Literal, NewType, Self, cast
 
 from pydantic import Field
 
@@ -149,3 +150,32 @@ class ArtifactsProvider:
         if cls._get_artifact_local_path is None:
             raise RuntimeError("ArtifactsProvider.get_artifact_local_path has not been registered")
         return cls._get_artifact_local_path(composite_id)
+
+
+def parse_json(
+    store_id: ArtifactStoreId,
+    data: str,
+    compatibility_check: Callable[[AnemoiCheckpoint], tuple[bool, str | None]],
+) -> Iterator[tuple[CompositeArtifactId, ArtifactResolved]]:
+    """Parse an artifacts.json payload into resolved artifacts."""
+    store_data = json.loads(data)
+    artifacts = store_data.get("artifacts", {})
+    for artifact_id, artifact_data in artifacts.items():
+        composite_id = CompositeArtifactId(artifact_store_id=store_id, artifact_local_id=ArtifactLocalId(artifact_id))
+        artifact_type = cast(ArtifactType, artifact_data["artifact_type"])
+        store_info_data = artifact_data["store_info"]
+        if artifact_type == "AnemoiCheckpoint":
+            store_info = AnemoiCheckpoint(**store_info_data)
+            is_locally_compatible, local_compatibility_detail = compatibility_check(store_info)
+        else:
+            raise ValueError(f"Unsupported artifact type: {artifact_type}")
+
+        yield (
+            composite_id,
+            ArtifactResolved(
+                artifact_type=artifact_type,
+                store_info=store_info,
+                is_locally_compatible=is_locally_compatible,
+                local_compatibility_detail=local_compatibility_detail,
+            ),
+        )

--- a/backend/packages/fiab-core/tests/test_artifacts.py
+++ b/backend/packages/fiab-core/tests/test_artifacts.py
@@ -1,0 +1,46 @@
+# (C) Copyright 2026- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import json
+
+from fiab_core.artifacts import AnemoiCheckpoint, ArtifactLocalId, ArtifactStoreId, CompositeArtifactId, parse_json
+
+
+def test_parse_json() -> None:
+    payload = {
+        "display_name": "Store",
+        "artifacts": {
+            "model1": {
+                "artifact_type": "AnemoiCheckpoint",
+                "store_info": {
+                    "url": "https://example.com/model1.ckpt",
+                    "display_name": "Model 1",
+                    "display_author": "ECMWF",
+                    "display_description": "Example model",
+                    "disk_size_bytes": 1,
+                    "pip_package_constraints": [],
+                    "supported_platforms": ["linux"],
+                    "input_characteristics": [],
+                    "input_qube": {},
+                    "output_qube": {},
+                    "timestep": "1h",
+                },
+            }
+        },
+    }
+
+    parsed = dict(parse_json(ArtifactStoreId("store1"), json.dumps(payload), lambda checkpoint: (True, checkpoint.display_name)))
+
+    composite_id = CompositeArtifactId(artifact_store_id=ArtifactStoreId("store1"), artifact_local_id=ArtifactLocalId("model1"))
+    artifact = parsed[composite_id]
+
+    assert isinstance(artifact.store_info, AnemoiCheckpoint)
+    assert artifact.store_info.display_name == "Model 1"
+    assert artifact.is_locally_compatible is True
+    assert artifact.local_compatibility_detail == "Model 1"

--- a/backend/src/forecastbox/domain/artifact/catalog.py
+++ b/backend/src/forecastbox/domain/artifact/catalog.py
@@ -9,21 +9,32 @@
 
 """Artifact catalog: loading and querying available artifacts from remote stores."""
 
-import json
 import logging
-from typing import cast
+from urllib.parse import urlparse, urlunparse
 
 import httpx
 from cascade.low.func import assert_never
-from fiab_core.artifacts import AnemoiCheckpoint, ArtifactLocalId, ArtifactResolved, ArtifactStoreId, ArtifactType
+from fiab_core.artifacts import parse_json
 from pyrsistent import pmap
 
-from forecastbox.domain.artifact.base import ArtifactCatalog, CompositeArtifactId
+from forecastbox.domain.artifact.base import ArtifactCatalog
 from forecastbox.domain.artifact.compatibility import get_model_checkpoint_compatibility, get_platform_info
 from forecastbox.utility.config import ArtifactStoresConfig
+from forecastbox.utility.git import get_all_repo_tags, get_highest_tag
 from forecastbox.utility.httpx import fetch_content
 
 logger = logging.getLogger(__name__)
+
+
+def _tagged_url(url: str, tag: str) -> str:
+    parsed = urlparse(url)
+    parts = parsed.path.split("/")
+    for index in range(len(parts) - 2):
+        if parts[index] == "refs" and parts[index + 1] == "heads":
+            parts[index + 1] = "tags"
+            parts[index + 2] = tag
+            return urlunparse(parsed._replace(path="/".join(parts)))
+    raise ValueError(f"Cannot derive tagged URL from {url}")
 
 
 def get_artifacts_catalog(artifact_stores_config: ArtifactStoresConfig) -> ArtifactCatalog:
@@ -34,27 +45,19 @@ def get_artifacts_catalog(artifact_stores_config: ArtifactStoresConfig) -> Artif
     with httpx.Client(follow_redirects=True) as client:
         for store_id, store_config in artifact_stores_config.items():
             if store_config.method == "file":
-                raw = fetch_content(store_config.url, client)
-                store_data = json.loads(raw)
-                artifacts = store_data.get("artifacts", {})
-                for artifact_id, artifact_data in artifacts.items():
-                    composite_id = CompositeArtifactId(artifact_store_id=store_id, artifact_local_id=ArtifactLocalId(artifact_id))
-                    artifact_type = cast(ArtifactType, artifact_data["artifact_type"])
-                    store_info_data = artifact_data["store_info"]
-                    if artifact_type == "AnemoiCheckpoint":
-                        store_info = AnemoiCheckpoint(**store_info_data)
-                        is_locally_compatible, local_compatibility_detail = get_model_checkpoint_compatibility(store_info, platform_info)
-                    else:
-                        assert_never(artifact_type)
-
-                    catalog[composite_id] = ArtifactResolved(
-                        artifact_type=artifact_type,
-                        store_info=store_info,
-                        is_locally_compatible=is_locally_compatible,
-                        local_compatibility_detail=local_compatibility_detail,
-                    )
-                    logger.debug(f"Loaded artifact {composite_id} from store {store_id}")
+                raw = fetch_content(store_config.url, client).decode("utf-8")
+            elif store_config.method == "gittag":
+                tag = get_highest_tag(tag for tag in get_all_repo_tags(client) if tag.startswith("c"))
+                raw = fetch_content(_tagged_url(store_config.url, tag), client).decode("utf-8")
             else:
                 assert_never(store_config.method)
+
+            for composite_id, artifact in parse_json(
+                store_id,
+                raw,
+                lambda store_info: get_model_checkpoint_compatibility(store_info, platform_info),
+            ):
+                catalog[composite_id] = artifact
+                logger.debug(f"Loaded artifact {composite_id} from store {store_id}")
 
     return pmap(catalog)

--- a/backend/src/forecastbox/domain/artifact/catalog.py
+++ b/backend/src/forecastbox/domain/artifact/catalog.py
@@ -9,12 +9,11 @@
 
 """Artifact catalog: loading and querying available artifacts from remote stores."""
 
-import logging
-from urllib.parse import urlparse, urlunparse
+from collections.abc import Iterator
 
 import httpx
 from cascade.low.func import assert_never
-from fiab_core.artifacts import parse_json
+from fiab_core.artifacts import ArtifactResolved, CompositeArtifactId, parse_json
 from pyrsistent import pmap
 
 from forecastbox.domain.artifact.base import ArtifactCatalog
@@ -23,41 +22,33 @@ from forecastbox.utility.config import ArtifactStoresConfig
 from forecastbox.utility.git import get_all_repo_tags, get_highest_tag
 from forecastbox.utility.httpx import fetch_content
 
-logger = logging.getLogger(__name__)
-
 
 def _tagged_url(url: str, tag: str) -> str:
-    parsed = urlparse(url)
-    parts = parsed.path.split("/")
-    for index in range(len(parts) - 2):
-        if parts[index] == "refs" and parts[index + 1] == "heads":
-            parts[index + 1] = "tags"
-            parts[index + 2] = tag
-            return urlunparse(parsed._replace(path="/".join(parts)))
-    raise ValueError(f"Cannot derive tagged URL from {url}")
+    return url.replace("${TAG}", tag)
+
+
+def _iter_artifacts(
+    artifact_stores_config: ArtifactStoresConfig,
+    client: httpx.Client,
+) -> Iterator[tuple[CompositeArtifactId, ArtifactResolved]]:
+    platform_info = get_platform_info()
+    for store_id, store_config in artifact_stores_config.items():
+        if store_config.method == "file":
+            raw = fetch_content(store_config.url, client).decode("utf-8")
+        elif store_config.method == "gittag":
+            tag = get_highest_tag(tag for tag in get_all_repo_tags(client) if tag.startswith("c"))
+            raw = fetch_content(_tagged_url(store_config.url, tag), client).decode("utf-8")
+        else:
+            assert_never(store_config.method)
+
+        yield from parse_json(
+            store_id,
+            raw,
+            lambda store_info: get_model_checkpoint_compatibility(store_info, platform_info),
+        )
 
 
 def get_artifacts_catalog(artifact_stores_config: ArtifactStoresConfig) -> ArtifactCatalog:
     """Query each artifact store and return a composed catalog of all available artifacts."""
-    catalog = {}
-    platform_info = get_platform_info()
-
     with httpx.Client(follow_redirects=True) as client:
-        for store_id, store_config in artifact_stores_config.items():
-            if store_config.method == "file":
-                raw = fetch_content(store_config.url, client).decode("utf-8")
-            elif store_config.method == "gittag":
-                tag = get_highest_tag(tag for tag in get_all_repo_tags(client) if tag.startswith("c"))
-                raw = fetch_content(_tagged_url(store_config.url, tag), client).decode("utf-8")
-            else:
-                assert_never(store_config.method)
-
-            for composite_id, artifact in parse_json(
-                store_id,
-                raw,
-                lambda store_info: get_model_checkpoint_compatibility(store_info, platform_info),
-            ):
-                catalog[composite_id] = artifact
-                logger.debug(f"Loaded artifact {composite_id} from store {store_id}")
-
-    return pmap(catalog)
+        return pmap(_iter_artifacts(artifact_stores_config, client))

--- a/backend/src/forecastbox/domain/artifact/catalog.py
+++ b/backend/src/forecastbox/domain/artifact/catalog.py
@@ -9,7 +9,10 @@
 
 """Artifact catalog: loading and querying available artifacts from remote stores."""
 
+import importlib.metadata
+import logging
 from collections.abc import Iterator
+from itertools import chain
 
 import httpx
 from cascade.low.func import assert_never
@@ -22,33 +25,40 @@ from forecastbox.utility.config import ArtifactStoresConfig
 from forecastbox.utility.git import get_all_repo_tags, get_highest_tag
 from forecastbox.utility.httpx import fetch_content
 
-
-def _tagged_url(url: str, tag: str) -> str:
-    return url.replace("${TAG}", tag)
-
-
-def _iter_artifacts(
-    artifact_stores_config: ArtifactStoresConfig,
-    client: httpx.Client,
-) -> Iterator[tuple[CompositeArtifactId, ArtifactResolved]]:
-    platform_info = get_platform_info()
-    for store_id, store_config in artifact_stores_config.items():
-        if store_config.method == "file":
-            raw = fetch_content(store_config.url, client).decode("utf-8")
-        elif store_config.method == "gittag":
-            tag = get_highest_tag(tag for tag in get_all_repo_tags(client) if tag.startswith("c"))
-            raw = fetch_content(_tagged_url(store_config.url, tag), client).decode("utf-8")
-        else:
-            assert_never(store_config.method)
-
-        yield from parse_json(
-            store_id,
-            raw,
-            lambda store_info: get_model_checkpoint_compatibility(store_info, platform_info),
-        )
+logger = logging.getLogger(__name__)
 
 
 def get_artifacts_catalog(artifact_stores_config: ArtifactStoresConfig) -> ArtifactCatalog:
     """Query each artifact store and return a composed catalog of all available artifacts."""
+    artifacts_iter = iter(())
     with httpx.Client(follow_redirects=True) as client:
-        return pmap(_iter_artifacts(artifact_stores_config, client))
+        platform_info = get_platform_info()
+        for store_id, store_config in artifact_stores_config.items():
+            if store_config.method == "file":
+                raw = fetch_content(store_config.url, client).decode("utf-8")
+            elif store_config.method == "gittag":
+                core_version = importlib.metadata.version("fiab-core")
+                if core_version == "0.0.0":
+                    logger.debug("fiab-core is 0.0.0, assuming development environment and picking highest tag for artifact catalog fetch")
+                    tag_prefix = "c"
+                else:
+                    logger.debug(f"considering fiab-core's version {core_version} for artifact catalog fetch")
+                    tag_prefix = f"c{core_version}"
+                actual_tag = get_highest_tag(tag for tag in get_all_repo_tags(client) if tag.startswith(tag_prefix))
+
+                logger.debug(f"going with tag {actual_tag} for artifact catalog fetch")
+                resolved_url = store_config.url.replace("${TAG}", actual_tag)
+                raw = fetch_content(resolved_url, client).decode("utf-8")
+            else:
+                assert_never(store_config.method)
+
+            artifacts_iter = chain(
+                artifacts_iter,
+                parse_json(
+                    store_id,
+                    raw,
+                    lambda store_info: get_model_checkpoint_compatibility(store_info, platform_info),
+                ),
+            )
+
+    return pmap(artifacts_iter)

--- a/backend/src/forecastbox/utility/config.py
+++ b/backend/src/forecastbox/utility/config.py
@@ -157,6 +157,12 @@ class ArtifactStoreConfig(FiabBaseModel):
     url: str
     method: Literal["file", "gittag"]
 
+    @model_validator(mode="after")
+    def validate_method_url(self) -> Self:
+        if self.method == "gittag" and "${TAG}" not in self.url:
+            raise ValueError("for method='gittag', url must contain ${TAG}")
+        return self
+
 
 ArtifactStoresConfig = dict[ArtifactStoreId, ArtifactStoreConfig]
 

--- a/backend/src/forecastbox/utility/config.py
+++ b/backend/src/forecastbox/utility/config.py
@@ -155,7 +155,7 @@ def _default_plugin_stores() -> PluginStoresConfig:
 
 class ArtifactStoreConfig(FiabBaseModel):
     url: str
-    method: Literal["file"]
+    method: Literal["file", "gittag"]
 
 
 ArtifactStoresConfig = dict[ArtifactStoreId, ArtifactStoreConfig]

--- a/backend/src/forecastbox/utility/config.py
+++ b/backend/src/forecastbox/utility/config.py
@@ -170,8 +170,8 @@ ArtifactStoresConfig = dict[ArtifactStoreId, ArtifactStoreConfig]
 def _default_artifact_stores() -> ArtifactStoresConfig:
     return {
         ArtifactStoreId("ecmwf"): ArtifactStoreConfig(
-            url="https://raw.githubusercontent.com/ecmwf/forecast-in-a-box/refs/heads/main/install/artifacts.json",
-            method="file",
+            url="https://raw.githubusercontent.com/ecmwf/forecast-in-a-box/refs/tags/${TAG}/install/artifacts.json",
+            method="gittag",
         ),
     }
 

--- a/backend/src/forecastbox/utility/git.py
+++ b/backend/src/forecastbox/utility/git.py
@@ -16,7 +16,7 @@ import httpx
 
 _GITHUB_OWNER = "ecmwf"
 _GITHUB_REPO = "forecast-in-a-box"
-_TAG_RE = re.compile(r"^c(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:\.(?P<build>\d+))?$")
+_PREFIXED_VERSION_TAG_RE = re.compile(r"^[a-z](?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:\.(?P<build>\d+))?$")
 
 
 def get_all_repo_tags(client: httpx.Client) -> Iterator[str]:
@@ -37,11 +37,11 @@ def get_all_repo_tags(client: httpx.Client) -> Iterator[str]:
 
 
 def get_highest_tag(tags: Iterator[str]) -> str:
-    """Return the highest semantic c-tag from an iterator."""
+    """Return the highest prefixed semantic version tag from an iterator."""
     best_tag: str | None = None
     best_key: tuple[int, int, int, int] | None = None
     for tag in tags:
-        match = _TAG_RE.fullmatch(tag)
+        match = _PREFIXED_VERSION_TAG_RE.fullmatch(tag)
         if match is None:
             continue
         major = int(match.group("major") or 0)
@@ -53,5 +53,5 @@ def get_highest_tag(tags: Iterator[str]) -> str:
             best_key = key
             best_tag = tag
     if best_tag is None:
-        raise ValueError("No c-tags found")
+        raise ValueError("No version tags found")
     return best_tag

--- a/backend/src/forecastbox/utility/git.py
+++ b/backend/src/forecastbox/utility/git.py
@@ -1,0 +1,57 @@
+# (C) Copyright 2026- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Helpers for reading repository tags from GitHub."""
+
+import re
+from collections.abc import Iterator
+
+import httpx
+
+_GITHUB_OWNER = "ecmwf"
+_GITHUB_REPO = "forecast-in-a-box"
+_TAG_RE = re.compile(r"^c(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:\.(?P<build>\d+))?$")
+
+
+def get_all_repo_tags(client: httpx.Client) -> Iterator[str]:
+    """Yield all repository tags from the GitHub API."""
+    page = 1
+    while True:
+        response = client.get(
+            f"https://api.github.com/repos/{_GITHUB_OWNER}/{_GITHUB_REPO}/tags",
+            params={"per_page": 100, "page": page},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if not payload:
+            return
+        for tag_data in payload:
+            yield tag_data["name"]
+        page += 1
+
+
+def get_highest_tag(tags: Iterator[str]) -> str:
+    """Return the highest semantic c-tag from an iterator."""
+    best_tag: str | None = None
+    best_key: tuple[int, int, int, int] | None = None
+    for tag in tags:
+        match = _TAG_RE.fullmatch(tag)
+        if match is None:
+            continue
+        major = int(match.group("major") or 0)
+        minor = int(match.group("minor") or 0)
+        patch = int(match.group("patch") or 0)
+        build = int(match.group("build") or 0)
+        key = (major, minor, patch, build)
+        if best_key is None or key > best_key:
+            best_key = key
+            best_tag = tag
+    if best_tag is None:
+        raise ValueError("No c-tags found")
+    return best_tag

--- a/backend/tests/unit/test_artifacts.py
+++ b/backend/tests/unit/test_artifacts.py
@@ -134,9 +134,6 @@ def test_composite_artifact_id_from_str_missing_colon() -> None:
         CoreCompositeArtifactId.from_str("no_colon_here")
 
 
-import pytest
-
-
 def test_get_artifacts_catalog(sample_artifact_stores_config: Any, sample_checkpoint: Any) -> None:
     """Test getting artifacts catalog from multiple stores"""
     store1_data = {
@@ -183,10 +180,44 @@ def test_get_artifacts_catalog(sample_artifact_stores_config: Any, sample_checkp
             assert artifact.local_compatibility_detail is None
 
 
+def test_get_artifacts_catalog_from_git_tag(sample_checkpoint: Any) -> None:
+    """Test that gittag stores fetch artifacts from the highest c-tag."""
+    store_data = {
+        "display_name": "Store 1",
+        "artifacts": {
+            "model1": {"artifact_type": "AnemoiCheckpoint", "store_info": sample_checkpoint.model_dump()},
+        },
+    }
+
+    config: ArtifactStoresConfig = {
+        ArtifactStoreId("store1"): ArtifactStoreConfig(
+            url="https://raw.githubusercontent.com/ecmwf/forecast-in-a-box/refs/heads/main/install/artifacts.json",
+            method="gittag",
+        ),
+    }
+
+    with patch("httpx.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value.__enter__.return_value = mock_client
+        with patch("forecastbox.domain.artifact.catalog.get_all_repo_tags", return_value=iter(["v1.2.3", "c0.0.7.0", "c0.0.8.0"])):
+            with patch("forecastbox.domain.artifact.catalog.fetch_content") as mock_fetch:
+                mock_fetch.return_value = json.dumps(store_data).encode()
+
+                catalog = get_artifacts_catalog(config)
+
+    expected_url = "https://raw.githubusercontent.com/ecmwf/forecast-in-a-box/refs/tags/c0.0.8.0/install/artifacts.json"
+    mock_fetch.assert_called_once_with(expected_url, mock_client)
+    assert len(catalog) == 1
+    composite_id = CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1"))
+    assert composite_id in catalog
+
+
 def test_get_artifacts_catalog_with_error(sample_artifact_stores_config: Any) -> None:
     """Test get_artifacts_catalog raises when there's a network error"""
-    with patch("httpx.get") as mock_get:
-        mock_get.side_effect = httpx.HTTPError("Network error")
+    with patch("httpx.Client") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value.__enter__.return_value = mock_client
+        mock_client.get.side_effect = httpx.HTTPError("Network error")
         with pytest.raises(httpx.HTTPError):
             get_artifacts_catalog(sample_artifact_stores_config)
 

--- a/backend/tests/unit/test_artifacts.py
+++ b/backend/tests/unit/test_artifacts.py
@@ -191,7 +191,7 @@ def test_get_artifacts_catalog_from_git_tag(sample_checkpoint: Any) -> None:
 
     config: ArtifactStoresConfig = {
         ArtifactStoreId("store1"): ArtifactStoreConfig(
-            url="https://raw.githubusercontent.com/ecmwf/forecast-in-a-box/refs/heads/main/install/artifacts.json",
+            url="https://raw.githubusercontent.com/ecmwf/forecast-in-a-box/refs/tags/${TAG}/install/artifacts.json",
             method="gittag",
         ),
     }
@@ -210,6 +210,14 @@ def test_get_artifacts_catalog_from_git_tag(sample_checkpoint: Any) -> None:
     assert len(catalog) == 1
     composite_id = CompositeArtifactId(ArtifactStoreId("store1"), ArtifactLocalId("model1"))
     assert composite_id in catalog
+
+
+def test_artifact_store_config_requires_placeholder_for_gittag() -> None:
+    with pytest.raises(ValueError, match=r"url must contain \$\{TAG\}"):
+        ArtifactStoreConfig(
+            url="https://raw.githubusercontent.com/ecmwf/forecast-in-a-box/refs/tags/main/install/artifacts.json",
+            method="gittag",
+        )
 
 
 def test_get_artifacts_catalog_with_error(sample_artifact_stores_config: Any) -> None:

--- a/backend/tests/unit/utility/test_git.py
+++ b/backend/tests/unit/utility/test_git.py
@@ -1,0 +1,45 @@
+# (C) Copyright 2026- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from forecastbox.utility.git import get_all_repo_tags, get_highest_tag
+
+
+def test_get_all_repo_tags_paginates() -> None:
+    client = MagicMock()
+    first = MagicMock()
+    first.raise_for_status.return_value = None
+    first.json.return_value = [{"name": "c0.0.7.0"}, {"name": "v1.0.0"}]
+
+    second = MagicMock()
+    second.raise_for_status.return_value = None
+    second.json.return_value = []
+
+    client.get.side_effect = [first, second]
+
+    assert list(get_all_repo_tags(client)) == ["c0.0.7.0", "v1.0.0"]
+
+
+@pytest.mark.parametrize(
+    ("tags", "expected"),
+    [
+        (["c0.0.6.0", "c0.0.7.0", "c0.0.8.0"], "c0.0.8.0"),
+        (["c1.0.0.0", "c0.9.9.9", "c1.0.0.1"], "c1.0.0.1"),
+    ],
+)
+def test_get_highest_tag(tags: list[str], expected: str) -> None:
+    assert get_highest_tag(iter(tags)) == expected
+
+
+def test_get_highest_tag_ignores_non_c_tags() -> None:
+    with pytest.raises(ValueError):
+        get_highest_tag(iter(["v1.0.0", "d1.0.0"]))

--- a/backend/tests/unit/utility/test_git.py
+++ b/backend/tests/unit/utility/test_git.py
@@ -34,12 +34,13 @@ def test_get_all_repo_tags_paginates() -> None:
     [
         (["c0.0.6.0", "c0.0.7.0", "c0.0.8.0"], "c0.0.8.0"),
         (["c1.0.0.0", "c0.9.9.9", "c1.0.0.1"], "c1.0.0.1"),
+        (["v1.0.0", "d1.2.0", "c1.1.9"], "d1.2.0"),
     ],
 )
 def test_get_highest_tag(tags: list[str], expected: str) -> None:
     assert get_highest_tag(iter(tags)) == expected
 
 
-def test_get_highest_tag_ignores_non_c_tags() -> None:
+def test_get_highest_tag_ignores_non_version_tags() -> None:
     with pytest.raises(ValueError):
-        get_highest_tag(iter(["v1.0.0", "d1.0.0"]))
+        get_highest_tag(iter(["1.0.0", "release"]))

--- a/docs/developer/changeSpecs/serverside-model_registry.md
+++ b/docs/developer/changeSpecs/serverside-model_registry.md
@@ -3,7 +3,8 @@
 ## Affected User Flows
 User wants to run a forecast using a model checkpoint.
 
-## Current status
+## Current Status
+### As of 2026.06.03
 A model registry exists as a file on github, see the `install/` at the repo's top level.
 There is an `artifacts` domain and router in the backend that interacts with it.
 The `fiab-core` package within backend defines the basic contract.
@@ -15,6 +16,13 @@ In particular, it forbids us merging any breaking changes into the `main` branch
 There are two assumptions:
 1. Model releases are occassional now, but expected to increase in the future -- thus a short term solution can involve a chore when there is a new model, but a long term solution cannot.
 2. We expect to have a number of distinct clients in the wild -- multiple deployment scenarios, not necessarily sharing the same version or feature set. This is expected to only grow.
+
+### Update on 2026.06.04
+We have implemented the `Finer git-side management` option, see below for details, and assume that server side is the long term goal.
+Migration towards server-side would involve:
+1/ adding a new ArtifactsStoreConfig option and its implementation -- presumably utilizing the same `core_version` variable required for the newly-added `gittag` option.
+2/ changing the `just val` of fiab-core to instead validate the artifacts compatibility with the server
+3/ the `cd-artifacts_update.yml` GH action would become a CLI command instead
 
 ## Options
 


### PR DESCRIPTION
1/ adds a new gittag method to artifacts store config
2/ said gittag retrieves all tags of the form cX.Y.Z.d from the repo, filters for those which share X.Y.Z with current fiab-core version, and retrieves the artifacts.json for the highest of them
3/ makes the fiab-core release verify that current artifacts.json is compatible with it
4/ adds a new gh action that pushes d+1 for the given cX.Y.Z, verifying there is no other change except artifacts.json, and that even changed it still parses