### PR TITLE
Feat/fiabcore compat check

### DIFF
--- a/backend/packages/fiab-plugin-ecmwf/justfile
+++ b/backend/packages/fiab-plugin-ecmwf/justfile
@@ -1,5 +1,5 @@
 val:
-    uv run ty check
+    uv run ty check src tests
     uv run pytest ./tests/unit && uv run --extra runtime pytest ./tests/runtime
 
 build:

--- a/backend/src/forecastbox/domain/blueprint/db.py
+++ b/backend/src/forecastbox/domain/blueprint/db.py
@@ -39,7 +39,7 @@ async def upsert_blueprint(
     builder: dict | None = None,
     display_name: str | None = None,
     display_description: str | None = None,
-    tags: list[str] | None = None,
+    tags: list[dict] | None = None,
     parent_id: str | None = None,
     expected_version: int | None = None,
 ) -> tuple[BlueprintId, int]:

--- a/backend/src/forecastbox/domain/blueprint/db.py
+++ b/backend/src/forecastbox/domain/blueprint/db.py
@@ -27,6 +27,7 @@ from forecastbox.domain.blueprint.types import BlueprintId
 from forecastbox.schemata.jobs import Blueprint, BlueprintSource
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.db import dbRetry, executeAndCommit, querySingle
+from forecastbox.utility.packages import get_fiabcore_version
 
 
 async def upsert_blueprint(
@@ -97,6 +98,7 @@ async def upsert_blueprint(
                     display_description=display_description,
                     tags=tags,
                     builder=builder,
+                    fiabcore_major=get_fiabcore_version().major,
                     is_deleted=False,
                 )
             )

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -79,6 +79,7 @@ class BlueprintRetrieveResult(FiabBaseModel):
     display_description: str | None = None
     tags: list[str] = []
     parent_id: str | None = None
+    fiabcore_major: int
 
 
 class BlueprintValidationExpansion(FiabBaseModel):
@@ -344,4 +345,5 @@ async def load_builder(blueprint_id: BlueprintId, version: int | None = None) ->
         display_description=blueprint.display_description,  # ty:ignore[invalid-argument-type]
         tags=blueprint.tags or [],  # ty:ignore[invalid-argument-type]
         parent_id=blueprint.parent_id,  # ty:ignore[invalid-argument-type]
+        fiabcore_major=cast(int, blueprint.fiabcore_major),
     )

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -55,6 +55,17 @@ from forecastbox.utility.pydantic import FiabBaseModel
 logger = logging.getLogger(__name__)
 
 
+class Tag(FiabBaseModel):
+    """A key-value tag that can be attached to a Blueprint.
+
+    ``value`` is ``None`` for plain label tags; non-None for informational
+    key=value pairs (e.g. the ``CoreVersionMismatch`` warning tag).
+    """
+
+    key: str
+    value: str | None = None
+
+
 class BlueprintBuilder(FiabBaseModel):
     # NOTE warning -- this class is used by the web api. Be careful about changes here
     blocks: dict[BlockInstanceId, BlockInstance]
@@ -77,7 +88,7 @@ class BlueprintRetrieveResult(FiabBaseModel):
     builder: BlueprintBuilder
     display_name: str | None = None
     display_description: str | None = None
-    tags: list[str] = []
+    tags: list[Tag] = []
     parent_id: str | None = None
     fiabcore_major: int
 
@@ -99,7 +110,7 @@ class BlueprintSaveCommand(FiabBaseModel):
     builder: BlueprintBuilder
     display_name: str | None = None
     display_description: str | None = None
-    tags: list[str] = []
+    tags: list[Tag] = []
     parent_id: str | None = None
 
 
@@ -319,7 +330,7 @@ async def save_builder(
         builder=payload.builder.model_dump(mode="json"),
         display_name=payload.display_name,
         display_description=payload.display_description,
-        tags=payload.tags if payload.tags else None,
+        tags=[t.model_dump() for t in payload.tags] if payload.tags else None,
         parent_id=payload.parent_id,
         expected_version=expected_version,
     )
@@ -337,13 +348,14 @@ async def load_builder(blueprint_id: BlueprintId, version: int | None = None) ->
     if blueprint.builder is None:
         raise BlueprintNotFound(f"Blueprint {blueprint_id!r} has no builder spec.")
     builder = BlueprintBuilder.model_validate(blueprint.builder)
+    raw_tags: list[dict] = blueprint.tags or []  # ty:ignore[invalid-argument-type,invalid-assignment]
     return BlueprintRetrieveResult(
         blueprint_id=BlueprintId(str(blueprint.blueprint_id)),  # ty:ignore[invalid-argument-type]
         blueprint_version=cast(int, blueprint.version),
         builder=builder,
         display_name=blueprint.display_name,  # ty:ignore[invalid-argument-type]
         display_description=blueprint.display_description,  # ty:ignore[invalid-argument-type]
-        tags=blueprint.tags or [],  # ty:ignore[invalid-argument-type]
+        tags=[Tag.model_validate(t) for t in raw_tags],
         parent_id=blueprint.parent_id,  # ty:ignore[invalid-argument-type]
         fiabcore_major=cast(int, blueprint.fiabcore_major),
     )

--- a/backend/src/forecastbox/domain/plugin/compatibility.py
+++ b/backend/src/forecastbox/domain/plugin/compatibility.py
@@ -1,0 +1,61 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Plugin compatibility helpers.
+
+Centralises the version-compatibility rules between plugins and ``fiab-core``:
+
+* A plugin version ``a.b.c`` is compatible with a ``fiab-core`` version ``x.y.z``
+  if and only if ``a == x`` (same major version).
+
+Public API
+----------
+install_specifier(version)
+    Build the ``SpecifierSet`` used when pip-installing a plugin.
+get_compatible_versions(plugin_settings, available_versions)
+    Filter an iterable of version strings to only compatible ones.
+"""
+
+import logging
+from collections.abc import Iterator
+
+from packaging.specifiers import SpecifierSet
+from packaging.version import InvalidVersion, Version
+
+from forecastbox.utility.config import PluginSettings
+from forecastbox.utility.packages import get_fiabcore_version
+
+logger = logging.getLogger(__name__)
+
+
+def install_specifier(version: Version | None) -> SpecifierSet:
+    """Return the ``SpecifierSet`` to use when installing a plugin. If `version` not given,
+    derive a major-version compatibility range from the currently installed ``fiab-core``
+    (e.g. ``>=1,<2``). Otherwise, pin to that exact release (e.g. ``==1.2.3``). Does not
+    check whether that release is within the fiab core bounds!
+    """
+    if version is None:
+        major = get_fiabcore_version().major
+        return SpecifierSet(f">={major},<{major + 1}")
+    return SpecifierSet(f"=={version}")
+
+
+def get_compatible_versions(plugin_settings: PluginSettings, available_versions: Iterator[str]) -> Iterator[str]:
+    """Yield versions from *available_versions* that are compatible with the installed ``fiab-core``, that is,
+    the plugin major version equals the ``fiab-core`` major version."""
+    fiabcore_major = get_fiabcore_version().major
+    for version_str in available_versions:
+        try:
+            v = Version(version_str)
+        except InvalidVersion:
+            # NOTE should not happen, these should come from pypi
+            logger.error(f"Skipping invalid version string {version_str!r} for {plugin_settings.pip_source!r}")
+            continue
+        if v.major == fiabcore_major:
+            yield version_str

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -25,16 +25,11 @@ or when running the initial plugin load -- but inside the updater threads,
 we lock for longer.
 """
 
-import datetime as dt
 import importlib
-import importlib.metadata
 import logging
-import pathlib
-import subprocess
 import threading
 import time
 from concurrent.futures import Future
-from types import ModuleType
 from typing import Iterator, Literal
 
 from cascade.low.func import assert_never
@@ -45,59 +40,10 @@ from pyrsistent.typing import PMap
 
 from forecastbox.utility.concurrent import delayed_thread, timed_acquire
 from forecastbox.utility.config import PluginSettings, PluginsSettings, config, config_edit_lock
+from forecastbox.utility.packages import try_import, try_install, try_updatedate, try_version
 from forecastbox.utility.pydantic import FiabBaseModel
 
 logger = logging.getLogger(__name__)
-
-
-def _try_import(module_name: str) -> ModuleType | None:
-    try:
-        return importlib.import_module(module_name)
-    except ModuleNotFoundError:
-        return None
-
-
-def _try_version(pluginSettings: PluginSettings) -> str:
-    try:
-        return importlib.metadata.version(pluginSettings.pip_source)
-    except importlib.metadata.PackageNotFoundError:
-        module = _try_import(pluginSettings.module_name)
-        if module is not None:
-            if hasattr(module, "_version"):
-                version = module._version
-                if isinstance(version, str):
-                    return version
-        return "unknown"
-
-
-def _try_updatedate(pluginSettings: PluginSettings) -> str:
-    try:
-        dist = importlib.metadata.distribution(pluginSettings.pip_source)
-    except importlib.metadata.PackageNotFoundError:
-        return "unknown"
-    if dist.files is None:
-        return "unknown"
-    try:
-        mtdf = next(f for f in dist.files if f.name == "METADATA")
-    except StopIteration:
-        return "unknown"
-    try:
-        path = pathlib.Path(mtdf.locate())
-        install_time = dt.datetime.fromtimestamp(path.stat().st_ctime)
-        return install_time.strftime("%Y/%m/%d")
-    except Exception:  # too much could happen -- file not exist, no rights, malformed ts, etc
-        return "unknown"
-
-
-def _try_install(pip_source: str) -> None:
-    install_command = ["uv", "pip", "install", "--upgrade"] + (pip_source.split(" ", 1) if pip_source.startswith("-e") else [pip_source])
-    try:
-        result = subprocess.run(install_command, check=False, capture_output=True)
-    except FileNotFoundError as ex:
-        logger.error(f"installing {pip_source} failure: {repr(ex)}")
-    if result.returncode != 0:
-        msg = f"installing {pip_source} failure: {result.returncode}. Stderr: {result.stderr}, Stdout: {result.stdout}, Args: {result.args}"
-        logger.error(msg)
 
 
 class PluginManager:
@@ -112,7 +58,7 @@ class PluginManager:
 
 def load_single(plugin: PluginSettings) -> Plugin | str:
     errors = []
-    plugin_impl = _try_import(plugin.module_name)
+    plugin_impl = try_import(plugin.module_name)
     if plugin_impl is None:
         errors.append(f"failed to import plugin {plugin.module_name}")
     elif not hasattr(plugin_impl, "plugin"):
@@ -141,11 +87,11 @@ def load_plugins(plugins: PluginsSettings) -> None:
             # NOTE consider running all pip invocations at once -- worse error reporting but better perf
             if pluginSettings.update_strategy == "auto":
                 logger.info(f"auto-updating {pluginSettings.module_name}")
-                _try_install(pluginSettings.pip_source)
+                try_install(pluginSettings.pip_source)
             else:
-                if _try_import(pluginSettings.module_name) is None:
+                if try_import(pluginSettings.module_name) is None:
                     logger.info(f"installing {pluginSettings.module_name} for the first time")
-                    _try_install(pluginSettings.pip_source)
+                    try_install(pluginSettings.pip_source)
 
             if pluginKey in lookup:
                 errors[pluginKey] = f"plugin {pluginKey} is provided by more than just {pluginSettings.pip_source}"
@@ -158,8 +104,8 @@ def load_plugins(plugins: PluginsSettings) -> None:
                     errors[pluginKey] = result
                 else:
                     assert_never(result)
-                versions[pluginKey] = _try_version(pluginSettings)
-                updatedate[pluginKey] = _try_updatedate(pluginSettings)
+                versions[pluginKey] = try_version(pluginSettings.pip_source, pluginSettings.module_name)
+                updatedate[pluginKey] = try_updatedate(pluginSettings.pip_source)
 
         with timed_acquire(PluginManager.lock, 60) as result:
             if not result:
@@ -179,10 +125,10 @@ def load_plugins(plugins: PluginsSettings) -> None:
 def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, isUpdate: bool) -> None:
     try:
         if isUpdate:
-            _try_install(pluginSettings.pip_source)
+            try_install(pluginSettings.pip_source)
         # NOTE we need to recommend in the docs to re-launch app after this change, this wont cover all cases
         importlib.reload(importlib.import_module(pluginSettings.module_name))
-        plugin_impl = _try_import(pluginSettings.module_name)
+        plugin_impl = try_import(pluginSettings.module_name)
         result = load_single(pluginSettings)
         logger.debug(f"plugin {pluginId} loaded with success: {isinstance(result, Plugin)}")
         with timed_acquire(PluginManager.lock, 60) as acquire_result:
@@ -194,8 +140,10 @@ def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, i
                 PluginManager.errors = PluginManager.errors.set(pluginId, result)
             else:
                 assert_never(result)
-            PluginManager.versions = PluginManager.versions.set(pluginId, _try_version(pluginSettings))
-            PluginManager.updatedate = PluginManager.updatedate.set(pluginId, _try_updatedate(pluginSettings))
+            PluginManager.versions = PluginManager.versions.set(
+                pluginId, try_version(pluginSettings.pip_source, pluginSettings.module_name)
+            )
+            PluginManager.updatedate = PluginManager.updatedate.set(pluginId, try_updatedate(pluginSettings.pip_source))
         logger.debug(f"single plugin loading finished: {pluginId}")
     except Exception as e:
         logger.exception(f"updating thread failed with {repr(e)}")

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -35,6 +35,7 @@ from typing import Iterator, Literal
 from cascade.low.func import assert_never
 from fiab_core.fable import BlockFactoryCatalogue, PluginCompositeId
 from fiab_core.plugin import Plugin
+from packaging.specifiers import SpecifierSet
 from pyrsistent import pmap
 from pyrsistent.typing import PMap
 
@@ -122,10 +123,10 @@ def load_plugins(plugins: PluginsSettings) -> None:
             PluginManager.updater_error = repr(e)
 
 
-def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, isUpdate: bool) -> None:
+def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, specifier_set: SpecifierSet | None) -> None:
     try:
-        if isUpdate:
-            try_install(pluginSettings.pip_source)
+        if specifier_set is not None:
+            try_install(pluginSettings.pip_source, specifier_set)
         # NOTE we need to recommend in the docs to re-launch app after this change, this wont cover all cases
         importlib.reload(importlib.import_module(pluginSettings.module_name))
         plugin_impl = try_import(pluginSettings.module_name)
@@ -228,7 +229,7 @@ def catalogue_view() -> dict[PluginCompositeId, BlockFactoryCatalogue] | bool:
             return {plugin_id: plugin.catalogue for plugin_id, plugin in PluginManager.plugins.items()}
 
 
-def submit_update_single(pluginId: PluginCompositeId, isUpdate: bool) -> str:
+def submit_update_single(pluginId: PluginCompositeId, specifier_set: SpecifierSet | None) -> str:
     pluginSettings = config.external.plugins.get(pluginId, None)
     if pluginSettings is None:
         return f"plugin {pluginId} not configured"
@@ -245,7 +246,7 @@ def submit_update_single(pluginId: PluginCompositeId, isUpdate: bool) -> str:
                 else:
                     PluginManager.updater.join(0)
                     # we join despite thread not being alive to ensure resource collection
-            PluginManager.updater = threading.Thread(target=update_single, args=(pluginId, pluginSettings, isUpdate))
+            PluginManager.updater = threading.Thread(target=update_single, args=(pluginId, pluginSettings, specifier_set))
             PluginManager.updater.start()
     return ""
 
@@ -270,7 +271,7 @@ def modify_enabled(pluginId: PluginCompositeId, isEnabled: bool) -> None:
     if not isEnabled:
         unload_single(pluginId)
     else:
-        submit_update_single(pluginId, isUpdate=False)
+        submit_update_single(pluginId, specifier_set=None)
 
 
 def join_updater_thread(timeout_sec: int) -> None:

--- a/backend/src/forecastbox/domain/plugin/store.py
+++ b/backend/src/forecastbox/domain/plugin/store.py
@@ -17,16 +17,15 @@ import httpx
 import orjson
 from cascade.low.func import assert_never
 from fiab_core.fable import PluginCompositeId, PluginId
-from packaging.specifiers import SpecifierSet
 from pyrsistent import pmap
 from pyrsistent.typing import PMap
 from typing_extensions import Self
 
+from forecastbox.domain.plugin.compatibility import install_specifier
 from forecastbox.domain.plugin.manager import submit_update_single
 from forecastbox.utility.concurrent import timed_acquire
 from forecastbox.utility.config import PluginSettings, PluginStoreConfig, PluginStoreId, PluginStoresConfig, config, config_edit_lock
 from forecastbox.utility.httpx import fetch_content
-from forecastbox.utility.packages import get_fiabcore_version
 from forecastbox.utility.pydantic import FiabBaseModel
 
 logger = logging.getLogger(__name__)
@@ -168,8 +167,7 @@ def submit_install_plugin(plugin_composite_key: PluginCompositeId) -> None:
             )
             config.save_to_file()
 
-    major = get_fiabcore_version().major
-    submit_update_single(plugin_composite_key, specifier_set=SpecifierSet(f">={major},<{major + 1}"))
+    submit_update_single(plugin_composite_key, specifier_set=install_specifier(None))
 
 
 def join_stores_thread(timeout_sec: int) -> None:

--- a/backend/src/forecastbox/domain/plugin/store.py
+++ b/backend/src/forecastbox/domain/plugin/store.py
@@ -17,6 +17,7 @@ import httpx
 import orjson
 from cascade.low.func import assert_never
 from fiab_core.fable import PluginCompositeId, PluginId
+from packaging.specifiers import SpecifierSet
 from pyrsistent import pmap
 from pyrsistent.typing import PMap
 from typing_extensions import Self
@@ -25,6 +26,7 @@ from forecastbox.domain.plugin.manager import submit_update_single
 from forecastbox.utility.concurrent import timed_acquire
 from forecastbox.utility.config import PluginSettings, PluginStoreConfig, PluginStoreId, PluginStoresConfig, config, config_edit_lock
 from forecastbox.utility.httpx import fetch_content
+from forecastbox.utility.packages import get_fiabcore_version
 from forecastbox.utility.pydantic import FiabBaseModel
 
 logger = logging.getLogger(__name__)
@@ -166,7 +168,8 @@ def submit_install_plugin(plugin_composite_key: PluginCompositeId) -> None:
             )
             config.save_to_file()
 
-    submit_update_single(plugin_composite_key, isUpdate=True)
+    major = get_fiabcore_version().major
+    submit_update_single(plugin_composite_key, specifier_set=SpecifierSet(f">={major},<{major + 1}"))
 
 
 def join_stores_thread(timeout_sec: int) -> None:

--- a/backend/src/forecastbox/routes/blueprint.py
+++ b/backend/src/forecastbox/routes/blueprint.py
@@ -55,6 +55,7 @@ from forecastbox.domain.glyphs.types import GlobalGlyphId
 from forecastbox.domain.plugin.manager import catalogue_view, plugins_ready
 from forecastbox.schemata.jobs import GlobalGlyph
 from forecastbox.utility.auth import AuthContext
+from forecastbox.utility.packages import get_fiabcore_version
 from forecastbox.utility.pagination import PaginationSpec
 from forecastbox.utility.pydantic import FiabBaseModel
 
@@ -101,7 +102,7 @@ class BlueprintGetResponse(FiabBaseModel):
     builder: BlueprintBuilder
     display_name: str | None = None
     display_description: str | None = None
-    tags: list[str] = []
+    tags: list[tuple[str, str | None]] = []
     parent_id: str | None = None
 
 
@@ -266,13 +267,17 @@ async def get_blueprint(
         retrieved = await service.load_builder(spec.blueprint_id, spec.version)
     except BlueprintNotFound as e:
         raise HTTPException(status_code=404, detail=str(e))
+    tags: list[tuple[str, str | None]] = [(t, None) for t in retrieved.tags]
+    current_fiabcore_major = get_fiabcore_version().major
+    if retrieved.fiabcore_major != current_fiabcore_major:
+        tags.append(("CoreVersionMismatch", f"!{retrieved.fiabcore_major} != {current_fiabcore_major}"))
     return BlueprintGetResponse(
         blueprint_id=retrieved.blueprint_id,
         version=retrieved.blueprint_version,
         builder=retrieved.builder,
         display_name=retrieved.display_name,
         display_description=retrieved.display_description,
-        tags=retrieved.tags,
+        tags=tags,
         parent_id=retrieved.parent_id,
     )
 

--- a/backend/src/forecastbox/routes/blueprint.py
+++ b/backend/src/forecastbox/routes/blueprint.py
@@ -46,7 +46,7 @@ from forecastbox.domain.blueprint.exceptions import (
     BlueprintNotFound,
     BlueprintVersionConflict,
 )
-from forecastbox.domain.blueprint.service import BlueprintBuilder, BlueprintSaveCommand, BlueprintValidationExpansion
+from forecastbox.domain.blueprint.service import BlueprintBuilder, BlueprintSaveCommand, BlueprintValidationExpansion, Tag
 from forecastbox.domain.blueprint.types import BlueprintId
 from forecastbox.domain.glyphs import global_db
 from forecastbox.domain.glyphs.intrinsic import AvailableIntrinsicGlyphs, get_values_and_examples
@@ -65,6 +65,23 @@ router = APIRouter(
     tags=["blueprint"],
     responses={404: {"description": "Not found"}},
 )
+
+_CORE_VERSION_MISMATCH_KEY = "CoreVersionMismatch"
+
+
+def _maybe_append_coreversion_mismatch(tags: list[Tag], entity_coreversion: int, current_coreversion: int) -> None:
+    """Append a ``CoreVersionMismatch`` tag when the stored and current fiab-core major versions differ."""
+    if entity_coreversion != current_coreversion:
+        tags.append(Tag(key=_CORE_VERSION_MISMATCH_KEY, value=f"!{entity_coreversion} != {current_coreversion}"))
+
+
+def _reject_reserved_tags(tags: list[Tag]) -> None:
+    """Raise HTTP 422 if any tag uses a key reserved for system use."""
+    if any(t.key == _CORE_VERSION_MISMATCH_KEY for t in tags):
+        raise HTTPException(
+            status_code=422,
+            detail=f"Tag key {_CORE_VERSION_MISMATCH_KEY!r} is reserved and may not be set by callers.",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -87,7 +104,7 @@ class BlueprintCreateRequest(FiabBaseModel):
     builder: BlueprintBuilder
     display_name: str | None = None
     display_description: str | None = None
-    tags: list[str] = []
+    tags: list[Tag] = []
     parent_id: str | None = None
 
 
@@ -102,7 +119,7 @@ class BlueprintGetResponse(FiabBaseModel):
     builder: BlueprintBuilder
     display_name: str | None = None
     display_description: str | None = None
-    tags: list[tuple[str, str | None]] = []
+    tags: list[Tag] = []
     parent_id: str | None = None
 
 
@@ -111,7 +128,7 @@ class BlueprintListItem(FiabBaseModel):
     version: int
     display_name: str | None = None
     display_description: str | None = None
-    tags: list[str] | None = None
+    tags: list[Tag] | None = None
     source: str | None = None
     created_by: str | None = None
 
@@ -129,7 +146,7 @@ class BlueprintUpdateRequest(FiabBaseModel):
     builder: BlueprintBuilder
     display_name: str | None = None
     display_description: str | None = None
-    tags: list[str] = []
+    tags: list[Tag] = []
     parent_id: str | None = None
 
 
@@ -232,7 +249,9 @@ async def create_blueprint(
 
     Returns 422 if the builder fails validation (unknown plugins, undefined
     glyphs, config errors, intrinsic glyph key collisions, etc.).
+    Returns 422 if any of the supplied tags has a reserved key.
     """
+    _reject_reserved_tags(request.tags)
     validation = await service.validate_expand(request.builder, auth_context, validate_only=True)
     if validation.global_errors or validation.block_errors:
         raise HTTPException(
@@ -267,10 +286,8 @@ async def get_blueprint(
         retrieved = await service.load_builder(spec.blueprint_id, spec.version)
     except BlueprintNotFound as e:
         raise HTTPException(status_code=404, detail=str(e))
-    tags: list[tuple[str, str | None]] = [(t, None) for t in retrieved.tags]
-    current_fiabcore_major = get_fiabcore_version().major
-    if retrieved.fiabcore_major != current_fiabcore_major:
-        tags.append(("CoreVersionMismatch", f"!{retrieved.fiabcore_major} != {current_fiabcore_major}"))
+    tags = list(retrieved.tags)
+    _maybe_append_coreversion_mismatch(tags, retrieved.fiabcore_major, get_fiabcore_version().major)
     return BlueprintGetResponse(
         blueprint_id=retrieved.blueprint_id,
         version=retrieved.blueprint_version,
@@ -291,18 +308,23 @@ async def list_blueprints(
     total = await db.count_blueprints(auth_context=auth_context)
     start = pagination.start()
     page_defs = list(await db.list_blueprints(auth_context=auth_context, offset=start, limit=pagination.page_size))
-    items = [
-        BlueprintListItem(
-            blueprint_id=BlueprintId(str(defn.blueprint_id)),  # ty:ignore[invalid-argument-type]
-            version=cast(int, defn.version),
-            display_name=cast(str | None, defn.display_name),
-            display_description=cast(str | None, defn.display_description),
-            tags=cast(list[str] | None, defn.tags),
-            source=cast(str | None, defn.source),
-            created_by=cast(str | None, defn.created_by),
+    current_fiabcore_major = get_fiabcore_version().major
+    items = []
+    for defn in page_defs:
+        raw_tags: list[dict] = cast(list[dict], defn.tags) or []
+        tags = [Tag.model_validate(t) for t in raw_tags]
+        _maybe_append_coreversion_mismatch(tags, cast(int, defn.fiabcore_major), current_fiabcore_major)
+        items.append(
+            BlueprintListItem(
+                blueprint_id=BlueprintId(str(defn.blueprint_id)),  # ty:ignore[invalid-argument-type]
+                version=cast(int, defn.version),
+                display_name=cast(str | None, defn.display_name),
+                display_description=cast(str | None, defn.display_description),
+                tags=tags,
+                source=cast(str | None, defn.source),
+                created_by=cast(str | None, defn.created_by),
+            )
         )
-        for defn in page_defs
-    ]
     return BlueprintListResponse(blueprints=items, total=total, page=pagination.page, page_size=pagination.page_size)
 
 
@@ -316,8 +338,10 @@ async def update_blueprint(
     ``version`` must match the current latest version; returns 409 if it does not.
     Returns 422 if the builder fails validation (unknown plugins, undefined
     glyphs, config errors, intrinsic glyph key collisions, etc.).
+    Returns 422 if any of the supplied tags has a reserved key.
     Returns the new version number on success.
     """
+    _reject_reserved_tags(request.tags)
     validation = await service.validate_expand(request.builder, auth_context, validate_only=True)
     if validation.global_errors or validation.block_errors:
         raise HTTPException(

--- a/backend/src/forecastbox/routes/plugins.py
+++ b/backend/src/forecastbox/routes/plugins.py
@@ -14,7 +14,7 @@ Contains:
  - complete CRUD+List routes for the Plugin entity.
 """
 
-from typing import Literal
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import Response
@@ -152,7 +152,7 @@ class PluginVersions(FiabBaseModel):
 
 
 @router.get("/versions")
-def get_plugin_versions(pluginCompositeId: PluginCompositeId) -> PluginVersions:
+def get_plugin_versions(pluginCompositeId: Annotated[PluginCompositeId, Depends()]) -> PluginVersions:
     """Return available PyPI versions of a plugin that are compatible with the installed ``fiab-core``.
 
     Compatibility is defined as equal major version.  Only versions published

--- a/backend/src/forecastbox/routes/plugins.py
+++ b/backend/src/forecastbox/routes/plugins.py
@@ -19,12 +19,15 @@ from typing import Literal
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import RedirectResponse, Response
 from fiab_core.fable import PluginCompositeId
+from packaging.specifiers import SpecifierSet
+from packaging.version import InvalidVersion, Version
 
 from forecastbox.domain.auth.users import UserRead
 from forecastbox.domain.plugin.manager import PluginsStatus, modify_enabled, status_full, submit_update_single, uninstall_plugin
 from forecastbox.domain.plugin.store import PluginRemoteInfo, PluginStoreEntry, get_plugins_detail, submit_install_plugin
 from forecastbox.routes.admin import get_admin_user
 from forecastbox.utility.config import config
+from forecastbox.utility.packages import get_fiabcore_version
 from forecastbox.utility.pydantic import FiabBaseModel
 
 PREFIX = "/api/v1/plugin"
@@ -115,9 +118,30 @@ get_catalogue_redirect = lambda request: Response(status_code=202)
 
 
 @router.post("/update")
-def update_plugin(request: Request, pluginCompositeId: PluginCompositeId, admin: UserRead | None = Depends(get_admin_user)) -> Response:
-    # TODO possibly add optional version parameter
-    result = submit_update_single(pluginCompositeId, isUpdate=True)
+def update_plugin(
+    request: Request,
+    pluginCompositeId: PluginCompositeId,
+    version: str | None = None,
+    admin: UserRead | None = Depends(get_admin_user),
+) -> Response:
+    """Trigger a pip-install update for a plugin.
+
+    If ``version`` is provided it must be a valid PEP 440 version string; the
+    plugin will be pinned to exactly that version (``==version``).
+    If omitted, a compatibility range derived from the current ``fiab-core``
+    major version is used (``>=major,<major+1``), ensuring the installed plugin
+    stays within the same major-version family as the core library.
+    """
+    if version is not None:
+        try:
+            parsed = Version(version)
+        except InvalidVersion:
+            raise HTTPException(status_code=422, detail=f"Invalid version string: {version!r}")
+        specifier_set = SpecifierSet(f"=={parsed}")
+    else:
+        major = get_fiabcore_version().major
+        specifier_set = SpecifierSet(f">={major},<{major + 1}")
+    result = submit_update_single(pluginCompositeId, specifier_set=specifier_set)
     if result:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=result)
     return get_catalogue_redirect(request)

--- a/backend/src/forecastbox/routes/plugins.py
+++ b/backend/src/forecastbox/routes/plugins.py
@@ -17,17 +17,17 @@ Contains:
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from fastapi.responses import RedirectResponse, Response
+from fastapi.responses import Response
 from fiab_core.fable import PluginCompositeId
-from packaging.specifiers import SpecifierSet
 from packaging.version import InvalidVersion, Version
 
 from forecastbox.domain.auth.users import UserRead
+from forecastbox.domain.plugin.compatibility import get_compatible_versions, install_specifier
 from forecastbox.domain.plugin.manager import PluginsStatus, modify_enabled, status_full, submit_update_single, uninstall_plugin
 from forecastbox.domain.plugin.store import PluginRemoteInfo, PluginStoreEntry, get_plugins_detail, submit_install_plugin
 from forecastbox.routes.admin import get_admin_user
-from forecastbox.utility.config import config
-from forecastbox.utility.packages import get_fiabcore_version
+from forecastbox.utility.config import PluginSettings, config
+from forecastbox.utility.packages import get_package_versions
 from forecastbox.utility.pydantic import FiabBaseModel
 
 PREFIX = "/api/v1/plugin"
@@ -134,17 +134,48 @@ def update_plugin(
     """
     if version is not None:
         try:
-            parsed = Version(version)
+            parsed: Version | None = Version(version)
         except InvalidVersion:
             raise HTTPException(status_code=422, detail=f"Invalid version string: {version!r}")
-        specifier_set = SpecifierSet(f"=={parsed}")
     else:
-        major = get_fiabcore_version().major
-        specifier_set = SpecifierSet(f">={major},<{major + 1}")
+        parsed = None
+    specifier_set = install_specifier(parsed)
     result = submit_update_single(pluginCompositeId, specifier_set=specifier_set)
     if result:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=result)
     return get_catalogue_redirect(request)
+
+
+class PluginVersions(FiabBaseModel):
+    versions: list[str]
+    """Compatible versions, sorted newest first."""
+
+
+@router.get("/versions")
+def get_plugin_versions(pluginCompositeId: PluginCompositeId) -> PluginVersions:
+    """Return available PyPI versions of a plugin that are compatible with the installed ``fiab-core``.
+
+    Compatibility is defined as equal major version.  Only versions published
+    on PyPI are considered; locally-installed or git-sourced plugins will
+    receive an empty list.
+    """
+    pip_source: str | None = None
+
+    store_detail = get_plugins_detail()
+    if pluginCompositeId in store_detail:
+        store_entry, _ = store_detail[pluginCompositeId]
+        pip_source = store_entry.pip_source
+        plugin_settings = PluginSettings(pip_source=pip_source, module_name=store_entry.module_name)
+    elif pluginCompositeId in config.external.plugins:
+        plugin_settings = config.external.plugins[pluginCompositeId]
+        pip_source = plugin_settings.pip_source
+    else:
+        raise HTTPException(status_code=404, detail=f"Plugin {pluginCompositeId!r} not found")
+
+    available = get_package_versions(pip_source)
+    compatible = get_compatible_versions(plugin_settings, available)
+    sorted_versions = sorted(compatible, key=lambda v: Version(v), reverse=True)
+    return PluginVersions(versions=sorted_versions)
 
 
 @router.post("/install")

--- a/backend/src/forecastbox/schemata/jobs.py
+++ b/backend/src/forecastbox/schemata/jobs.py
@@ -63,6 +63,8 @@ class Blueprint(Base):
     # stores the full forecastbox.domain.blueprint.service.BlueprintBuilder as JSON
     builder = Column(JSON, nullable=True)
 
+    fiabcore_major = Column(Integer, nullable=False)
+
     is_deleted = Column(Boolean, nullable=False, default=False)
 
 

--- a/backend/src/forecastbox/utility/packages.py
+++ b/backend/src/forecastbox/utility/packages.py
@@ -21,6 +21,7 @@ import pathlib
 import subprocess
 from types import ModuleType
 
+from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 logger = logging.getLogger(__name__)
@@ -74,16 +75,28 @@ def try_updatedate(pip_source: str) -> str:
         return "unknown"
 
 
-def try_install(pip_source: str) -> None:
+def try_install(pip_source: str, specifier_set: SpecifierSet | None = None) -> None:
     """Run ``uv pip install --upgrade`` for the given ``pip_source``.
 
     The currently installed ``fiab-core`` version is pinned in the install
     command to prevent accidental core upgrades or downgrades.
     # TODO -- include the whole pylock.toml
+
+    If ``specifier_set`` is provided and ``pip_source`` is not an editable
+    install, the specifier is appended to the package argument to constrain
+    which version is installed (e.g. ``"my-plugin>=1,<2"``).
+    Editable installs (``-e ...``) are version-agnostic; the specifier is
+    silently ignored for them.
     """
     fiabcore_pin = f"fiab-core=={get_fiabcore_version()}"
-    base_args = pip_source.split(" ", 1) if pip_source.startswith("-e") else [pip_source]
-    install_command = ["uv", "pip", "install", "--upgrade"] + base_args + [fiabcore_pin]
+    is_editable = pip_source.startswith("-e")
+    if is_editable:
+        base_args = pip_source.split(" ", 1)
+        package_arg = base_args  # specifier_set not applicable for editable installs
+    else:
+        package_spec = pip_source if specifier_set is None else f"{pip_source}{specifier_set}"
+        package_arg = [package_spec]
+    install_command = ["uv", "pip", "install", "--upgrade"] + package_arg + [fiabcore_pin]
     try:
         result = subprocess.run(install_command, check=False, capture_output=True)
     except FileNotFoundError as ex:

--- a/backend/src/forecastbox/utility/packages.py
+++ b/backend/src/forecastbox/utility/packages.py
@@ -1,0 +1,94 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Utility helpers for querying and managing installed Python packages.
+
+These are low-level helpers used by the plugin manager and other components
+that need to interact with the Python package environment at runtime.
+"""
+
+import datetime as dt
+import importlib
+import importlib.metadata
+import logging
+import pathlib
+import subprocess
+from types import ModuleType
+
+from packaging.version import Version
+
+logger = logging.getLogger(__name__)
+
+
+def get_fiabcore_version() -> Version:
+    """Return the currently installed version of ``fiab-core`` as a ``Version`` object."""
+    raw = importlib.metadata.version("fiab-core")
+    return Version(raw)
+
+
+def try_import(module_name: str) -> ModuleType | None:
+    """Attempt to import a module by name; return ``None`` on ``ModuleNotFoundError``."""
+    try:
+        return importlib.import_module(module_name)
+    except ModuleNotFoundError:
+        return None
+
+
+def try_version(pip_source: str, module_name: str) -> str:
+    """Return the installed version of a package, falling back to a module attribute or "unknown"."""
+    try:
+        return importlib.metadata.version(pip_source)
+    except importlib.metadata.PackageNotFoundError:
+        module = try_import(module_name)
+        if module is not None:
+            if hasattr(module, "_version"):
+                version = module._version
+                if isinstance(version, str):
+                    return version
+        return "unknown"
+
+
+def try_updatedate(pip_source: str) -> str:
+    """Return the install date of a package as ``YYYY/MM/DD``, or "unknown"."""
+    try:
+        dist = importlib.metadata.distribution(pip_source)
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
+    if dist.files is None:
+        return "unknown"
+    try:
+        mtdf = next(f for f in dist.files if f.name == "METADATA")
+    except StopIteration:
+        return "unknown"
+    try:
+        path = pathlib.Path(mtdf.locate())
+        install_time = dt.datetime.fromtimestamp(path.stat().st_ctime)
+        return install_time.strftime("%Y/%m/%d")
+    except Exception:  # too much could happen -- file not exist, no rights, malformed ts, etc
+        return "unknown"
+
+
+def try_install(pip_source: str) -> None:
+    """Run ``uv pip install --upgrade`` for the given ``pip_source``.
+
+    The currently installed ``fiab-core`` version is pinned in the install
+    command to prevent accidental core upgrades or downgrades.
+    # TODO -- include the whole pylock.toml
+    """
+    fiabcore_pin = f"fiab-core=={get_fiabcore_version()}"
+    base_args = pip_source.split(" ", 1) if pip_source.startswith("-e") else [pip_source]
+    install_command = ["uv", "pip", "install", "--upgrade"] + base_args + [fiabcore_pin]
+    try:
+        result = subprocess.run(install_command, check=False, capture_output=True)
+    except FileNotFoundError as ex:
+        logger.error(f"installing {pip_source} failure: {repr(ex)}")
+        return
+    if result.returncode != 0:
+        msg = f"installing {pip_source} failure: {result.returncode}. Stderr: {result.stderr}, Stdout: {result.stdout}, Args: {result.args}"
+        logger.error(msg)

--- a/backend/src/forecastbox/utility/packages.py
+++ b/backend/src/forecastbox/utility/packages.py
@@ -19,8 +19,10 @@ import importlib.metadata
 import logging
 import pathlib
 import subprocess
+from collections.abc import Iterator
 from types import ModuleType
 
+import httpx
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
@@ -31,6 +33,34 @@ def get_fiabcore_version() -> Version:
     """Return the currently installed version of ``fiab-core`` as a ``Version`` object."""
     raw = importlib.metadata.version("fiab-core")
     return Version(raw)
+
+
+def get_package_versions(pip_source: str) -> Iterator[str]:
+    """Return all versions of *pip_source* available on PyPI.
+
+    Fetches ``https://pypi.org/pypi/{pip_source}/json`` and yields every key
+    from the ``releases`` mapping.  PyPI does not paginate this endpoint, but
+    if a ``next`` link is ever introduced the loop below handles it.
+    """
+    url: str | None = f"https://pypi.org/pypi/{pip_source}/json"
+    with httpx.Client() as client:
+        while url is not None:
+            try:
+                response = client.get(url)
+            except Exception:
+                logger.exception(f"Failed to reach PyPI for {pip_source!r}")
+                return
+            if response.status_code != 200:
+                logger.warning(f"PyPI returned {response.status_code} for {pip_source!r}")
+                return
+            try:
+                data = response.json()
+            except Exception:
+                logger.exception(f"Failed to parse PyPI JSON for {pip_source!r}")
+                return
+            yield from data.get("releases", {}).keys()
+            # PyPI JSON API does not currently paginate; guard for the future.
+            url = data.get("next", None)
 
 
 def try_import(module_name: str) -> ModuleType | None:

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -143,7 +143,7 @@ def test_blueprint_save_and_retrieve(backend_client_with_auth: httpx.Client) -> 
     assert retrieved["blueprint_id"] == saved["blueprint_id"]
     assert retrieved["version"] == 1
     assert retrieved["display_name"] == "Test Blueprint"
-    assert retrieved["tags"] == ["test", "integration"]
+    assert retrieved["tags"] == [["test", None], ["integration", None]]
     assert retrieved["builder"]["blocks"]["source_42"]["factory_id"]["factory"] == "source_42"
     assert retrieved["builder"]["environment"]["hosts"] == 2
     assert retrieved["builder"]["environment"]["workers_per_host"] == 4

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -37,7 +37,7 @@ import pytest
 from fiab_core.fable import BlockFactoryId, BlockInstance, BlockInstanceId, ConfigurationOptionId, PluginBlockFactoryId, PluginCompositeId
 
 from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
-from forecastbox.domain.blueprint.service import BlueprintBuilder, BlueprintSaveCommand
+from forecastbox.domain.blueprint.service import BlueprintBuilder, BlueprintSaveCommand, Tag
 from forecastbox.domain.glyphs.intrinsic import AvailableIntrinsicGlyphs
 from forecastbox.routes.run import CompilationDetailResponse, RunCreateResponse
 
@@ -126,7 +126,7 @@ def test_blueprint_save_and_retrieve(backend_client_with_auth: httpx.Client) -> 
         builder=builder,
         display_name="Test Blueprint",
         display_description="A blueprint saved via the v2 API",
-        tags=["test", "integration"],
+        tags=[Tag(key="test"), Tag(key="integration")],
     )
 
     # Save new blueprint
@@ -143,7 +143,7 @@ def test_blueprint_save_and_retrieve(backend_client_with_auth: httpx.Client) -> 
     assert retrieved["blueprint_id"] == saved["blueprint_id"]
     assert retrieved["version"] == 1
     assert retrieved["display_name"] == "Test Blueprint"
-    assert retrieved["tags"] == [["test", None], ["integration", None]]
+    assert retrieved["tags"] == [{"key": "test", "value": None}, {"key": "integration", "value": None}]
     assert retrieved["builder"]["blocks"]["source_42"]["factory_id"]["factory"] == "source_42"
     assert retrieved["builder"]["environment"]["hosts"] == 2
     assert retrieved["builder"]["environment"]["workers_per_host"] == 4

--- a/backend/tests/unit/domain/plugins/test_compatibility.py
+++ b/backend/tests/unit/domain/plugins/test_compatibility.py
@@ -1,0 +1,123 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Unit tests for domain.plugin.compatibility."""
+
+from unittest.mock import patch
+
+import pytest
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+from forecastbox.domain.plugin.compatibility import get_compatible_versions, install_specifier
+from forecastbox.utility.config import PluginSettings
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PLUGIN = PluginSettings(pip_source="my-plugin", module_name="my_plugin")
+
+
+# ---------------------------------------------------------------------------
+# install_specifier
+# ---------------------------------------------------------------------------
+
+
+def test_install_specifier_none_uses_fiabcore_major() -> None:
+    with patch("forecastbox.domain.plugin.compatibility.get_fiabcore_version", return_value=Version("1.5.3")):
+        spec = install_specifier(None)
+    assert Version("1.0.0") in spec
+    assert Version("1.99.0") in spec
+    assert Version("2.0.0") not in spec
+    assert Version("0.9.9") not in spec
+
+
+def test_install_specifier_none_major_zero() -> None:
+    with patch("forecastbox.domain.plugin.compatibility.get_fiabcore_version", return_value=Version("0.3.1")):
+        spec = install_specifier(None)
+    assert Version("0.0.0") in spec
+    assert Version("0.9.9") in spec
+    assert Version("1.0.0") not in spec
+
+
+def test_install_specifier_exact_version() -> None:
+    spec = install_specifier(Version("2.5.0"))
+    assert Version("2.5.0") in spec
+    assert Version("2.5.1") not in spec
+    assert Version("2.4.9") not in spec
+
+
+def test_install_specifier_returns_specifier_set() -> None:
+    spec = install_specifier(Version("3.0.0"))
+    assert isinstance(spec, SpecifierSet)
+
+
+def test_install_specifier_none_returns_specifier_set() -> None:
+    with patch("forecastbox.domain.plugin.compatibility.get_fiabcore_version", return_value=Version("1.0.0")):
+        spec = install_specifier(None)
+    assert isinstance(spec, SpecifierSet)
+
+
+def test_install_specifier_consistent_with_major() -> None:
+    """Minor/patch of fiab-core version must not affect the range."""
+    with patch("forecastbox.domain.plugin.compatibility.get_fiabcore_version", return_value=Version("2.0.0")):
+        spec_a = install_specifier(None)
+    with patch("forecastbox.domain.plugin.compatibility.get_fiabcore_version", return_value=Version("2.7.3")):
+        spec_b = install_specifier(None)
+    assert str(spec_a) == str(spec_b)
+
+
+# ---------------------------------------------------------------------------
+# get_compatible_versions
+# ---------------------------------------------------------------------------
+
+
+def test_compatible_versions_filters_by_major() -> None:
+    versions = ["1.0.0", "1.1.0", "2.0.0", "0.9.0"]
+    with patch("forecastbox.domain.plugin.compatibility.get_fiabcore_version", return_value=Version("1.0.0")):
+        result = list(get_compatible_versions(_PLUGIN, iter(versions)))
+    assert result == ["1.0.0", "1.1.0"]
+
+
+def test_compatible_versions_empty_input() -> None:
+    with patch("forecastbox.domain.plugin.compatibility.get_fiabcore_version", return_value=Version("1.0.0")):
+        result = list(get_compatible_versions(_PLUGIN, iter([])))
+    assert result == []
+
+
+def test_compatible_versions_none_match() -> None:
+    versions = ["2.0.0", "3.0.0"]
+    with patch("forecastbox.domain.plugin.compatibility.get_fiabcore_version", return_value=Version("1.0.0")):
+        result = list(get_compatible_versions(_PLUGIN, iter(versions)))
+    assert result == []
+
+
+def test_compatible_versions_skips_invalid_strings() -> None:
+    versions = ["1.0.0", "not-a-version", "1.2.3", "bad"]
+    with patch("forecastbox.domain.plugin.compatibility.get_fiabcore_version", return_value=Version("1.0.0")):
+        result = list(get_compatible_versions(_PLUGIN, iter(versions)))
+    assert result == ["1.0.0", "1.2.3"]
+
+
+def test_compatible_versions_major_zero() -> None:
+    versions = ["0.1.0", "0.2.0", "1.0.0"]
+    with patch("forecastbox.domain.plugin.compatibility.get_fiabcore_version", return_value=Version("0.5.0")):
+        result = list(get_compatible_versions(_PLUGIN, iter(versions)))
+    assert result == ["0.1.0", "0.2.0"]
+
+
+def test_compatible_versions_is_streaming() -> None:
+    """Verify the function is a generator (lazy evaluation)."""
+    versions = ["1.0.0", "1.1.0"]
+    with patch("forecastbox.domain.plugin.compatibility.get_fiabcore_version", return_value=Version("1.0.0")):
+        gen = get_compatible_versions(_PLUGIN, iter(versions))
+    import inspect
+
+    assert inspect.isgenerator(gen)

--- a/backend/tests/unit/routes/test_blueprint.py
+++ b/backend/tests/unit/routes/test_blueprint.py
@@ -1,0 +1,113 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Unit tests for the blueprint route helpers."""
+
+import pytest
+from fastapi.exceptions import HTTPException
+
+from forecastbox.domain.blueprint.service import Tag
+from forecastbox.routes.blueprint import _CORE_VERSION_MISMATCH_KEY, _maybe_append_coreversion_mismatch, _reject_reserved_tags
+
+# ---------------------------------------------------------------------------
+# _maybe_append_coreversion_mismatch
+# ---------------------------------------------------------------------------
+
+
+def test_no_tag_when_versions_match() -> None:
+    tags: list[Tag] = [Tag(key="foo")]
+    _maybe_append_coreversion_mismatch(tags, entity_coreversion=1, current_coreversion=1)
+    assert len(tags) == 1
+    assert tags[0].key == "foo"
+
+
+def test_appends_tag_when_versions_differ() -> None:
+    tags: list[Tag] = []
+    _maybe_append_coreversion_mismatch(tags, entity_coreversion=0, current_coreversion=1)
+    assert len(tags) == 1
+    assert tags[0].key == _CORE_VERSION_MISMATCH_KEY
+    assert tags[0].value == "!0 != 1"
+
+
+def test_mismatch_message_uses_entity_version_first() -> None:
+    tags: list[Tag] = []
+    _maybe_append_coreversion_mismatch(tags, entity_coreversion=2, current_coreversion=5)
+    assert tags[0].value == "!2 != 5"
+
+
+def test_existing_tags_preserved_when_mismatch() -> None:
+    tags: list[Tag] = [Tag(key="a"), Tag(key="b", value="v")]
+    _maybe_append_coreversion_mismatch(tags, entity_coreversion=0, current_coreversion=1)
+    assert len(tags) == 3
+    assert tags[0].key == "a"
+    assert tags[1].key == "b"
+    assert tags[2].key == _CORE_VERSION_MISMATCH_KEY
+
+
+def test_no_tag_appended_on_zero_versions_match() -> None:
+    tags: list[Tag] = []
+    _maybe_append_coreversion_mismatch(tags, entity_coreversion=0, current_coreversion=0)
+    assert tags == []
+
+
+# ---------------------------------------------------------------------------
+# Tag model
+# ---------------------------------------------------------------------------
+
+
+def test_tag_default_value_is_none() -> None:
+    tag = Tag(key="label")
+    assert tag.value is None
+
+
+def test_tag_with_value() -> None:
+    tag = Tag(key="k", value="v")
+    assert tag.key == "k"
+    assert tag.value == "v"
+
+
+def test_tag_serializes_to_dict() -> None:
+    tag = Tag(key="foo", value=None)
+    d = tag.model_dump()
+    assert d == {"key": "foo", "value": None}
+
+
+def test_tag_roundtrip_via_model_validate() -> None:
+    original = Tag(key="CoreVersionMismatch", value="!0 != 1")
+    dumped = original.model_dump()
+    restored = Tag.model_validate(dumped)
+    assert restored == original
+
+
+# ---------------------------------------------------------------------------
+# _reject_reserved_tags
+# ---------------------------------------------------------------------------
+
+
+def test_reject_reserved_tags_raises_on_reserved_key() -> None:
+    tags = [Tag(key=_CORE_VERSION_MISMATCH_KEY)]
+    with pytest.raises(HTTPException) as exc_info:
+        _reject_reserved_tags(tags)
+    assert exc_info.value.status_code == 422
+
+
+def test_reject_reserved_tags_passes_with_normal_tags() -> None:
+    tags = [Tag(key="foo"), Tag(key="bar", value="baz")]
+    _reject_reserved_tags(tags)  # should not raise
+
+
+def test_reject_reserved_tags_passes_for_empty_list() -> None:
+    _reject_reserved_tags([])  # should not raise
+
+
+def test_reject_reserved_tags_mixed_raises() -> None:
+    tags = [Tag(key="ok"), Tag(key=_CORE_VERSION_MISMATCH_KEY, value="!0 != 1")]
+    with pytest.raises(HTTPException) as exc_info:
+        _reject_reserved_tags(tags)
+    assert exc_info.value.status_code == 422

--- a/backend/tests/unit/routes/test_plugins.py
+++ b/backend/tests/unit/routes/test_plugins.py
@@ -1,0 +1,89 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Unit tests for plugin route helpers — version/specifier parsing logic."""
+
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+# ---------------------------------------------------------------------------
+# Helpers that mirror the route logic without depending on FastAPI/HTTP stack
+# ---------------------------------------------------------------------------
+
+
+def _build_specifier_for_version(version_str: str) -> SpecifierSet:
+    """Mirrors the route logic: parse a version string into an exact SpecifierSet."""
+    return SpecifierSet(f"=={Version(version_str)}")
+
+
+def _build_default_specifier(fiabcore_version: Version) -> SpecifierSet:
+    """Mirrors the route logic: derive a compatible range from the fiabcore major."""
+    major = fiabcore_version.major
+    return SpecifierSet(f">={major},<{major + 1}")
+
+
+# ---------------------------------------------------------------------------
+# Version-string → SpecifierSet (explicit version)
+# ---------------------------------------------------------------------------
+
+
+def test_exact_specifier_from_simple_version() -> None:
+    spec = _build_specifier_for_version("1.2.3")
+    assert Version("1.2.3") in spec
+    assert Version("1.2.4") not in spec
+    assert Version("1.2.2") not in spec
+
+
+def test_exact_specifier_from_zero_version() -> None:
+    spec = _build_specifier_for_version("0.0.0")
+    assert Version("0.0.0") in spec
+    assert Version("0.0.1") not in spec
+
+
+def test_exact_specifier_rejects_invalid_string() -> None:
+    import pytest
+    from packaging.version import InvalidVersion
+
+    with pytest.raises(InvalidVersion):
+        _build_specifier_for_version("not-a-version")
+
+
+# ---------------------------------------------------------------------------
+# Default specifier derived from fiabcore major
+# ---------------------------------------------------------------------------
+
+
+def test_default_specifier_major_zero() -> None:
+    spec = _build_default_specifier(Version("0.5.0"))
+    assert Version("0.0.0") in spec
+    assert Version("0.9.9") in spec
+    assert Version("1.0.0") not in spec
+
+
+def test_default_specifier_major_one() -> None:
+    spec = _build_default_specifier(Version("1.0.0"))
+    assert Version("1.0.0") in spec
+    assert Version("1.99.0") in spec
+    assert Version("2.0.0") not in spec
+    assert Version("0.9.9") not in spec
+
+
+def test_default_specifier_major_two() -> None:
+    spec = _build_default_specifier(Version("2.3.1"))
+    assert Version("2.0.0") in spec
+    assert Version("2.99.99") in spec
+    assert Version("3.0.0") not in spec
+    assert Version("1.99.99") not in spec
+
+
+def test_default_specifier_patch_irrelevant() -> None:
+    # Only the major component matters for the range
+    spec_a = _build_default_specifier(Version("1.0.0"))
+    spec_b = _build_default_specifier(Version("1.5.3"))
+    assert str(spec_a) == str(spec_b)

--- a/backend/tests/unit/routes/test_plugins.py
+++ b/backend/tests/unit/routes/test_plugins.py
@@ -7,10 +7,19 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-"""Unit tests for plugin route helpers — version/specifier parsing logic."""
+"""Unit tests for plugin route helpers — version/specifier parsing logic and /versions route."""
 
+from unittest.mock import patch
+
+import pytest
+from fastapi.exceptions import HTTPException
+from fiab_core.fable import PluginCompositeId, PluginId, PluginStoreId
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
+
+from forecastbox.domain.plugin.store import PluginRemoteInfo, PluginStoreEntry
+from forecastbox.routes.plugins import get_plugin_versions
+from forecastbox.utility.config import PluginSettings
 
 # ---------------------------------------------------------------------------
 # Helpers that mirror the route logic without depending on FastAPI/HTTP stack
@@ -87,3 +96,75 @@ def test_default_specifier_patch_irrelevant() -> None:
     spec_a = _build_default_specifier(Version("1.0.0"))
     spec_b = _build_default_specifier(Version("1.5.3"))
     assert str(spec_a) == str(spec_b)
+
+
+# ---------------------------------------------------------------------------
+# /versions route — get_plugin_versions
+# ---------------------------------------------------------------------------
+
+_COMPOSITE_ID = PluginCompositeId(store=PluginStoreId("ecmwf"), local=PluginId("ecmwf-base"))
+_STORE_ENTRY = PluginStoreEntry(
+    pip_source="fiab-plugin-ecmwf",
+    module_name="fiab_plugin_ecmwf",
+    display_title="ECMWF Plugin",
+    display_description="desc",
+    display_author="ECMWF",
+)
+_REMOTE_INFO = PluginRemoteInfo(version="1.2.0")
+
+
+from unittest.mock import _patch as PatchType
+
+
+def _patch_versions(versions: list[str]) -> PatchType:
+    return patch("forecastbox.routes.plugins.get_package_versions", return_value=iter(versions))
+
+
+def _patch_store(entry: PluginStoreEntry = _STORE_ENTRY) -> PatchType:
+    return patch("forecastbox.routes.plugins.get_plugins_detail", return_value={_COMPOSITE_ID: (entry, _REMOTE_INFO)})
+
+
+def _patch_fiabcore(version_str: str = "1.0.0") -> PatchType:
+    return patch("forecastbox.domain.plugin.compatibility.get_fiabcore_version", return_value=Version(version_str))
+
+
+def test_versions_returns_compatible_sorted_descending() -> None:
+    available = ["1.0.0", "1.2.0", "2.0.0", "1.1.0"]
+    with _patch_store(), _patch_versions(available), _patch_fiabcore("1.0.0"):
+        result = get_plugin_versions(_COMPOSITE_ID)
+    assert result.versions == ["1.2.0", "1.1.0", "1.0.0"]
+
+
+def test_versions_returns_empty_when_nothing_compatible() -> None:
+    available = ["2.0.0", "3.0.0"]
+    with _patch_store(), _patch_versions(available), _patch_fiabcore("1.0.0"):
+        result = get_plugin_versions(_COMPOSITE_ID)
+    assert result.versions == []
+
+
+def test_versions_404_when_plugin_not_in_store_or_config() -> None:
+    unknown_id = PluginCompositeId(store=PluginStoreId("unknown"), local=PluginId("unknown"))
+    with patch("forecastbox.routes.plugins.get_plugins_detail", return_value={}):
+        with patch("forecastbox.routes.plugins.config") as mock_config:
+            mock_config.external.plugins = {}
+            with pytest.raises(HTTPException) as exc_info:
+                get_plugin_versions(unknown_id)
+    assert exc_info.value.status_code == 404
+
+
+def test_versions_falls_back_to_config_when_not_in_store() -> None:
+    plugin_settings = PluginSettings(pip_source="fiab-plugin-ecmwf", module_name="fiab_plugin_ecmwf")
+    available = ["1.0.0", "1.3.0"]
+    with patch("forecastbox.routes.plugins.get_plugins_detail", return_value={}):
+        with patch("forecastbox.routes.plugins.config") as mock_config:
+            mock_config.external.plugins = {_COMPOSITE_ID: plugin_settings}
+            with _patch_versions(available), _patch_fiabcore("1.5.0"):
+                result = get_plugin_versions(_COMPOSITE_ID)
+    assert result.versions == ["1.3.0", "1.0.0"]
+
+
+def test_versions_pip_source_passed_to_get_package_versions() -> None:
+    with _patch_store() as mock_detail, _patch_fiabcore("1.0.0"):
+        with patch("forecastbox.routes.plugins.get_package_versions", return_value=iter([])) as mock_gpv:
+            get_plugin_versions(_COMPOSITE_ID)
+    mock_gpv.assert_called_once_with("fiab-plugin-ecmwf")

--- a/backend/tests/unit/utility/test_packages.py
+++ b/backend/tests/unit/utility/test_packages.py
@@ -18,6 +18,7 @@ from packaging.version import Version
 
 from forecastbox.utility.packages import (
     get_fiabcore_version,
+    get_package_versions,
     try_import,
     try_install,
     try_updatedate,
@@ -246,3 +247,61 @@ def test_get_fiabcore_version_current_install() -> None:
     # Smoke test: fiab-core is installed in this environment
     result = get_fiabcore_version()
     assert isinstance(result, Version)
+
+
+# ---------------------------------------------------------------------------
+# get_package_versions
+# ---------------------------------------------------------------------------
+
+
+def _make_pypi_response(releases: dict) -> MagicMock:
+    """Build a fake httpx.Response-like mock for the PyPI JSON API."""
+    mock = MagicMock()
+    mock.status_code = 200
+    mock.json.return_value = {"releases": releases}
+    return mock
+
+
+def test_get_package_versions_returns_all_releases() -> None:
+    releases = {"1.0.0": [], "1.1.0": [], "2.0.0": []}
+    with patch("httpx.Client.get", return_value=_make_pypi_response(releases)):
+        result = list(get_package_versions("some-plugin"))
+    assert set(result) == {"1.0.0", "1.1.0", "2.0.0"}
+
+
+def test_get_package_versions_empty_releases() -> None:
+    with patch("httpx.Client.get", return_value=_make_pypi_response({})):
+        result = list(get_package_versions("some-plugin"))
+    assert result == []
+
+
+def test_get_package_versions_non_200_returns_empty() -> None:
+    mock_resp = MagicMock()
+    mock_resp.status_code = 404
+    with patch("httpx.Client.get", return_value=mock_resp):
+        result = list(get_package_versions("nonexistent-plugin"))
+    assert result == []
+
+
+def test_get_package_versions_network_error_returns_empty() -> None:
+    with patch("httpx.Client.get", side_effect=Exception("network failure")):
+        result = list(get_package_versions("some-plugin"))
+    assert result == []
+
+
+def test_get_package_versions_bad_json_returns_empty() -> None:
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.side_effect = ValueError("not JSON")
+    with patch("httpx.Client.get", return_value=mock_resp):
+        result = list(get_package_versions("some-plugin"))
+    assert result == []
+
+
+def test_get_package_versions_is_iterator() -> None:
+    releases = {"1.0.0": [], "2.0.0": []}
+    with patch("httpx.Client.get", return_value=_make_pypi_response(releases)):
+        result = get_package_versions("some-plugin")
+    import inspect
+
+    assert inspect.isgenerator(result)

--- a/backend/tests/unit/utility/test_packages.py
+++ b/backend/tests/unit/utility/test_packages.py
@@ -1,0 +1,207 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import importlib.metadata
+import subprocess
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+from packaging.version import Version
+
+from forecastbox.utility.packages import (
+    get_fiabcore_version,
+    try_import,
+    try_install,
+    try_updatedate,
+    try_version,
+)
+
+# ---------------------------------------------------------------------------
+# try_import
+# ---------------------------------------------------------------------------
+
+
+def test_try_import_success() -> None:
+    result = try_import("os")
+    assert result is not None
+    import os
+
+    assert result is os
+
+
+def test_try_import_not_found() -> None:
+    result = try_import("definitely_nonexistent_module_xyz")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# try_version
+# ---------------------------------------------------------------------------
+
+
+def test_try_version_from_metadata() -> None:
+    with patch("importlib.metadata.version", return_value="1.2.3"):
+        result = try_version("some-package", "some_module")
+    assert result == "1.2.3"
+
+
+def test_try_version_falls_back_to_module_attribute() -> None:
+    with patch("importlib.metadata.version", side_effect=importlib.metadata.PackageNotFoundError):
+        fake_module = MagicMock(spec=ModuleType)
+        fake_module._version = "0.9.1"
+        with patch("forecastbox.utility.packages.try_import", return_value=fake_module):
+            result = try_version("missing-package", "some_module")
+    assert result == "0.9.1"
+
+
+def test_try_version_returns_unknown_when_all_fail() -> None:
+    with patch("importlib.metadata.version", side_effect=importlib.metadata.PackageNotFoundError):
+        with patch("forecastbox.utility.packages.try_import", return_value=None):
+            result = try_version("missing-package", "missing_module")
+    assert result == "unknown"
+
+
+def test_try_version_returns_unknown_when_module_has_no_version_attribute() -> None:
+    with patch("importlib.metadata.version", side_effect=importlib.metadata.PackageNotFoundError):
+        fake_module = MagicMock(spec=ModuleType)
+        del fake_module._version  # ensure attribute is absent
+        with patch("forecastbox.utility.packages.try_import", return_value=fake_module):
+            result = try_version("missing-package", "some_module")
+    assert result == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# try_updatedate
+# ---------------------------------------------------------------------------
+
+
+def test_try_updatedate_package_not_found() -> None:
+    with patch("importlib.metadata.distribution", side_effect=importlib.metadata.PackageNotFoundError):
+        result = try_updatedate("nonexistent-package")
+    assert result == "unknown"
+
+
+def test_try_updatedate_success(tmp_path: pytest.TempPathFactory) -> None:
+    metadata_file = tmp_path / "METADATA"  # type: ignore[operator]
+    metadata_file.write_text("Metadata-Version: 2.1")
+
+    fake_file = MagicMock()
+    fake_file.name = "METADATA"
+    fake_file.locate.return_value = metadata_file
+
+    fake_dist = MagicMock()
+    fake_dist.files = [fake_file]
+
+    with patch("importlib.metadata.distribution", return_value=fake_dist):
+        result = try_updatedate("some-package")
+
+    assert result != "unknown"
+    # Should be in YYYY/MM/DD format
+    parts = result.split("/")
+    assert len(parts) == 3
+    assert len(parts[0]) == 4  # year
+
+
+def test_try_updatedate_no_metadata_file() -> None:
+    fake_dist = MagicMock()
+    fake_dist.files = []  # no METADATA file
+
+    with patch("importlib.metadata.distribution", return_value=fake_dist):
+        result = try_updatedate("some-package")
+
+    assert result == "unknown"
+
+
+def test_try_updatedate_dist_has_no_files() -> None:
+    fake_dist = MagicMock()
+    fake_dist.files = None
+
+    with patch("importlib.metadata.distribution", return_value=fake_dist):
+        result = try_updatedate("some-package")
+
+    assert result == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# try_install
+# ---------------------------------------------------------------------------
+
+
+def test_try_install_calls_uv_pip_install() -> None:
+    fake_result = MagicMock()
+    fake_result.returncode = 0
+    with patch("subprocess.run", return_value=fake_result) as mock_run:
+        with patch("forecastbox.utility.packages.get_fiabcore_version", return_value=Version("1.2.3")):
+            try_install("some-plugin==2.0.0")
+    mock_run.assert_called_once()
+    args = mock_run.call_args[0][0]
+    assert args[:3] == ["uv", "pip", "install"]
+    assert "--upgrade" in args
+    assert "some-plugin==2.0.0" in args
+
+
+def test_try_install_includes_fiabcore_pin() -> None:
+    fake_result = MagicMock()
+    fake_result.returncode = 0
+    with patch("subprocess.run", return_value=fake_result) as mock_run:
+        with patch("forecastbox.utility.packages.get_fiabcore_version", return_value=Version("1.2.3")):
+            try_install("my-plugin")
+    args = mock_run.call_args[0][0]
+    assert "fiab-core==1.2.3" in args
+
+
+def test_try_install_handles_editable_source() -> None:
+    fake_result = MagicMock()
+    fake_result.returncode = 0
+    with patch("subprocess.run", return_value=fake_result) as mock_run:
+        with patch("forecastbox.utility.packages.get_fiabcore_version", return_value=Version("0.0.0")):
+            try_install("-e /path/to/package")
+    args = mock_run.call_args[0][0]
+    assert "-e" in args
+    assert "/path/to/package" in args
+
+
+def test_try_install_logs_on_failure() -> None:
+    fake_result = MagicMock()
+    fake_result.returncode = 1
+    fake_result.stderr = b"some error"
+    fake_result.stdout = b""
+    fake_result.args = []
+    with patch("subprocess.run", return_value=fake_result):
+        with patch("forecastbox.utility.packages.get_fiabcore_version", return_value=Version("0.0.0")):
+            # Should not raise, only log
+            try_install("bad-package")
+
+
+def test_try_install_handles_uv_not_found() -> None:
+    with patch("subprocess.run", side_effect=FileNotFoundError("uv not found")):
+        with patch("forecastbox.utility.packages.get_fiabcore_version", return_value=Version("0.0.0")):
+            # Should not raise
+            try_install("some-package")
+
+
+# ---------------------------------------------------------------------------
+# get_fiabcore_version
+# ---------------------------------------------------------------------------
+
+
+def test_get_fiabcore_version_returns_version_object() -> None:
+    with patch("importlib.metadata.version", return_value="2.5.3"):
+        result = get_fiabcore_version()
+    assert isinstance(result, Version)
+    assert result.major == 2
+    assert result.minor == 5
+    assert result.micro == 3
+
+
+def test_get_fiabcore_version_current_install() -> None:
+    # Smoke test: fiab-core is installed in this environment
+    result = get_fiabcore_version()
+    assert isinstance(result, Version)

--- a/backend/tests/unit/utility/test_packages.py
+++ b/backend/tests/unit/utility/test_packages.py
@@ -13,6 +13,7 @@ from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest
+from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 from forecastbox.utility.packages import (
@@ -164,6 +165,46 @@ def test_try_install_handles_editable_source() -> None:
         with patch("forecastbox.utility.packages.get_fiabcore_version", return_value=Version("0.0.0")):
             try_install("-e /path/to/package")
     args = mock_run.call_args[0][0]
+    assert "-e" in args
+    assert "/path/to/package" in args
+
+
+def test_try_install_appends_specifier_to_package() -> None:
+    fake_result = MagicMock()
+    fake_result.returncode = 0
+    spec = SpecifierSet(">=1,<2")
+    with patch("subprocess.run", return_value=fake_result) as mock_run:
+        with patch("forecastbox.utility.packages.get_fiabcore_version", return_value=Version("1.0.0")):
+            try_install("my-plugin", spec)
+    args = mock_run.call_args[0][0]
+    # package arg must include both the name and the specifier
+    package_args = [a for a in args if a.startswith("my-plugin")]
+    assert len(package_args) == 1
+    assert "my-plugin" in package_args[0]
+    assert "1" in package_args[0]  # the specifier contains version numbers
+
+
+def test_try_install_exact_version_specifier() -> None:
+    fake_result = MagicMock()
+    fake_result.returncode = 0
+    spec = SpecifierSet("==2.5.0")
+    with patch("subprocess.run", return_value=fake_result) as mock_run:
+        with patch("forecastbox.utility.packages.get_fiabcore_version", return_value=Version("1.0.0")):
+            try_install("my-plugin", spec)
+    args = mock_run.call_args[0][0]
+    assert "my-plugin==2.5.0" in args
+
+
+def test_try_install_ignores_specifier_for_editable_source() -> None:
+    fake_result = MagicMock()
+    fake_result.returncode = 0
+    spec = SpecifierSet(">=1,<2")
+    with patch("subprocess.run", return_value=fake_result) as mock_run:
+        with patch("forecastbox.utility.packages.get_fiabcore_version", return_value=Version("1.0.0")):
+            try_install("-e /path/to/package", spec)
+    args = mock_run.call_args[0][0]
+    # specifier should NOT appear in the command for editable installs
+    assert not any(">=1" in a or "<2" in a for a in args)
     assert "-e" in args
     assert "/path/to/package" in args
 

--- a/frontend/mocks/handlers/fable.handlers.ts
+++ b/frontend/mocks/handlers/fable.handlers.ts
@@ -161,6 +161,11 @@ export const fableHandlers = [
 
     const { builder, display_name, display_description, tags, parent_id } = body
 
+    // Tags are now sent as {key, value} objects; extract the key for internal storage.
+    const storedTags = (tags as Array<string | { key: string }>).map((t) =>
+      typeof t === 'string' ? t : t.key,
+    )
+
     for (const instance of Object.values(builder.blocks)) {
       const factory = getFactory(mockCatalogue, instance.factory_id)
       if (!factory) {
@@ -193,7 +198,7 @@ export const fableHandlers = [
         fable: builder,
         display_name,
         display_description,
-        tags: tags.length > 0 ? tags : existing.tags,
+        tags: storedTags.length > 0 ? storedTags : existing.tags,
         updated_at: now,
       }
 
@@ -211,7 +216,7 @@ export const fableHandlers = [
       name: display_name ?? '',
       display_name,
       display_description,
-      tags,
+      tags: storedTags,
       user_id: 'mock-user-123',
       created_at: now,
       updated_at: now,
@@ -255,7 +260,11 @@ export const fableHandlers = [
       display_name: body.display_name ?? existing.display_name,
       display_description:
         body.display_description ?? existing.display_description,
-      tags: body.tags ?? existing.tags,
+      tags: body.tags
+        ? (body.tags as Array<string | { key: string }>).map((t) =>
+            typeof t === 'string' ? t : t.key,
+          )
+        : existing.tags,
       updated_at: new Date().toISOString(),
     }
 
@@ -277,7 +286,7 @@ export const fableHandlers = [
         version: fableVersions[id] ?? 1,
         display_name: entry.display_name,
         display_description: entry.display_description,
-        tags: entry.tags,
+        tags: entry.tags.map((k) => ({ key: k, value: '' })),
         source: null,
         created_by: entry.user_id,
       }))
@@ -481,7 +490,7 @@ export const fableHandlers = [
       builder: saved.fable,
       display_name: saved.display_name,
       display_description: saved.display_description,
-      tags: saved.tags,
+      tags: saved.tags.map((k) => ({ key: k, value: '' })),
       created_at: saved.created_at,
       updated_at: saved.updated_at,
     })

--- a/frontend/src/api/endpoints/fable.ts
+++ b/frontend/src/api/endpoints/fable.ts
@@ -103,9 +103,11 @@ export async function retrieveFable(
 export async function upsertFable(
   request: FableUpsertRequest,
 ): Promise<FableUpsertResponse> {
-  return apiClient.post(API_ENDPOINTS.fable.create, request, {
-    schema: FableUpsertResponseSchema,
-  })
+  return apiClient.post(
+    API_ENDPOINTS.fable.create,
+    { ...request, tags: request.tags.map((k) => ({ key: k })) },
+    { schema: FableUpsertResponseSchema },
+  )
 }
 
 /**
@@ -127,9 +129,14 @@ export async function listBlueprints(
 export async function updateBlueprint(
   request: BlueprintUpdateRequest,
 ): Promise<FableUpsertResponse> {
-  return apiClient.post(API_ENDPOINTS.fable.update, request, {
-    schema: FableUpsertResponseSchema,
-  })
+  return apiClient.post(
+    API_ENDPOINTS.fable.update,
+    {
+      ...request,
+      tags: request.tags?.map((k) => ({ key: k })),
+    },
+    { schema: FableUpsertResponseSchema },
+  )
 }
 
 /**

--- a/frontend/src/api/types/fable.types.ts
+++ b/frontend/src/api/types/fable.types.ts
@@ -243,13 +243,23 @@ export interface FableUpsertRequest {
   parent_id?: string
 }
 
+/**
+ * A tag as returned by the backend: an object with a `key` and an optional
+ * `value`. The `value` is intentionally ignored — existing functionality only
+ * uses the key. The schema transforms the object to the key string so all
+ * downstream code continues to work with plain strings.
+ */
+const TagApiSchema = z
+  .object({ key: z.string(), value: z.string().optional() })
+  .transform((t) => t.key)
+
 /** routes/blueprint.py: BlueprintListItem */
 export const BlueprintListItemSchema = z.object({
   blueprint_id: z.string(),
   version: z.number(),
   display_name: z.string().nullable(),
   display_description: z.string().nullable(),
-  tags: z.array(z.string()).nullable(),
+  tags: z.array(TagApiSchema).nullable(),
   source: z.string().nullable(),
   created_by: z.string().nullable(),
 })
@@ -289,7 +299,7 @@ export const FableRetrieveResponseSchema = z.object({
   builder: FableBuilderV1Schema,
   display_name: z.string().nullable(),
   display_description: z.string().nullable(),
-  tags: z.array(z.string()),
+  tags: z.array(TagApiSchema),
   parent_id: z.string().nullable().optional(),
 })
 

--- a/frontend/tests/integration/features/dashboard/config-presets.test.tsx
+++ b/frontend/tests/integration/features/dashboard/config-presets.test.tsx
@@ -22,7 +22,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { userEvent } from 'vitest/browser'
 import { renderWithRouter } from '@tests/utils/render'
 import { worker } from '@tests/test-extend'
-import type { BlueprintListItem } from '@/api/types/fable.types'
 import { ConfigPresetsSection } from '@/features/dashboard/components/ConfigPresetsSection'
 import { PresetsPage } from '@/features/dashboard/components/PresetsPage'
 import { API_ENDPOINTS } from '@/api/endpoints'
@@ -33,13 +32,29 @@ vi.mock('@/hooks/useMedia', () => ({
   useMedia: () => true,
 }))
 
-const mockBlueprints: Array<BlueprintListItem> = [
+// Wire format for a blueprint list item as returned by the backend.
+// Differs from the parsed `BlueprintListItem` type: `tags` are objects here
+// but are transformed to strings by the Zod schema before reaching the app.
+interface WireBlueprint {
+  blueprint_id: string
+  version: number
+  display_name: string | null
+  display_description: string | null
+  tags: Array<{ key: string; value: string }> | null
+  source: string | null
+  created_by: string | null
+}
+
+const mockBlueprints: Array<WireBlueprint> = [
   {
     blueprint_id: 'bp-001',
     version: 1,
     display_name: 'European Forecast',
     display_description: 'Standard European config',
-    tags: ['prod', 'europe'],
+    tags: [
+      { key: 'prod', value: '' },
+      { key: 'europe', value: '' },
+    ],
     source: 'user_defined',
     created_by: null,
   },
@@ -57,14 +72,14 @@ const mockBlueprints: Array<BlueprintListItem> = [
     version: 1,
     display_name: 'Global Forecast',
     display_description: 'Full global run',
-    tags: ['global'],
+    tags: [{ key: 'global', value: '' }],
     source: 'user_defined',
     created_by: null,
   },
 ]
 
 function useBlueprintListHandler(
-  blueprints: Array<BlueprintListItem> = mockBlueprints,
+  blueprints: Array<WireBlueprint> = mockBlueprints,
 ) {
   worker.use(
     http.get(API_ENDPOINTS.fable.list, () => {
@@ -141,7 +156,7 @@ describe('ConfigPresetsSection', () => {
         version: 1,
         display_name: 'Saved Config',
         display_description: null,
-        tags: ['prod'],
+        tags: [{ key: 'prod', value: '' }],
         source: 'user_defined',
         created_by: null,
       },
@@ -150,7 +165,7 @@ describe('ConfigPresetsSection', () => {
         version: 1,
         display_name: 'One-off Run',
         display_description: null,
-        tags: [ONEOFF_TAG],
+        tags: [{ key: ONEOFF_TAG, value: '' }],
         source: 'user_defined',
         created_by: null,
       },

--- a/frontend/tests/unit/api/endpoints/fable.test.ts
+++ b/frontend/tests/unit/api/endpoints/fable.test.ts
@@ -175,7 +175,7 @@ describe('retrieveFable', () => {
       builder: mockFable,
       display_name: 'My Config',
       display_description: 'Some description',
-      tags: ['tag1'],
+      tags: [{ key: 'tag1', value: '' }],
       created_at: '2026-01-01T00:00:00Z',
       updated_at: '2026-01-01T00:00:00Z',
     }


### PR DESCRIPTION
backwards incompatible change due to database schema expansion

1/ Stores the current fiab-core major version into each Blueprint database entity when created
2/ When retrieving a blueprint (via get/list route), we include a new tag CoreVersionMismatch -- presumably for the frontend to display with a warning (cc @liefra)
3/ We change the schema of the blueprint entity's `tags` to be list[{key, value|None}] instead of list[str]. A minimalistic change has been included to preserve current frontend behaviour, ie, converting `tag: str` to `key=tag, value=None`, in https://github.com/ecmwf/forecast-in-a-box/commit/45c5e4cc1bfb8f15cfe7f39d2a4be27b5c3b717a (cc @liefra ). My suggestion would be to display the value in the tooltip when hovered over the key, or smth like that. The CoreVersionMismatch tag contains the f"{blueprint's core version} != {current core version}" string. It is intended as a soft warning, not a hard error which prevents running a job from that blueprint or working with it further
4/ When installing a plugin, we include a guard with the current version of fiab-core to prevent accidental core upgrades
5/ The update_plugin now accepts a version to install to. It is not checked whether this version is compatbile, ie, we do allow explicit breach if the user asks for it. When version is not given, we install the newest one that is compatible
6/ There is a new endpoint, plugins/versions, which returns a list of compatible versions for a given plugin