### PR TITLE
[frontend] fix: align with ekdSource → operationalForecastSource rename, rework dashboard presets

### DIFF
--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -501,7 +501,6 @@ class MapPlotSink(Sink):
             title="Parameters",
             description="Parameters to select and plot (e.g. '2t', 'msl')",
             value_type="list[str]",
-            default_value="2t,msl",
         ),
         DOMAIN: BlockConfigurationOption(
             title="Domain",
@@ -519,13 +518,13 @@ class MapPlotSink(Sink):
             title="Group By",
             description="Dimension to create subplots over",
             value_type="enumClosed['valid_datetime', 'step', 'number', 'none']",
-            default_value="step",
+            default_value="none",
         ),
         SPLITBY: BlockConfigurationOption(
             title="Split By",
             description="Dimensions to separate plots by",
             value_type="list[str]",
-            default_value="none",
+            default_value="step",
         ),
         # ConfigurationOptionId("style_schema"): BlockConfigurationOption(
         #     title="Style Schema",

--- a/frontend/mocks/data/fable.data.ts
+++ b/frontend/mocks/data/fable.data.ts
@@ -46,25 +46,42 @@ export const mockCatalogue: BlockFactoryCatalogue = {
   // ECMWF base plugin - matches live backend exactly
   ['ecmwf/ecmwf-base']: {
     factories: {
-      ekdSource: {
+      operationalForecastSource: {
         kind: 'source',
-        title: 'Earthkit Data Source',
-        description: 'Fetch data from mars or ecmwf open data',
+        title: 'Operational forecast source',
+        description:
+          'Fetch operational forecast data from mars or ecmwf open data',
         configuration_options: {
           source: {
             title: 'Source',
             description: 'Top level source for earthkit data',
             value_type: "enumClosed['mars', 'ecmwf-open-data']",
           },
-          date: {
-            title: 'Date',
-            description: 'The date dimension of the data',
-            value_type: 'date',
+          forecast: {
+            title: 'Forecast model',
+            description: 'Name of forecast',
+            value_type: 'enumClosed[aifs-ens,ifs-ens]',
+            default_value: 'aifs-ens',
           },
-          expver: {
-            title: 'Expver',
-            description: 'The expver value of the forecast',
-            value_type: 'str',
+          base_time: {
+            title: 'Base time',
+            description: 'Base time of the forecast',
+            value_type: 'datetime',
+          },
+          param: {
+            title: 'Parameters',
+            description: "Parameters to select and plot (e.g. '2t', 'msl')",
+            value_type: 'list[str]',
+          },
+          step: {
+            title: 'Steps',
+            description: "Forecast steps to select (e.g. '0,6,12,...')",
+            value_type: 'list[int]',
+          },
+          number: {
+            title: 'Ensemble Members',
+            description: "Ensemble members to select (e.g. '1,2,3,...')",
+            value_type: 'list[int]',
           },
         },
         inputs: [],
@@ -194,12 +211,12 @@ export const mockSavedFables: Record<
         block_source_1: {
           factory_id: {
             plugin: pluginId('ecmwf', 'ecmwf-base'),
-            factory: 'ekdSource',
+            factory: 'operationalForecastSource',
           },
           configuration_values: {
             source: 'mars',
-            date: '2024-01-15',
-            expver: '0001',
+            forecast: 'aifs-ens',
+            base_time: '2024-01-15T00:00:00',
           },
           input_ids: {},
         },
@@ -243,12 +260,12 @@ export const mockSavedFables: Record<
         block_source_1: {
           factory_id: {
             plugin: pluginId('ecmwf', 'ecmwf-base'),
-            factory: 'ekdSource',
+            factory: 'operationalForecastSource',
           },
           configuration_values: {
             source: 'ecmwf-open-data',
-            date: '2024-01-14',
-            expver: '0001',
+            forecast: 'aifs-ens',
+            base_time: '2024-01-14T00:00:00',
           },
           input_ids: {},
         },
@@ -292,7 +309,10 @@ export function calculateExpansion(fable: FableBuilderV1): {
   // Available blocks by kind (using new PluginCompositeId format)
   // Only ecmwf-base plugin is loaded
   const sourceBlocks: Array<PluginBlockFactoryId> = [
-    { plugin: pluginId('ecmwf', 'ecmwf-base'), factory: 'ekdSource' },
+    {
+      plugin: pluginId('ecmwf', 'ecmwf-base'),
+      factory: 'operationalForecastSource',
+    },
   ]
   const productBlocks: Array<BlockExpansion> = [
     {

--- a/frontend/src/features/fable-builder/presets/presets.ts
+++ b/frontend/src/features/fable-builder/presets/presets.ts
@@ -10,7 +10,7 @@
 
 import type { FableBuilderV1 } from '@/api/types/fable.types'
 import type { PluginCompositeId } from '@/api/types/plugins.types'
-import { getAppTimeZone, todayInZone, yesterdayInZone } from '@/lib/datetime'
+import { getAppTimeZone, yesterdayInZone } from '@/lib/datetime'
 import i18n from '@/lib/i18n'
 
 export type PresetId =
@@ -36,11 +36,6 @@ function pluginId(store: string, local: string): PluginCompositeId {
   return { store, local }
 }
 
-/** Today's calendar date in the application timezone, evaluated per call. */
-function today(): string {
-  return todayInZone(getAppTimeZone())
-}
-
 /** Yesterday's calendar date in the application timezone, evaluated per call. */
 function yesterday(): string {
   return yesterdayInZone(getAppTimeZone())
@@ -61,12 +56,12 @@ function quickStartPreset(): FablePreset {
         source_1: {
           factory_id: {
             plugin: pluginId('ecmwf', 'ecmwf-base'),
-            factory: 'ekdSource',
+            factory: 'operationalForecastSource',
           },
           configuration_values: {
             source: 'ecmwf-open-data',
-            date: today(),
-            expver: '0001',
+            forecast: 'aifs-ens',
+            base_time: yesterdayBaseTime(),
             param: '2t',
             step: '0',
             number: '1,2,3,4,5,6',
@@ -113,12 +108,12 @@ function standardPreset(): FablePreset {
         source_1: {
           factory_id: {
             plugin: pluginId('ecmwf', 'ecmwf-base'),
-            factory: 'ekdSource',
+            factory: 'operationalForecastSource',
           },
           configuration_values: {
             source: 'mars',
-            date: today(),
-            expver: '0001',
+            forecast: 'aifs-ens',
+            base_time: yesterdayBaseTime(),
             param: '2t',
             step: '0',
             number: '0',
@@ -151,12 +146,12 @@ function datasetPreset(): FablePreset {
         source_1: {
           factory_id: {
             plugin: pluginId('ecmwf', 'ecmwf-base'),
-            factory: 'ekdSource',
+            factory: 'operationalForecastSource',
           },
           configuration_values: {
             source: 'ecmwf-open-data',
-            date: today(),
-            expver: '0001',
+            forecast: 'aifs-ens',
+            base_time: yesterdayBaseTime(),
             param: '2t',
             step: '0',
             number: '0',
@@ -178,12 +173,12 @@ function ecmwfOpenDataPreset(): FablePreset {
         source_1: {
           factory_id: {
             plugin: pluginId('ecmwf', 'ecmwf-base'),
-            factory: 'ekdSource',
+            factory: 'operationalForecastSource',
           },
           configuration_values: {
             source: 'ecmwf-open-data',
-            date: yesterday(),
-            expver: '1',
+            forecast: 'aifs-ens',
+            base_time: yesterdayBaseTime(),
             param: '2t',
             step: '24,48,72,360',
             number: '1,2,3,4,5,6',
@@ -245,32 +240,20 @@ function aifsForecastPreset(): FablePreset {
           },
           input_ids: {},
         },
-        transform_1: {
-          factory_id: {
-            plugin: pluginId('ecmwf', 'ecmwf-base'),
-            factory: 'selectSteps',
-          },
-          configuration_values: {
-            step: '6,12,18,24,30,36,42,48,54,60,66,72',
-          },
-          input_ids: {
-            dataset: 'source_1',
-          },
-        },
         sink_1: {
           factory_id: {
             plugin: pluginId('ecmwf', 'ecmwf-base'),
             factory: 'mapPlotSink',
           },
           configuration_values: {
-            param: '10u,10v',
+            param: '10u',
             domain: 'europe',
             format: 'png',
             groupby: 'none',
-            splitby: 'none',
+            splitby: 'step',
           },
           input_ids: {
-            dataset: 'transform_1',
+            dataset: 'source_1',
           },
         },
         sink_2: {
@@ -283,10 +266,10 @@ function aifsForecastPreset(): FablePreset {
             domain: 'global',
             format: 'pdf',
             groupby: 'none',
-            splitby: 'none',
+            splitby: 'step',
           },
           input_ids: {
-            dataset: 'transform_1',
+            dataset: 'source_1',
           },
         },
       },
@@ -318,10 +301,10 @@ function aifsDatasetPreset(): FablePreset {
         sink_1: {
           factory_id: {
             plugin: pluginId('ecmwf', 'ecmwf-base'),
-            factory: 'zarrSink',
+            factory: 'gribSink',
           },
           configuration_values: {
-            path: '/tmp/${runId}__${attemptCount}.zarr',
+            path: '/tmp/${runId}__${attemptCount}.grib2',
           },
           input_ids: {
             dataset: 'source_1',

--- a/frontend/src/features/plugins/utils/pipeline-generator.ts
+++ b/frontend/src/features/plugins/utils/pipeline-generator.ts
@@ -237,7 +237,6 @@ function findUpstreamBlock(
  */
 const KNOWN_FIELD_DEFAULTS: Record<string, string> = {
   // Common string fields
-  expver: '0001',
   path: '/tmp/output.zarr',
   variable: '2t',
   // Common numeric fields (as strings)

--- a/frontend/src/locales/en/configure.json
+++ b/frontend/src/locales/en/configure.json
@@ -235,7 +235,7 @@
     "aifsForecastName": "AIFS 72h Forecast",
     "aifsForecastDescription": "72-hour AIFS Open Data forecast with global PDF and European PNG map plots",
     "aifsDatasetName": "AIFS Ensemble Dataset",
-    "aifsDatasetDescription": "10-member AIFS Open Data ensemble exported as a Zarr archive"
+    "aifsDatasetDescription": "10-member AIFS Open Data ensemble exported as a GRIB file"
   },
   "draftRestored": {
     "justNow": "just now",

--- a/frontend/src/locales/en/dashboard.json
+++ b/frontend/src/locales/en/dashboard.json
@@ -90,11 +90,11 @@
     },
     "aifsDataset": {
       "title": "AIFS Ensemble Dataset",
-      "description": "10-member AIFS Open Data ensemble exported as a Zarr archive.",
+      "description": "10-member AIFS Open Data ensemble exported as a GRIB file.",
       "tags": {
         "source": "AIFS Open Data",
         "members": "10 Members",
-        "format": "Zarr Export"
+        "format": "GRIB Export"
       }
     }
   },

--- a/frontend/tests/e2e/configure-forecast.spec.ts
+++ b/frontend/tests/e2e/configure-forecast.spec.ts
@@ -84,7 +84,7 @@ test.describe('Fable Builder - Form Mode', () => {
     // Look for add block buttons in the form canvas area
     // In form mode, available block factories appear as "Add" buttons
     const addButtons = page.getByRole('button', {
-      name: /earthkit|ensemble|temporal|zarr/i,
+      name: /operational forecast|ensemble|temporal|zarr/i,
     })
     const addCount = await addButtons.count()
 
@@ -117,7 +117,7 @@ test.describe('Fable Builder - Form Mode', () => {
 
     // Add a block
     const addButtons = page.getByRole('button', {
-      name: /earthkit|ensemble|temporal|zarr/i,
+      name: /operational forecast|ensemble|temporal|zarr/i,
     })
     if ((await addButtons.count()) > 0) {
       await addButtons.first().click()
@@ -145,7 +145,7 @@ test.describe('Fable Builder - Form Mode', () => {
 
     // Add a source block
     const addButtons = page.getByRole('button', {
-      name: /earthkit|ensemble|temporal|zarr/i,
+      name: /operational forecast|ensemble|temporal|zarr/i,
     })
     if ((await addButtons.count()) > 0) {
       await addButtons.first().click()
@@ -180,7 +180,7 @@ test.describe('Fable Builder - Form Mode', () => {
       if (await nextButton.isVisible({ timeout: 3000 }).catch(() => false)) {
         // Add a source block first so we can navigate
         const addButtons = page.getByRole('button', {
-          name: /earthkit|ensemble|temporal|zarr/i,
+          name: /operational forecast|ensemble|temporal|zarr/i,
         })
         if ((await addButtons.count()) > 0) {
           await addButtons.first().click()
@@ -202,7 +202,7 @@ test.describe('Fable Builder - Form Mode', () => {
   test('unsaved badge appears after making changes', async ({ page }) => {
     // Add a block to make changes
     const addButtons = page.getByRole('button', {
-      name: /earthkit|ensemble|temporal|zarr/i,
+      name: /operational forecast|ensemble|temporal|zarr/i,
     })
 
     // Check palette sidebar for blocks
@@ -330,12 +330,12 @@ test.describe('Fable Builder - Graph Mode', () => {
           block_source_1: {
             factory_id: {
               plugin: { store: 'ecmwf', local: 'ecmwf-base' },
-              factory: 'ekdSource',
+              factory: 'operationalForecastSource',
             },
             configuration_values: {
               source: 'mars',
-              date: '2024-01-15',
-              expver: '0001',
+              forecast: 'aifs-ens',
+              base_time: '2024-01-15T00:00:00',
             },
             input_ids: {},
           },

--- a/frontend/tests/integration/features/fable-builder/build-flow.test.tsx
+++ b/frontend/tests/integration/features/fable-builder/build-flow.test.tsx
@@ -12,6 +12,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderWithRouter } from '@tests/utils/render'
 import { FableBuilderPage } from '@/features/fable-builder/components/FableBuilderPage'
 import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
+import { useUiStore } from '@/stores/uiStore'
 
 // Mock useMedia to simulate desktop layout (three-column with sidebars)
 vi.mock('@/hooks/useMedia', () => ({
@@ -44,12 +45,15 @@ function setupValidFableWithSink(): void {
       source1: {
         factory_id: {
           plugin: { store: 'ecmwf', local: 'ecmwf-base' },
-          factory: 'ekdSource',
+          factory: 'operationalForecastSource',
         },
         configuration_values: {
           source: 'mars',
-          date: '2026-01-01',
-          expver: '0001',
+          forecast: 'aifs-ens',
+          base_time: '2026-01-01T00:00:00',
+          param: '2t',
+          step: '0',
+          number: '1',
         },
         input_ids: {},
       },
@@ -96,7 +100,7 @@ describe('Fable Builder Integration', () => {
 
     // Verify source block buttons are visible and enabled (available by default when no validationState)
     const sourceButton = screen.getByRole('button', {
-      name: /Earthkit Data Source/i,
+      name: /Operational forecast source/i,
     })
     await expect.element(sourceButton).toBeVisible()
   })
@@ -107,10 +111,10 @@ describe('Fable Builder Integration', () => {
     // Wait for palette to load
     await expect.element(screen.getByText('Block Palette')).toBeVisible()
 
-    // Find the "Earthkit Data Source" button in the palette
+    // Find the "Operational forecast source" button in the palette
     // For empty fables, validationState is null so all factories are available by default
     const addSourceButton = screen.getByRole('button', {
-      name: /Earthkit Data Source/i,
+      name: /Operational forecast source/i,
     })
     await expect.element(addSourceButton).toBeVisible()
 
@@ -144,7 +148,7 @@ describe('Fable Builder Integration', () => {
 
     // Add a source block
     const addSourceButton = screen.getByRole('button', {
-      name: /Earthkit Data Source/i,
+      name: /Operational forecast source/i,
     })
     await addSourceButton.click()
 
@@ -152,40 +156,42 @@ describe('Fable Builder Integration', () => {
     // Factory title appears as header in config panel (use heading role to be specific)
     await expect
       .element(
-        screen.getByRole('heading', { name: 'Earthkit Data Source' }).first(),
+        screen
+          .getByRole('heading', { name: 'Operational forecast source' })
+          .first(),
       )
       .toBeVisible()
 
     // Configuration fields should be visible with their titles as labels
-    // These come from mockCatalogue configuration_options for ekdSource
-    // Source is an enum (combobox), Date and Expver are text inputs
-    await expect.element(screen.getByLabelText('Date')).toBeVisible()
-    await expect.element(screen.getByLabelText('Expver')).toBeVisible()
+    // These come from mockCatalogue configuration_options for operationalForecastSource
+    // Source and Forecast model are enums; Base time is a datetime input
+    await expect.element(screen.getByLabelText('Base time')).toBeVisible()
+    await expect.element(screen.getByLabelText('Parameters')).toBeVisible()
   })
 
   it('allows configuring a block via input fields', async () => {
+    useUiStore.setState({ timeZone: 'UTC' })
     const screen = await renderWithRouter(<FableBuilderPage />)
 
     // Wait for palette to load
     await expect.element(screen.getByText('Block Palette')).toBeVisible()
 
     // Add a source block
-    await screen.getByRole('button', { name: /Earthkit Data Source/i }).click()
+    await screen
+      .getByRole('button', { name: /Operational forecast source/i })
+      .click()
 
-    // Fill text input configuration fields (Source is an enum/combobox, skip .fill())
-    const dateInput = screen.getByLabelText('Date')
-    await dateInput.fill('2026-01-15')
+    // Fill the Base time date control (Source/Forecast model are enums — skip .fill())
+    const baseTimeInput = screen.getByLabelText('Base time')
+    await baseTimeInput.fill('2026-01-15')
 
-    const expverInput = screen.getByLabelText('Expver')
-    await expverInput.fill('0001')
-
-    // Verify store state was updated
+    // Verify store state was updated. tz is UTC (set above) and the time defaults
+    // to 00:00, so the canonical base_time is exactly midnight UTC.
     const state = useFableBuilderStore.getState()
     const blockId = Object.keys(state.fable.blocks)[0]
     const block = state.fable.blocks[blockId]
 
-    expect(block.configuration_values.date).toBe('2026-01-15')
-    expect(block.configuration_values.expver).toBe('0001')
+    expect(block.configuration_values.base_time).toBe('2026-01-15T00:00:00')
   })
 
   it('allows saving a fable draft', async () => {
@@ -195,10 +201,11 @@ describe('Fable Builder Integration', () => {
     await expect.element(screen.getByText('Block Palette')).toBeVisible()
 
     // Add and configure a source block
-    await screen.getByRole('button', { name: /Earthkit Data Source/i }).click()
+    await screen
+      .getByRole('button', { name: /Operational forecast source/i })
+      .click()
 
-    await screen.getByLabelText('Date').fill('2026-01-15')
-    await screen.getByLabelText('Expver').fill('0001')
+    await screen.getByLabelText('Base time').fill('2026-01-15')
 
     // Verify fable is dirty
     expect(useFableBuilderStore.getState().isDirty).toBe(true)
@@ -301,7 +308,9 @@ describe('Fable Builder Integration', () => {
     await expect.element(screen.getByText('Block Palette')).toBeVisible()
 
     // 2. Add a source block via palette
-    await screen.getByRole('button', { name: /Earthkit Data Source/i }).click()
+    await screen
+      .getByRole('button', { name: /Operational forecast source/i })
+      .click()
 
     // Verify block added
     expect(
@@ -309,14 +318,27 @@ describe('Fable Builder Integration', () => {
     ).toHaveLength(1)
 
     // 3. Configure the source block (fill text inputs, set enum via store)
-    await screen.getByLabelText('Date').fill('2026-01-15')
-    await screen.getByLabelText('Expver').fill('0001')
+    await screen.getByLabelText('Base time').fill('2026-01-15')
     const sourceBlockIdForConfig = Object.keys(
       useFableBuilderStore.getState().fable.blocks,
     )[0]
     useFableBuilderStore
       .getState()
       .updateBlockConfig(sourceBlockIdForConfig, 'source', 'mars')
+    // operationalForecastSource exposes 6 options; fill the rest so the fable
+    // validates (isValid) for the review step below.
+    useFableBuilderStore
+      .getState()
+      .updateBlockConfig(sourceBlockIdForConfig, 'forecast', 'aifs-ens')
+    useFableBuilderStore
+      .getState()
+      .updateBlockConfig(sourceBlockIdForConfig, 'param', '2t')
+    useFableBuilderStore
+      .getState()
+      .updateBlockConfig(sourceBlockIdForConfig, 'step', '0')
+    useFableBuilderStore
+      .getState()
+      .updateBlockConfig(sourceBlockIdForConfig, 'number', '1')
 
     // 4. Add a connected sink block programmatically for review eligibility
     const sourceBlockId = Object.keys(
@@ -354,7 +376,7 @@ describe('Fable Builder Integration', () => {
       .getState()
       .connectBlocks(sinkBlockId, 'dataset', sourceBlockId)
 
-    // Source config fields were already filled via UI, no additional fields to fill
+    // Source + sink configuration completed above
 
     // 5. Save (open popover, then click Save)
     await screen.getByRole('button', { name: /Save Config/i }).click()

--- a/frontend/tests/integration/features/fable-builder/form-mode.test.tsx
+++ b/frontend/tests/integration/features/fable-builder/form-mode.test.tsx
@@ -12,6 +12,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderWithRouter } from '@tests/utils/render'
 import { FableBuilderPage } from '@/features/fable-builder/components/FableBuilderPage'
 import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
+import { useUiStore } from '@/stores/uiStore'
 
 // Mock useMedia to simulate desktop layout
 vi.mock('@/hooks/useMedia', () => ({
@@ -43,12 +44,12 @@ function setupValidFableWithSink(): void {
       source1: {
         factory_id: {
           plugin: { store: 'ecmwf', local: 'ecmwf-base' },
-          factory: 'ekdSource',
+          factory: 'operationalForecastSource',
         },
         configuration_values: {
           source: 'mars',
-          date: '2026-01-01',
-          expver: '0001',
+          forecast: 'aifs-ens',
+          base_time: '2026-01-01T00:00:00',
         },
         input_ids: {},
       },
@@ -98,7 +99,7 @@ describe('Fable Builder Form Mode', () => {
 
     // Add a source block via the palette
     const addSourceButton = screen.getByRole('button', {
-      name: /Earthkit Data Source/i,
+      name: /Operational forecast source/i,
     })
     await expect.element(addSourceButton).toBeVisible()
     await addSourceButton.click()
@@ -110,10 +111,10 @@ describe('Fable Builder Form Mode', () => {
     // Block should be auto-selected after adding
     expect(state.selectedBlockId).toBeTruthy()
 
-    // Configuration fields should be visible (FieldRenderer uses Label with htmlFor)
-    // Source is an enum (combobox), Date and Expver are text inputs
-    await expect.element(screen.getByLabelText('Date')).toBeVisible()
-    await expect.element(screen.getByLabelText('Expver')).toBeVisible()
+    // Configuration fields should be visible (FieldRenderer uses Label with htmlFor).
+    // Source/Forecast model are enums; Base time's labelled control is a date input.
+    await expect.element(screen.getByLabelText('Base time')).toBeVisible()
+    await expect.element(screen.getByLabelText('Parameters')).toBeVisible()
 
     // Fable should be marked as dirty
     expect(useFableBuilderStore.getState().isDirty).toBe(true)
@@ -128,28 +129,28 @@ describe('Fable Builder Form Mode', () => {
   })
 
   it('allows configuring block parameters via form fields', async () => {
+    useUiStore.setState({ timeZone: 'UTC' })
     const screen = await renderWithRouter(<FableBuilderPage />)
 
     // Wait for catalogue
     await expect.element(screen.getByText('Block Palette')).toBeVisible()
 
     // Add a source block via palette
-    await screen.getByRole('button', { name: /Earthkit Data Source/i }).click()
+    await screen
+      .getByRole('button', { name: /Operational forecast source/i })
+      .click()
 
-    // Fill text input configuration fields (Source is an enum/combobox, skip .fill())
-    const dateInput = screen.getByLabelText('Date')
-    await dateInput.fill('2026-01-15')
+    // Fill the Base time date control (Source/Forecast model are enums — skip .fill())
+    const baseTimeInput = screen.getByLabelText('Base time')
+    await baseTimeInput.fill('2026-01-15')
 
-    const expverInput = screen.getByLabelText('Expver')
-    await expverInput.fill('0001')
-
-    // Verify store state was updated
+    // Verify store state was updated. tz is UTC (set above) and the time defaults
+    // to 00:00, so the canonical base_time is exactly midnight UTC.
     const state = useFableBuilderStore.getState()
     const blockId = Object.keys(state.fable.blocks)[0]
     const block = state.fable.blocks[blockId]
 
-    expect(block.configuration_values.date).toBe('2026-01-15')
-    expect(block.configuration_values.expver).toBe('0001')
+    expect(block.configuration_values.base_time).toBe('2026-01-15T00:00:00')
 
     // Fable should be marked as dirty
     expect(state.isDirty).toBe(true)
@@ -162,13 +163,19 @@ describe('Fable Builder Form Mode', () => {
     await expect.element(screen.getByText('Block Palette')).toBeVisible()
 
     // Add a source block
-    await screen.getByRole('button', { name: /Earthkit Data Source/i }).click()
+    await screen
+      .getByRole('button', { name: /Operational forecast source/i })
+      .click()
 
     // The block instance card should show the factory description
     // Use .first() since the description also appears in the palette
     await expect
       .element(
-        screen.getByText('Fetch data from mars or ecmwf open data').first(),
+        screen
+          .getByText(
+            'Fetch operational forecast data from mars or ecmwf open data',
+          )
+          .first(),
       )
       .toBeVisible()
   })
@@ -180,14 +187,16 @@ describe('Fable Builder Form Mode', () => {
     await expect.element(screen.getByText('Block Palette')).toBeVisible()
 
     // Add a source block first so the UI renders the card
-    await screen.getByRole('button', { name: /Earthkit Data Source/i }).click()
+    await screen
+      .getByRole('button', { name: /Operational forecast source/i })
+      .click()
 
     // Now set up missing config to trigger validation errors
     // The block was added to store; clear its config values
     const blockId = Object.keys(useFableBuilderStore.getState().fable.blocks)[0]
     useFableBuilderStore.getState().updateBlockConfig(blockId, 'source', '')
-    useFableBuilderStore.getState().updateBlockConfig(blockId, 'date', '')
-    useFableBuilderStore.getState().updateBlockConfig(blockId, 'expver', '')
+    useFableBuilderStore.getState().updateBlockConfig(blockId, 'forecast', '')
+    useFableBuilderStore.getState().updateBlockConfig(blockId, 'base_time', '')
 
     // Wait for validation to run and produce errors
     await expect
@@ -209,6 +218,7 @@ describe('Fable Builder Form Mode', () => {
   })
 
   it('shows existing blocks with pre-filled configuration values', async () => {
+    useUiStore.setState({ timeZone: 'UTC' })
     const screen = await renderWithRouter(<FableBuilderPage />)
 
     // Wait for catalogue
@@ -220,15 +230,11 @@ describe('Fable Builder Form Mode', () => {
     // Select the source block so its card shows
     useFableBuilderStore.getState().selectBlock('source1')
 
-    // The source block card should show pre-filled config values
-    // Expver field (text input) should have "0001"
-    const expverInput = screen.getByLabelText('Expver')
-    await expect.element(expverInput).toBeVisible()
-    await expect.element(expverInput).toHaveValue('0001')
-
-    // Date field should have the configured date
-    const dateInput = screen.getByLabelText('Date')
-    await expect.element(dateInput).toHaveValue('2026-01-01')
+    // The source block card should show pre-filled config values. The Base time
+    // date control shows the configured date (tz UTC; fixture is midnight UTC).
+    const baseTimeInput = screen.getByLabelText('Base time')
+    await expect.element(baseTimeInput).toBeVisible()
+    await expect.element(baseTimeInput).toHaveValue('2026-01-01')
   })
 
   it('renders pipeline structure sidebar text', async () => {
@@ -256,7 +262,9 @@ describe('Fable Builder Form Mode', () => {
     ).toHaveLength(0)
 
     // Add a source block via the palette
-    await screen.getByRole('button', { name: /Earthkit Data Source/i }).click()
+    await screen
+      .getByRole('button', { name: /Operational forecast source/i })
+      .click()
 
     // Verify block was added to store
     const state = useFableBuilderStore.getState()
@@ -265,10 +273,10 @@ describe('Fable Builder Form Mode', () => {
     // Block should be auto-selected
     expect(state.selectedBlockId).toBeTruthy()
 
-    // The selected block's factory should be ekdSource
+    // The selected block's factory should be operationalForecastSource
     const blockId = state.selectedBlockId!
     const block = state.fable.blocks[blockId]
-    expect(block.factory_id.factory).toBe('ekdSource')
+    expect(block.factory_id.factory).toBe('operationalForecastSource')
     expect(block.factory_id.plugin.local).toBe('ecmwf-base')
   })
 

--- a/frontend/tests/integration/features/fable-builder/graph-mode.test.tsx
+++ b/frontend/tests/integration/features/fable-builder/graph-mode.test.tsx
@@ -53,12 +53,12 @@ function createMultiBlockFable(): FableBuilderV1 {
       source1: {
         factory_id: {
           plugin: { store: 'ecmwf', local: 'ecmwf-base' },
-          factory: 'ekdSource',
+          factory: 'operationalForecastSource',
         },
         configuration_values: {
           source: 'mars',
-          date: '2026-01-01',
-          expver: '0001',
+          forecast: 'aifs-ens',
+          base_time: '2026-01-01T00:00:00',
         },
         input_ids: {},
       },
@@ -94,12 +94,12 @@ function createSourceOnlyFable(): FableBuilderV1 {
       source1: {
         factory_id: {
           plugin: { store: 'ecmwf', local: 'ecmwf-base' },
-          factory: 'ekdSource',
+          factory: 'operationalForecastSource',
         },
         configuration_values: {
           source: 'mars',
-          date: '2026-01-01',
-          expver: '0001',
+          forecast: 'aifs-ens',
+          base_time: '2026-01-01T00:00:00',
         },
         input_ids: {},
       },
@@ -139,7 +139,7 @@ describe('Graph Mode - Utility Functions', () => {
       const nodes = fableToNodes(fable, mockCatalogue)
 
       const sourceNode = nodes.find((n) => n.id === 'source1')
-      expect(sourceNode?.data.label).toBe('Earthkit Data Source')
+      expect(sourceNode?.data.label).toBe('Operational forecast source')
       expect(sourceNode?.data.instanceId).toBe('source1')
       expect(sourceNode?.data.factory.kind).toBe('source')
     })
@@ -363,11 +363,11 @@ describe('Graph Mode - Builder Integration', () => {
 
     // In graph mode, the ConfigPanel sidebar shows the factory title
     await expect
-      .element(screen.getByText('Earthkit Data Source').first())
+      .element(screen.getByText('Operational forecast source').first())
       .toBeVisible()
 
-    // Configuration fields should appear (use Expver, a text input, to avoid enum combobox)
-    await expect.element(screen.getByLabelText('Expver')).toBeVisible()
+    // Configuration fields should appear (Base time's labelled control is a date input)
+    await expect.element(screen.getByLabelText('Base time')).toBeVisible()
   })
 
   it('shows "Select a block to configure" when no block is selected', async () => {

--- a/frontend/tests/integration/features/fable-builder/save-and-load.test.tsx
+++ b/frontend/tests/integration/features/fable-builder/save-and-load.test.tsx
@@ -15,6 +15,7 @@ import { worker } from '@tests/test-extend'
 import { mockSavedFables } from '../../../../mocks/data/fable.data'
 import { FableBuilderPage } from '@/features/fable-builder/components/FableBuilderPage'
 import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
+import { useUiStore } from '@/stores/uiStore'
 import { API_ENDPOINTS } from '@/api/endpoints'
 
 // Mock useMedia to simulate desktop layout (three-column with sidebars)
@@ -47,12 +48,12 @@ function setupFableWithSource(): string {
       source1: {
         factory_id: {
           plugin: { store: 'ecmwf', local: 'ecmwf-base' },
-          factory: 'ekdSource',
+          factory: 'operationalForecastSource',
         },
         configuration_values: {
           source: 'mars',
-          date: '2026-01-01',
-          expver: '0001',
+          forecast: 'aifs-ens',
+          base_time: '2026-01-01T00:00:00',
         },
         input_ids: {},
       },
@@ -188,6 +189,7 @@ describe('Fable Builder Save & Load', () => {
 
   describe('Load configuration from backend', () => {
     it('populates the builder when setFable is called with loaded data', async () => {
+      useUiStore.setState({ timeZone: 'UTC' })
       const screen = await renderWithRouter(<FableBuilderPage />)
 
       // Wait for catalogue to load
@@ -212,13 +214,15 @@ describe('Fable Builder Save & Load', () => {
       // Config panel should show the source block's values
       await expect
         .element(
-          screen.getByRole('heading', { name: 'Earthkit Data Source' }).first(),
+          screen
+            .getByRole('heading', { name: 'Operational forecast source' })
+            .first(),
         )
         .toBeVisible()
 
-      // Expver field (text input) should contain the loaded value
-      const expverInput = screen.getByLabelText('Expver')
-      await expect.element(expverInput).toHaveValue('0001')
+      // Base time date control should contain the loaded date (tz UTC; midnight UTC)
+      const baseTimeInput = screen.getByLabelText('Base time')
+      await expect.element(baseTimeInput).toHaveValue('2024-01-15')
     })
 
     it('handles retrieve error by showing error message', async () => {
@@ -296,7 +300,7 @@ describe('Fable Builder Save & Load', () => {
       useFableBuilderStore.getState().selectBlock('block_source_1')
       useFableBuilderStore
         .getState()
-        .updateBlockConfig('block_source_1', 'expver', '0002')
+        .updateBlockConfig('block_source_1', 'forecast', 'ifs-ens')
 
       // Should now be dirty
       expect(useFableBuilderStore.getState().isDirty).toBe(true)
@@ -350,10 +354,9 @@ describe('Fable Builder Save & Load', () => {
 
       // 2. Add and configure a source block via palette
       await screen
-        .getByRole('button', { name: /Earthkit Data Source/i })
+        .getByRole('button', { name: /Operational forecast source/i })
         .click()
-      await screen.getByLabelText('Date').fill('2026-01-15')
-      await screen.getByLabelText('Expver').fill('0001')
+      await screen.getByLabelText('Base time').fill('2026-01-15')
 
       // 3. First save
       await screen.getByRole('button', { name: /Save Config/i }).click()
@@ -368,7 +371,7 @@ describe('Fable Builder Save & Load', () => {
       expect(firstSaveId).toBeTruthy()
 
       // 4. Modify the configuration
-      await screen.getByLabelText('Expver').fill('0002')
+      await screen.getByLabelText('Base time').fill('2026-02-01')
       expect(useFableBuilderStore.getState().isDirty).toBe(true)
 
       // 5. Re-save (should update existing)

--- a/frontend/tests/integration/features/fable-builder/timezone-base-time.test.tsx
+++ b/frontend/tests/integration/features/fable-builder/timezone-base-time.test.tsx
@@ -43,9 +43,9 @@ function seedSourceBlock() {
       source1: {
         factory_id: {
           plugin: { store: 'ecmwf', local: 'ecmwf-base' },
-          factory: 'ekdSource',
+          factory: 'operationalForecastSource',
         },
-        configuration_values: { source: 'mars', expver: '0001' },
+        configuration_values: { source: 'mars', forecast: 'aifs-ens' },
         input_ids: {},
       },
     },

--- a/frontend/tests/integration/features/plugins/plugin-detail.test.tsx
+++ b/frontend/tests/integration/features/plugins/plugin-detail.test.tsx
@@ -119,7 +119,9 @@ describe('Plugin Detail Page', () => {
       // matching descriptions that contain similar text (vitest browser
       // mode uses case-insensitive getByText)
       await expect
-        .element(screen.getByRole('heading', { name: 'Earthkit Data Source' }))
+        .element(
+          screen.getByRole('heading', { name: 'Operational forecast source' }),
+        )
         .toBeInTheDocument()
       await expect
         .element(screen.getByRole('heading', { name: 'Ensemble Statistics' }))
@@ -139,7 +141,9 @@ describe('Plugin Detail Page', () => {
 
       // Wait for blocks to render
       await expect
-        .element(screen.getByRole('heading', { name: 'Earthkit Data Source' }))
+        .element(
+          screen.getByRole('heading', { name: 'Operational forecast source' }),
+        )
         .toBeInTheDocument()
 
       // The source block button should be enabled

--- a/frontend/tests/unit/features/executions/utils/job-name.test.ts
+++ b/frontend/tests/unit/features/executions/utils/job-name.test.ts
@@ -19,9 +19,9 @@ import { useUiStore } from '@/stores/uiStore'
 const CATALOGUE: BlockFactoryCatalogue = {
   'ecmwf/ecmwf-base': {
     factories: {
-      ekdSource: {
+      operationalForecastSource: {
         kind: 'source',
-        title: 'Earthkit Data Source',
+        title: 'Operational forecast source',
         description: '',
         configuration_options: {},
         inputs: [],
@@ -136,11 +136,11 @@ describe('buildDefaultJobName', () => {
   it('drops a missing sink gracefully', () => {
     expect(
       buildDefaultJobName({
-        fable: { blocks: { src_1: source('ekdSource') } },
+        fable: { blocks: { src_1: source('operationalForecastSource') } },
         catalogue: CATALOGUE,
         now: FIXED_NOW,
       }),
-    ).toBe(`Earthkit Data Source · ${TIMESTAMP_LABEL}`)
+    ).toBe(`Operational forecast source · ${TIMESTAMP_LABEL}`)
   })
 
   it('truncates very long names to 72 characters', () => {

--- a/frontend/tests/unit/features/fable-builder/hooks/useDraftPersistence.test.ts
+++ b/frontend/tests/unit/features/fable-builder/hooks/useDraftPersistence.test.ts
@@ -26,7 +26,7 @@ function makeDraft(overrides: Partial<FableDraft> = {}): FableDraft {
         block_1: {
           factory_id: {
             plugin: { store: 'ecmwf', local: 'base' },
-            factory: 'ekdSource',
+            factory: 'operationalForecastSource',
           },
           configuration_values: { source: 'ecmwf-open-data' },
           input_ids: {},

--- a/frontend/tests/unit/features/fable-builder/presets.test.ts
+++ b/frontend/tests/unit/features/fable-builder/presets.test.ts
@@ -27,7 +27,14 @@ import { getPreset } from '@/features/fable-builder/presets/presets'
 
 // Full set of `configuration_options` keys per block factory (backend mirror).
 const FACTORY_CONFIG_KEYS: Record<string, ReadonlyArray<string>> = {
-  ekdSource: ['source', 'date', 'expver', 'param', 'step', 'number'],
+  operationalForecastSource: [
+    'source',
+    'forecast',
+    'base_time',
+    'param',
+    'step',
+    'number',
+  ],
   ensembleStatistics: ['param', 'statistic'],
   selectSteps: ['step'],
   zarrSink: ['path'],


### PR DESCRIPTION
## Summary

Aligns the frontend with the backend's `ekdSource` → `operationalForecastSource` rename (new config schema: `forecast`/`base_time`/`param`/`step`/`number` replacing `date`/`expver`), and fixes the dashboard "Getting Started" presets that broke or degraded along the way. Includes one minimal backend change (map-plot default values in the plugin catalogue).

## Changes

### Rename alignment (frontend)
- Presets, mock catalogue, and all affected unit/integration/e2e tests now use `operationalForecastSource` with the new config schema. The mock catalogue mirrors the live plugin field-for-field.
- Dropped the now-dead `expver` default from the plugin pipeline generator.

### Dashboard presets
- All presets default `base_time` to yesterday 00:00 UTC 
- AIFS 72h Forecast: removed the `selectSteps` block — it selected `6,12,…,72`, i.e. every step a 72 h / 6 h-timestep source emits, so it was a no-op. 
- AIFS Ensemble Dataset: exports GRIB (`gribSink`) instead of Zarr.
- Map plots in presets use `groupby=none`, `splitby=step`.

### Map-plot defaults (backend, `fiab-plugin-ecmwf/blocks.py`)
- `param`: no default (was `2t,msl`) — the field starts empty and shows a required-value hint instead of silently plotting params the user didn't pick.
- `groupby`: `none` (was `step`); `splitby`: `step` (was `none`).


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
