### PR TITLE
New approach for dynamic configuration restrictions

### DIFF
--- a/backend/packages/fiab-core/src/fiab_core/plugin.py
+++ b/backend/packages/fiab-core/src/fiab_core/plugin.py
@@ -24,6 +24,7 @@ from fiab_core.fable import (
     BlockInstance,
     BlockInstanceId,
     BlockInstanceOutput,
+    ConfigurationOptionRestriction,
 )
 
 Error = str
@@ -31,7 +32,10 @@ Validator = Callable[[BlockInstance, dict[str, BlockInstanceOutput]], Either[Blo
 """Given a block instance corresponding to this plugin's Factory and its inputs, either provide error or determine what it outputs"""
 
 Expander = Callable[[BlockInstanceOutput], list[BlockExpansion]]
-"""Given a block instance output (including from other plugin), provide which block factories from this plugin can expand it"""
+"""Given a block instance output, provide which block factories can expand it"""
+
+Restrictor = Callable[[BlockInstance, dict[str, BlockInstanceOutput]], ConfigurationOptionRestriction]
+"""Given a block instance and its inputs, provide restrictions for the block's own configuration options"""
 
 Compiler = Callable[
     [ActionLookup, BlockInstanceId, BlockInstance], Either[Action, Error]  # type:ignore[invalid-argument] # semigroup
@@ -51,3 +55,4 @@ class Plugin:
     validator: Validator
     expander: Expander
     compiler: Compiler
+    restrictor: Restrictor | None = None

--- a/backend/packages/fiab-core/src/fiab_core/plugin.py
+++ b/backend/packages/fiab-core/src/fiab_core/plugin.py
@@ -11,8 +11,8 @@
 Types pertaining to declaring FIAB Plugins, in particular their Fable-based interface.
 """
 
-from dataclasses import dataclass
-from typing import Callable, NamedTuple
+from dataclasses import dataclass, field
+from typing import Callable
 
 from cascade.low.func import Either
 from earthkit.workflows.fluent import Action
@@ -29,9 +29,10 @@ from fiab_core.fable import (
 Error = str
 
 
-class BlockValidation(NamedTuple):
+@dataclass(frozen=True, eq=True, slots=True)
+class BlockValidation:
     result: Either[BlockInstanceOutput, Error]  # type:ignore[invalid-argument] # semigroup
-    restrictions: ConfigurationOptionRestriction = {}
+    restrictions: ConfigurationOptionRestriction = field(default_factory=dict)
 
     def get_or_raise(self) -> BlockInstanceOutput:
         return self.result.get_or_raise()

--- a/backend/packages/fiab-core/src/fiab_core/plugin.py
+++ b/backend/packages/fiab-core/src/fiab_core/plugin.py
@@ -50,7 +50,7 @@ Validator = Callable[[BlockInstance, dict[str, BlockInstanceOutput]], BlockValid
 """Given a block instance and its inputs, return either error or output and configuration restrictions"""
 
 Expander = Callable[[BlockInstanceOutput], list[BlockExpansion]]
-"""Given a block instance output, provide which block factories can expand it"""
+"""Given a block instance output (including from other plugin), provide which block factories from this plugin can expand it"""
 
 Compiler = Callable[[ActionLookup, BlockInstance], Either[Action, Error]]  # type:ignore[invalid-argument] # semigroup
 """Given a cascade builder, represented as lookup of fluent actions, and a block instance corresponding to this plugin's Factory, either return the fluent action resulting from this block or an error"""

--- a/backend/packages/fiab-core/src/fiab_core/plugin.py
+++ b/backend/packages/fiab-core/src/fiab_core/plugin.py
@@ -12,7 +12,7 @@ Types pertaining to declaring FIAB Plugins, in particular their Fable-based inte
 """
 
 from dataclasses import dataclass
-from typing import Callable
+from typing import Callable, NamedTuple
 
 from cascade.low.func import Either
 from earthkit.workflows.fluent import Action
@@ -28,14 +28,29 @@ from fiab_core.fable import (
 )
 
 Error = str
-Validator = Callable[[BlockInstance, dict[str, BlockInstanceOutput]], Either[BlockInstanceOutput, Error]]  # type:ignore[invalid-argument] # semigroup
-"""Given a block instance corresponding to this plugin's Factory and its inputs, either provide error or determine what it outputs"""
+
+
+class BlockValidation(NamedTuple):
+    result: Either[BlockInstanceOutput, Error]  # type:ignore[invalid-argument] # semigroup
+    restrictions: ConfigurationOptionRestriction = {}
+
+    def get_or_raise(self) -> BlockInstanceOutput:
+        return self.result.get_or_raise()
+
+    @property
+    def t(self) -> BlockInstanceOutput | None:
+        return self.result.t
+
+    @property
+    def e(self) -> Error | None:
+        return self.result.e
+
+
+Validator = Callable[[BlockInstance, dict[str, BlockInstanceOutput]], BlockValidation]
+"""Given a block instance and its inputs, return either error or output and configuration restrictions"""
 
 Expander = Callable[[BlockInstanceOutput], list[BlockExpansion]]
 """Given a block instance output, provide which block factories can expand it"""
-
-Restrictor = Callable[[BlockInstance, dict[str, BlockInstanceOutput]], ConfigurationOptionRestriction]
-"""Given a block instance and its inputs, provide restrictions for the block's own configuration options"""
 
 Compiler = Callable[
     [ActionLookup, BlockInstanceId, BlockInstance], Either[Action, Error]  # type:ignore[invalid-argument] # semigroup
@@ -55,4 +70,3 @@ class Plugin:
     validator: Validator
     expander: Expander
     compiler: Compiler
-    restrictor: Restrictor | None = None

--- a/backend/packages/fiab-core/src/fiab_core/plugin.py
+++ b/backend/packages/fiab-core/src/fiab_core/plugin.py
@@ -22,7 +22,6 @@ from fiab_core.fable import (
     BlockExpansion,
     BlockFactoryCatalogue,
     BlockInstance,
-    BlockInstanceId,
     BlockInstanceOutput,
     ConfigurationOptionRestriction,
 )
@@ -52,9 +51,7 @@ Validator = Callable[[BlockInstance, dict[str, BlockInstanceOutput]], BlockValid
 Expander = Callable[[BlockInstanceOutput], list[BlockExpansion]]
 """Given a block instance output, provide which block factories can expand it"""
 
-Compiler = Callable[
-    [ActionLookup, BlockInstanceId, BlockInstance], Either[Action, Error]  # type:ignore[invalid-argument] # semigroup
-]
+Compiler = Callable[[ActionLookup, BlockInstance], Either[Action, Error]]  # type:ignore[invalid-argument] # semigroup
 """Given a cascade builder, represented as lookup of fluent actions, and a block instance corresponding to this plugin's Factory, either return the fluent action resulting from this block or an error"""
 
 

--- a/backend/packages/fiab-core/src/fiab_core/tools/blocks.py
+++ b/backend/packages/fiab-core/src/fiab_core/tools/blocks.py
@@ -188,7 +188,8 @@ class QubedBlockBuilder(abc.ABC):
     def intersect(self, other: QubedOutput) -> bool:
         raise NotImplementedError
 
-    def restrictions(self, other: QubedOutput) -> ConfigurationOptionRestriction:
+    def restrictions(self, block: BlockInstanceRich, inputs: dict[str, QubedOutput]) -> ConfigurationOptionRestriction:
+        del block, inputs
         return {}
 
     def as_catalogue(self) -> BlockFactory:

--- a/backend/packages/fiab-core/src/fiab_core/tools/blocks.py
+++ b/backend/packages/fiab-core/src/fiab_core/tools/blocks.py
@@ -21,7 +21,6 @@ from fiab_core.fable import (
     BlockConfigurationOption,
     BlockFactory,
     BlockInstance,
-    BlockInstanceId,
     BlockInstanceOutput,
     BlockKind,
     ConfigurationOptionId,
@@ -179,7 +178,6 @@ class QubedBlockBuilder(abc.ABC):
     def compile(
         self,
         inputs: ActionLookup,
-        block_id: BlockInstanceId,
         block: BlockInstance,
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         raise NotImplementedError

--- a/backend/packages/fiab-core/src/fiab_core/tools/blocks.py
+++ b/backend/packages/fiab-core/src/fiab_core/tools/blocks.py
@@ -25,10 +25,9 @@ from fiab_core.fable import (
     BlockInstanceOutput,
     BlockKind,
     ConfigurationOptionId,
-    ConfigurationOptionRestriction,
     QubedOutput,
 )
-from fiab_core.plugin import Error
+from fiab_core.plugin import BlockValidation, Error
 from fiab_core.types import ClosedEnumType, DatetimeType, DateType, FloatType, IntType, ListType, OpenEnumType, StringType
 
 
@@ -174,7 +173,7 @@ class QubedBlockBuilder(abc.ABC):
     configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption]
     inputs: list[str]
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
+    def validate(self, block: BlockInstanceRich, inputs: dict[str, QubedOutput]) -> BlockValidation:
         raise NotImplementedError
 
     def compile(
@@ -187,10 +186,6 @@ class QubedBlockBuilder(abc.ABC):
 
     def intersect(self, other: QubedOutput) -> bool:
         raise NotImplementedError
-
-    def restrictions(self, block: BlockInstanceRich, inputs: dict[str, QubedOutput]) -> ConfigurationOptionRestriction:
-        del block, inputs
-        return {}
 
     def as_catalogue(self) -> BlockFactory:
         return BlockFactory(

--- a/backend/packages/fiab-core/src/fiab_core/tools/plugins.py
+++ b/backend/packages/fiab-core/src/fiab_core/tools/plugins.py
@@ -14,10 +14,9 @@ from fiab_core.fable import (
     BlockInstance,
     BlockInstanceId,
     BlockInstanceOutput,
-    ConfigurationOptionRestriction,
     QubedOutput,
 )
-from fiab_core.plugin import Error, Plugin
+from fiab_core.plugin import BlockValidation, Error, Plugin
 from fiab_core.tools.blocks import BlockInstanceConfigurationError, BlockInstanceRich, QubedBlockBuilder
 
 
@@ -53,14 +52,14 @@ class QubedPluginBuilder:
         self.block_builders = block_builders
         self.base_environment = [_detect_editable_install(e) for e in base_environment]
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
-        """Given a block instance corresponding to this plugin's Factory and its inputs, either provide error or determine what it outputs"""
+    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
+        """Given a block instance and its inputs, return either error or output and configuration restrictions."""
         factory = self.block_builders[block.factory_id.factory]
         rich_block = BlockInstanceRich.from_block(block, factory.configuration_options)
         try:
             return factory.validate(rich_block, inputs)
         except BlockInstanceConfigurationError as exc:
-            return Either.error(str(exc))
+            return BlockValidation(Either.error(str(exc)))
 
     def expand(self, output: QubedOutput) -> list[BlockExpansion]:
         """Given a block instance output (including from other plugin), provide which block factories from this plugin can expand it"""
@@ -69,17 +68,6 @@ class QubedPluginBuilder:
             if factory.intersect(output):
                 expansions.append(BlockExpansion(factory=factory_id))
         return expansions
-
-    def restrict(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> ConfigurationOptionRestriction:
-        """Provide restrictions for a block's own configuration options."""
-        factory = self.block_builders.get(block.factory_id.factory)
-        if factory is None:
-            return {}
-        rich_block = BlockInstanceRich.from_block(block, factory.configuration_options)
-        try:
-            return factory.restrictions(rich_block, inputs)
-        except BlockInstanceConfigurationError:
-            return {}
 
     def compile(
         self,
@@ -103,20 +91,13 @@ class QubedPluginBuilder:
             else:
                 return []
 
-        def _generic_validate(block: BlockInstance, inputs: dict[str, BlockInstanceOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
+        def _generic_validate(block: BlockInstance, inputs: dict[str, BlockInstanceOutput]) -> BlockValidation:
             invalid = [f"{key}->{value.__class__.__name__}" for key, value in inputs.items() if not isinstance(value, QubedOutput)]
             if any(invalid):
-                return Either.error(f"Expected only QubedOutputs in inputs, gotten {','.join(invalid)}")
+                return BlockValidation(Either.error(f"Expected only QubedOutputs in inputs, gotten {','.join(invalid)}"))
             else:
                 inputs_validated = cast(dict[str, QubedOutput], inputs)
                 return self.validate(block, inputs_validated)
-
-        def _generic_restrict(block: BlockInstance, inputs: dict[str, BlockInstanceOutput]) -> ConfigurationOptionRestriction:
-            invalid = [f"{key}->{value.__class__.__name__}" for key, value in inputs.items() if not isinstance(value, QubedOutput)]
-            if any(invalid):
-                return {}
-            inputs_validated = cast(dict[str, QubedOutput], inputs)
-            return self.restrict(block, inputs_validated)
 
         return lambda: Plugin(
             catalogue=BlockFactoryCatalogue(
@@ -125,5 +106,4 @@ class QubedPluginBuilder:
             validator=_generic_validate,
             expander=_generic_expand,
             compiler=self.compile,
-            restrictor=_generic_restrict,
         )

--- a/backend/packages/fiab-core/src/fiab_core/tools/plugins.py
+++ b/backend/packages/fiab-core/src/fiab_core/tools/plugins.py
@@ -14,6 +14,7 @@ from fiab_core.fable import (
     BlockInstance,
     BlockInstanceId,
     BlockInstanceOutput,
+    ConfigurationOptionRestriction,
     QubedOutput,
 )
 from fiab_core.plugin import Error, Plugin
@@ -61,13 +62,24 @@ class QubedPluginBuilder:
         except BlockInstanceConfigurationError as exc:
             return Either.error(str(exc))
 
-    def expand(self, block: QubedOutput) -> list[BlockExpansion]:
+    def expand(self, output: QubedOutput) -> list[BlockExpansion]:
         """Given a block instance output (including from other plugin), provide which block factories from this plugin can expand it"""
         expansions: list[BlockExpansion] = []
         for factory_id, factory in self.block_builders.items():
-            if factory.intersect(block):
-                expansions.append(BlockExpansion(factory=factory_id, restrictions=factory.restrictions(block)))
+            if factory.intersect(output):
+                expansions.append(BlockExpansion(factory=factory_id))
         return expansions
+
+    def restrict(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> ConfigurationOptionRestriction:
+        """Provide restrictions for a block's own configuration options."""
+        factory = self.block_builders.get(block.factory_id.factory)
+        if factory is None:
+            return {}
+        rich_block = BlockInstanceRich.from_block(block, factory.configuration_options)
+        try:
+            return factory.restrictions(rich_block, inputs)
+        except BlockInstanceConfigurationError:
+            return {}
 
     def compile(
         self,
@@ -99,6 +111,13 @@ class QubedPluginBuilder:
                 inputs_validated = cast(dict[str, QubedOutput], inputs)
                 return self.validate(block, inputs_validated)
 
+        def _generic_restrict(block: BlockInstance, inputs: dict[str, BlockInstanceOutput]) -> ConfigurationOptionRestriction:
+            invalid = [f"{key}->{value.__class__.__name__}" for key, value in inputs.items() if not isinstance(value, QubedOutput)]
+            if any(invalid):
+                return {}
+            inputs_validated = cast(dict[str, QubedOutput], inputs)
+            return self.restrict(block, inputs_validated)
+
         return lambda: Plugin(
             catalogue=BlockFactoryCatalogue(
                 factories={factory_id: factory.as_catalogue() for factory_id, factory in self.block_builders.items()}
@@ -106,4 +125,5 @@ class QubedPluginBuilder:
             validator=_generic_validate,
             expander=_generic_expand,
             compiler=self.compile,
+            restrictor=_generic_restrict,
         )

--- a/backend/packages/fiab-core/src/fiab_core/tools/plugins.py
+++ b/backend/packages/fiab-core/src/fiab_core/tools/plugins.py
@@ -12,7 +12,6 @@ from fiab_core.fable import (
     BlockFactoryCatalogue,
     BlockFactoryId,
     BlockInstance,
-    BlockInstanceId,
     BlockInstanceOutput,
     QubedOutput,
 )
@@ -72,7 +71,6 @@ class QubedPluginBuilder:
     def compile(
         self,
         inputs: ActionLookup,
-        block_id: BlockInstanceId,
         block: BlockInstance,
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         """Given a cascade builder and a block instance corresponding to this plugin's Factory, either update the builder with corresponding tasks or provide error"""
@@ -80,7 +78,7 @@ class QubedPluginBuilder:
             factory = self.block_builders[block.factory_id.factory]
             rich_block = BlockInstanceRich.from_block(block, factory.configuration_options)
             try:
-                return factory.compile(inputs, block_id, rich_block)
+                return factory.compile(inputs, rich_block)
             except BlockInstanceConfigurationError as exc:
                 return Either.error(str(exc))
 

--- a/backend/packages/fiab-plugin-demo/src/fiab_plugin_demo/blocks.py
+++ b/backend/packages/fiab-plugin-demo/src/fiab_plugin_demo/blocks.py
@@ -13,7 +13,6 @@ from fiab_core.fable import (
     ActionLookup,
     BlockConfigurationOption,
     BlockInstance,
-    BlockInstanceId,
     BlockInstanceOutput,
     ConfigurationOptionId,
     NoOutput,
@@ -39,7 +38,6 @@ class _DemoTransform(Transform):
     def compile(
         self,
         inputs: ActionLookup,
-        block_id: BlockInstanceId,
         block: BlockInstance,
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         return Either.ok(inputs[block.input_ids["dataset"]])
@@ -61,7 +59,6 @@ class _DemoProduct(Product):
     def compile(
         self,
         inputs: ActionLookup,
-        block_id: BlockInstanceId,
         block: BlockInstance,
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         return Either.ok(inputs[block.input_ids["dataset"]])
@@ -82,7 +79,6 @@ class _DemoSink(Sink):
     def compile(
         self,
         inputs: ActionLookup,
-        block_id: BlockInstanceId,
         block: BlockInstance,
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         return Either.ok(inputs[block.input_ids["dataset"]])

--- a/backend/packages/fiab-plugin-demo/src/fiab_plugin_demo/blocks.py
+++ b/backend/packages/fiab-plugin-demo/src/fiab_plugin_demo/blocks.py
@@ -19,7 +19,7 @@ from fiab_core.fable import (
     NoOutput,
     QubedOutput,
 )
-from fiab_core.plugin import Error
+from fiab_core.plugin import BlockValidation, Error
 from fiab_core.tools.blocks import Product, Sink, Transform
 
 DIR = ConfigurationOptionId("dir")
@@ -30,11 +30,11 @@ class _DemoTransform(Transform):
     configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {}
     inputs: list[str] = ["dataset"]
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
+    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
         dataset = inputs.get("dataset")
         if dataset is None:
-            return Either.error("Missing input 'dataset'")
-        return Either.ok(dataset)
+            return BlockValidation(Either.error("Missing input 'dataset'"))
+        return BlockValidation(Either.ok(dataset))
 
     def compile(
         self,
@@ -52,11 +52,11 @@ class _DemoProduct(Product):
     configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {}
     inputs: list[str] = ["dataset"]
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
+    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
         dataset = inputs.get("dataset")
         if dataset is None:
-            return Either.error("Missing input 'dataset'")
-        return Either.ok(dataset)
+            return BlockValidation(Either.error("Missing input 'dataset'"))
+        return BlockValidation(Either.ok(dataset))
 
     def compile(
         self,
@@ -74,10 +74,10 @@ class _DemoSink(Sink):
     configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {}
     inputs: list[str] = ["dataset"]
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
+    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
         if "dataset" not in inputs:
-            return Either.error("Missing input 'dataset'")
-        return Either.ok(NoOutput())
+            return BlockValidation(Either.error("Missing input 'dataset'"))
+        return BlockValidation(Either.ok(NoOutput()))
 
     def compile(
         self,

--- a/backend/packages/fiab-plugin-demo/tests/test_blocks.py
+++ b/backend/packages/fiab-plugin-demo/tests/test_blocks.py
@@ -9,7 +9,7 @@
 
 import pytest
 from fiab_core.fable import BlockFactoryId, BlockInstance, BlockInstanceId, NoOutput, PluginBlockFactoryId, PluginCompositeId, QubedOutput
-from fiab_core.tools.blocks import QubedBlockBuilder
+from fiab_core.tools.blocks import BlockInstanceRich, QubedBlockBuilder
 
 from fiab_plugin_demo import plugin
 from fiab_plugin_demo.blocks import (
@@ -45,6 +45,10 @@ def _block(factory_id: BlockFactoryId) -> BlockInstance:
     )
 
 
+def _rich_block(factory_id: BlockFactoryId, builder: QubedBlockBuilder) -> BlockInstanceRich:
+    return BlockInstanceRich.from_block(_block(factory_id), builder.configuration_options)
+
+
 @pytest.fixture
 def dummy_output() -> QubedOutput:
     return QubedOutput()
@@ -75,7 +79,7 @@ def test_demo_blocks_pass_through_dataset(
     builder: QubedBlockBuilder,
     dummy_output: QubedOutput,
 ) -> None:
-    block = _block(factory_id)
+    block = _rich_block(factory_id, builder)
     validated = builder.validate(block=block, inputs={"dataset": dummy_output}).get_or_raise()
     assert validated is dummy_output
 
@@ -88,7 +92,7 @@ def test_demo_blocks_pass_through_dataset(
     ],
 )
 def test_demo_sinks_return_no_output(factory_id: BlockFactoryId, builder: QubedBlockBuilder, dummy_output: QubedOutput) -> None:
-    block = _block(factory_id)
+    block = _rich_block(factory_id, builder)
     validated = builder.validate(block=block, inputs={"dataset": dummy_output}).get_or_raise()
     assert isinstance(validated, NoOutput)
 
@@ -108,7 +112,7 @@ def test_demo_sinks_return_no_output(factory_id: BlockFactoryId, builder: QubedB
     ],
 )
 def test_demo_blocks_require_dataset(factory_id: BlockFactoryId, builder: QubedBlockBuilder) -> None:
-    block = _block(factory_id)
+    block = _rich_block(factory_id, builder)
     result = builder.validate(block=block, inputs={})
     with pytest.raises(Exception, match="Missing input 'dataset'"):
         result.get_or_raise()

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/__init__.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/__init__.py
@@ -11,7 +11,7 @@ from fiab_core.fable import BlockFactoryId
 from fiab_core.tools.blocks import QubedBlockBuilder
 from fiab_core.tools.plugins import QubedPluginBuilder
 
-from fiab_plugin_ecmwf.anemoi.blocks import DATASET, AnemoiInputSource, AnemoiSource, AnemoiTransform
+from fiab_plugin_ecmwf.anemoi.blocks import AnemoiInputSource, AnemoiSource, AnemoiTransform
 from fiab_plugin_ecmwf.blocks import (
     EnsembleStatistics,
     GribSink,
@@ -32,11 +32,6 @@ blocks: dict[BlockFactoryId, QubedBlockBuilder] = {
     BlockFactoryId("anemoiSource"): AnemoiSource(),
     BlockFactoryId("anemoiInputSource"): AnemoiInputSource(),
     BlockFactoryId("anemoiTransform"): AnemoiTransform(),
-    BlockFactoryId("selectDataset"): SelectDimension(
-        option_id=DATASET,
-        item_python_type=str,
-        selection_label="dataset",
-    ),
     BlockFactoryId("mapPlotSink"): MapPlotSink(),
 }
 

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/__init__.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/__init__.py
@@ -13,14 +13,11 @@ from fiab_core.tools.plugins import QubedPluginBuilder
 
 from fiab_plugin_ecmwf.anemoi.blocks import DATASET, AnemoiInputSource, AnemoiSource, AnemoiTransform
 from fiab_plugin_ecmwf.blocks import (
-    ENSEMBLE,
-    PARAM,
-    STEP,
     EnsembleStatistics,
     GribSink,
     MapPlotSink,
     OperationalForecastSource,
-    SelectDimension,
+    Select,
     TemporalStatistics,
     ZarrSink,
 )
@@ -29,21 +26,7 @@ blocks: dict[BlockFactoryId, QubedBlockBuilder] = {
     BlockFactoryId("operationalForecastSource"): OperationalForecastSource(),
     BlockFactoryId("ensembleStatistics"): EnsembleStatistics(),
     BlockFactoryId("temporalStatistics"): TemporalStatistics(),
-    BlockFactoryId("selectParameters"): SelectDimension(
-        option_id=PARAM,
-        item_python_type=str,
-        selection_label="parameters",
-    ),
-    BlockFactoryId("selectSteps"): SelectDimension(
-        option_id=STEP,
-        item_python_type=int,
-        selection_label="steps",
-    ),
-    BlockFactoryId("selectMembers"): SelectDimension(
-        option_id=ENSEMBLE,
-        item_python_type=int,
-        selection_label="members",
-    ),
+    BlockFactoryId("select"): Select(),
     BlockFactoryId("zarrSink"): ZarrSink(),
     BlockFactoryId("gribSink"): GribSink(),
     BlockFactoryId("anemoiSource"): AnemoiSource(),

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
@@ -18,18 +18,15 @@ from earthkit.workflows.plugins.anemoi.types import DATE
 from fiab_core.fable import (
     ActionLookup,
     BlockConfigurationOption,
-    BlockInstanceOutput,
     ConfigurationOptionId,
-    ConfigurationOptionRestriction,
     QubedOutput,
 )
 from fiab_core.plugin import BlockValidation, Error
-from fiab_core.tools.blocks import BlockInstanceConfigurationError, Source, Transform
 from fiab_core.tools.blocks import BlockInstanceRich as BlockInstance
-from fiab_core.tools.validators import negative, positive
-from fiab_core.types import ClosedEnumType, ListType
+from fiab_core.tools.blocks import Source, Transform
+from fiab_core.tools.validators import positive
 
-from fiab_plugin_ecmwf.qubed_utils import axes, collapse, contains, dimensions, expand
+from fiab_plugin_ecmwf.qubed_utils import axes, contains, expand
 
 from .utils import (
     CheckpointArtifact,
@@ -47,7 +44,6 @@ CHECKPOINT = ConfigurationOptionId("checkpoint")
 LEAD_TIME = ConfigurationOptionId("lead_time")
 INPUT_SOURCE = ConfigurationOptionId("input_source")
 BASE_TIME = ConfigurationOptionId("base_time")
-DATASET = ConfigurationOptionId("dataset")
 
 
 class AnemoiBuilder:
@@ -207,11 +203,11 @@ class AnemoiInputSource(Source):
         ),
     }
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
+    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
         checkpoint = CheckpointArtifact(block.config_as_str(CHECKPOINT))
         number = block.config_as_int(ENSEMBLE, validator=positive)
         if number < 1:
-            return Either.error("Ensemble members must be an int, positive and non zero.")
+            return BlockValidation(Either.error("Ensemble members must be an int, positive and non zero."))
         model_input = checkpoint.combine_if_nested_qube(checkpoint.get_model_input())
         model_input = expand(model_input, {ENSEMBLE: [number]})
 

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
@@ -18,7 +18,6 @@ from earthkit.workflows.plugins.anemoi.types import DATE
 from fiab_core.fable import (
     ActionLookup,
     BlockConfigurationOption,
-    BlockInstanceId,
     BlockInstanceOutput,
     ConfigurationOptionId,
     ConfigurationOptionRestriction,
@@ -163,7 +162,6 @@ class AnemoiSource(Source):
     def compile(  # type:ignore[invalid-argument] # semigroup
         self,
         inputs: ActionLookup,
-        block_id: BlockInstanceId,
         block: BlockInstance,
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
 
@@ -222,7 +220,6 @@ class AnemoiInputSource(Source):
     def compile(  # type:ignore[invalid-argument] # semigroup
         self,
         inputs: ActionLookup,
-        block_id: BlockInstanceId,
         block: BlockInstance,
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
 
@@ -279,7 +276,6 @@ class AnemoiTransform(Transform):
     def compile(  # type:ignore[invalid-argument] # semigroup
         self,
         inputs: ActionLookup,
-        block_id: BlockInstanceId,
         block: BlockInstance,
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         input_task = block.input_ids["initial conditions"]

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
@@ -24,9 +24,9 @@ from fiab_core.fable import (
     ConfigurationOptionRestriction,
     QubedOutput,
 )
-from fiab_core.plugin import Error
+from fiab_core.plugin import BlockValidation, Error
+from fiab_core.tools.blocks import BlockInstanceConfigurationError, Source, Transform
 from fiab_core.tools.blocks import BlockInstanceRich as BlockInstance
-from fiab_core.tools.blocks import Source, Transform
 from fiab_core.tools.validators import negative, positive
 from fiab_core.types import ClosedEnumType, ListType
 
@@ -143,21 +143,22 @@ class AnemoiSource(Source):
         ),
     }
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
+    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
         ensemble_members = block.config_as_int(ENSEMBLE, validator=positive)
-        if ensemble_members < 1:
-            return Either.error("Ensemble members must be an int, positive and non zero.")
-
         checkpoint = CheckpointArtifact(block.config_as_str(CHECKPOINT))
         lead_time = block.config_as_int(LEAD_TIME, validator=positive)
+        if ensemble_members < 1:
+            return BlockValidation(Either.error("Ensemble members must be an int, positive and non zero."))
+
         validation_error = checkpoint.validate_lead_time(lead_time)
         if validation_error is not None:
-            return Either.error(validation_error)
+            return BlockValidation(Either.error(validation_error))
 
         qubed_output = checkpoint.combine_if_nested_qube(checkpoint.get_model_output(lead_time))
         if ensemble_members > 1:
             qubed_output = expand(qubed_output, {"number": range(1, ensemble_members + 1)})
-        return Either.ok(QubedOutput(dataqube=qubed_output))
+        qubed_output = QubedOutput(dataqube=qubed_output)
+        return BlockValidation(Either.ok(qubed_output))
 
     def compile(  # type:ignore[invalid-argument] # semigroup
         self,
@@ -216,7 +217,7 @@ class AnemoiInputSource(Source):
         model_input = checkpoint.combine_if_nested_qube(checkpoint.get_model_input())
         model_input = expand(model_input, {ENSEMBLE: [number]})
 
-        return Either.ok(QubedOutput(dataqube=model_input))
+        return BlockValidation(Either.ok(QubedOutput(dataqube=model_input)))
 
     def compile(  # type:ignore[invalid-argument] # semigroup
         self,
@@ -254,24 +255,26 @@ class AnemoiTransform(Transform):
         ),
     }
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
+    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
         checkpoint = CheckpointArtifact(block.config_as_str(CHECKPOINT))
+        lead_time = block.config_as_int(LEAD_TIME, validator=positive)
         qubed_input = checkpoint.combine_if_nested_qube(checkpoint.get_model_input())
         if not contains(inputs["dataset"], qubed_input):
             difference_qube = qubed_input ^ inputs["dataset"].dataqube
-            return Either.error(f"Input dataset is not compatible with the model checkpoint. Difference in qubes: {difference_qube}")
+            return BlockValidation(
+                Either.error(f"Input dataset is not compatible with the model checkpoint. Difference in qubes: {difference_qube}")
+            )
 
-        lead_time = block.config_as_int(LEAD_TIME, validator=positive)
         validation_error = checkpoint.validate_lead_time(lead_time)
         if validation_error is not None:
-            return Either.error(validation_error)
+            return BlockValidation(Either.error(validation_error))
 
         qubed_output = checkpoint.combine_if_nested_qube(checkpoint.get_model_output(lead_time=lead_time))
 
         input_dataset = inputs["dataset"]
         if contains(input_dataset, ENSEMBLE):
             qubed_output = expand(qubed_output, {ENSEMBLE: axes(input_dataset)[ENSEMBLE]})
-        return Either.ok(QubedOutput(dataqube=qubed_output))
+        return BlockValidation(Either.ok(QubedOutput(dataqube=qubed_output)))
 
     def compile(  # type:ignore[invalid-argument] # semigroup
         self,

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -373,16 +373,29 @@ class Select(Transform):
         except BlockInstanceConfigurationError as exc:
             return BlockValidation(Either.error(str(exc)), restrict)
 
-        axis_values = axes(input_dataset).get(dimension)
-        if axis_values is not None:
-            input_values = _axis_value_strings(axis_values)
-            if input_values:
-                restrict[VALUES] = ListType(ClosedEnumType(input_values))
+        input_axes = axes(input_dataset)
+        axis_values = input_axes.get(dimension)
+        if axis_values is None:
+            return BlockValidation(
+                Either.error(f"dimension {dimension} is not in the input dimensions: {input_dimensions}"),
+                restrict,
+            )
+
+        input_values = _axis_value_strings(axis_values)
+        if input_values:
+            restrict[VALUES] = ListType(ClosedEnumType(input_values))
 
         try:
             selected_values = [_parse_axis_value(value) for value in self._selected_values(block)]
         except BlockInstanceConfigurationError as exc:
             return BlockValidation(Either.error(str(exc)), restrict)
+
+        missing_values = [value for value in selected_values if value not in axis_values]
+        if missing_values:
+            return BlockValidation(
+                Either.error(f"values {missing_values} are not in dimension {dimension}: {input_values}"),
+                restrict,
+            )
 
         output = select(input_dataset, {dimension: selected_values})
 
@@ -507,20 +520,29 @@ class MapPlotSink(Sink):
 
         restrict: ConfigurationOptionRestriction = {}
 
-        param_values = [value for value in axes(input_dataset).get(PARAM, set()) if isinstance(value, str)]
+        input_axes = axes(input_dataset)
+        input_param_values = input_axes.get(PARAM, set())
+        param_values = [value for value in input_param_values if isinstance(value, str)]
         if param_values:
             restrict[PARAM] = ListType(ClosedEnumType(sorted(param_values)))
 
         common = common_dimensions(input_dataset).intersection({PARAM, STEP, ENSEMBLE, LEVEL})
-        splitby = [x for x in common if len(axes(input_dataset)[x]) > 1]
+        splitby = [x for x in common if len(input_axes[x]) > 1]
         restrict[SPLITBY] = ListType(ClosedEnumType(sorted(splitby) + ["none"]))
 
         try:
-            block.config_as_list(PARAM, str, allow_empty=False)
+            params = block.config_as_list(PARAM, str, allow_empty=False)
             splitby_value = block.config_as_list(SPLITBY, str, allow_empty=True)
             fmt = block.config_as_str(FORMAT)
         except BlockInstanceConfigurationError as exc:
             return BlockValidation(Either.error(str(exc)), restrict)
+
+        missing_params = [param for param in params if param not in input_param_values]
+        if missing_params:
+            return BlockValidation(
+                Either.error(f"params {missing_params} are not in the input parameters: {_axis_value_strings(input_param_values)}"),
+                restrict,
+            )
 
         if "none" in splitby_value and len(splitby_value) != 1:
             return BlockValidation(

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -26,9 +26,9 @@ from fiab_core.fable import (
     QubedOutput,
     RawOutput,
 )
-from fiab_core.plugin import Error
+from fiab_core.plugin import BlockValidation, Error
+from fiab_core.tools.blocks import BlockInstanceConfigurationError, Product, Sink, Source, Transform
 from fiab_core.tools.blocks import BlockInstanceRich as BlockInstance
-from fiab_core.tools.blocks import Product, Sink, Source, Transform
 from fiab_core.types import ClosedEnumType, ListType
 from qubed import Qube
 
@@ -72,6 +72,14 @@ PLOT_FORMAT_TO_MIME: dict[str, str] = {
 FORECAST_DATASETS = load_datasets()
 
 
+def _extract_dataset(inputs: dict[str, QubedOutput], name: str) -> QubedOutput:
+    input_dataset = inputs.get(name)
+    if not isinstance(input_dataset, QubedOutput):
+        actual_type = type(input_dataset).__name__ if input_dataset is not None else "None"
+        raise BlockInstanceConfigurationError(f"Unsupported input type for '{name}': expected QubedOutput, got {actual_type}")
+    return input_dataset
+
+
 def _restriction_value_strings(axis_values: set[Any], item_python_type: type[str] | type[int]) -> list[str]:
     if item_python_type is str:
         return sorted(value for value in axis_values if isinstance(value, str))
@@ -88,7 +96,7 @@ def _axis_value_strings(axis_values: set[Any]) -> list[str]:
     return sorted(str(value) for value in axis_values)
 
 
-def _guess_axis_value(value: str) -> str | int:
+def _parse_axis_value(value: str) -> str | int:
     try:
         int_value = int(value)
     except ValueError:
@@ -122,16 +130,16 @@ class OperationalForecastSource(Source):
     def _convert_time(cls, time: int) -> str:
         return f"{time:02d}00"
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
+    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
         forecast = block.config_as_str(FORECAST)
         basetime = block.config_as_datetime(BASETIME)
         time = self._convert_time(basetime.time().hour)
 
         ifs_qoutput = QubedOutput(dataqube=FORECAST_DATASETS[forecast].as_qube(ens_dim=ENSEMBLE, include_member_zero=True))
         if not contains(ifs_qoutput, {"time": time}):
-            return Either.error(f"Invalid time: must be in {axes(ifs_qoutput)['time']}")
+            return BlockValidation(Either.error(f"Invalid time: must be in {axes(ifs_qoutput)['time']}"))
 
-        return Either.ok(select(ifs_qoutput, {"time": time}))
+        return BlockValidation(Either.ok(select(ifs_qoutput, {"time": time})))
 
     def compile(
         self,
@@ -206,15 +214,15 @@ class EnsembleStatistics(Product):
     }
     inputs: list[str] = ["dataset"]
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
-        input_dataset = inputs["dataset"]
+    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
+        input_dataset = _extract_dataset(inputs, "dataset")
 
         param = block.config_as_str(PARAM)
         if not contains(input_dataset, {PARAM: param}):
-            return Either.error(f"param {param} is not in the input parameters: {axes(input_dataset).get(PARAM, [])}")
+            return BlockValidation(Either.error(f"param {param} is not in the input parameters: {axes(input_dataset).get(PARAM, [])}"))
 
         output = coxpand(input_dataset, [PARAM, ENSEMBLE], {PARAM: [param]})
-        return Either.ok(output)
+        return BlockValidation(Either.ok(output))
 
     def compile(
         self,
@@ -251,14 +259,14 @@ class TemporalStatistics(Product):
     }
     inputs: list[str] = ["dataset"]
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
-        input_dataset = inputs["dataset"]
+    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
+        input_dataset = _extract_dataset(inputs, "dataset")
 
         param = block.config_as_str(PARAM)
         if not contains(input_dataset, {PARAM: param}):
-            return Either.error(f"param {param} is not in the input parameters: {axes(input_dataset).get(PARAM, [])}")
+            return BlockValidation(Either.error(f"param {param} is not in the input parameters: {axes(input_dataset).get(PARAM, [])}"))
         output = coxpand(input_dataset, [PARAM, STEP], {PARAM: [param]})
-        return Either.ok(output)
+        return BlockValidation(Either.ok(output))
 
     def compile(
         self,
@@ -298,8 +306,9 @@ class ZarrSink(Sink):
     }
     inputs: list[str] = ["dataset"]
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
-        return Either.ok(RawOutput(type_fqn="bytes", mime_type="text/plain"))
+    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
+        _extract_dataset(inputs, "dataset")
+        return BlockValidation(Either.ok(RawOutput(type_fqn="bytes", mime_type="text/plain")))
 
     def compile(
         self,
@@ -329,9 +338,6 @@ class ZarrSink(Sink):
         return bool(dimensions(other))
 
 
-SelectAxisValue = str | int
-
-
 class Select(Transform):
     title: str = "Select"
     description: str = "Select values from one dimension of the input dataset"
@@ -350,36 +356,42 @@ class Select(Transform):
     inputs: list[str] = ["dataset"]
 
     def _selected_dimension(self, block: BlockInstance) -> ConfigurationOptionId:
-        return ConfigurationOptionId(block.config_as_str(DIMENSION))
+        dimension = ConfigurationOptionId(block.config_as_str(DIMENSION))
+        if not dimension:
+            raise BlockInstanceConfigurationError(f"Configuration option '{DIMENSION}' must be provided")
+        return dimension
 
-    def _selected_value_strings(self, block: BlockInstance) -> list[str]:
+    def _selected_values(self, block: BlockInstance) -> list[str]:
         return block.config_as_list(VALUES, str, allow_empty=False)
 
-    def _selected_axis_values(self, block: BlockInstance, input_dataset: QubedOutput) -> tuple[list[SelectAxisValue] | None, Error | None]:
-        dimension = self._selected_dimension(block)
+    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
+        input_dataset = _extract_dataset(inputs, "dataset")
+
+        restrict: ConfigurationOptionRestriction = {}
+
+        input_dimensions = sorted(dimensions(input_dataset))
+        if input_dimensions:
+            restrict[DIMENSION] = ClosedEnumType(input_dimensions)
+
+        try:
+            dimension = self._selected_dimension(block)
+        except BlockInstanceConfigurationError as exc:
+            return BlockValidation(Either.error(str(exc)), restrict)
+
         axis_values = axes(input_dataset).get(dimension)
-        if axis_values is None:
-            return None, f"Dimension {dimension!r} is not in the input dimensions: {sorted(dimensions(input_dataset))}"
+        if axis_values is not None:
+            input_values = _axis_value_strings(axis_values)
+            if input_values:
+                restrict[VALUES] = ListType(ClosedEnumType(input_values))
 
-        axis_lookup = {str(value): value for value in axis_values if isinstance(value, (str, int))}
-        selected_strings = self._selected_value_strings(block)
-        missing = [value for value in selected_strings if value not in axis_lookup]
-        if missing:
-            return None, f"Values {missing} are not in the input {dimension}: {_axis_value_strings(axis_values)}"
-        return cast(list[SelectAxisValue], [axis_lookup[value] for value in selected_strings]), None
+        try:
+            selected_values = [_parse_axis_value(value) for value in self._selected_values(block)]
+        except BlockInstanceConfigurationError as exc:
+            return BlockValidation(Either.error(str(exc)), restrict)
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
-        input_dataset = inputs.get("dataset")
-        if not isinstance(input_dataset, QubedOutput):
-            actual_type = type(input_dataset).__name__ if input_dataset is not None else "None"
-            return Either.error(f"Unsupported input type for 'dataset': expected QubedOutput, got {actual_type}")
-
-        selected_values, error = self._selected_axis_values(block, input_dataset)
-        if selected_values is None:
-            return Either.error(cast(str, error))
-        dimension = self._selected_dimension(block)
         output = select(input_dataset, {dimension: selected_values})
-        return Either.ok(output)
+
+        return BlockValidation(Either.ok(output), restrict)
 
     def compile(
         self,
@@ -389,32 +401,9 @@ class Select(Transform):
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         input_task = block.input_ids["dataset"]
         dimension = self._selected_dimension(block)
-        selected_values = [_guess_axis_value(value) for value in self._selected_value_strings(block)]
-        selected = inputs[input_task].select({dimension: selected_values if len(selected_values) > 1 else selected_values[0]})
+        values = [_parse_axis_value(value) for value in self._selected_values(block)]
+        selected = inputs[input_task].select({dimension: values if len(values) > 1 else values[0]})
         return Either.ok(selected)
-
-    def restrictions(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> ConfigurationOptionRestriction:
-        input_dataset = inputs.get("dataset")
-        if not isinstance(input_dataset, QubedOutput):
-            return {}
-
-        restrict: ConfigurationOptionRestriction = {}
-        dimension_values = sorted(dimensions(input_dataset))
-        if dimension_values:
-            restrict[DIMENSION] = ClosedEnumType(dimension_values)
-
-        raw_dimension = block.configuration_values.get(DIMENSION)
-        if not isinstance(raw_dimension, str):
-            return restrict
-
-        axis_values = axes(input_dataset).get(raw_dimension)
-        if axis_values is None:
-            return restrict
-
-        values = _axis_value_strings(axis_values)
-        if values:
-            restrict[VALUES] = ListType(ClosedEnumType(values))
-        return restrict
 
     def intersect(self, other: QubedOutput) -> bool:
         return bool(dimensions(other))
@@ -435,16 +424,13 @@ class GribSink(Sink):
     def _find_template_values(cls, path: str) -> list[str]:
         return re.findall(r"\[(.*?)\]", path)
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
-        input_dataset = inputs.get("dataset")
-        if not isinstance(input_dataset, QubedOutput):
-            actual_type = type(input_dataset).__name__ if input_dataset is not None else "None"
-            return Either.error(f"Unsupported input type for 'dataset': expected QubedOutput, got {actual_type}")
+    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
+        _extract_dataset(inputs, "dataset")  # check format of input and existence of dataset
         path = block.config_as_str(PATH)
         dirname = os.path.dirname(path)
         if len(self._find_template_values(dirname)) != 0:
-            return Either.error(f"Invalid filepath: directory path can not contain template values")
-        return Either.ok(RawOutput(type_fqn="bytes", mime_type=GRIB_MIME))
+            return BlockValidation(Either.error(f"Invalid filepath: directory path can not contain template values"))
+        return BlockValidation(Either.ok(RawOutput(type_fqn="bytes", mime_type=GRIB_MIME)))
 
     def compile(
         self,
@@ -523,26 +509,35 @@ class MapPlotSink(Sink):
     }
     inputs: list[str] = ["dataset"]
 
-    def validate(self, block: BlockInstance, inputs: dict[str, BlockInstanceOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
-        input_dataset = inputs.get("dataset")
-        if not isinstance(input_dataset, QubedOutput):
-            actual_type = type(input_dataset).__name__ if input_dataset is not None else "None"
-            return Either.error(f"Unsupported input type for 'dataset': expected QubedOutput, got {actual_type}")
+    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
+        input_dataset = _extract_dataset(inputs, "dataset")
 
-        params = block.config_as_list(PARAM, str, allow_empty=False)
-        missing = [p for p in params if not contains(input_dataset, {PARAM: p})]
-        if missing:
-            return Either.error(f"params {missing} are not in the input parameters: {axes(input_dataset).get(PARAM, [])}")
+        restrict: ConfigurationOptionRestriction = {}
 
-        splitby_value = block.config_as_list(SPLITBY, str, allow_empty=True)
+        param_values = [value for value in axes(input_dataset).get(PARAM, set()) if isinstance(value, str)]
+        if param_values:
+            restrict[PARAM] = ListType(ClosedEnumType(sorted(param_values)))
+
+        common = common_dimensions(input_dataset).intersection({PARAM, STEP, ENSEMBLE, LEVEL})
+        splitby = [x for x in common if len(axes(input_dataset)[x]) > 1]
+        restrict[SPLITBY] = ListType(ClosedEnumType(sorted(splitby) + ["none"]))
+
+        try:
+            block.config_as_list(PARAM, str, allow_empty=False)
+            splitby_value = block.config_as_list(SPLITBY, str, allow_empty=True)
+            fmt = block.config_as_str(FORMAT)
+        except BlockInstanceConfigurationError as exc:
+            return BlockValidation(Either.error(str(exc)), restrict)
+
         if "none" in splitby_value and len(splitby_value) != 1:
-            return Either.error(f"Invalid splitby value: if none is selected, no other dimensions can be present")
+            return BlockValidation(
+                Either.error(f"Invalid splitby value: if none is selected, no other dimensions can be present"), restrict
+            )
 
-        fmt = block.config_as_str(FORMAT)
         mime_type = PLOT_FORMAT_TO_MIME.get(fmt)
         if mime_type is None:
-            return Either.error(f"Unsupported output format: {fmt}")
-        return Either.ok(RawOutput(type_fqn="bytes", mime_type=mime_type))
+            return BlockValidation(Either.error(f"Unsupported output format: {fmt}"), restrict)
+        return BlockValidation(Either.ok(RawOutput(type_fqn="bytes", mime_type=mime_type)), restrict)
 
     def compile(
         self,
@@ -578,22 +573,6 @@ class MapPlotSink(Sink):
             )
         )
         return Either.ok(action)
-
-    def restrictions(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> ConfigurationOptionRestriction:
-        del block
-        input_dataset = inputs.get("dataset")
-        if not isinstance(input_dataset, QubedOutput):
-            return {}
-        restrict: ConfigurationOptionRestriction = {}
-
-        param_values = [value for value in axes(input_dataset).get(PARAM, set()) if isinstance(value, str)]
-        if param_values:
-            restrict[PARAM] = ListType(ClosedEnumType(sorted(param_values)))
-
-        common = common_dimensions(input_dataset).intersection({PARAM, STEP, ENSEMBLE, LEVEL})
-        splitby = [x for x in common if len(axes(input_dataset)[x]) > 1]
-        restrict[SPLITBY] = ListType(ClosedEnumType(sorted(splitby) + ["none"]))
-        return restrict
 
     def intersect(self, other: QubedOutput) -> bool:
         return contains(other, PARAM)

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -46,6 +46,8 @@ ENSEMBLE = ConfigurationOptionId("number")
 STEP = ConfigurationOptionId("step")
 LEVTYPE = ConfigurationOptionId("levtype")
 LEVEL = ConfigurationOptionId("levelist")
+DIMENSION = ConfigurationOptionId("dimension")
+VALUES = ConfigurationOptionId("values")
 GROUPBY = ConfigurationOptionId("groupby")
 SPLITBY = ConfigurationOptionId("splitby")
 FORECAST = ConfigurationOptionId("forecast")
@@ -70,6 +72,30 @@ PLOT_FORMAT_TO_MIME: dict[str, str] = {
 FORECAST_DATASETS = load_datasets()
 
 
+def _restriction_value_strings(axis_values: set[Any], item_python_type: type[str] | type[int]) -> list[str]:
+    if item_python_type is str:
+        return sorted(value for value in axis_values if isinstance(value, str))
+    if item_python_type is int:
+        return [str(value) for value in sorted(value for value in axis_values if type(value) is int)]
+    raise TypeError(f"Unsupported select value type {item_python_type!r}")
+
+
+def _axis_value_strings(axis_values: set[Any]) -> list[str]:
+    if all(isinstance(value, str) for value in axis_values):
+        return _restriction_value_strings(axis_values, str)
+    if all(type(value) is int for value in axis_values):
+        return _restriction_value_strings(axis_values, int)
+    return sorted(str(value) for value in axis_values)
+
+
+def _guess_axis_value(value: str) -> str | int:
+    try:
+        int_value = int(value)
+    except ValueError:
+        return value
+    return int_value if str(int_value) == value else value
+
+
 class OperationalForecastSource(Source):
     title: str = "Operational forecast source"
     description: str = "Fetch operational forecast data from mars or ecmwf open data"
@@ -90,21 +116,6 @@ class OperationalForecastSource(Source):
             description="Base time of the forecast",
             value_type="datetime",
         ),
-        PARAM: BlockConfigurationOption(
-            title="Parameters",
-            description="Parameters to select and plot (e.g. '2t', 'msl')",
-            value_type="list[str]",
-        ),
-        STEP: BlockConfigurationOption(
-            title="Steps",
-            description="Forecast steps to select (e.g. '0,6,12,...')",
-            value_type="list[int]",
-        ),
-        ENSEMBLE: BlockConfigurationOption(
-            title="Ensemble Members",
-            description="Ensemble members to select (e.g. '1,2,3,...')",
-            value_type="list[int]",
-        ),
     }
     inputs: list[str] = []
 
@@ -115,31 +126,12 @@ class OperationalForecastSource(Source):
         forecast = block.config_as_str(FORECAST)
         basetime = block.config_as_datetime(BASETIME)
         time = self._convert_time(basetime.time().hour)
-        params = block.config_as_list(PARAM, str, allow_empty=False)
-        steps = block.config_as_list(STEP, int, allow_empty=False)
-        numbers = block.config_as_list(ENSEMBLE, int, allow_empty=False)
 
         ifs_qoutput = QubedOutput(dataqube=FORECAST_DATASETS[forecast].as_qube(ens_dim=ENSEMBLE, include_member_zero=True))
         if not contains(ifs_qoutput, {"time": time}):
             return Either.error(f"Invalid time: must be in {axes(ifs_qoutput)['time']}")
 
-        ifs_qoutput = select(ifs_qoutput, {"time": time})
-        for param in params:
-            if not contains(ifs_qoutput, {PARAM: param}):
-                return Either.error(f"Invalid {PARAM}: must be in {axes(ifs_qoutput)[PARAM]}")
-            param_qoutput = select(ifs_qoutput, {PARAM: param})
-            for dim, config in [(STEP, steps), (ENSEMBLE, numbers)]:
-                if not contains(param_qoutput, {dim: config}):
-                    return Either.error(f"Invalid {dim}: must be in {axes(param_qoutput)[dim]} for param {param}")
-                param_qoutput = select(param_qoutput, {dim: config})
-
-        select_dims: dict[str, Any] = {
-            PARAM: params,
-            ENSEMBLE: numbers,
-            STEP: steps,
-        }
-        output = select(ifs_qoutput, select_dims)
-        return Either.ok(output)
+        return Either.ok(select(ifs_qoutput, {"time": time}))
 
     def compile(
         self,
@@ -151,20 +143,11 @@ class OperationalForecastSource(Source):
         fc_preset = FORECAST_DATASETS[forecast]
         fc_qube = fc_preset.as_qube(ens_dim=ENSEMBLE)
 
-        param = block.config_as_list(PARAM, str, allow_empty=False)
-        step = block.config_as_list(STEP, int, allow_empty=False)
-        number = block.config_as_list(ENSEMBLE, int, allow_empty=False)
         basetime = block.config_as_datetime(BASETIME)
         date = basetime.date().isoformat()
         time = self._convert_time(basetime.time().hour)
 
-        select_dims: dict[str, Any] = {
-            PARAM: param,
-            ENSEMBLE: number,
-            STEP: step,
-            "time": time,
-        }
-        subqube = fc_qube.select(select_dims)
+        subqube = fc_qube.select({"time": time})
         actions = {}
         for levtype in subqube.axes()[LEVTYPE]:
             path = f"levtype={levtype}"
@@ -205,7 +188,7 @@ class OperationalForecastSource(Source):
             merged = merge(**levtype_actions)
             for branch in ens_branches:
                 merged = merged.combine_branches(dim=ENSEMBLE, path=branch)
-            actions[path] = merged.combine_branches(dim=PARAM)
+            actions[path] = merged
         final_action = merge(**actions)
         return Either.ok(final_action)
 
@@ -349,45 +332,41 @@ class ZarrSink(Sink):
 SelectAxisValue = str | int
 
 
-class SelectDimension(Transform):
+class Select(Transform):
+    title: str = "Select"
+    description: str = "Select values from one dimension of the input dataset"
+    configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {
+        DIMENSION: BlockConfigurationOption(
+            title="Dimension",
+            description="Dimension to select from the dataset",
+            value_type="str",
+        ),
+        VALUES: BlockConfigurationOption(
+            title="Values",
+            description="Values to select from the chosen dimension",
+            value_type="list[str]",
+        ),
+    }
     inputs: list[str] = ["dataset"]
 
-    def __init__(
-        self,
-        *,
-        option_id: ConfigurationOptionId,
-        item_python_type: type[str] | type[int],
-        selection_label: str,
-    ) -> None:
-        label_title = selection_label.title()
-        label_sentence = selection_label[:1].upper() + selection_label[1:]
+    def _selected_dimension(self, block: BlockInstance) -> ConfigurationOptionId:
+        return ConfigurationOptionId(block.config_as_str(DIMENSION))
 
-        self.title = f"Select {label_title}"
-        self.description = f"Select {selection_label} from the input dataset"
-        self.option_id = option_id
-        self.item_python_type = item_python_type
-        self.selection_label = selection_label
-        self.configuration_options = {
-            option_id: BlockConfigurationOption(
-                title=label_title,
-                description=f"{label_sentence} to select from the dataset",
-                value_type=f"list[{self._value_type_name()}]",
-            )
-        }
+    def _selected_value_strings(self, block: BlockInstance) -> list[str]:
+        return block.config_as_list(VALUES, str, allow_empty=False)
 
-    def _value_type_name(self) -> str:
-        if self.item_python_type is str:
-            return "str"
-        if self.item_python_type is int:
-            return "int"
-        raise TypeError(f"Unsupported select value type {self.item_python_type!r}")
+    def _selected_axis_values(self, block: BlockInstance, input_dataset: QubedOutput) -> tuple[list[SelectAxisValue] | None, Error | None]:
+        dimension = self._selected_dimension(block)
+        axis_values = axes(input_dataset).get(dimension)
+        if axis_values is None:
+            return None, f"Dimension {dimension!r} is not in the input dimensions: {sorted(dimensions(input_dataset))}"
 
-    def _selected_values(self, block: BlockInstance) -> list[SelectAxisValue]:
-        if self.item_python_type is str:
-            return cast(list[SelectAxisValue], block.config_as_list(self.option_id, str, allow_empty=False))
-        if self.item_python_type is int:
-            return cast(list[SelectAxisValue], block.config_as_list(self.option_id, int, allow_empty=False))
-        raise TypeError(f"Unsupported select value type {self.item_python_type!r}")
+        axis_lookup = {str(value): value for value in axis_values if isinstance(value, (str, int))}
+        selected_strings = self._selected_value_strings(block)
+        missing = [value for value in selected_strings if value not in axis_lookup]
+        if missing:
+            return None, f"Values {missing} are not in the input {dimension}: {_axis_value_strings(axis_values)}"
+        return cast(list[SelectAxisValue], [axis_lookup[value] for value in selected_strings]), None
 
     def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
         input_dataset = inputs.get("dataset")
@@ -395,14 +374,11 @@ class SelectDimension(Transform):
             actual_type = type(input_dataset).__name__ if input_dataset is not None else "None"
             return Either.error(f"Unsupported input type for 'dataset': expected QubedOutput, got {actual_type}")
 
-        selected_values = self._selected_values(block)
-        if not contains(input_dataset, {self.option_id: selected_values}):
-            return Either.error(
-                f"{self.selection_label} {selected_values} are not in the input "
-                f"{self.selection_label}: {axes(input_dataset).get(self.option_id, [])}"
-            )
-
-        output = select(input_dataset, {self.option_id: selected_values})
+        selected_values, error = self._selected_axis_values(block, input_dataset)
+        if selected_values is None:
+            return Either.error(cast(str, error))
+        dimension = self._selected_dimension(block)
+        output = select(input_dataset, {dimension: selected_values})
         return Either.ok(output)
 
     def compile(
@@ -412,23 +388,36 @@ class SelectDimension(Transform):
         block: BlockInstance,
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         input_task = block.input_ids["dataset"]
-        selected_values = self._selected_values(block)
-        selected = inputs[input_task].select({self.option_id: selected_values if len(selected_values) > 1 else selected_values[0]})
+        dimension = self._selected_dimension(block)
+        selected_values = [_guess_axis_value(value) for value in self._selected_value_strings(block)]
+        selected = inputs[input_task].select({dimension: selected_values if len(selected_values) > 1 else selected_values[0]})
         return Either.ok(selected)
 
-    def _restriction_value_strings(self, axis_values: set[Any]) -> list[str]:
-        if self.item_python_type is str:
-            return sorted(value for value in axis_values if isinstance(value, str))
-        if self.item_python_type is int:
-            return [str(value) for value in sorted(value for value in axis_values if type(value) is int)]
-        raise TypeError(f"Unsupported select value type {self.item_python_type!r}")
+    def restrictions(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> ConfigurationOptionRestriction:
+        input_dataset = inputs.get("dataset")
+        if not isinstance(input_dataset, QubedOutput):
+            return {}
 
-    def restrictions(self, other: QubedOutput) -> ConfigurationOptionRestriction:
-        values = self._restriction_value_strings(axes(other).get(self.option_id, set()))
-        return {self.option_id: ListType(ClosedEnumType(values))} if values else {}
+        restrict: ConfigurationOptionRestriction = {}
+        dimension_values = sorted(dimensions(input_dataset))
+        if dimension_values:
+            restrict[DIMENSION] = ClosedEnumType(dimension_values)
+
+        raw_dimension = block.configuration_values.get(DIMENSION)
+        if not isinstance(raw_dimension, str):
+            return restrict
+
+        axis_values = axes(input_dataset).get(raw_dimension)
+        if axis_values is None:
+            return restrict
+
+        values = _axis_value_strings(axis_values)
+        if values:
+            restrict[VALUES] = ListType(ClosedEnumType(values))
+        return restrict
 
     def intersect(self, other: QubedOutput) -> bool:
-        return contains(other, self.option_id)
+        return bool(dimensions(other))
 
 
 class GribSink(Sink):
@@ -590,15 +579,19 @@ class MapPlotSink(Sink):
         )
         return Either.ok(action)
 
-    def restrictions(self, other: QubedOutput) -> ConfigurationOptionRestriction:
-        restrict = {}
+    def restrictions(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> ConfigurationOptionRestriction:
+        del block
+        input_dataset = inputs.get("dataset")
+        if not isinstance(input_dataset, QubedOutput):
+            return {}
+        restrict: ConfigurationOptionRestriction = {}
 
-        param_values = [value for value in axes(other).get(PARAM, set()) if isinstance(value, str)]
+        param_values = [value for value in axes(input_dataset).get(PARAM, set()) if isinstance(value, str)]
         if param_values:
             restrict[PARAM] = ListType(ClosedEnumType(sorted(param_values)))
 
-        common = common_dimensions(other).intersection({PARAM, STEP, ENSEMBLE, LEVEL})
-        splitby = [x for x in common if len(axes(other)[x]) > 1]
+        common = common_dimensions(input_dataset).intersection({PARAM, STEP, ENSEMBLE, LEVEL})
+        splitby = [x for x in common if len(axes(input_dataset)[x]) > 1]
         restrict[SPLITBY] = ListType(ClosedEnumType(sorted(splitby) + ["none"]))
         return restrict
 

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -19,7 +19,6 @@ from earthkit.workflows.nodetree import nodetree_dimensions, nodetree_new_dimens
 from fiab_core.fable import (
     ActionLookup,
     BlockConfigurationOption,
-    BlockInstanceId,
     BlockInstanceOutput,
     ConfigurationOptionId,
     ConfigurationOptionRestriction,
@@ -144,7 +143,6 @@ class OperationalForecastSource(Source):
     def compile(
         self,
         inputs: ActionLookup,
-        block_id: BlockInstanceId,
         block: BlockInstance,
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         forecast = block.config_as_str(FORECAST)
@@ -227,7 +225,6 @@ class EnsembleStatistics(Product):
     def compile(
         self,
         inputs: ActionLookup,
-        block_id: BlockInstanceId,
         block: BlockInstance,
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         input_task = block.input_ids["dataset"]
@@ -271,7 +268,6 @@ class TemporalStatistics(Product):
     def compile(
         self,
         inputs: ActionLookup,
-        block_id: BlockInstanceId,
         block: BlockInstance,
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         input_task = block.input_ids["dataset"]
@@ -313,7 +309,6 @@ class ZarrSink(Sink):
     def compile(
         self,
         inputs: ActionLookup,
-        block_id: BlockInstanceId,
         block: BlockInstance,
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         input_task = block.input_ids["dataset"]
@@ -396,7 +391,6 @@ class Select(Transform):
     def compile(
         self,
         inputs: ActionLookup,
-        block_id: BlockInstanceId,
         block: BlockInstance,
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         input_task = block.input_ids["dataset"]
@@ -435,7 +429,6 @@ class GribSink(Sink):
     def compile(
         self,
         inputs: ActionLookup,
-        block_id: BlockInstanceId,
         block: BlockInstance,
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         input_task = block.input_ids["dataset"]
@@ -542,7 +535,6 @@ class MapPlotSink(Sink):
     def compile(
         self,
         inputs: ActionLookup,
-        block_id: BlockInstanceId,
         block: BlockInstance,
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         input_task = block.input_ids["dataset"]

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -11,8 +11,9 @@
 from datetime import datetime
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
-from earthkit.workflows.fluent import Action
+from earthkit.workflows.fluent import Action, Payload, from_source
 from earthkit.workflows.nodetree import nodetree_arrays, nodetree_dimensions
 from fiab_core.fable import (
     BlockFactoryId,
@@ -65,19 +66,45 @@ def _select() -> Select:
     return block
 
 
+def _block_instance(
+    factory_id: str, values: dict[str, object], *, input_ids: dict[str, BlockInstanceId] | None = None
+) -> BlockInstanceBase:
+    return BlockInstanceBase(
+        factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId(factory_id)),
+        input_ids=input_ids or {},
+        configuration_values=_config(values),
+    )
+
+
+class _TinyForecastPreset:
+    def as_qube(self, ens_dim: ConfigurationOptionId, *, include_member_zero: bool = False) -> Qube:
+        numbers = [0, 1] if include_member_zero else [1]
+        return Qube.from_datacube(
+            {
+                "time": ["0000"],
+                "levtype": ["sfc"],
+                PARAM: ["2t"],
+                STEP: [0, 6],
+                ens_dim: numbers,
+                "levelist": [0, 1],
+            }
+        )
+
+    def is_member_zero(self, datacube: dict[str, object]) -> bool:
+        numbers = datacube[ENSEMBLE]
+        return isinstance(numbers, list) and 0 in numbers
+
+
 @pytest.fixture
 def dummy_blockinstance() -> BlockInstance:
     return BlockInstance.from_block(
-        BlockInstanceBase(
-            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="dummy"),  # type: ignore
-            input_ids={},
-            configuration_values=_config(
-                {
-                    "source": "ecmwf-open-data",
-                    "base_time": datetime(2024, 1, 1),
-                    "forecast": "aifs-ens",
-                }
-            ),
+        _block_instance(
+            "dummy",
+            {
+                "source": "ecmwf-open-data",
+                "base_time": datetime(2024, 1, 1),
+                "forecast": "ifs-ens",
+            },
         ),
         OperationalForecastSource.configuration_options,
     )
@@ -91,29 +118,37 @@ def dummy_blockinstance_output() -> QubedOutput:
 @pytest.fixture
 def operational_forecast_source_configuration() -> BlockInstance:
     return BlockInstance.from_block(
-        BlockInstanceBase(
-            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="OperationalForecastSource"),  # type: ignore
-            input_ids={},
-            configuration_values=_config(
-                {
-                    "source": "ecmwf-open-data",
-                    "base_time": datetime(2024, 1, 1),
-                    "forecast": "ifs-ens",
-                }
-            ),
+        _block_instance(
+            "operationalForecastSource",
+            {
+                "source": "ecmwf-open-data",
+                "base_time": datetime(2024, 1, 1),
+                "forecast": "ifs-ens",
+            },
         ),
         OperationalForecastSource.configuration_options,
     )
 
 
 @pytest.fixture
-def operational_forecast_source_output(dummy_blockinstance: BlockInstance) -> QubedOutput:
-    return OperationalForecastSource().validate(block=dummy_blockinstance, inputs={}).get_or_raise()  # type: ignore[return-value]
+def operational_forecast_source_output() -> QubedOutput:
+    return QubedOutput(
+        dataqube=Qube.from_datacube(
+            {
+                PARAM: ["2t", "msl", "u"],
+                STEP: [0, 6, 12],
+                ENSEMBLE: [0, 1, 2, 3, 4],
+            }
+        )
+    )
 
 
 @pytest.fixture
-def operational_forecast_source_action(dummy_blockinstance: BlockInstance) -> Action:
-    return OperationalForecastSource().compile(inputs={}, block=dummy_blockinstance).get_or_raise()
+def operational_forecast_source_action(operational_forecast_source_output: QubedOutput) -> Action:
+    return from_source(np.asarray(Payload("fiab_plugin_ecmwf.tests.noop"), dtype=object)).expand_as_qube(
+        operational_forecast_source_output.dataqube,
+        dims=[PARAM, STEP, ENSEMBLE],
+    )
 
 
 @pytest.fixture
@@ -147,6 +182,21 @@ def temporal_statistics_configuration() -> BlockInstance:
             ),
         ),
         TemporalStatistics.configuration_options,
+    )
+
+
+@pytest.fixture
+def select_configuration() -> BlockInstance:
+    return BlockInstance.from_block(
+        _block_instance(
+            "select",
+            {
+                "dimension": "param",
+                "values": ["2t"],
+            },
+            input_ids={"dataset": BlockInstanceId("source_output")},
+        ),
+        _select().configuration_options,
     )
 
 
@@ -230,11 +280,24 @@ class TestOperationalForecastSource:
         assert contains(output, "param")
         assert contains(output, "step")
         assert contains(output, "number")
-        if forecast != "aifs-ens":
-            return
+
+    def test_compile_builds_action_from_catalogue(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setitem(FORECAST_DATASETS, "aifs-ens", _TinyForecastPreset())
+        block = OperationalForecastSource()
+        block_instance = BlockInstance.from_block(
+            _block_instance(
+                "operationalForecastSource",
+                {
+                    "source": "ecmwf-open-data",
+                    "base_time": datetime(2024, 1, 1),
+                    "forecast": "aifs-ens",
+                },
+            ),
+            OperationalForecastSource.configuration_options,
+        )
         action = block.compile({}, block_instance).get_or_raise()
         for _, array in nodetree_arrays(action.nodes):
-            assert array.sizes[STEP] > 0
+            assert array.sizes[STEP] == 2
             assert array.sizes[ENSEMBLE] > 0
         assert "levelist" in nodetree_dimensions(action.nodes)
 
@@ -463,138 +526,85 @@ class TestSelect:
         assert _select().configuration_options[DIMENSION].value_type == "str"
         assert _select().configuration_options[VALUES].value_type == "list[str]"
 
-    def test_validator_adds_dimension_restrictions(self, operational_forecast_source_output: QubedOutput) -> None:
-        config = BlockInstance.from_block(
-            BlockInstanceBase(
-                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("select")),
-                input_ids={"dataset": BlockInstanceId("source_output")},
-                configuration_values=_config({"dimension": "step", "values": ["0"]}),
-            ),
-            _select().configuration_options,
-        )
+    def test_from_operational_forecast_source(
+        self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
+    ) -> None:
+        block = _select()
+        assert block.intersect(other=operational_forecast_source_output)  # type: ignore[arg-type]
+        output = block.validate(block=select_configuration, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
+        assert isinstance(output, QubedOutput)
+        assert output.dataqube is not None
+        assert axes(output)[PARAM] == {"2t"}
 
-        _, restrictions = plugin().validator(config, {"dataset": operational_forecast_source_output})
+    def test_from_operational_forecast_source_multiple_parameters(
+        self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
+    ) -> None:
+        block = _select()
+        config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "param", "values": ["2t", "msl"]})})
+        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
+        assert isinstance(output, QubedOutput)
+        assert axes(output)[PARAM] == {"2t", "msl"}
+
+    def test_selects_integer_dimension_from_string_values(
+        self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
+    ) -> None:
+        block = _select()
+        config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "step", "values": ["0", "6"]})})
+        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
+        assert isinstance(output, QubedOutput)
+        assert axes(output)[STEP] == {0, 6}
+
+    def test_validator_adds_dimension_restrictions(
+        self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
+    ) -> None:
+        _, restrictions = plugin().validator(select_configuration, {"dataset": operational_forecast_source_output})
         restriction = restrictions[DIMENSION].serialize()
         assert restriction.startswith("enumClosed[")
         assert "param" in restriction
         assert "step" in restriction
         assert "number" in restriction
 
-    def test_validator_adds_values_for_selected_dimension(self, operational_forecast_source_output: QubedOutput) -> None:
-        config = BlockInstance.from_block(
-            BlockInstanceBase(
-                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("select")),
-                input_ids={"dataset": BlockInstanceId("source_output")},
-                configuration_values=_config({"dimension": "step", "values": ["0"]}),
-            ),
-            _select().configuration_options,
-        )
-
+    def test_validator_adds_values_for_selected_dimension(
+        self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
+    ) -> None:
+        config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "step", "values": ["0"]})})
         _, restrictions = plugin().validator(config, {"dataset": operational_forecast_source_output})
+        assert restrictions[VALUES].serialize() == "list[enumClosed[0,6,12]]"
 
-        assert restrictions[DIMENSION].serialize().startswith("enumClosed[")
-        values_restriction = restrictions[VALUES].serialize()
-        assert values_restriction.startswith("list[enumClosed[")
-        assert "0" in values_restriction
-        assert "6" in values_restriction
-        assert "12" in values_restriction
-
-    def test_validator_keeps_restrictions_when_configuration_is_missing(self, operational_forecast_source_output: QubedOutput) -> None:
-        config = BlockInstance.from_block(
-            BlockInstanceBase(
-                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("select")),
-                input_ids={"dataset": BlockInstanceId("source_output")},
-                configuration_values=_config({"dimension": "step"}),
-            ),
-            _select().configuration_options,
-        )
-
+    def test_validator_keeps_restrictions_when_configuration_is_missing(
+        self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
+    ) -> None:
+        config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "step"})})
         result, restrictions = plugin().validator(config, {"dataset": operational_forecast_source_output})
-
         assert result.e is not None
         assert DIMENSION in restrictions
         assert VALUES in restrictions
 
-    def test_selects_string_dimension(self, operational_forecast_source_output: QubedOutput) -> None:
-        block = _select()
-        config = BlockInstance.from_block(
-            BlockInstanceBase(
-                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("select")),
-                input_ids={"dataset": BlockInstanceId("source_output")},
-                configuration_values=_config({"dimension": "param", "values": ["2t"]}),
-            ),
-            block.configuration_options,
-        )
-
-        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()
-
-        assert isinstance(output, QubedOutput)
-        assert axes(output)[PARAM] == {"2t"}
-
-    def test_selects_integer_dimension_from_string_values(self, operational_forecast_source_output: QubedOutput) -> None:
-        block = _select()
-        config = BlockInstance.from_block(
-            BlockInstanceBase(
-                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("select")),
-                input_ids={"dataset": BlockInstanceId("source_output")},
-                configuration_values=_config({"dimension": "step", "values": ["0", "6"]}),
-            ),
-            block.configuration_options,
-        )
-
-        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()
-
-        assert isinstance(output, QubedOutput)
-        assert axes(output)[STEP] == {0, 6}
-
-    def test_validate_does_not_recheck_restricted_dimension(self, operational_forecast_source_output: QubedOutput) -> None:
-        block = _select()
-        config = BlockInstance.from_block(
-            BlockInstanceBase(
-                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("select")),
-                input_ids={"dataset": BlockInstanceId("source_output")},
-                configuration_values=_config({"dimension": "missing", "values": ["0"]}),
-            ),
-            block.configuration_options,
-        )
-
-        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()
-
-        assert isinstance(output, QubedOutput)
-
-    def test_validate_does_not_recheck_restricted_values(self, operational_forecast_source_output: QubedOutput) -> None:
-        block = _select()
-        config = BlockInstance.from_block(
-            BlockInstanceBase(
-                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("select")),
-                input_ids={"dataset": BlockInstanceId("source_output")},
-                configuration_values=_config({"dimension": "step", "values": ["999"]}),
-            ),
-            block.configuration_options,
-        )
-
-        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()
-
-        assert isinstance(output, QubedOutput)
-
-    def test_compile_calls_select_with_integer_values(self) -> None:
+    def test_compile_calls_select(self, select_configuration: BlockInstance) -> None:
         block = _select()
         input_action = MagicMock()
         selected_action = MagicMock()
         input_action.select.return_value = selected_action
-        config = BlockInstance.from_block(
-            BlockInstanceBase(
-                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("select")),
-                input_ids={"dataset": BlockInstanceId("source_output")},
-                configuration_values=_config({"dimension": "step", "values": ["0", "6"]}),
-            ),
-            block.configuration_options,
-        )
 
-        result = block.compile(inputs={BlockInstanceId("source_output"): input_action}, block=config)
+        result = block.compile(inputs={BlockInstanceId("source_output"): input_action}, block=select_configuration)  # type: ignore[dict-item]
+        assert result.t is selected_action
+        input_action.select.assert_called_once_with({PARAM: "2t"})
 
+    def test_compile_calls_select_with_integer_values(self, select_configuration: BlockInstance) -> None:
+        block = _select()
+        input_action = MagicMock()
+        selected_action = MagicMock()
+        input_action.select.return_value = selected_action
+        config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "step", "values": ["0", "6"]})})
+
+        result = block.compile(inputs={BlockInstanceId("source_output"): input_action}, block=config)  # type: ignore[dict-item]
         assert result.t is selected_action
         input_action.select.assert_called_once_with({STEP: [0, 6]})
+
+    def test_expander_offers_select_without_static_restrictions(self, operational_forecast_source_output: QubedOutput) -> None:
+        expansions = plugin().expander(operational_forecast_source_output)
+        select_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("select"))
+        assert select_expansion.restrictions == {}
 
 
 def test_anemoi_catalogue_value_types_are_canonical(registered_provider: None) -> None:
@@ -758,10 +768,7 @@ class TestMapPlotSink:
         self, map_plot_sink_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
     ) -> None:
         _, restrictions = plugin().validator(map_plot_sink_configuration, {"dataset": operational_forecast_source_output})
-        param_restriction = restrictions[PARAM].serialize()
-        assert param_restriction.startswith("list[enumClosed[")
-        assert "2t" in param_restriction
-        assert "msl" in param_restriction
+        assert restrictions[PARAM].serialize() == "list[enumClosed[2t,msl,u]]"
 
     def test_expander_has_no_parameters_restrictions(self, operational_forecast_source_output: QubedOutput) -> None:
         expansions = plugin().expander(operational_forecast_source_output)

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -466,7 +466,7 @@ class TestSelect:
         assert _select().configuration_options[DIMENSION].value_type == "str"
         assert _select().configuration_options[VALUES].value_type == "list[str]"
 
-    def test_restrictor_adds_dimension_restrictions(self, operational_forecast_source_output: QubedOutput) -> None:
+    def test_validator_adds_dimension_restrictions(self, operational_forecast_source_output: QubedOutput) -> None:
         config = BlockInstance.from_block(
             BlockInstanceBase(
                 factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("select")),
@@ -476,15 +476,14 @@ class TestSelect:
             _select().configuration_options,
         )
 
-        restrictor = plugin().restrictor
-        assert restrictor is not None
-        restriction = restrictor(config, {"dataset": operational_forecast_source_output})[DIMENSION].serialize()
+        _, restrictions = plugin().validator(config, {"dataset": operational_forecast_source_output})
+        restriction = restrictions[DIMENSION].serialize()
         assert restriction.startswith("enumClosed[")
         assert "param" in restriction
         assert "step" in restriction
         assert "number" in restriction
 
-    def test_restrictor_adds_values_for_selected_dimension(self, operational_forecast_source_output: QubedOutput) -> None:
+    def test_validator_adds_values_for_selected_dimension(self, operational_forecast_source_output: QubedOutput) -> None:
         config = BlockInstance.from_block(
             BlockInstanceBase(
                 factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("select")),
@@ -494,9 +493,7 @@ class TestSelect:
             _select().configuration_options,
         )
 
-        restrictor = plugin().restrictor
-        assert restrictor is not None
-        restrictions = restrictor(config, {"dataset": operational_forecast_source_output})
+        _, restrictions = plugin().validator(config, {"dataset": operational_forecast_source_output})
 
         assert restrictions[DIMENSION].serialize().startswith("enumClosed[")
         values_restriction = restrictions[VALUES].serialize()
@@ -504,6 +501,22 @@ class TestSelect:
         assert "0" in values_restriction
         assert "6" in values_restriction
         assert "12" in values_restriction
+
+    def test_validator_keeps_restrictions_when_configuration_is_missing(self, operational_forecast_source_output: QubedOutput) -> None:
+        config = BlockInstance.from_block(
+            BlockInstanceBase(
+                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("select")),
+                input_ids={"dataset": BlockInstanceId("source_output")},
+                configuration_values=_config({"dimension": "step"}),
+            ),
+            _select().configuration_options,
+        )
+
+        result, restrictions = plugin().validator(config, {"dataset": operational_forecast_source_output})
+
+        assert result.e is not None
+        assert DIMENSION in restrictions
+        assert VALUES in restrictions
 
     def test_selects_string_dimension(self, operational_forecast_source_output: QubedOutput) -> None:
         block = _select()
@@ -537,7 +550,7 @@ class TestSelect:
         assert isinstance(output, QubedOutput)
         assert axes(output)[STEP] == {0, 6}
 
-    def test_missing_dimension(self, operational_forecast_source_output: QubedOutput) -> None:
+    def test_validate_does_not_recheck_restricted_dimension(self, operational_forecast_source_output: QubedOutput) -> None:
         block = _select()
         config = BlockInstance.from_block(
             BlockInstanceBase(
@@ -548,11 +561,11 @@ class TestSelect:
             block.configuration_options,
         )
 
-        result = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})
-        with pytest.raises(Exception, match="Dimension 'missing' is not in the input dimensions"):
-            result.get_or_raise()
+        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()
 
-    def test_missing_values(self, operational_forecast_source_output: QubedOutput) -> None:
+        assert isinstance(output, QubedOutput)
+
+    def test_validate_does_not_recheck_restricted_values(self, operational_forecast_source_output: QubedOutput) -> None:
         block = _select()
         config = BlockInstance.from_block(
             BlockInstanceBase(
@@ -563,9 +576,9 @@ class TestSelect:
             block.configuration_options,
         )
 
-        result = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})
-        with pytest.raises(Exception, match="Values \\['999'\\] are not in the input step"):
-            result.get_or_raise()
+        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()
+
+        assert isinstance(output, QubedOutput)
 
     def test_compile_calls_select_with_integer_values(self) -> None:
         block = _select()
@@ -746,12 +759,10 @@ class TestMapPlotSink:
         collapsed = collapse(operational_forecast_source_output, "param")
         assert not block.intersect(other=collapsed)  # type: ignore[arg-type]
 
-    def test_restrictor_adds_parameters_restrictions(
+    def test_validator_adds_parameters_restrictions(
         self, map_plot_sink_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
     ) -> None:
-        restrictor = plugin().restrictor
-        assert restrictor is not None
-        restrictions = restrictor(map_plot_sink_configuration, {"dataset": operational_forecast_source_output})
+        _, restrictions = plugin().validator(map_plot_sink_configuration, {"dataset": operational_forecast_source_output})
         param_restriction = restrictions[PARAM].serialize()
         assert param_restriction.startswith("list[enumClosed[")
         assert "2t" in param_restriction
@@ -829,7 +840,7 @@ class TestMapPlotSink:
         output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
         assert isinstance(output, RawOutput)
 
-    def test_validate_missing_param(self, operational_forecast_source_output: QubedOutput) -> None:
+    def test_validate_does_not_recheck_restricted_param(self, operational_forecast_source_output: QubedOutput) -> None:
         block = MapPlotSink()
         config = BlockInstance.from_block(
             BlockInstanceBase(
@@ -847,11 +858,10 @@ class TestMapPlotSink:
             ),
             MapPlotSink.configuration_options,
         )
-        result = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})  # type: ignore[dict-item]
-        with pytest.raises(Exception, match="params \\['nonexistent'\\] are not in the input parameters"):
-            result.get_or_raise()
+        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
+        assert isinstance(output, RawOutput)
 
-    def test_validate_partial_missing_params(self, operational_forecast_source_output: QubedOutput) -> None:
+    def test_validate_does_not_recheck_partial_restricted_params(self, operational_forecast_source_output: QubedOutput) -> None:
         block = MapPlotSink()
         config = BlockInstance.from_block(
             BlockInstanceBase(
@@ -869,9 +879,8 @@ class TestMapPlotSink:
             ),
             MapPlotSink.configuration_options,
         )
-        result = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})  # type: ignore[dict-item]
-        with pytest.raises(Exception, match="params \\['nonexistent'\\] are not in the input parameters"):
-            result.get_or_raise()
+        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
+        assert isinstance(output, RawOutput)
 
     def test_validate_from_ensemble_statistics(
         self,

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -113,9 +113,7 @@ def operational_forecast_source_output(dummy_blockinstance: BlockInstance) -> Qu
 
 @pytest.fixture
 def operational_forecast_source_action(dummy_blockinstance: BlockInstance) -> Action:
-    return (
-        OperationalForecastSource().compile(inputs={}, block_id=BlockInstanceId("source_output"), block=dummy_blockinstance).get_or_raise()
-    )
+    return OperationalForecastSource().compile(inputs={}, block=dummy_blockinstance).get_or_raise()
 
 
 @pytest.fixture
@@ -234,7 +232,7 @@ class TestOperationalForecastSource:
         assert contains(output, "number")
         if forecast != "aifs-ens":
             return
-        action = block.compile({}, BlockInstanceId("operationalForecastSource"), block_instance).get_or_raise()
+        action = block.compile({}, block_instance).get_or_raise()
         for _, array in nodetree_arrays(action.nodes):
             assert array.sizes[STEP] > 0
             assert array.sizes[ENSEMBLE] > 0
@@ -455,7 +453,6 @@ class TestZarrSink:
         block.validate(block=zarr_sink_configuration, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
         action = block.compile(
             inputs={BlockInstanceId("source_output"): operational_forecast_source_action},
-            block_id=BlockInstanceId("grib"),
             block=zarr_sink_configuration,
         ).get_or_raise()
         assert action.nodes.dims == {}
@@ -594,7 +591,7 @@ class TestSelect:
             block.configuration_options,
         )
 
-        result = block.compile(inputs={BlockInstanceId("source_output"): input_action}, block_id=BlockInstanceId("select"), block=config)
+        result = block.compile(inputs={BlockInstanceId("source_output"): input_action}, block=config)
 
         assert result.t is selected_action
         input_action.select.assert_called_once_with({STEP: [0, 6]})
@@ -739,9 +736,7 @@ class TestGribSink:
             GribSink.configuration_options,
         )
         block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
-        action = block.compile(
-            inputs={BlockInstanceId("source_output"): operational_forecast_source_action}, block_id=BlockInstanceId("grib"), block=config
-        ).get_or_raise()
+        action = block.compile(inputs={BlockInstanceId("source_output"): operational_forecast_source_action}, block=config).get_or_raise()
         assert action.nodes.dims == dims
 
 
@@ -921,9 +916,7 @@ class TestMapPlotSink:
             MapPlotSink.configuration_options,
         )
         block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
-        action = block.compile(
-            inputs={BlockInstanceId("source_output"): operational_forecast_source_action}, block_id=BlockInstanceId("plot"), block=config
-        ).get_or_raise()
+        action = block.compile(inputs={BlockInstanceId("source_output"): operational_forecast_source_action}, block=config).get_or_raise()
         assert action.nodes.dims == {}
 
     def test_validate_splitby(self, operational_forecast_source_output: QubedOutput) -> None:
@@ -975,7 +968,5 @@ class TestMapPlotSink:
             MapPlotSink.configuration_options,
         )
         block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
-        action = block.compile(
-            inputs={BlockInstanceId("source_output"): operational_forecast_source_action}, block_id=BlockInstanceId("plot"), block=config
-        ).get_or_raise()
+        action = block.compile(inputs={BlockInstanceId("source_output"): operational_forecast_source_action}, block=config).get_or_raise()
         assert action.nodes.dims == dims

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -34,15 +34,17 @@ from fiab_plugin_ecmwf import blocks as ecmwf_block_builders
 from fiab_plugin_ecmwf import plugin
 from fiab_plugin_ecmwf.anemoi.utils import get_checkpoint_enum_type
 from fiab_plugin_ecmwf.blocks import (
+    DIMENSION,
     ENSEMBLE,
     FORECAST_DATASETS,
     PARAM,
     STEP,
+    VALUES,
     EnsembleStatistics,
     GribSink,
     MapPlotSink,
     OperationalForecastSource,
-    SelectDimension,
+    Select,
     TemporalStatistics,
     ZarrSink,
 )
@@ -57,21 +59,9 @@ def _block_builder(factory_id: str) -> QubedBlockBuilder:
     return ecmwf_block_builders[BlockFactoryId(factory_id)]
 
 
-def _select_parameters() -> SelectDimension:
-    block = _block_builder("selectParameters")
-    assert isinstance(block, SelectDimension)
-    return block
-
-
-def _select_steps() -> SelectDimension:
-    block = _block_builder("selectSteps")
-    assert isinstance(block, SelectDimension)
-    return block
-
-
-def _select_members() -> SelectDimension:
-    block = _block_builder("selectMembers")
-    assert isinstance(block, SelectDimension)
+def _select() -> Select:
+    block = _block_builder("select")
+    assert isinstance(block, Select)
     return block
 
 
@@ -85,10 +75,7 @@ def dummy_blockinstance() -> BlockInstance:
                 {
                     "source": "ecmwf-open-data",
                     "base_time": datetime(2024, 1, 1),
-                    "forecast": "ifs-ens",
-                    "param": ["2t", "msl", "u"],
-                    "step": [0, 6, 12],
-                    "number": [0, 1, 2, 3, 4],
+                    "forecast": "aifs-ens",
                 }
             ),
         ),
@@ -111,9 +98,7 @@ def operational_forecast_source_configuration() -> BlockInstance:
                 {
                     "source": "ecmwf-open-data",
                     "base_time": datetime(2024, 1, 1),
-                    "step": [0, 6, 12],
-                    "number": [1, 2, 3, 4, 5],
-                    "param": ["2t", "msl"],
+                    "forecast": "ifs-ens",
                 }
             ),
         ),
@@ -168,54 +153,6 @@ def temporal_statistics_configuration() -> BlockInstance:
 
 
 @pytest.fixture
-def select_parameters_configuration() -> BlockInstance:
-    return BlockInstance.from_block(
-        BlockInstanceBase(
-            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="selectParameters"),  # type: ignore
-            input_ids={"dataset": BlockInstanceId("source_output")},
-            configuration_values=_config(
-                {
-                    "param": ["2t"],
-                }
-            ),
-        ),
-        _select_parameters().configuration_options,
-    )
-
-
-@pytest.fixture
-def select_steps_configuration() -> BlockInstance:
-    return BlockInstance.from_block(
-        BlockInstanceBase(
-            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="selectSteps"),  # type: ignore
-            input_ids={"dataset": BlockInstanceId("source_output")},
-            configuration_values=_config(
-                {
-                    "step": [0],
-                }
-            ),
-        ),
-        _select_steps().configuration_options,
-    )
-
-
-@pytest.fixture
-def select_members_configuration() -> BlockInstance:
-    return BlockInstance.from_block(
-        BlockInstanceBase(
-            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="selectMembers"),  # type: ignore
-            input_ids={"dataset": BlockInstanceId("source_output")},
-            configuration_values=_config(
-                {
-                    "number": [1],
-                }
-            ),
-        ),
-        _select_members().configuration_options,
-    )
-
-
-@pytest.fixture
 def zarr_sink_configuration() -> BlockInstance:
     return BlockInstance.from_block(
         BlockInstanceBase(
@@ -251,7 +188,7 @@ def grib_sink_configuration() -> BlockInstance:
 def map_plot_sink_configuration() -> BlockInstance:
     return BlockInstance.from_block(
         BlockInstanceBase(
-            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="MapPlotSink"),  # type: ignore
+            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("mapPlotSink")),
             input_ids={"dataset": BlockInstanceId("source_output")},
             configuration_values=_config(
                 {
@@ -282,9 +219,6 @@ class TestOperationalForecastSource:
                         {
                             "source": "ecmwf-open-data",
                             "base_time": datetime(2024, 1, 1),
-                            "step": [0, 6, 12],
-                            "number": [0, 1, 2, 3, 4],
-                            "param": ["2t", "msl", "u"],
                             "forecast": forecast,
                         },
                     )
@@ -296,20 +230,20 @@ class TestOperationalForecastSource:
         assert isinstance(output, QubedOutput)
         assert output.dataqube is not None
         assert contains(output, "param")
+        assert contains(output, "step")
+        assert contains(output, "number")
+        if forecast != "aifs-ens":
+            return
         action = block.compile({}, BlockInstanceId("operationalForecastSource"), block_instance).get_or_raise()
         for _, array in nodetree_arrays(action.nodes):
-            assert array.sizes[STEP] == 3
-            assert array.sizes[ENSEMBLE] == 5
+            assert array.sizes[STEP] > 0
+            assert array.sizes[ENSEMBLE] > 0
         assert "levelist" in nodetree_dimensions(action.nodes)
 
     @pytest.mark.parametrize(
         "config, error",
         [
-            [{"param": ["unknown"]}, "Invalid param"],
-            [{"step": [0, 6, 400]}, "Invalid step"],
-            [{"number": [0, 50, 100]}, "Invalid number"],
             [{"base_time": datetime(2024, 1, 1, 9)}, "Invalid time"],
-            [{"base_time": datetime(2024, 1, 1, 6), "step": [150]}, "Invalid step"],
         ],
     )
     def test_validate(self, config: dict, error: str) -> None:
@@ -323,9 +257,6 @@ class TestOperationalForecastSource:
                         {
                             "source": "ecmwf-open-data",
                             "base_time": datetime(2024, 1, 1),
-                            "step": [0, 6, 12],
-                            "number": [1, 2, 3, 4, 5],
-                            "param": ["2t", "msl"],
                             "forecast": "ifs-ens",
                         },
                         **config,
@@ -343,6 +274,9 @@ class TestOperationalForecastSource:
             == "enumClosed['mars', 'ecmwf-open-data']"
         )
         assert OperationalForecastSource.configuration_options[ConfigurationOptionId("base_time")].value_type == "datetime"
+        assert PARAM not in OperationalForecastSource.configuration_options
+        assert STEP not in OperationalForecastSource.configuration_options
+        assert ENSEMBLE not in OperationalForecastSource.configuration_options
 
 
 class TestEnsembleStatistics:
@@ -527,221 +461,130 @@ class TestZarrSink:
         assert action.nodes.dims == {}
 
 
-class TestSelectParameters:
-    def test_catalogue_value_type_is_canonical(self) -> None:
-        assert _select_parameters().configuration_options[PARAM].value_type == "list[str]"
+class TestSelect:
+    def test_catalogue_value_types_are_canonical(self) -> None:
+        assert _select().configuration_options[DIMENSION].value_type == "str"
+        assert _select().configuration_options[VALUES].value_type == "list[str]"
 
-    def test_from_operational_forecast_source(
-        self, select_parameters_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
-    ) -> None:
-        block = _select_parameters()
-        assert block.intersect(other=operational_forecast_source_output)  # type: ignore[arg-type]
-        output = block.validate(
-            block=select_parameters_configuration, inputs={"dataset": operational_forecast_source_output}
-        ).get_or_raise()  # type: ignore[dict-item]
-        assert isinstance(output, QubedOutput)
-        assert output.dataqube is not None
-        assert axes(output)["param"] == {"2t"}
-
-    def test_from_operational_forecast_source_multiple_parameters(
-        self, select_parameters_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
-    ) -> None:
-        block = _select_parameters()
-        config = select_parameters_configuration.model_copy(update={"configuration_values": _config({"param": ["2t", "msl"]})})
-        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
-        assert isinstance(output, QubedOutput)
-        assert axes(output)["param"] == {"2t", "msl"}
-
-    def test_missing_parameters(
-        self, select_parameters_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
-    ) -> None:
-        block = _select_parameters()
-        config = select_parameters_configuration.model_copy(update={"configuration_values": _config({"param": ["nonexistent"]})})
-        result = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})  # type: ignore[dict-item]
-        with pytest.raises(Exception, match="parameters \\['nonexistent'\\] are not in the input parameters"):
-            result.get_or_raise()
-
-    def test_compile_calls_select(self, select_parameters_configuration: BlockInstance) -> None:
-        block = _select_parameters()
-        input_action = MagicMock()
-        selected_action = MagicMock()
-        input_action.select.return_value = selected_action
-
-        result = block.compile(
-            inputs={BlockInstanceId("source_output"): input_action},  # type: ignore[dict-item]
-            block_id=BlockInstanceId("select_parameters"),
-            block=select_parameters_configuration,
+    def test_restrictor_adds_dimension_restrictions(self, operational_forecast_source_output: QubedOutput) -> None:
+        config = BlockInstance.from_block(
+            BlockInstanceBase(
+                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("select")),
+                input_ids={"dataset": BlockInstanceId("source_output")},
+                configuration_values=_config({"dimension": "step", "values": ["0"]}),
+            ),
+            _select().configuration_options,
         )
-        assert result.t is selected_action
-        input_action.select.assert_called_once_with({ConfigurationOptionId("param"): "2t"})
 
-    def test_compile_calls_select_with_multiple_parameters(self, select_parameters_configuration: BlockInstance) -> None:
-        block = _select_parameters()
-        input_action = MagicMock()
-        selected_action = MagicMock()
-        input_action.select.return_value = selected_action
-        config = select_parameters_configuration.model_copy(update={"configuration_values": _config({"param": ["2t", "msl"]})})
+        restrictor = plugin().restrictor
+        assert restrictor is not None
+        restriction = restrictor(config, {"dataset": operational_forecast_source_output})[DIMENSION].serialize()
+        assert restriction.startswith("enumClosed[")
+        assert "param" in restriction
+        assert "step" in restriction
+        assert "number" in restriction
 
-        result = block.compile(
-            inputs={BlockInstanceId("source_output"): input_action},  # type: ignore[dict-item]
-            block_id=BlockInstanceId("select_parameters"),
-            block=config,
+    def test_restrictor_adds_values_for_selected_dimension(self, operational_forecast_source_output: QubedOutput) -> None:
+        config = BlockInstance.from_block(
+            BlockInstanceBase(
+                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("select")),
+                input_ids={"dataset": BlockInstanceId("source_output")},
+                configuration_values=_config({"dimension": "step", "values": ["0"]}),
+            ),
+            _select().configuration_options,
         )
-        assert result.t is selected_action
-        input_action.select.assert_called_once_with({ConfigurationOptionId("param"): ["2t", "msl"]})
 
-    def test_expander_adds_parameters_restrictions(self, operational_forecast_source_output: QubedOutput) -> None:
-        expansions = plugin().expander(operational_forecast_source_output)
-        select_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("selectParameters"))
-        assert select_expansion.restrictions[PARAM].serialize() == "list[enumClosed[2t,msl,u]]"
+        restrictor = plugin().restrictor
+        assert restrictor is not None
+        restrictions = restrictor(config, {"dataset": operational_forecast_source_output})
 
-    def test_expander_skips_restriction_for_non_string_axes(self) -> None:
-        output = QubedOutput(dataqube=Qube.from_datacube({"param": [1, 2]}))
-        expansions = plugin().expander(output)
-        select_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("selectParameters"))
-        assert select_expansion.restrictions == {}
+        assert restrictions[DIMENSION].serialize().startswith("enumClosed[")
+        values_restriction = restrictions[VALUES].serialize()
+        assert values_restriction.startswith("list[enumClosed[")
+        assert "0" in values_restriction
+        assert "6" in values_restriction
+        assert "12" in values_restriction
 
+    def test_selects_string_dimension(self, operational_forecast_source_output: QubedOutput) -> None:
+        block = _select()
+        config = BlockInstance.from_block(
+            BlockInstanceBase(
+                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("select")),
+                input_ids={"dataset": BlockInstanceId("source_output")},
+                configuration_values=_config({"dimension": "param", "values": ["2t"]}),
+            ),
+            block.configuration_options,
+        )
 
-class TestSelectSteps:
-    def test_catalogue_value_type_is_canonical(self) -> None:
-        assert _select_steps().configuration_options[STEP].value_type == "list[int]"
+        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()
 
-    def test_from_operational_forecast_source(
-        self, select_steps_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
-    ) -> None:
-        block = _select_steps()
-        assert block.intersect(other=operational_forecast_source_output)  # type: ignore[arg-type]
-        output = block.validate(block=select_steps_configuration, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
         assert isinstance(output, QubedOutput)
-        assert output.dataqube is not None
-        assert axes(output)[STEP] == {0}
+        assert axes(output)[PARAM] == {"2t"}
 
-    def test_from_operational_forecast_source_multiple_steps(
-        self, select_steps_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
-    ) -> None:
-        block = _select_steps()
-        config = select_steps_configuration.model_copy(update={"configuration_values": _config({"step": [0, 6]})})
-        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
+    def test_selects_integer_dimension_from_string_values(self, operational_forecast_source_output: QubedOutput) -> None:
+        block = _select()
+        config = BlockInstance.from_block(
+            BlockInstanceBase(
+                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("select")),
+                input_ids={"dataset": BlockInstanceId("source_output")},
+                configuration_values=_config({"dimension": "step", "values": ["0", "6"]}),
+            ),
+            block.configuration_options,
+        )
+
+        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()
+
         assert isinstance(output, QubedOutput)
         assert axes(output)[STEP] == {0, 6}
 
-    def test_missing_steps(self, select_steps_configuration: BlockInstance, operational_forecast_source_output: QubedOutput) -> None:
-        block = _select_steps()
-        config = select_steps_configuration.model_copy(update={"configuration_values": _config({"step": [999]})})
-        result = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})  # type: ignore[dict-item]
-        with pytest.raises(Exception, match="steps \\[999\\] are not in the input steps"):
+    def test_missing_dimension(self, operational_forecast_source_output: QubedOutput) -> None:
+        block = _select()
+        config = BlockInstance.from_block(
+            BlockInstanceBase(
+                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("select")),
+                input_ids={"dataset": BlockInstanceId("source_output")},
+                configuration_values=_config({"dimension": "missing", "values": ["0"]}),
+            ),
+            block.configuration_options,
+        )
+
+        result = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})
+        with pytest.raises(Exception, match="Dimension 'missing' is not in the input dimensions"):
             result.get_or_raise()
 
-    def test_compile_calls_select(self, select_steps_configuration: BlockInstance) -> None:
-        block = _select_steps()
+    def test_missing_values(self, operational_forecast_source_output: QubedOutput) -> None:
+        block = _select()
+        config = BlockInstance.from_block(
+            BlockInstanceBase(
+                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("select")),
+                input_ids={"dataset": BlockInstanceId("source_output")},
+                configuration_values=_config({"dimension": "step", "values": ["999"]}),
+            ),
+            block.configuration_options,
+        )
+
+        result = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})
+        with pytest.raises(Exception, match="Values \\['999'\\] are not in the input step"):
+            result.get_or_raise()
+
+    def test_compile_calls_select_with_integer_values(self) -> None:
+        block = _select()
         input_action = MagicMock()
         selected_action = MagicMock()
         input_action.select.return_value = selected_action
-
-        result = block.compile(
-            inputs={BlockInstanceId("source_output"): input_action},  # type: ignore[dict-item]
-            block_id=BlockInstanceId("select_steps"),
-            block=select_steps_configuration,
+        config = BlockInstance.from_block(
+            BlockInstanceBase(
+                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("select")),
+                input_ids={"dataset": BlockInstanceId("source_output")},
+                configuration_values=_config({"dimension": "step", "values": ["0", "6"]}),
+            ),
+            block.configuration_options,
         )
-        assert result.t is selected_action
-        input_action.select.assert_called_once_with({STEP: 0})
 
-    def test_compile_calls_select_with_multiple_steps(self, select_steps_configuration: BlockInstance) -> None:
-        block = _select_steps()
-        input_action = MagicMock()
-        selected_action = MagicMock()
-        input_action.select.return_value = selected_action
-        config = select_steps_configuration.model_copy(update={"configuration_values": _config({"step": [0, 6]})})
+        result = block.compile(inputs={BlockInstanceId("source_output"): input_action}, block_id=BlockInstanceId("select"), block=config)
 
-        result = block.compile(
-            inputs={BlockInstanceId("source_output"): input_action},  # type: ignore[dict-item]
-            block_id=BlockInstanceId("select_steps"),
-            block=config,
-        )
         assert result.t is selected_action
         input_action.select.assert_called_once_with({STEP: [0, 6]})
-
-    def test_expander_adds_step_restrictions(self, operational_forecast_source_output: QubedOutput) -> None:
-        expansions = plugin().expander(operational_forecast_source_output)
-        select_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("selectSteps"))
-        assert select_expansion.restrictions[STEP].serialize() == "list[enumClosed[0,6,12]]"
-
-    def test_expander_skips_restriction_for_non_int_axes(self) -> None:
-        output = QubedOutput(dataqube=Qube.from_datacube({STEP: ["0", "6"]}))
-        expansions = plugin().expander(output)
-        select_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("selectSteps"))
-        assert select_expansion.restrictions == {}
-
-
-class TestSelectMembers:
-    def test_catalogue_value_type_is_canonical(self) -> None:
-        assert _select_members().configuration_options[ENSEMBLE].value_type == "list[int]"
-
-    def test_from_operational_forecast_source(
-        self, select_members_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
-    ) -> None:
-        block = _select_members()
-        assert block.intersect(other=operational_forecast_source_output)  # type: ignore[arg-type]
-        output = block.validate(block=select_members_configuration, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
-        assert isinstance(output, QubedOutput)
-        assert output.dataqube is not None
-        assert axes(output)[ENSEMBLE] == {1}
-
-    def test_from_operational_forecast_source_multiple_members(
-        self, select_members_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
-    ) -> None:
-        block = _select_members()
-        config = select_members_configuration.model_copy(update={"configuration_values": _config({"number": [1, 2]})})
-        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
-        assert isinstance(output, QubedOutput)
-        assert axes(output)[ENSEMBLE] == {1, 2}
-
-    def test_missing_members(self, select_members_configuration: BlockInstance, operational_forecast_source_output: QubedOutput) -> None:
-        block = _select_members()
-        config = select_members_configuration.model_copy(update={"configuration_values": _config({"number": [999]})})
-        result = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})  # type: ignore[dict-item]
-        with pytest.raises(Exception, match="members \\[999\\] are not in the input members"):
-            result.get_or_raise()
-
-    def test_compile_calls_select(self, select_members_configuration: BlockInstance) -> None:
-        block = _select_members()
-        input_action = MagicMock()
-        selected_action = MagicMock()
-        input_action.select.return_value = selected_action
-
-        result = block.compile(
-            inputs={BlockInstanceId("source_output"): input_action},  # type: ignore[dict-item]
-            block_id=BlockInstanceId("select_members"),
-            block=select_members_configuration,
-        )
-        assert result.t is selected_action
-        input_action.select.assert_called_once_with({ENSEMBLE: 1})
-
-    def test_compile_calls_select_with_multiple_members(self, select_members_configuration: BlockInstance) -> None:
-        block = _select_members()
-        input_action = MagicMock()
-        selected_action = MagicMock()
-        input_action.select.return_value = selected_action
-        config = select_members_configuration.model_copy(update={"configuration_values": _config({"number": [1, 2]})})
-
-        result = block.compile(
-            inputs={BlockInstanceId("source_output"): input_action},  # type: ignore[dict-item]
-            block_id=BlockInstanceId("select_members"),
-            block=config,
-        )
-        assert result.t is selected_action
-        input_action.select.assert_called_once_with({ENSEMBLE: [1, 2]})
-
-    def test_expander_adds_member_restrictions(self, operational_forecast_source_output: QubedOutput) -> None:
-        expansions = plugin().expander(operational_forecast_source_output)
-        select_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("selectMembers"))
-        assert select_expansion.restrictions[ENSEMBLE].serialize() == "list[enumClosed[0,1,2,3,4]]"
-
-    def test_expander_skips_restriction_for_non_int_axes(self) -> None:
-        output = QubedOutput(dataqube=Qube.from_datacube({ENSEMBLE: ["1", "2"]}))
-        expansions = plugin().expander(output)
-        select_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("selectMembers"))
-        assert select_expansion.restrictions == {}
 
 
 def test_anemoi_catalogue_value_types_are_canonical(registered_provider: None) -> None:
@@ -903,10 +746,21 @@ class TestMapPlotSink:
         collapsed = collapse(operational_forecast_source_output, "param")
         assert not block.intersect(other=collapsed)  # type: ignore[arg-type]
 
-    def test_expander_adds_parameters_restrictions(self, operational_forecast_source_output: QubedOutput) -> None:
+    def test_restrictor_adds_parameters_restrictions(
+        self, map_plot_sink_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
+    ) -> None:
+        restrictor = plugin().restrictor
+        assert restrictor is not None
+        restrictions = restrictor(map_plot_sink_configuration, {"dataset": operational_forecast_source_output})
+        param_restriction = restrictions[PARAM].serialize()
+        assert param_restriction.startswith("list[enumClosed[")
+        assert "2t" in param_restriction
+        assert "msl" in param_restriction
+
+    def test_expander_has_no_parameters_restrictions(self, operational_forecast_source_output: QubedOutput) -> None:
         expansions = plugin().expander(operational_forecast_source_output)
         map_plot_expansion = next(expansion for expansion in expansions if expansion.factory == BlockFactoryId("mapPlotSink"))
-        assert map_plot_expansion.restrictions[PARAM].serialize() == "list[enumClosed[2t,msl,u]]"
+        assert map_plot_expansion.restrictions == {}
 
     def test_expander_skips_restriction_for_non_string_axes(self) -> None:
         output = QubedOutput(dataqube=Qube.from_datacube({"param": [1, 2]}))

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -554,10 +554,34 @@ class TestSelect:
         assert isinstance(output, QubedOutput)
         assert axes(output)[STEP] == {0, 6}
 
+    def test_validate_rejects_unknown_dimension(
+        self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
+    ) -> None:
+        block = _select()
+        config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "missing", "values": ["2t"]})})
+        validation = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})  # type: ignore[dict-item]
+
+        assert validation.e is not None
+        assert "dimension missing is not in the input dimensions" in validation.e
+        assert DIMENSION in validation.restrictions
+        assert VALUES not in validation.restrictions
+
+    def test_validate_rejects_unknown_values(
+        self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
+    ) -> None:
+        block = _select()
+        config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "param", "values": ["missing"]})})
+        validation = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})  # type: ignore[dict-item]
+
+        assert validation.e is not None
+        assert "values ['missing'] are not in dimension param" in validation.e
+        assert DIMENSION in validation.restrictions
+        assert VALUES in validation.restrictions
+
     def test_validator_adds_dimension_restrictions(
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
     ) -> None:
-        _, restrictions = plugin().validator(select_configuration, {"dataset": operational_forecast_source_output})
+        restrictions = plugin().validator(select_configuration, {"dataset": operational_forecast_source_output}).restrictions
         restriction = restrictions[DIMENSION].serialize()
         assert restriction.startswith("enumClosed[")
         assert "param" in restriction
@@ -568,17 +592,17 @@ class TestSelect:
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
     ) -> None:
         config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "step", "values": ["0"]})})
-        _, restrictions = plugin().validator(config, {"dataset": operational_forecast_source_output})
+        restrictions = plugin().validator(config, {"dataset": operational_forecast_source_output}).restrictions
         assert restrictions[VALUES].serialize() == "list[enumClosed[0,6,12]]"
 
     def test_validator_keeps_restrictions_when_configuration_is_missing(
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
     ) -> None:
         config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "step"})})
-        result, restrictions = plugin().validator(config, {"dataset": operational_forecast_source_output})
-        assert result.e is not None
-        assert DIMENSION in restrictions
-        assert VALUES in restrictions
+        validation = plugin().validator(config, {"dataset": operational_forecast_source_output})
+        assert validation.e is not None
+        assert DIMENSION in validation.restrictions
+        assert VALUES in validation.restrictions
 
     def test_compile_calls_select(self, select_configuration: BlockInstance) -> None:
         block = _select()
@@ -767,7 +791,7 @@ class TestMapPlotSink:
     def test_validator_adds_parameters_restrictions(
         self, map_plot_sink_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
     ) -> None:
-        _, restrictions = plugin().validator(map_plot_sink_configuration, {"dataset": operational_forecast_source_output})
+        restrictions = plugin().validator(map_plot_sink_configuration, {"dataset": operational_forecast_source_output}).restrictions
         assert restrictions[PARAM].serialize() == "list[enumClosed[2t,msl,u]]"
 
     def test_expander_has_no_parameters_restrictions(self, operational_forecast_source_output: QubedOutput) -> None:
@@ -842,7 +866,7 @@ class TestMapPlotSink:
         output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
         assert isinstance(output, RawOutput)
 
-    def test_validate_does_not_recheck_restricted_param(self, operational_forecast_source_output: QubedOutput) -> None:
+    def test_validate_rejects_unknown_param(self, operational_forecast_source_output: QubedOutput) -> None:
         block = MapPlotSink()
         config = BlockInstance.from_block(
             BlockInstanceBase(
@@ -860,10 +884,13 @@ class TestMapPlotSink:
             ),
             MapPlotSink.configuration_options,
         )
-        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
-        assert isinstance(output, RawOutput)
+        validation = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})  # type: ignore[dict-item]
 
-    def test_validate_does_not_recheck_partial_restricted_params(self, operational_forecast_source_output: QubedOutput) -> None:
+        assert validation.e is not None
+        assert "params ['nonexistent'] are not in the input parameters" in validation.e
+        assert PARAM in validation.restrictions
+
+    def test_validate_rejects_partial_unknown_params(self, operational_forecast_source_output: QubedOutput) -> None:
         block = MapPlotSink()
         config = BlockInstance.from_block(
             BlockInstanceBase(
@@ -881,8 +908,11 @@ class TestMapPlotSink:
             ),
             MapPlotSink.configuration_options,
         )
-        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
-        assert isinstance(output, RawOutput)
+        validation = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})  # type: ignore[dict-item]
+
+        assert validation.e is not None
+        assert "params ['nonexistent'] are not in the input parameters" in validation.e
+        assert PARAM in validation.restrictions
 
     def test_validate_from_ensemble_statistics(
         self,

--- a/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
+++ b/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
@@ -11,7 +11,6 @@ from fiab_core.fable import (
     BlockFactoryCatalogue,
     BlockFactoryId,
     BlockInstance,
-    BlockInstanceId,
     BlockInstanceOutput,
     ConfigurationOptionId,
     ConfigurationOptionRestriction,
@@ -138,7 +137,7 @@ def expander(output: BlockInstanceOutput) -> list[BlockExpansion]:
     return []
 
 
-def compiler(lookup: ActionLookup, bid: BlockInstanceId, instance: BlockInstance) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
+def compiler(lookup: ActionLookup, instance: BlockInstance) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
     with PayloadBuildingContext(environment=[f"-e {pathlib.Path(__file__).parent.parent.parent}"]):
         # with PayloadBuildingContext(environment=["-e /home/dev/src/fiab-plugin-test"]): # TODO handle the ssh:// scenario intelligently
         if instance.factory_id.factory == "source_42":

--- a/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
+++ b/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
@@ -18,7 +18,7 @@ from fiab_core.fable import (
     NoOutput,
     RawOutput,
 )
-from fiab_core.plugin import Error, Plugin
+from fiab_core.plugin import BlockValidation, Error, Plugin
 from fiab_core.types import FableType
 
 TEXT = ConfigurationOptionId("text")
@@ -105,15 +105,18 @@ catalogue = lambda: BlockFactoryCatalogue(
 )
 
 
-def validator(instance: BlockInstance, inputs: dict[str, BlockInstanceOutput]) -> Either[BlockInstanceOutput, Error]:  # type:ignore[invalid-argument] # semigroup
+def validator(instance: BlockInstance, inputs: dict[str, BlockInstanceOutput]) -> BlockValidation:
+    restrictions: ConfigurationOptionRestriction = {}
+    if instance.factory_id.factory == BlockFactoryId("transform_increment"):
+        restrictions = {AMOUNT: FableType.parse("enumClosed[1,2,3]")}
     if instance.factory_id.factory in ("sink_file",):
-        return Either.ok(RawOutput(type_fqn="bytes", mime_type="text/plain"))
+        return BlockValidation(Either.ok(RawOutput(type_fqn="bytes", mime_type="text/plain")), restrictions)
     elif instance.factory_id.factory in ("sink_image",):
-        return Either.ok(RawOutput(type_fqn="bytes", mime_type="image/png"))
+        return BlockValidation(Either.ok(RawOutput(type_fqn="bytes", mime_type="image/png")), restrictions)
     elif instance.factory_id.factory in ("source_sleep", "source_text", "source_filesize"):
-        return Either.ok(RawOutput(type_fqn="str", mime_type="text/plain"))
+        return BlockValidation(Either.ok(RawOutput(type_fqn="str", mime_type="text/plain")), restrictions)
     elif instance.factory_id.factory in ("source_42", "transform_increment", "product_join"):
-        return Either.ok(RawOutput(type_fqn="int"))
+        return BlockValidation(Either.ok(RawOutput(type_fqn="int")), restrictions)
     else:
         raise TypeError(f"unexpected factory {instance.factory_id.factory}")
 
@@ -133,13 +136,6 @@ def expander(output: BlockInstanceOutput) -> list[BlockExpansion]:
         if output.type_fqn in ("str", "bytes"):
             return [BlockExpansion(factory=BlockFactoryId("sink_file"))]
     return []
-
-
-def restrictor(instance: BlockInstance, inputs: dict[str, BlockInstanceOutput]) -> ConfigurationOptionRestriction:
-    del inputs
-    if instance.factory_id.factory == BlockFactoryId("transform_increment"):
-        return {AMOUNT: FableType.parse("enumClosed[1,2,3]")}
-    return {}
 
 
 def compiler(lookup: ActionLookup, bid: BlockInstanceId, instance: BlockInstance) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
@@ -194,4 +190,4 @@ def compiler(lookup: ActionLookup, bid: BlockInstanceId, instance: BlockInstance
         return Either.ok(action)
 
 
-plugin = lambda: Plugin(catalogue=catalogue(), validator=validator, expander=expander, compiler=compiler, restrictor=restrictor)
+plugin = lambda: Plugin(catalogue=catalogue(), validator=validator, expander=expander, compiler=compiler)

--- a/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
+++ b/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
@@ -14,6 +14,7 @@ from fiab_core.fable import (
     BlockInstanceId,
     BlockInstanceOutput,
     ConfigurationOptionId,
+    ConfigurationOptionRestriction,
     NoOutput,
     RawOutput,
 )
@@ -134,6 +135,13 @@ def expander(output: BlockInstanceOutput) -> list[BlockExpansion]:
     return []
 
 
+def restrictor(instance: BlockInstance, inputs: dict[str, BlockInstanceOutput]) -> ConfigurationOptionRestriction:
+    del inputs
+    if instance.factory_id.factory == BlockFactoryId("transform_increment"):
+        return {AMOUNT: FableType.parse("enumClosed[1,2,3]")}
+    return {}
+
+
 def compiler(lookup: ActionLookup, bid: BlockInstanceId, instance: BlockInstance) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
     with PayloadBuildingContext(environment=[f"-e {pathlib.Path(__file__).parent.parent.parent}"]):
         # with PayloadBuildingContext(environment=["-e /home/dev/src/fiab-plugin-test"]): # TODO handle the ssh:// scenario intelligently
@@ -186,4 +194,4 @@ def compiler(lookup: ActionLookup, bid: BlockInstanceId, instance: BlockInstance
         return Either.ok(action)
 
 
-plugin = lambda: Plugin(catalogue=catalogue(), validator=validator, expander=expander, compiler=compiler)
+plugin = lambda: Plugin(catalogue=catalogue(), validator=validator, expander=expander, compiler=compiler, restrictor=restrictor)

--- a/backend/packages/fiab-plugin-test/tests/test_base.py
+++ b/backend/packages/fiab-plugin-test/tests/test_base.py
@@ -16,7 +16,6 @@ from fiab_core.artifacts import ArtifactsProvider, CompositeArtifactId
 from fiab_core.fable import (
     BlockFactoryId,
     BlockInstance,
-    BlockInstanceId,
     ConfigurationOptionId,
     PluginBlockFactoryId,
     PluginCompositeId,
@@ -116,7 +115,7 @@ def test_compiler_source_filesize_embeds_path_and_artifact_in_payload(tmp_path: 
 
     with patch.object(ArtifactsProvider, "get_artifact_local_path", return_value=artifact_path):
         instance = _make_instance("source_filesize", {"checkpoint": "mystore:mycheckpoint"})
-        result = compiler({}, BlockInstanceId("src"), instance)
+        result = compiler({}, instance)
 
     assert result.t is not None, f"compiler returned error: {result.e}"
 

--- a/backend/packages/fiab-plugin-test/tests/test_base.py
+++ b/backend/packages/fiab-plugin-test/tests/test_base.py
@@ -97,8 +97,9 @@ def _make_instance(factory: str, config: dict) -> BlockInstance:
 
 def test_validator_source_filesize_returns_str_raw_output() -> None:
     instance = _make_instance("source_filesize", {"checkpoint": "mystore:mycheckpoint"})
-    result, restrictions = validator(instance, {})
-    assert restrictions == {}
+    validation = validator(instance, {})
+    result = validation.result
+    assert validation.restrictions == {}
     assert result.t is not None
     assert isinstance(result.t, RawOutput)
     assert result.t.type_fqn == "str"

--- a/backend/packages/fiab-plugin-test/tests/test_base.py
+++ b/backend/packages/fiab-plugin-test/tests/test_base.py
@@ -98,7 +98,8 @@ def _make_instance(factory: str, config: dict) -> BlockInstance:
 
 def test_validator_source_filesize_returns_str_raw_output() -> None:
     instance = _make_instance("source_filesize", {"checkpoint": "mystore:mycheckpoint"})
-    result = validator(instance, {})
+    result, restrictions = validator(instance, {})
+    assert restrictions == {}
     assert result.t is not None
     assert isinstance(result.t, RawOutput)
     assert result.t.type_fqn == "str"

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -263,12 +263,9 @@ async def validate_expand(
             continue
 
         inputs = {input_id: outputs[source_id] for input_id, source_id in blockInstance.input_ids.items()}
-        if not validate_only and plugin.restrictor is not None:
-            restrictions = plugin.restrictor(blockInstance, inputs)
-            if restrictions:
-                configuration_restrictions[blockId] = {k: v.serialize() for k, v in restrictions.items()}
-
-        output_or_error = plugin.validator(blockInstance, inputs)
+        output_or_error, restrictions = plugin.validator(blockInstance, inputs)
+        if not validate_only and restrictions:
+            configuration_restrictions[blockId] = {k: v.serialize() for k, v in restrictions.items()}
         if output_or_error.t is None:
             block_errors[blockId] += [cast(str, output_or_error.e)]
             invalidable.add(blockId)

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -26,10 +26,10 @@ from itertools import groupby
 from typing import cast
 
 from fiab_core.fable import (
-    BlockExpansion,
     BlockFactoryId,
     BlockInstance,
     BlockInstanceId,
+    BlockInstanceOutput,
     BlockKind,
     ConfigurationOptionId,
     NoOutput,
@@ -100,6 +100,7 @@ class BlueprintValidationExpansion(FiabBaseModel):
     block_errors: dict[BlockInstanceId, list[str]]
     possible_sources: list[PluginBlockFactoryId]
     possible_expansions: dict[BlockInstanceId, list[PluginBlockExpansion]]
+    configuration_restrictions: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = {}
     resolved_configuration_options: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = {}
     missing_glyphs: dict[BlockInstanceId, dict[ConfigurationOptionId, list[str]]] = {}
 
@@ -150,6 +151,7 @@ async def validate_expand(
         ]
     )
     possible_expansions: dict[BlockInstanceId, list[PluginBlockExpansion]] = {}
+    configuration_restrictions: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = {}
     resolved_configuration_options: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = {}
     block_errors: dict[BlockInstanceId, list[str]] = defaultdict(list)
     missing_glyphs_result: dict[BlockInstanceId, dict[ConfigurationOptionId, list[str]]] = {}
@@ -261,6 +263,11 @@ async def validate_expand(
             continue
 
         inputs = {input_id: outputs[source_id] for input_id, source_id in blockInstance.input_ids.items()}
+        if not validate_only and plugin.restrictor is not None:
+            restrictions = plugin.restrictor(blockInstance, inputs)
+            if restrictions:
+                configuration_restrictions[blockId] = {k: v.serialize() for k, v in restrictions.items()}
+
         output_or_error = plugin.validator(blockInstance, inputs)
         if output_or_error.t is None:
             block_errors[blockId] += [cast(str, output_or_error.e)]
@@ -294,6 +301,7 @@ async def validate_expand(
     return BlueprintValidationExpansion(
         possible_sources=possible_sources,
         possible_expansions=possible_expansions,
+        configuration_restrictions=configuration_restrictions,
         resolved_configuration_options=resolved_configuration_options,
         block_errors=block_errors,
         global_errors=global_errors,

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -36,6 +36,7 @@ from fiab_core.fable import (
     PluginBlockExpansion,
     PluginBlockFactoryId,
 )
+from pydantic import Field
 
 from forecastbox.domain.blueprint import db
 from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
@@ -70,7 +71,7 @@ class BlueprintBuilder(FiabBaseModel):
     # NOTE warning -- this class is used by the web api. Be careful about changes here
     blocks: dict[BlockInstanceId, BlockInstance]
     environment: EnvironmentSpecification | None = None
-    local_glyphs: dict[str, str] = {}
+    local_glyphs: dict[str, str] = Field(default_factory=dict)
 
 
 class BlueprintSaveResult(FiabBaseModel):
@@ -88,7 +89,7 @@ class BlueprintRetrieveResult(FiabBaseModel):
     builder: BlueprintBuilder
     display_name: str | None = None
     display_description: str | None = None
-    tags: list[Tag] = []
+    tags: list[Tag] = Field(default_factory=list)
     parent_id: str | None = None
     fiabcore_major: int
 
@@ -100,9 +101,9 @@ class BlueprintValidationExpansion(FiabBaseModel):
     block_errors: dict[BlockInstanceId, list[str]]
     possible_sources: list[PluginBlockFactoryId]
     possible_expansions: dict[BlockInstanceId, list[PluginBlockExpansion]]
-    configuration_restrictions: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = {}
-    resolved_configuration_options: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = {}
-    missing_glyphs: dict[BlockInstanceId, dict[ConfigurationOptionId, list[str]]] = {}
+    configuration_restrictions: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = Field(default_factory=dict)
+    resolved_configuration_options: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = Field(default_factory=dict)
+    missing_glyphs: dict[BlockInstanceId, dict[ConfigurationOptionId, list[str]]] = Field(default_factory=dict)
 
 
 class BlueprintSaveCommand(FiabBaseModel):
@@ -111,7 +112,7 @@ class BlueprintSaveCommand(FiabBaseModel):
     builder: BlueprintBuilder
     display_name: str | None = None
     display_description: str | None = None
-    tags: list[Tag] = []
+    tags: list[Tag] = Field(default_factory=list)
     parent_id: str | None = None
 
 
@@ -263,7 +264,9 @@ async def validate_expand(
             continue
 
         inputs = {input_id: outputs[source_id] for input_id, source_id in blockInstance.input_ids.items()}
-        output_or_error, restrictions = plugin.validator(blockInstance, inputs)
+        validation = plugin.validator(blockInstance, inputs)
+        output_or_error = validation.result
+        restrictions = validation.restrictions
         if not validate_only and restrictions:
             configuration_restrictions[blockId] = {k: v.serialize() for k, v in restrictions.items()}
         if output_or_error.t is None:

--- a/backend/src/forecastbox/domain/run/compile.py
+++ b/backend/src/forecastbox/domain/run/compile.py
@@ -110,7 +110,7 @@ def compile_builder(
             raise ValueError(f"compile failed at {blockId=} with {converted_values.e}")
         blockInstance.configuration_values = converted_values.t
         with PayloadBuildingContext(blockId=blockId):
-            result = plugin.compiler(action_lookup, blockId, blockInstance)
+            result = plugin.compiler(action_lookup, blockInstance)
         if result.t is None:
             raise ValueError(f"compile failed at {blockId=} with {result.e}")
         action_lookup[blockId] = result.t

--- a/backend/src/forecastbox/domain/run/compile.py
+++ b/backend/src/forecastbox/domain/run/compile.py
@@ -122,7 +122,7 @@ def compile_builder(
             input_name: block_outputs[source_id] for input_name, source_id in blockInstance.input_ids.items() if source_id in block_outputs
         }
         try:
-            validated = plugin.validator(blockInstance, validator_inputs)
+            validated, _ = plugin.validator(blockInstance, validator_inputs)
             if validated.t is None:
                 raise ValueError(f"compile failed at {blockId=} with {validated.e}")
             block_outputs[blockId] = validated.t

--- a/backend/src/forecastbox/domain/run/compile.py
+++ b/backend/src/forecastbox/domain/run/compile.py
@@ -122,7 +122,7 @@ def compile_builder(
             input_name: block_outputs[source_id] for input_name, source_id in blockInstance.input_ids.items() if source_id in block_outputs
         }
         try:
-            validated, _ = plugin.validator(blockInstance, validator_inputs)
+            validated = plugin.validator(blockInstance, validator_inputs).result
             if validated.t is None:
                 raise ValueError(f"compile failed at {blockId=} with {validated.e}")
             block_outputs[blockId] = validated.t

--- a/backend/src/forecastbox/routes/blueprint.py
+++ b/backend/src/forecastbox/routes/blueprint.py
@@ -167,6 +167,7 @@ class BlueprintValidationExpansionResponse(FiabBaseModel):
     block_errors: dict[BlockInstanceId, list[str]]
     possible_sources: list[PluginBlockFactoryId]
     possible_expansions: dict[BlockInstanceId, list[PluginBlockExpansion]]
+    configuration_restrictions: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = {}
     resolved_configuration_options: dict[BlockInstanceId, dict[ConfigurationOptionId, str]]
     missing_glyphs: dict[BlockInstanceId, dict[ConfigurationOptionId, list[str]]] = {}
 
@@ -426,6 +427,7 @@ async def expand_blueprint(
         block_errors=result.block_errors,
         possible_sources=result.possible_sources,
         possible_expansions=result.possible_expansions,
+        configuration_restrictions=result.configuration_restrictions,
         resolved_configuration_options=result.resolved_configuration_options,
         missing_glyphs=result.missing_glyphs,
     )

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -326,11 +326,12 @@ def test_blueprint_expand(tmpdir: Any, backend_client_with_auth: httpx.Client) -
 
 
 def test_blueprint_expand_restrictions(backend_client_with_auth: httpx.Client) -> None:
-    """The expand endpoint carries non-empty restrictions from the test plugin expander.
+    """The expand endpoint carries non-empty restrictions from test plugin hooks.
 
     The test plugin returns enumClosed[1,2,3] as a restriction on the 'amount'
     configuration option when expanding an int-producing block to transform_increment.
-    This test verifies the restriction survives the full route round-trip.
+    It also returns the same restriction for transform_increment's own configuration.
+    This test verifies both restrictions survive the full route round-trip.
     """
     source_42 = BlockInstance(
         factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_42")),
@@ -346,6 +347,21 @@ def test_blueprint_expand_restrictions(backend_client_with_auth: httpx.Client) -
     assert increment_expansion["restrictions"] == {"amount": "enumClosed[1,2,3]"}, (
         "transform_increment expansion must carry an enumClosed[1,2,3] restriction on 'amount'"
     )
+
+    transform_increment = BlockInstance(
+        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("transform_increment")),
+        configuration_values=_config({"amount": "2"}),
+        input_ids={"a": BlockInstanceId("source_42")},
+    )
+    builder = BlueprintBuilder(
+        blocks={
+            BlockInstanceId("source_42"): source_42,
+            BlockInstanceId("transform_increment"): transform_increment,
+        }
+    )
+    response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())
+    assert response.is_success, response.text
+    assert response.json()["configuration_restrictions"]["transform_increment"] == {"amount": "enumClosed[1,2,3]"}
 
 
 def test_blueprint_expand_missing_glyph_warnings(tmpdir: Any, backend_client_with_auth: httpx.Client) -> None:

--- a/backend/tests/unit/domain/run/test_compile.py
+++ b/backend/tests/unit/domain/run/test_compile.py
@@ -16,7 +16,7 @@ from fiab_core.fable import (
     PluginBlockFactoryId,
     PluginCompositeId,
 )
-from fiab_core.plugin import Plugin
+from fiab_core.plugin import BlockValidation, Plugin
 from pyrsistent import pmap
 
 from forecastbox.domain.blueprint.service import BlueprintBuilder
@@ -143,9 +143,9 @@ def test_compile_builder_fails_missing_config_before_plugin_compile(monkeypatch:
         compiler_called = True
         return Either.error("should not be called")
 
-    def _validator(instance: BlockInstance, inputs: dict[str, BlockInstanceOutput]) -> Either[BlockInstanceOutput, str]:  # type:ignore[invalid-type-arguments] # semigroup
+    def _validator(instance: BlockInstance, inputs: dict[str, BlockInstanceOutput]) -> BlockValidation:
         del instance, inputs
-        return Either.ok(NoOutput())
+        return BlockValidation(Either.ok(NoOutput()))
 
     def _expander(output: BlockInstanceOutput) -> list[BlockExpansion]:
         del output

--- a/backend/tests/unit/domain/run/test_compile.py
+++ b/backend/tests/unit/domain/run/test_compile.py
@@ -137,9 +137,9 @@ def test_compile_builder_fails_missing_config_before_plugin_compile(monkeypatch:
     option_id = ConfigurationOptionId("amount")
     compiler_called = False
 
-    def _compiler(lookup: ActionLookup, bid: BlockInstanceId, instance: BlockInstance) -> Either[Action, str]:  # type:ignore[invalid-type-arguments] # semigroup
+    def _compiler(lookup: ActionLookup, instance: BlockInstance) -> Either[Action, str]:  # type:ignore[invalid-type-arguments] # semigroup
         nonlocal compiler_called
-        del lookup, bid, instance
+        del lookup, instance
         compiler_called = True
         return Either.error("should not be called")
 

--- a/frontend/mocks/data/fable.data.ts
+++ b/frontend/mocks/data/fable.data.ts
@@ -68,32 +68,35 @@ export const mockCatalogue: BlockFactoryCatalogue = {
             description: 'Base time of the forecast',
             value_type: 'datetime',
           },
-          param: {
-            title: 'Parameters',
-            description: "Parameters to select and plot (e.g. '2t', 'msl')",
-            value_type: 'list[str]',
-          },
-          step: {
-            title: 'Steps',
-            description: "Forecast steps to select (e.g. '0,6,12,...')",
-            value_type: 'list[int]',
-          },
-          number: {
-            title: 'Ensemble Members',
-            description: "Ensemble members to select (e.g. '1,2,3,...')",
-            value_type: 'list[int]',
-          },
         },
         inputs: [],
+      },
+      select: {
+        kind: 'transform',
+        title: 'Select',
+        description: 'Select values from one dimension of the input dataset',
+        configuration_options: {
+          dimension: {
+            title: 'Dimension',
+            description: 'Dimension to select from the dataset',
+            value_type: 'str',
+          },
+          values: {
+            title: 'Values',
+            description: 'Values to select from the chosen dimension',
+            value_type: 'list[str]',
+          },
+        },
+        inputs: ['dataset'],
       },
       ensembleStatistics: {
         kind: 'product',
         title: 'Ensemble Statistics',
         description: 'Computes ensemble mean or standard deviation',
         configuration_options: {
-          variable: {
-            title: 'Variable',
-            description: "Variable name like '2t'",
+          param: {
+            title: 'Parameter',
+            description: "Parameter name like '2t'",
             value_type: 'str',
           },
           statistic: {
@@ -109,9 +112,9 @@ export const mockCatalogue: BlockFactoryCatalogue = {
         title: 'Temporal Statistics',
         description: 'Computes temporal statistics',
         configuration_options: {
-          variable: {
-            title: 'Variable',
-            description: "Variable name like '2t'",
+          param: {
+            title: 'param',
+            description: "Param name like '2t'",
             value_type: 'str',
           },
           statistic: {
@@ -226,7 +229,7 @@ export const mockSavedFables: Record<
             factory: 'ensembleStatistics',
           },
           configuration_values: {
-            variable: '2t',
+            param: '2t',
             statistic: 'mean',
           },
           input_ids: {
@@ -314,7 +317,12 @@ export function calculateExpansion(fable: FableBuilderV1): {
       factory: 'operationalForecastSource',
     },
   ]
-  const productBlocks: Array<BlockExpansion> = [
+  const qubedBlocks: Array<BlockExpansion> = [
+    {
+      plugin: pluginId('ecmwf', 'ecmwf-base'),
+      factory: 'select',
+      restrictions: {},
+    },
     {
       plugin: pluginId('ecmwf', 'ecmwf-base'),
       factory: 'ensembleStatistics',
@@ -363,8 +371,8 @@ export function calculateExpansion(fable: FableBuilderV1): {
     }
 
     // Calculate possible expansions based on block kind
-    if (factory.kind === 'source') {
-      possible_expansions[blockId] = productBlocks
+    if (factory.kind === 'source' || factory.kind === 'transform') {
+      possible_expansions[blockId] = qubedBlocks
     } else if (factory.kind === 'product') {
       possible_expansions[blockId] = sinkBlocks
     }

--- a/frontend/src/api/types/fable.types.ts
+++ b/frontend/src/api/types/fable.types.ts
@@ -214,6 +214,10 @@ export const FableValidationExpansionSchema = z.object({
   block_errors: z.record(z.string(), z.array(z.string())),
   possible_sources: z.array(PluginBlockFactoryIdSchema),
   possible_expansions: z.record(z.string(), z.array(BlockExpansionSchema)),
+  configuration_restrictions: z
+    .record(z.string(), z.record(z.string(), z.string()))
+    .optional()
+    .default({}),
   resolved_configuration_options: z
     .record(z.string(), z.record(z.string(), z.string()))
     .optional()
@@ -319,6 +323,8 @@ export interface BlockValidationState {
    * `factoryIdToKey(childId)`; inner maps option id → FableType (e.g.
    * `mapPlotSink → { param: "list[enumClosed[…]]" }`). */
   possibleExpansionRestrictions: Record<string, Record<string, string>>
+  /** Config restrictions for this block's own fields. */
+  configurationRestrictions: Record<string, string>
   /** Unknown glyph names per option, from /blueprint/expand. */
   missingGlyphs: Record<string, Array<string>>
 }
@@ -608,11 +614,13 @@ export function toValidationState(
   catalogue?: BlockFactoryCatalogue,
 ): FableValidationState {
   const blockStates: Record<BlockInstanceId, BlockValidationState> = {}
+  const configurationRestrictionsByBlock = expansion.configuration_restrictions
   const missingRequiredByBlock =
     fable && catalogue ? getMissingRequiredConfigErrors(fable, catalogue) : {}
   const allBlockIds = new Set<string>([
     ...Object.keys(expansion.block_errors),
     ...Object.keys(expansion.possible_expansions),
+    ...Object.keys(configurationRestrictionsByBlock),
     ...Object.keys(missingRequiredByBlock),
     ...Object.keys(expansion.missing_glyphs),
   ])
@@ -632,6 +640,8 @@ export function toValidationState(
       possibleExpansions: toPluginFactoryIds(possibleExpansions),
       possibleExpansionRestrictions:
         toExpansionRestrictionMap(possibleExpansions),
+      configurationRestrictions:
+        configurationRestrictionsByBlock[blockId] ?? {},
       missingGlyphs,
     }
   }
@@ -700,6 +710,8 @@ export function getBlockConfigurationRestrictions(
 
     Object.assign(restrictions, sourceRestrictions)
   }
+  const blockState = getRecordItem(validationState.blockStates, blockId)
+  Object.assign(restrictions, blockState?.configurationRestrictions)
   return restrictions
 }
 

--- a/frontend/src/features/fable-builder/presets/presets.ts
+++ b/frontend/src/features/fable-builder/presets/presets.ts
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-import type { FableBuilderV1 } from '@/api/types/fable.types'
+import type { BlockInstance, FableBuilderV1 } from '@/api/types/fable.types'
 import type { PluginCompositeId } from '@/api/types/plugins.types'
 import { getAppTimeZone, yesterdayInZone } from '@/lib/datetime'
 import i18n from '@/lib/i18n'
@@ -36,6 +36,48 @@ function pluginId(store: string, local: string): PluginCompositeId {
   return { store, local }
 }
 
+function ecmwfBasePlugin(): PluginCompositeId {
+  return pluginId('ecmwf', 'ecmwf-base')
+}
+
+function operationalForecastSourceBlock(
+  source: string,
+  forecast = 'aifs-ens',
+): BlockInstance {
+  return {
+    factory_id: {
+      plugin: ecmwfBasePlugin(),
+      factory: 'operationalForecastSource',
+    },
+    configuration_values: {
+      source,
+      forecast,
+      base_time: yesterdayBaseTime(),
+    },
+    input_ids: {},
+  }
+}
+
+function selectBlock(
+  inputId: string,
+  dimension: string,
+  values: string,
+): BlockInstance {
+  return {
+    factory_id: {
+      plugin: ecmwfBasePlugin(),
+      factory: 'select',
+    },
+    configuration_values: {
+      dimension,
+      values,
+    },
+    input_ids: {
+      dataset: inputId,
+    },
+  }
+}
+
 /** Yesterday's calendar date in the application timezone, evaluated per call. */
 function yesterday(): string {
   return yesterdayInZone(getAppTimeZone())
@@ -53,24 +95,17 @@ function quickStartPreset(): FablePreset {
     description: i18n.t('configure:presets.quickStartDescription'),
     fable: {
       blocks: {
-        source_1: {
-          factory_id: {
-            plugin: pluginId('ecmwf', 'ecmwf-base'),
-            factory: 'operationalForecastSource',
-          },
-          configuration_values: {
-            source: 'ecmwf-open-data',
-            forecast: 'aifs-ens',
-            base_time: yesterdayBaseTime(),
-            param: '2t',
-            step: '0',
-            number: '1,2,3,4,5,6',
-          },
-          input_ids: {},
-        },
+        source_1: operationalForecastSourceBlock('ecmwf-open-data'),
+        select_param_1: selectBlock('source_1', 'param', '2t'),
+        select_step_1: selectBlock('select_param_1', 'step', '0'),
+        select_number_1: selectBlock(
+          'select_step_1',
+          'number',
+          '1,2,3,4,5,6',
+        ),
         product_1: {
           factory_id: {
-            plugin: pluginId('ecmwf', 'ecmwf-base'),
+            plugin: ecmwfBasePlugin(),
             factory: 'ensembleStatistics',
           },
           configuration_values: {
@@ -78,12 +113,12 @@ function quickStartPreset(): FablePreset {
             statistic: 'mean',
           },
           input_ids: {
-            dataset: 'source_1',
+            dataset: 'select_number_1',
           },
         },
         sink_1: {
           factory_id: {
-            plugin: pluginId('ecmwf', 'ecmwf-base'),
+            plugin: ecmwfBasePlugin(),
             factory: 'zarrSink',
           },
           configuration_values: {
@@ -105,21 +140,10 @@ function standardPreset(): FablePreset {
     description: i18n.t('configure:presets.standardDescription'),
     fable: {
       blocks: {
-        source_1: {
-          factory_id: {
-            plugin: pluginId('ecmwf', 'ecmwf-base'),
-            factory: 'operationalForecastSource',
-          },
-          configuration_values: {
-            source: 'mars',
-            forecast: 'aifs-ens',
-            base_time: yesterdayBaseTime(),
-            param: '2t',
-            step: '0',
-            number: '0',
-          },
-          input_ids: {},
-        },
+        source_1: operationalForecastSourceBlock('mars'),
+        select_param_1: selectBlock('source_1', 'param', '2t'),
+        select_step_1: selectBlock('select_param_1', 'step', '0'),
+        select_number_1: selectBlock('select_step_1', 'number', '0'),
       },
     },
   }
@@ -143,21 +167,10 @@ function datasetPreset(): FablePreset {
     description: i18n.t('configure:presets.datasetDescription'),
     fable: {
       blocks: {
-        source_1: {
-          factory_id: {
-            plugin: pluginId('ecmwf', 'ecmwf-base'),
-            factory: 'operationalForecastSource',
-          },
-          configuration_values: {
-            source: 'ecmwf-open-data',
-            forecast: 'aifs-ens',
-            base_time: yesterdayBaseTime(),
-            param: '2t',
-            step: '0',
-            number: '0',
-          },
-          input_ids: {},
-        },
+        source_1: operationalForecastSourceBlock('ecmwf-open-data'),
+        select_param_1: selectBlock('source_1', 'param', '2t'),
+        select_step_1: selectBlock('select_param_1', 'step', '0'),
+        select_number_1: selectBlock('select_step_1', 'number', '0'),
       },
     },
   }
@@ -170,24 +183,21 @@ function ecmwfOpenDataPreset(): FablePreset {
     description: i18n.t('configure:presets.ecmwfOpenDataDescription'),
     fable: {
       blocks: {
-        source_1: {
-          factory_id: {
-            plugin: pluginId('ecmwf', 'ecmwf-base'),
-            factory: 'operationalForecastSource',
-          },
-          configuration_values: {
-            source: 'ecmwf-open-data',
-            forecast: 'aifs-ens',
-            base_time: yesterdayBaseTime(),
-            param: '2t',
-            step: '24,48,72,360',
-            number: '1,2,3,4,5,6',
-          },
-          input_ids: {},
-        },
+        source_1: operationalForecastSourceBlock('ecmwf-open-data'),
+        select_param_1: selectBlock('source_1', 'param', '2t'),
+        select_step_1: selectBlock(
+          'select_param_1',
+          'step',
+          '24,48,72,360',
+        ),
+        select_number_1: selectBlock(
+          'select_step_1',
+          'number',
+          '1,2,3,4,5,6',
+        ),
         product_1: {
           factory_id: {
-            plugin: pluginId('ecmwf', 'ecmwf-base'),
+            plugin: ecmwfBasePlugin(),
             factory: 'ensembleStatistics',
           },
           configuration_values: {
@@ -195,12 +205,12 @@ function ecmwfOpenDataPreset(): FablePreset {
             statistic: 'mean',
           },
           input_ids: {
-            dataset: 'source_1',
+            dataset: 'select_number_1',
           },
         },
         sink_1: {
           factory_id: {
-            plugin: pluginId('ecmwf', 'ecmwf-base'),
+            plugin: ecmwfBasePlugin(),
             factory: 'mapPlotSink',
           },
           configuration_values: {

--- a/frontend/src/features/fable-builder/presets/presets.ts
+++ b/frontend/src/features/fable-builder/presets/presets.ts
@@ -98,11 +98,7 @@ function quickStartPreset(): FablePreset {
         source_1: operationalForecastSourceBlock('ecmwf-open-data'),
         select_param_1: selectBlock('source_1', 'param', '2t'),
         select_step_1: selectBlock('select_param_1', 'step', '0'),
-        select_number_1: selectBlock(
-          'select_step_1',
-          'number',
-          '1,2,3,4,5,6',
-        ),
+        select_number_1: selectBlock('select_step_1', 'number', '1,2,3,4,5,6'),
         product_1: {
           factory_id: {
             plugin: ecmwfBasePlugin(),
@@ -185,16 +181,8 @@ function ecmwfOpenDataPreset(): FablePreset {
       blocks: {
         source_1: operationalForecastSourceBlock('ecmwf-open-data'),
         select_param_1: selectBlock('source_1', 'param', '2t'),
-        select_step_1: selectBlock(
-          'select_param_1',
-          'step',
-          '24,48,72,360',
-        ),
-        select_number_1: selectBlock(
-          'select_step_1',
-          'number',
-          '1,2,3,4,5,6',
-        ),
+        select_step_1: selectBlock('select_param_1', 'step', '24,48,72,360'),
+        select_number_1: selectBlock('select_step_1', 'number', '1,2,3,4,5,6'),
         product_1: {
           factory_id: {
             plugin: ecmwfBasePlugin(),

--- a/frontend/src/features/fable-builder/presets/presets.ts
+++ b/frontend/src/features/fable-builder/presets/presets.ts
@@ -240,6 +240,19 @@ function aifsForecastPreset(): FablePreset {
           },
           input_ids: {},
         },
+        transform_1: {
+          factory_id: {
+            plugin: pluginId('ecmwf', 'ecmwf-base'),
+            factory: 'select',
+          },
+          configuration_values: {
+            dimension: 'step',
+            values: '6,12,18,24,30,36,42,48,54,60,66,72',
+          },
+          input_ids: {
+            dataset: 'source_1',
+          },
+        },
         sink_1: {
           factory_id: {
             plugin: pluginId('ecmwf', 'ecmwf-base'),

--- a/frontend/src/features/plugins/utils/pipeline-generator.ts
+++ b/frontend/src/features/plugins/utils/pipeline-generator.ts
@@ -238,7 +238,7 @@ function findUpstreamBlock(
 const KNOWN_FIELD_DEFAULTS: Record<string, string> = {
   // Common string fields
   path: '/tmp/output.zarr',
-  variable: '2t',
+  param: '2t',
   // Common numeric fields (as strings)
   lead_time: '24',
   ensemble_members: '4',

--- a/frontend/tests/e2e/configure-forecast.spec.ts
+++ b/frontend/tests/e2e/configure-forecast.spec.ts
@@ -344,7 +344,7 @@ test.describe('Fable Builder - Graph Mode', () => {
               plugin: { store: 'ecmwf', local: 'ecmwf-base' },
               factory: 'ensembleStatistics',
             },
-            configuration_values: { variable: '2t', statistic: 'mean' },
+            configuration_values: { param: '2t', statistic: 'mean' },
             input_ids: { dataset: 'block_source_1' },
           },
           block_sink_1: {

--- a/frontend/tests/integration/features/fable-builder/build-flow.test.tsx
+++ b/frontend/tests/integration/features/fable-builder/build-flow.test.tsx
@@ -51,9 +51,6 @@ function setupValidFableWithSink(): void {
           source: 'mars',
           forecast: 'aifs-ens',
           base_time: '2026-01-01T00:00:00',
-          param: '2t',
-          step: '0',
-          number: '1',
         },
         input_ids: {},
       },
@@ -162,11 +159,10 @@ describe('Fable Builder Integration', () => {
       )
       .toBeVisible()
 
-    // Configuration fields should be visible with their titles as labels
-    // These come from mockCatalogue configuration_options for operationalForecastSource
-    // Source and Forecast model are enums; Base time is a datetime input
+    // Configuration fields should be visible with their titles as labels.
+    // Source and Forecast model are enums; Base time is a datetime input.
     await expect.element(screen.getByLabelText('Base time')).toBeVisible()
-    await expect.element(screen.getByLabelText('Parameters')).toBeVisible()
+    await expect.element(screen.getByLabelText('Forecast model')).toBeVisible()
   })
 
   it('allows configuring a block via input fields', async () => {
@@ -325,20 +321,11 @@ describe('Fable Builder Integration', () => {
     useFableBuilderStore
       .getState()
       .updateBlockConfig(sourceBlockIdForConfig, 'source', 'mars')
-    // operationalForecastSource exposes 6 options; fill the rest so the fable
-    // validates (isValid) for the review step below.
+    // Fill the remaining required source enum so the fable validates for the
+    // review step below.
     useFableBuilderStore
       .getState()
       .updateBlockConfig(sourceBlockIdForConfig, 'forecast', 'aifs-ens')
-    useFableBuilderStore
-      .getState()
-      .updateBlockConfig(sourceBlockIdForConfig, 'param', '2t')
-    useFableBuilderStore
-      .getState()
-      .updateBlockConfig(sourceBlockIdForConfig, 'step', '0')
-    useFableBuilderStore
-      .getState()
-      .updateBlockConfig(sourceBlockIdForConfig, 'number', '1')
 
     // 4. Add a connected sink block programmatically for review eligibility
     const sourceBlockId = Object.keys(

--- a/frontend/tests/integration/features/fable-builder/form-mode.test.tsx
+++ b/frontend/tests/integration/features/fable-builder/form-mode.test.tsx
@@ -114,7 +114,7 @@ describe('Fable Builder Form Mode', () => {
     // Configuration fields should be visible (FieldRenderer uses Label with htmlFor).
     // Source/Forecast model are enums; Base time's labelled control is a date input.
     await expect.element(screen.getByLabelText('Base time')).toBeVisible()
-    await expect.element(screen.getByLabelText('Parameters')).toBeVisible()
+    await expect.element(screen.getByLabelText('Forecast model')).toBeVisible()
 
     // Fable should be marked as dirty
     expect(useFableBuilderStore.getState().isDirty).toBe(true)

--- a/frontend/tests/integration/features/fable-builder/graph-mode.test.tsx
+++ b/frontend/tests/integration/features/fable-builder/graph-mode.test.tsx
@@ -68,7 +68,7 @@ function createMultiBlockFable(): FableBuilderV1 {
           factory: 'ensembleStatistics',
         },
         configuration_values: {
-          variable: '2t',
+          param: '2t',
           statistic: 'mean',
         },
         input_ids: { dataset: 'source1' },

--- a/frontend/tests/integration/features/plugins/plugin-detail.test.tsx
+++ b/frontend/tests/integration/features/plugins/plugin-detail.test.tsx
@@ -115,7 +115,7 @@ describe('Plugin Detail Page', () => {
         <PluginDetailPage plugin={mockPlugin} catalogue={mockCatalogue} />,
       )
 
-      // ecmwf/ecmwf-base has 4 factories — use heading role to avoid
+      // Use heading role to avoid
       // matching descriptions that contain similar text (vitest browser
       // mode uses case-insensitive getByText)
       await expect

--- a/frontend/tests/unit/api/endpoints/fable.test.ts
+++ b/frontend/tests/unit/api/endpoints/fable.test.ts
@@ -120,6 +120,9 @@ describe('expandFable', () => {
           },
         ],
       },
+      configuration_restrictions: {
+        'block-1': { param1: "enumClosed['value1','value2']" },
+      },
       missing_glyphs: {},
     }
 
@@ -132,6 +135,9 @@ describe('expandFable', () => {
     const result = await expandFable(mockFable)
     expect(result.global_errors).toEqual([])
     expect(result.block_errors).toEqual({})
+    expect(result.configuration_restrictions).toEqual({
+      'block-1': { param1: "enumClosed['value1','value2']" },
+    })
   })
 
   it('sends fable as JSON body', async () => {

--- a/frontend/tests/unit/api/fable-types.test.ts
+++ b/frontend/tests/unit/api/fable-types.test.ts
@@ -14,7 +14,10 @@ import type {
   FableBuilderV1,
   FableValidationExpansion,
 } from '@/api/types/fable.types'
-import { toValidationState } from '@/api/types/fable.types'
+import {
+  getBlockConfigurationRestrictions,
+  toValidationState,
+} from '@/api/types/fable.types'
 
 const mockCatalogue: BlockFactoryCatalogue = {
   'ecmwf/base': {
@@ -68,6 +71,7 @@ describe('toValidationState', () => {
       block_errors: {},
       possible_sources: [],
       possible_expansions: {},
+      configuration_restrictions: {},
       resolved_configuration_options: {},
       missing_glyphs: {},
     }
@@ -87,6 +91,7 @@ describe('toValidationState', () => {
       block_errors: {},
       possible_sources: [],
       possible_expansions: {},
+      configuration_restrictions: {},
       resolved_configuration_options: {},
       missing_glyphs: {
         sink_file: {
@@ -113,6 +118,7 @@ describe('toValidationState', () => {
       block_errors: {},
       possible_sources: [],
       possible_expansions: {},
+      configuration_restrictions: {},
       resolved_configuration_options: {},
       missing_glyphs: { sink_file: {} },
     }
@@ -137,6 +143,7 @@ describe('toValidationState', () => {
           },
         ],
       },
+      configuration_restrictions: {},
       resolved_configuration_options: {},
       missing_glyphs: {},
     }
@@ -152,5 +159,40 @@ describe('toValidationState', () => {
     expect(result.blockStates.b1.possibleExpansionRestrictions).toEqual({
       'ecmwf/base:sink': { amount: 'enumClosed[1,2,3]' },
     })
+  })
+
+  it('exposes configuration restrictions for a block itself', () => {
+    const fable: FableBuilderV1 = {
+      blocks: {
+        b1: {
+          factory_id: {
+            plugin: { store: 'ecmwf', local: 'base' },
+            factory: 'source',
+          },
+          configuration_values: { required: 'ifs-ens', optional: '' },
+          input_ids: {},
+        },
+      },
+    }
+    const expansion: FableValidationExpansion = {
+      global_errors: [],
+      block_errors: {},
+      possible_sources: [],
+      possible_expansions: {},
+      configuration_restrictions: {
+        b1: { param: 'list[enumClosed[2t,msl]]' },
+      },
+      resolved_configuration_options: {},
+      missing_glyphs: {},
+    }
+
+    const validationState = toValidationState(expansion, fable, mockCatalogue)
+
+    expect(validationState.blockStates.b1.configurationRestrictions).toEqual({
+      param: 'list[enumClosed[2t,msl]]',
+    })
+    expect(
+      getBlockConfigurationRestrictions(fable, validationState, 'b1'),
+    ).toEqual({ param: 'list[enumClosed[2t,msl]]' })
   })
 })

--- a/frontend/tests/unit/features/fable-builder/presets.test.ts
+++ b/frontend/tests/unit/features/fable-builder/presets.test.ts
@@ -27,14 +27,7 @@ import { getPreset } from '@/features/fable-builder/presets/presets'
 
 // Full set of `configuration_options` keys per block factory (backend mirror).
 const FACTORY_CONFIG_KEYS: Record<string, ReadonlyArray<string>> = {
-  operationalForecastSource: [
-    'source',
-    'forecast',
-    'base_time',
-    'param',
-    'step',
-    'number',
-  ],
+  operationalForecastSource: ['source', 'forecast', 'base_time'],
   ensembleStatistics: ['param', 'statistic'],
   select: ['dimension', 'values'],
   zarrSink: ['path'],
@@ -59,6 +52,31 @@ const PRESET_IDS: ReadonlyArray<PresetId> = [
   'aifs-dataset',
 ]
 
+const OPERATIONAL_PRESET_SELECTS: Partial<
+  Record<PresetId, ReadonlyArray<Readonly<[string, string]>>>
+> = {
+  'quick-start': [
+    ['param', '2t'],
+    ['step', '0'],
+    ['number', '1,2,3,4,5,6'],
+  ],
+  standard: [
+    ['param', '2t'],
+    ['step', '0'],
+    ['number', '0'],
+  ],
+  dataset: [
+    ['param', '2t'],
+    ['step', '0'],
+    ['number', '0'],
+  ],
+  'ecmwf-open-data': [
+    ['param', '2t'],
+    ['step', '24,48,72,360'],
+    ['number', '1,2,3,4,5,6'],
+  ],
+}
+
 describe('config presets match the block factory schema', () => {
   it.each(PRESET_IDS)('preset %s has schema-complete block configs', (id) => {
     const { fable } = getPreset(id)
@@ -78,4 +96,19 @@ describe('config presets match the block factory schema', () => {
       ).toEqual([...expected].sort())
     }
   })
+
+  it.each(Object.entries(OPERATIONAL_PRESET_SELECTS))(
+    'preset %s applies operational source selections with select blocks',
+    (id, expectedSelects) => {
+      const { fable } = getPreset(id as PresetId)
+      const selectConfigs = Object.values(fable.blocks)
+        .filter((block) => block.factory_id.factory === 'select')
+        .map((block) => [
+          block.configuration_values.dimension,
+          block.configuration_values.values,
+        ])
+
+      expect(selectConfigs).toEqual(expectedSelects)
+    },
+  )
 })

--- a/frontend/tests/unit/features/fable-builder/presets.test.ts
+++ b/frontend/tests/unit/features/fable-builder/presets.test.ts
@@ -36,7 +36,7 @@ const FACTORY_CONFIG_KEYS: Record<string, ReadonlyArray<string>> = {
     'number',
   ],
   ensembleStatistics: ['param', 'statistic'],
-  selectSteps: ['step'],
+  select: ['dimension', 'values'],
   zarrSink: ['path'],
   gribSink: ['path'],
   mapPlotSink: ['param', 'domain', 'format', 'groupby', 'splitby'],

--- a/frontend/tests/unit/features/fable-builder/stores/fableBuilderStore.test.ts
+++ b/frontend/tests/unit/features/fable-builder/stores/fableBuilderStore.test.ts
@@ -701,6 +701,7 @@ describe('useFableBuilderStore', () => {
                   param: 'list[enumClosed[2t,msl]]',
                 },
               },
+              configurationRestrictions: {},
               missingGlyphs: {},
             },
             unrestricted: {
@@ -708,6 +709,7 @@ describe('useFableBuilderStore', () => {
               hasErrors: false,
               possibleExpansions: [],
               possibleExpansionRestrictions: {},
+              configurationRestrictions: {},
               missingGlyphs: {},
             },
           }),
@@ -730,6 +732,7 @@ describe('useFableBuilderStore', () => {
               hasErrors: false,
               possibleExpansions: [],
               possibleExpansionRestrictions: {},
+              configurationRestrictions: {},
               missingGlyphs: {},
             },
           }),


### PR DESCRIPTION
To be discussed first - **DO NOT MERGE NOW**.

@liefra and @tmi, please tell me if this makes sense. The idea is to allow dynamic configuration, where one block option can change the restrictions on the other options. This allows for instance a generic Select block instead of SelectDimension, SelectSteps, etc. This should solve issues encountered by @jinmannwong and @HCookie.

Backend and frontend implementation should be reviewed and cleaned up before merging.

### Description

This pull request introduces significant refactoring and generalization of the "select" block functionality in the ECMWF plugin, as well as improvements to plugin configuration option restriction handling throughout the core framework. The main changes are the consolidation of several dimension-specific "Select" blocks into a single, more flexible `Select` block, the introduction of a standardized mechanism for restricting configuration options based on input data, and the corresponding updates to the plugin and block interfaces to support these features.

**Generalization and Refactoring of Select Logic:**

* Replaced the dimension-specific `SelectDimension` blocks (for parameters, steps, members) with a single, configurable `Select` block that can select values from any dimension of the input dataset. The new block uses `DIMENSION` and `VALUES` configuration options, and its logic has been rewritten for greater flexibility and maintainability. [[1]](diffhunk://#diff-c9403c8584dedb84b6580759eda4f5ec58297f78b31308c92b1a01293a0445ccL16-R20) [[2]](diffhunk://#diff-c9403c8584dedb84b6580759eda4f5ec58297f78b31308c92b1a01293a0445ccL32-R29) [[3]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL352-R381) [[4]](diffhunk://#diff-e2aca903e02ed1c838dc135c2505f6e2ebead9543f46f466e1ab97877adacf4aR37-R47)
* Removed hardcoded parameter, step, and ensemble member selection logic from `OperationalForecastSource`, simplifying its validation and compilation logic to only handle time selection. [[1]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL93-L107) [[2]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL118-R134) [[3]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL154-R150) [[4]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL208-R191)

**Plugin and Framework Enhancements:**

* Introduced the `Restrictor` callable and `ConfigurationOptionRestriction` mechanism in the core plugin framework, allowing plugins and blocks to dynamically restrict configuration options based on their inputs. Updated the plugin interface, plugin instantiation, and block base classes to support this new mechanism. [[1]](diffhunk://#diff-31429e6991e54e3741398b08a32325948893f0202ee4d2686e1706b9a743d167R27-R38) [[2]](diffhunk://#diff-31429e6991e54e3741398b08a32325948893f0202ee4d2686e1706b9a743d167R58) [[3]](diffhunk://#diff-3de6b6cdeee67db13a58b12404069c2cf5c56c0d53270926aeb30b08818cadcaR17) [[4]](diffhunk://#diff-3de6b6cdeee67db13a58b12404069c2cf5c56c0d53270926aeb30b08818cadcaL64-R83) [[5]](diffhunk://#diff-3de6b6cdeee67db13a58b12404069c2cf5c56c0d53270926aeb30b08818cadcaR114-R128) [[6]](diffhunk://#diff-3e072eccae57f08e3215f2e92da479ef230990392b98f2de40914d05cc2b871fL191-R192)
* Updated all relevant blocks (including `Select`, `GribSink`, etc.) to implement the new `restrictions` interface, providing dynamic configuration option restrictions based on the input dataset's axes. [[1]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL415-R420) [[2]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL594-R595)

**Utility Improvements:**

* Added utility functions for inferring axis value types and formatting value lists for configuration restrictions, improving robustness and user experience when presenting selectable values in the UI.

These changes collectively improve the flexibility, maintainability, and user experience of block configuration and selection in the ECMWF plugin and the fiab-core framework.

**References:** [[1]](diffhunk://#diff-31429e6991e54e3741398b08a32325948893f0202ee4d2686e1706b9a743d167R27-R38) [[2]](diffhunk://#diff-31429e6991e54e3741398b08a32325948893f0202ee4d2686e1706b9a743d167R58) [[3]](diffhunk://#diff-3e072eccae57f08e3215f2e92da479ef230990392b98f2de40914d05cc2b871fL191-R192) [[4]](diffhunk://#diff-3de6b6cdeee67db13a58b12404069c2cf5c56c0d53270926aeb30b08818cadcaR17) [[5]](diffhunk://#diff-3de6b6cdeee67db13a58b12404069c2cf5c56c0d53270926aeb30b08818cadcaL64-R83) [[6]](diffhunk://#diff-3de6b6cdeee67db13a58b12404069c2cf5c56c0d53270926aeb30b08818cadcaR114-R128) [[7]](diffhunk://#diff-c9403c8584dedb84b6580759eda4f5ec58297f78b31308c92b1a01293a0445ccL16-R20) [[8]](diffhunk://#diff-c9403c8584dedb84b6580759eda4f5ec58297f78b31308c92b1a01293a0445ccL32-R29) [[9]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dR49-R50) [[10]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dR75-R98) [[11]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL93-L107) [[12]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL118-R134) [[13]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL154-R150) [[14]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL208-R191) [[15]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL352-R381) [[16]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL415-R420) [[17]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dL594-R595) [[18]](diffhunk://#diff-e2aca903e02ed1c838dc135c2505f6e2ebead9543f46f466e1ab97877adacf4aR37-R47)

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
