### PR TITLE
Lead time validation

### DIFF
--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
@@ -15,7 +15,6 @@ from cascade.low.func import Either
 from earthkit.workflows.fluent import Action
 from earthkit.workflows.plugins.anemoi.fluent import Inference, get_initial_conditions  # ty: ignore[unresolved-import]
 from earthkit.workflows.plugins.anemoi.types import DATE
-from fiab_core.artifacts import CompositeArtifactId
 from fiab_core.fable import (
     ActionLookup,
     BlockConfigurationOption,
@@ -145,9 +144,13 @@ class AnemoiSource(Source):
         if ensemble_members < 1:
             return Either.error("Ensemble members must be an int, positive and non zero.")
 
-        qubed_output = CheckpointArtifact(CompositeArtifactId.from_str(block.config_as_str(CHECKPOINT))).get_model_output(
-            lead_time=block.config_as_int(LEAD_TIME, validator=positive)
-        )
+        checkpoint = CheckpointArtifact(block.config_as_str(CHECKPOINT))
+        lead_time = block.config_as_int(LEAD_TIME, validator=positive)
+        validation_error = checkpoint.validate_lead_time(lead_time)
+        if validation_error is not None:
+            return Either.error(validation_error)
+
+        qubed_output = checkpoint.get_model_output(lead_time=lead_time)
         if ensemble_members > 1:
             qubed_output = expand(qubed_output, {"number": range(1, ensemble_members + 1)})
         return Either.ok(qubed_output)
@@ -234,14 +237,18 @@ class AnemoiTransform(Transform):
     }
 
     def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
-        qubed_input = CheckpointArtifact(block.config_as_str(CHECKPOINT)).get_model_input()
+        checkpoint = CheckpointArtifact(block.config_as_str(CHECKPOINT))
+        qubed_input = checkpoint.get_model_input()
         if not contains(inputs["dataset"], qubed_input):
             difference_qube = qubed_input ^ inputs["dataset"].dataqube
             return Either.error(f"Input dataset is not compatible with the model checkpoint. Difference in qubes: {difference_qube}")
 
-        qubed_output = CheckpointArtifact(block.config_as_str(CHECKPOINT)).get_model_output(
-            lead_time=block.config_as_int(LEAD_TIME, validator=positive)
-        )
+        lead_time = block.config_as_int(LEAD_TIME, validator=positive)
+        validation_error = checkpoint.validate_lead_time(lead_time)
+        if validation_error is not None:
+            return Either.error(validation_error)
+
+        qubed_output = checkpoint.get_model_output(lead_time=lead_time)
 
         input_dataset = inputs["dataset"]
         if contains(input_dataset, "number"):

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/utils.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/utils.py
@@ -23,6 +23,15 @@ INPUT_SOURCE_CONFIGURATION_OPTIONS = {"polytope": {"collection": "initial-condit
 logger = logging.getLogger(__name__)
 
 
+def _timestep_seconds(timestep: str) -> int:
+    from earthkit.data.utils.dates import to_timedelta
+
+    timestep_seconds = int(to_timedelta(timestep).total_seconds())
+    if timestep_seconds <= 0:
+        raise ValueError(f"Checkpoint timestep must be positive, got {timestep!r}")
+    return timestep_seconds
+
+
 def get_available_checkpoints() -> dict[CompositeArtifactId, AnemoiCheckpoint]:
     all_artifacts = ArtifactsProvider.get_artifacts_lookup()
     return {
@@ -68,15 +77,25 @@ class CheckpointArtifact:
         checkpoint = self.checkpoint()
         return Qube.from_json(checkpoint.input_qube)
 
+    def validate_lead_time(self, lead_time: int) -> str | None:
+        """Validate configured lead time against the checkpoint timestep."""
+        checkpoint = self.checkpoint()
+        model_step_seconds = _timestep_seconds(checkpoint.timestep)
+        lead_time_seconds = lead_time * 3600
+
+        if lead_time_seconds <= model_step_seconds:
+            return f"Configuration option 'lead_time' must be greater than checkpoint timestep {checkpoint.timestep!r}, got {lead_time}h"
+        if lead_time_seconds % model_step_seconds != 0:
+            return f"Configuration option 'lead_time' must be a multiple of checkpoint timestep {checkpoint.timestep!r}, got {lead_time}h"
+        return None
+
     def get_model_output(self, lead_time: int) -> QubedOutput:
         """Get the model output qube from the checkpoint artifact"""
         checkpoint = self.checkpoint()
         qube = Qube.from_json(checkpoint.output_qube)
 
-        from earthkit.data.utils.dates import to_timedelta
-
         lead_time_seconds = lead_time * 3600
-        model_step_seconds = int(to_timedelta(checkpoint.timestep).total_seconds())
+        model_step_seconds = _timestep_seconds(checkpoint.timestep)
         steps = list(map(lambda x: x // 3600, range(model_step_seconds, lead_time_seconds + model_step_seconds, model_step_seconds)))
 
         qubeoutput = QubedOutput(dataqube=qube)

--- a/backend/packages/fiab-plugin-ecmwf/tests/conftest.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/conftest.py
@@ -35,7 +35,9 @@ DUMMY_QUBE = Qube.from_json(
 
 
 @contextlib.contextmanager
-def dummy_provider() -> Generator[None, None, None]:
+def dummy_provider(*, timestep: str = "1h") -> Generator[None, None, None]:
+    previous_get_artifacts_lookup = ArtifactsProvider._get_artifacts_lookup
+    previous_get_artifact_local_path = ArtifactsProvider._get_artifact_local_path
     ArtifactsProvider.register_get_artifacts_lookup(
         lambda: {
             CompositeArtifactId.from_str("dummy_store:dummy_ckpt"): ArtifactResolved(
@@ -51,7 +53,7 @@ def dummy_provider() -> Generator[None, None, None]:
                     input_characteristics=[],
                     input_qube=DUMMY_QUBE.to_json(),
                     output_qube=DUMMY_QUBE.to_json(),
-                    timestep="1h",
+                    timestep=timestep,
                     comment="A dummy comment",
                 ),
                 is_locally_compatible=True,
@@ -62,9 +64,11 @@ def dummy_provider() -> Generator[None, None, None]:
     ArtifactsProvider.register_get_artifact_local_path(
         lambda composite_id: Path(f"/local/path/for/{CompositeArtifactId.to_str(composite_id)}")
     )
-    yield
-    ArtifactsProvider._get_artifacts_lookup = None
-    ArtifactsProvider._get_artifact_local_path = None
+    try:
+        yield
+    finally:
+        ArtifactsProvider._get_artifacts_lookup = previous_get_artifacts_lookup
+        ArtifactsProvider._get_artifact_local_path = previous_get_artifact_local_path
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -77,6 +81,12 @@ def registered_provider() -> Generator[None, None, None]:
 @pytest.fixture(scope="module")
 def dummy_checkpoint() -> str:
     return "dummy_store:dummy_ckpt"
+
+
+@pytest.fixture
+def six_hour_dummy_checkpoint() -> Generator[str, None, None]:
+    with dummy_provider(timestep="6h"):
+        yield "dummy_store:dummy_ckpt"
 
 
 @pytest.fixture(scope="module")

--- a/backend/packages/fiab-plugin-ecmwf/tests/runtime/test_anemoi_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/runtime/test_anemoi_blocks.py
@@ -186,6 +186,24 @@ class TestAnemoiSourceValidate:
         with pytest.raises(BlockInstanceConfigurationError, match="must be positive"):
             AnemoiSource().validate(block=block, inputs={})
 
+    def test_invalid_lead_time_equal_to_timestep(self, dummy_checkpoint: str) -> None:
+        block = _make_block(
+            AnemoiSource,
+            {"checkpoint": dummy_checkpoint, "lead_time": 1, "base_time": datetime(2024, 1, 1), "number": 1},
+        )
+        result = AnemoiSource().validate(block=block, inputs={})
+        with pytest.raises(Exception, match="must be greater than checkpoint timestep"):
+            result.get_or_raise()
+
+    def test_invalid_lead_time_not_a_timestep_multiple(self, six_hour_dummy_checkpoint: str) -> None:
+        block = _make_block(
+            AnemoiSource,
+            {"checkpoint": six_hour_dummy_checkpoint, "lead_time": 7, "base_time": datetime(2024, 1, 1), "number": 1},
+        )
+        result = AnemoiSource().validate(block=block, inputs={})
+        with pytest.raises(Exception, match="must be a multiple of checkpoint timestep"):
+            result.get_or_raise()
+
     def test_invalid_number_zero(self, dummy_checkpoint: str) -> None:
         block = _make_block(
             AnemoiSource,
@@ -339,6 +357,17 @@ class TestAnemoiTransformValidate:
         )
         with pytest.raises(BlockInstanceConfigurationError, match="must be positive"):
             AnemoiTransform().validate(block=block, inputs={"dataset": input_dataset})
+
+    def test_invalid_lead_time_not_a_timestep_multiple(self, six_hour_dummy_checkpoint: str, dummy_qube: Qube) -> None:
+        input_dataset = QubedOutput(dataqube=dummy_qube)
+        block = _make_block(
+            AnemoiTransform,
+            {"checkpoint": six_hour_dummy_checkpoint, "lead_time": 7},
+            input_ids={"dataset": "src"},
+        )
+        result = AnemoiTransform().validate(block=block, inputs={"dataset": input_dataset})
+        with pytest.raises(Exception, match="must be a multiple of checkpoint timestep"):
+            result.get_or_raise()
 
     def test_unknown_checkpoint(self, registered_provider: None, dummy_qube: Qube) -> None:
         input_dataset = QubedOutput(dataqube=dummy_qube)


### PR DESCRIPTION
### Description
This pull request adds stricter validation for the `lead_time` configuration option in Anemoi blocks, ensuring it is compatible with the checkpoint's timestep. The changes improve error handling and test coverage for invalid `lead_time` values, and refactor related code for clarity and maintainability.

**Validation improvements:**

* Added a `validate_lead_time` method to `CheckpointArtifact`, which checks that `lead_time` is greater than the checkpoint timestep and is a multiple of it. This validation is now called in both `AnemoiSource` and `AnemoiTransform` blocks before generating model outputs. [[1]](diffhunk://#diff-be733c2f434eb142a49bf382f3c170b7eee6b58136db9a6d953c5987b4b733e4R80-R98) [[2]](diffhunk://#diff-986656ee6c60fe2c1f2feee364b670c2ef6b09140ab590b8bb590f55d337825eL148-R153) [[3]](diffhunk://#diff-986656ee6c60fe2c1f2feee364b670c2ef6b09140ab590b8bb590f55d337825eL237-R251)
* Extracted timestep parsing logic to a new `_timestep_seconds` utility function, improving code reuse and error messages for invalid timesteps.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
