### PR TITLE
Bug/local fiab core

### DIFF
--- a/backend/src/forecastbox/domain/blueprint/__init__.py
+++ b/backend/src/forecastbox/domain/blueprint/__init__.py
@@ -12,5 +12,6 @@ Manages the Blueprint domain -- user-created entities that capture computation i
 Used to create Runs and Experiments.
 
 Depends on the Glyph domain, to resolve and validate Glyphs.
-Dependen on by Run and Experiment domains.
+Depends on the Plugin domain, to determine fiab-core compatibility.
+Depended on by Run and Experiment domains.
 """

--- a/backend/src/forecastbox/domain/blueprint/db.py
+++ b/backend/src/forecastbox/domain/blueprint/db.py
@@ -24,10 +24,10 @@ from sqlalchemy import func, or_, select, update
 import forecastbox.schemata.jobs as _jobs_module
 from forecastbox.domain.blueprint.exceptions import BlueprintAccessDenied, BlueprintNotFound, BlueprintVersionConflict
 from forecastbox.domain.blueprint.types import BlueprintId
+from forecastbox.domain.plugin.compatibility import get_fiabcore_version
 from forecastbox.schemata.jobs import Blueprint, BlueprintSource
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.db import dbRetry, executeAndCommit, querySingle
-from forecastbox.utility.packages import get_fiabcore_version
 
 
 async def upsert_blueprint(

--- a/backend/src/forecastbox/domain/plugin/compatibility.py
+++ b/backend/src/forecastbox/domain/plugin/compatibility.py
@@ -22,6 +22,7 @@ get_compatible_versions(plugin_settings, available_versions)
     Filter an iterable of version strings to only compatible ones.
 """
 
+import importlib
 import logging
 from collections.abc import Iterator
 
@@ -29,21 +30,24 @@ from packaging.specifiers import SpecifierSet
 from packaging.version import InvalidVersion, Version
 
 from forecastbox.utility.config import PluginSettings
-from forecastbox.utility.packages import get_fiabcore_version
+from forecastbox.utility.packages import get_existing_install_pin, try_install
 
 logger = logging.getLogger(__name__)
 
 
-def install_specifier(version: Version | None) -> SpecifierSet:
-    """Return the ``SpecifierSet`` to use when installing a plugin. If `version` not given,
-    derive a major-version compatibility range from the currently installed ``fiab-core``
-    (e.g. ``>=1,<2``). Otherwise, pin to that exact release (e.g. ``==1.2.3``). Does not
-    check whether that release is within the fiab core bounds!
+def get_fiabcore_version() -> Version:
+    """Return the currently installed version of ``fiab-core`` as a ``Version`` object."""
+    raw = importlib.metadata.version("fiab-core")
+    return Version(raw)
+
+
+def plugin_default_specifier() -> SpecifierSet:
+    """Return the ``SpecifierSet`` to use when installing a plugin when there is no
+    user version to start from. Derives a major-version compatibility range from
+    the currently installed ``fiab-core`` (e.g. ``>=1,<2``).
     """
-    if version is None:
-        major = get_fiabcore_version().major
-        return SpecifierSet(f">={major},<{major + 1}")
-    return SpecifierSet(f"=={version}")
+    major = get_fiabcore_version().major
+    return SpecifierSet(f">={major},<{major + 1}")
 
 
 def get_compatible_versions(plugin_settings: PluginSettings, available_versions: Iterator[str]) -> Iterator[str]:
@@ -59,3 +63,16 @@ def get_compatible_versions(plugin_settings: PluginSettings, available_versions:
             continue
         if v.major == fiabcore_major:
             yield version_str
+
+
+def install_plugin_compatibly(pip_source: str, version: Version | None) -> None:
+    if pip_source.startswith("-e"):
+        pkgs = pip_source.split(" ", 1)
+    else:
+        if version is not None:
+            pkgs = [f"{pip_source}=={version}"]
+        else:
+            pkgs = [f"{pip_source}{plugin_default_specifier()}"]
+    # TODO -- include the whole pylock.toml
+    pkgs += get_existing_install_pin("fiab-core")
+    try_install(pkgs)

--- a/backend/src/forecastbox/domain/plugin/compatibility.py
+++ b/backend/src/forecastbox/domain/plugin/compatibility.py
@@ -16,8 +16,10 @@ Centralises the version-compatibility rules between plugins and ``fiab-core``:
 
 Public API
 ----------
-install_specifier(version)
-    Build the ``SpecifierSet`` used when pip-installing a plugin.
+plugin_default_specifier()
+    Build the default ``SpecifierSet`` for a plugin install based on the installed fiab-core major.
+install_plugin_compatibly(pip_source, version)
+    Install a plugin, pinning fiab-core to the currently installed version.
 get_compatible_versions(plugin_settings, available_versions)
     Filter an iterable of version strings to only compatible ones.
 """

--- a/backend/src/forecastbox/domain/plugin/compatibility.py
+++ b/backend/src/forecastbox/domain/plugin/compatibility.py
@@ -49,7 +49,7 @@ def plugin_default_specifier() -> SpecifierSet:
     the currently installed ``fiab-core`` (e.g. ``>=1,<2``).
     """
     major = get_fiabcore_version().major
-    return SpecifierSet(f">={major},<{major + 1}")
+    return SpecifierSet(f">={major}.0.0,<{major + 1}.0.0")
 
 
 def get_compatible_versions(plugin_settings: PluginSettings, available_versions: Iterator[str]) -> Iterator[str]:

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -36,12 +36,14 @@ from cascade.low.func import assert_never
 from fiab_core.fable import BlockFactoryCatalogue, PluginCompositeId
 from fiab_core.plugin import Plugin
 from packaging.specifiers import SpecifierSet
+from packaging.version import Version
 from pyrsistent import pmap
 from pyrsistent.typing import PMap
 
+from forecastbox.domain.plugin.compatibility import install_plugin_compatibly
 from forecastbox.utility.concurrent import delayed_thread, timed_acquire
 from forecastbox.utility.config import PluginSettings, PluginsSettings, config, config_edit_lock
-from forecastbox.utility.packages import try_import, try_install, try_updatedate, try_version
+from forecastbox.utility.packages import try_import, try_updatedate, try_version
 from forecastbox.utility.pydantic import FiabBaseModel
 
 logger = logging.getLogger(__name__)
@@ -88,11 +90,11 @@ def load_plugins(plugins: PluginsSettings) -> None:
             # NOTE consider running all pip invocations at once -- worse error reporting but better perf
             if pluginSettings.update_strategy == "auto":
                 logger.info(f"auto-updating {pluginSettings.module_name}")
-                try_install(pluginSettings.pip_source)
+                install_plugin_compatibly(pluginSettings.pip_source, None)
             else:
                 if try_import(pluginSettings.module_name) is None:
                     logger.info(f"installing {pluginSettings.module_name} for the first time")
-                    try_install(pluginSettings.pip_source)
+                    install_plugin_compatibly(pluginSettings.pip_source, None)
 
             if pluginKey in lookup:
                 errors[pluginKey] = f"plugin {pluginKey} is provided by more than just {pluginSettings.pip_source}"
@@ -123,10 +125,10 @@ def load_plugins(plugins: PluginsSettings) -> None:
             PluginManager.updater_error = repr(e)
 
 
-def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, specifier_set: SpecifierSet | None) -> None:
+def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, install: bool, version: Version | None) -> None:
     try:
-        if specifier_set is not None:
-            try_install(pluginSettings.pip_source, specifier_set)
+        if install:
+            install_plugin_compatibly(pluginSettings.pip_source, version)
         # NOTE we need to recommend in the docs to re-launch app after this change, this wont cover all cases
         importlib.reload(importlib.import_module(pluginSettings.module_name))
         plugin_impl = try_import(pluginSettings.module_name)
@@ -229,7 +231,7 @@ def catalogue_view() -> dict[PluginCompositeId, BlockFactoryCatalogue] | bool:
             return {plugin_id: plugin.catalogue for plugin_id, plugin in PluginManager.plugins.items()}
 
 
-def submit_update_single(pluginId: PluginCompositeId, specifier_set: SpecifierSet | None) -> str:
+def submit_update_single(pluginId: PluginCompositeId, install: bool, version: Version | None) -> str:
     pluginSettings = config.external.plugins.get(pluginId, None)
     if pluginSettings is None:
         return f"plugin {pluginId} not configured"
@@ -246,7 +248,7 @@ def submit_update_single(pluginId: PluginCompositeId, specifier_set: SpecifierSe
                 else:
                     PluginManager.updater.join(0)
                     # we join despite thread not being alive to ensure resource collection
-            PluginManager.updater = threading.Thread(target=update_single, args=(pluginId, pluginSettings, specifier_set))
+            PluginManager.updater = threading.Thread(target=update_single, args=(pluginId, pluginSettings, install, version))
             PluginManager.updater.start()
     return ""
 
@@ -271,7 +273,7 @@ def modify_enabled(pluginId: PluginCompositeId, isEnabled: bool) -> None:
     if not isEnabled:
         unload_single(pluginId)
     else:
-        submit_update_single(pluginId, specifier_set=None)
+        submit_update_single(pluginId, install=False, version=None)
 
 
 def join_updater_thread(timeout_sec: int) -> None:

--- a/backend/src/forecastbox/domain/plugin/store.py
+++ b/backend/src/forecastbox/domain/plugin/store.py
@@ -21,7 +21,6 @@ from pyrsistent import pmap
 from pyrsistent.typing import PMap
 from typing_extensions import Self
 
-from forecastbox.domain.plugin.compatibility import install_specifier
 from forecastbox.domain.plugin.manager import submit_update_single
 from forecastbox.utility.concurrent import timed_acquire
 from forecastbox.utility.config import PluginSettings, PluginStoreConfig, PluginStoreId, PluginStoresConfig, config, config_edit_lock
@@ -167,7 +166,7 @@ def submit_install_plugin(plugin_composite_key: PluginCompositeId) -> None:
             )
             config.save_to_file()
 
-    submit_update_single(plugin_composite_key, specifier_set=install_specifier(None))
+    submit_update_single(plugin_composite_key, install=True, version=None)
 
 
 def join_stores_thread(timeout_sec: int) -> None:

--- a/backend/src/forecastbox/routes/blueprint.py
+++ b/backend/src/forecastbox/routes/blueprint.py
@@ -52,10 +52,10 @@ from forecastbox.domain.glyphs import global_db
 from forecastbox.domain.glyphs.intrinsic import AvailableIntrinsicGlyphs, get_values_and_examples
 from forecastbox.domain.glyphs.jinja_interpolation import get_custom_functions
 from forecastbox.domain.glyphs.types import GlobalGlyphId
+from forecastbox.domain.plugin.compatibility import get_fiabcore_version
 from forecastbox.domain.plugin.manager import catalogue_view, plugins_ready
 from forecastbox.schemata.jobs import GlobalGlyph
 from forecastbox.utility.auth import AuthContext
-from forecastbox.utility.packages import get_fiabcore_version
 from forecastbox.utility.pagination import PaginationSpec
 from forecastbox.utility.pydantic import FiabBaseModel
 

--- a/backend/src/forecastbox/routes/plugins.py
+++ b/backend/src/forecastbox/routes/plugins.py
@@ -22,7 +22,7 @@ from fiab_core.fable import PluginCompositeId
 from packaging.version import InvalidVersion, Version
 
 from forecastbox.domain.auth.users import UserRead
-from forecastbox.domain.plugin.compatibility import get_compatible_versions, install_specifier
+from forecastbox.domain.plugin.compatibility import get_compatible_versions
 from forecastbox.domain.plugin.manager import PluginsStatus, modify_enabled, status_full, submit_update_single, uninstall_plugin
 from forecastbox.domain.plugin.store import PluginRemoteInfo, PluginStoreEntry, get_plugins_detail, submit_install_plugin
 from forecastbox.routes.admin import get_admin_user
@@ -139,8 +139,7 @@ def update_plugin(
             raise HTTPException(status_code=422, detail=f"Invalid version string: {version!r}")
     else:
         parsed = None
-    specifier_set = install_specifier(parsed)
-    result = submit_update_single(pluginCompositeId, specifier_set=specifier_set)
+    result = submit_update_single(pluginCompositeId, install=True, version=parsed)
     if result:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=result)
     return get_catalogue_redirect(request)

--- a/backend/src/forecastbox/utility/packages.py
+++ b/backend/src/forecastbox/utility/packages.py
@@ -23,16 +23,11 @@ from collections.abc import Iterator
 from types import ModuleType
 
 import httpx
+import orjson
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 logger = logging.getLogger(__name__)
-
-
-def get_fiabcore_version() -> Version:
-    """Return the currently installed version of ``fiab-core`` as a ``Version`` object."""
-    raw = importlib.metadata.version("fiab-core")
-    return Version(raw)
 
 
 def get_package_versions(pip_source: str) -> Iterator[str]:
@@ -105,33 +100,39 @@ def try_updatedate(pip_source: str) -> str:
         return "unknown"
 
 
-def try_install(pip_source: str, specifier_set: SpecifierSet | None = None) -> None:
-    """Run ``uv pip install --upgrade`` for the given ``pip_source``.
-
-    The currently installed ``fiab-core`` version is pinned in the install
-    command to prevent accidental core upgrades or downgrades.
-    # TODO -- include the whole pylock.toml
-
-    If ``specifier_set`` is provided and ``pip_source`` is not an editable
-    install, the specifier is appended to the package argument to constrain
-    which version is installed (e.g. ``"my-plugin>=1,<2"``).
-    Editable installs (``-e ...``) are version-agnostic; the specifier is
-    silently ignored for them.
-    """
-    fiabcore_pin = f"fiab-core=={get_fiabcore_version()}"
-    is_editable = pip_source.startswith("-e")
-    if is_editable:
-        base_args = pip_source.split(" ", 1)
-        package_arg = base_args  # specifier_set not applicable for editable installs
-    else:
-        package_spec = pip_source if specifier_set is None else f"{pip_source}{specifier_set}"
-        package_arg = [package_spec]
-    install_command = ["uv", "pip", "install", "--upgrade"] + package_arg + [fiabcore_pin]
+def try_install(packages: list[str]) -> None:
+    """Run ``uv pip install`` with the given pkg specs."""
+    install_command = ["uv", "pip", "install"] + packages
     try:
         result = subprocess.run(install_command, check=False, capture_output=True)
     except FileNotFoundError as ex:
-        logger.error(f"installing {pip_source} failure: {repr(ex)}")
+        logger.error(f"installing {packages} failure: {repr(ex)}")
         return
     if result.returncode != 0:
-        msg = f"installing {pip_source} failure: {result.returncode}. Stderr: {result.stderr}, Stdout: {result.stdout}, Args: {result.args}"
+        msg = f"installing {packages} failure: {result.returncode}. Stderr: {result.stderr}, Stdout: {result.stdout}, Args: {result.args}"
         logger.error(msg)
+
+
+def get_existing_install_pin(distname: str) -> list[str]:
+    """If the distname's install is detected to be editable,
+    we return `-e path`, otherwise we return `distname==currentVersion`.
+    """
+    # NOTE: This block is for 3.14+
+    distribution = importlib.metadata.distribution(distname)
+    if hasattr(distribution, "origin"):
+        origin = distribution.origin
+        if hasattr(origin, "url") and isinstance(origin.url, str) and origin.url.startswith("file://"):
+            # NOTE this doesnt work well for non-std layout but again we can restrict to only that
+            return ["-e ", origin.url[len("file://") :]]
+
+    # NOTE: pre 3.14, eventually remove
+    direct_url_text = distribution.read_text("direct_url.json")
+    if direct_url_text:
+        info = orjson.loads(direct_url_text)
+        if info.get("dir_info", {}).get("editable"):
+            url = info.get("url", "")
+            if url.startswith("file://"):
+                return ["-e ", url[len("file://") :]]
+
+    version = importlib.metadata.version(distname)
+    return [f"{distname}=={version}"]

--- a/backend/src/forecastbox/utility/packages.py
+++ b/backend/src/forecastbox/utility/packages.py
@@ -103,6 +103,7 @@ def try_updatedate(pip_source: str) -> str:
 def try_install(packages: list[str]) -> None:
     """Run ``uv pip install`` with the given pkg specs."""
     install_command = ["uv", "pip", "install"] + packages
+    logger.debug(f"will run {install_command}")
     try:
         result = subprocess.run(install_command, check=False, capture_output=True)
     except FileNotFoundError as ex:
@@ -111,6 +112,7 @@ def try_install(packages: list[str]) -> None:
     if result.returncode != 0:
         msg = f"installing {packages} failure: {result.returncode}. Stderr: {result.stderr}, Stdout: {result.stdout}, Args: {result.args}"
         logger.error(msg)
+    logger.debug(f"install finished with {result.stdout=}, {result.stderr=}")
 
 
 def get_existing_install_pin(distname: str) -> list[str]:

--- a/backend/src/forecastbox/utility/packages.py
+++ b/backend/src/forecastbox/utility/packages.py
@@ -123,7 +123,7 @@ def get_existing_install_pin(distname: str) -> list[str]:
         origin = distribution.origin
         if hasattr(origin, "url") and isinstance(origin.url, str) and origin.url.startswith("file://"):
             # NOTE this doesnt work well for non-std layout but again we can restrict to only that
-            return ["-e ", origin.url[len("file://") :]]
+            return ["-e", origin.url[len("file://") :]]
 
     # NOTE: pre 3.14, eventually remove
     direct_url_text = distribution.read_text("direct_url.json")
@@ -132,7 +132,7 @@ def get_existing_install_pin(distname: str) -> list[str]:
         if info.get("dir_info", {}).get("editable"):
             url = info.get("url", "")
             if url.startswith("file://"):
-                return ["-e ", url[len("file://") :]]
+                return ["-e", url[len("file://") :]]
 
     version = importlib.metadata.version(distname)
     return [f"{distname}=={version}"]

--- a/backend/tests/unit/domain/plugins/test_compatibility.py
+++ b/backend/tests/unit/domain/plugins/test_compatibility.py
@@ -15,7 +15,7 @@ import pytest
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
-from forecastbox.domain.plugin.compatibility import get_compatible_versions, install_specifier
+from forecastbox.domain.plugin.compatibility import get_compatible_versions, install_plugin_compatibly, plugin_default_specifier
 from forecastbox.utility.config import PluginSettings
 
 # ---------------------------------------------------------------------------
@@ -26,13 +26,13 @@ _PLUGIN = PluginSettings(pip_source="my-plugin", module_name="my_plugin")
 
 
 # ---------------------------------------------------------------------------
-# install_specifier
+# plugin_default_specifier / install_plugin_compatibly
 # ---------------------------------------------------------------------------
 
 
 def test_install_specifier_none_uses_fiabcore_major() -> None:
     with patch("forecastbox.domain.plugin.compatibility.get_fiabcore_version", return_value=Version("1.5.3")):
-        spec = install_specifier(None)
+        spec = plugin_default_specifier()
     assert Version("1.0.0") in spec
     assert Version("1.99.0") in spec
     assert Version("2.0.0") not in spec
@@ -41,36 +41,39 @@ def test_install_specifier_none_uses_fiabcore_major() -> None:
 
 def test_install_specifier_none_major_zero() -> None:
     with patch("forecastbox.domain.plugin.compatibility.get_fiabcore_version", return_value=Version("0.3.1")):
-        spec = install_specifier(None)
+        spec = plugin_default_specifier()
     assert Version("0.0.0") in spec
     assert Version("0.9.9") in spec
     assert Version("1.0.0") not in spec
 
 
-def test_install_specifier_exact_version() -> None:
-    spec = install_specifier(Version("2.5.0"))
-    assert Version("2.5.0") in spec
-    assert Version("2.5.1") not in spec
-    assert Version("2.4.9") not in spec
+def test_install_plugin_compatibly_exact_version() -> None:
+    with patch("forecastbox.domain.plugin.compatibility.get_existing_install_pin", return_value=["fiab-core==1.0.0"]):
+        with patch("forecastbox.domain.plugin.compatibility.try_install") as mock_install:
+            install_plugin_compatibly("my-plugin", Version("2.5.0"))
+    pkgs = mock_install.call_args[0][0]
+    assert "my-plugin==2.5.0" in pkgs
+    assert "fiab-core==1.0.0" in pkgs
 
 
-def test_install_specifier_returns_specifier_set() -> None:
-    spec = install_specifier(Version("3.0.0"))
+def test_plugin_default_specifier_returns_specifier_set() -> None:
+    with patch("forecastbox.domain.plugin.compatibility.get_fiabcore_version", return_value=Version("3.0.0")):
+        spec = plugin_default_specifier()
     assert isinstance(spec, SpecifierSet)
 
 
 def test_install_specifier_none_returns_specifier_set() -> None:
     with patch("forecastbox.domain.plugin.compatibility.get_fiabcore_version", return_value=Version("1.0.0")):
-        spec = install_specifier(None)
+        spec = plugin_default_specifier()
     assert isinstance(spec, SpecifierSet)
 
 
 def test_install_specifier_consistent_with_major() -> None:
     """Minor/patch of fiab-core version must not affect the range."""
     with patch("forecastbox.domain.plugin.compatibility.get_fiabcore_version", return_value=Version("2.0.0")):
-        spec_a = install_specifier(None)
+        spec_a = plugin_default_specifier()
     with patch("forecastbox.domain.plugin.compatibility.get_fiabcore_version", return_value=Version("2.7.3")):
-        spec_b = install_specifier(None)
+        spec_b = plugin_default_specifier()
     assert str(spec_a) == str(spec_b)
 
 

--- a/backend/tests/unit/utility/test_packages.py
+++ b/backend/tests/unit/utility/test_packages.py
@@ -13,11 +13,10 @@ from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest
-from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
+from forecastbox.domain.plugin.compatibility import get_fiabcore_version
 from forecastbox.utility.packages import (
-    get_fiabcore_version,
     get_package_versions,
     try_import,
     try_install,
@@ -140,74 +139,11 @@ def test_try_install_calls_uv_pip_install() -> None:
     fake_result = MagicMock()
     fake_result.returncode = 0
     with patch("subprocess.run", return_value=fake_result) as mock_run:
-        with patch("forecastbox.utility.packages.get_fiabcore_version", return_value=Version("1.2.3")):
-            try_install("some-plugin==2.0.0")
+        try_install(["some-plugin==2.0.0"])
     mock_run.assert_called_once()
     args = mock_run.call_args[0][0]
     assert args[:3] == ["uv", "pip", "install"]
-    assert "--upgrade" in args
     assert "some-plugin==2.0.0" in args
-
-
-def test_try_install_includes_fiabcore_pin() -> None:
-    fake_result = MagicMock()
-    fake_result.returncode = 0
-    with patch("subprocess.run", return_value=fake_result) as mock_run:
-        with patch("forecastbox.utility.packages.get_fiabcore_version", return_value=Version("1.2.3")):
-            try_install("my-plugin")
-    args = mock_run.call_args[0][0]
-    assert "fiab-core==1.2.3" in args
-
-
-def test_try_install_handles_editable_source() -> None:
-    fake_result = MagicMock()
-    fake_result.returncode = 0
-    with patch("subprocess.run", return_value=fake_result) as mock_run:
-        with patch("forecastbox.utility.packages.get_fiabcore_version", return_value=Version("0.0.0")):
-            try_install("-e /path/to/package")
-    args = mock_run.call_args[0][0]
-    assert "-e" in args
-    assert "/path/to/package" in args
-
-
-def test_try_install_appends_specifier_to_package() -> None:
-    fake_result = MagicMock()
-    fake_result.returncode = 0
-    spec = SpecifierSet(">=1,<2")
-    with patch("subprocess.run", return_value=fake_result) as mock_run:
-        with patch("forecastbox.utility.packages.get_fiabcore_version", return_value=Version("1.0.0")):
-            try_install("my-plugin", spec)
-    args = mock_run.call_args[0][0]
-    # package arg must include both the name and the specifier
-    package_args = [a for a in args if a.startswith("my-plugin")]
-    assert len(package_args) == 1
-    assert "my-plugin" in package_args[0]
-    assert "1" in package_args[0]  # the specifier contains version numbers
-
-
-def test_try_install_exact_version_specifier() -> None:
-    fake_result = MagicMock()
-    fake_result.returncode = 0
-    spec = SpecifierSet("==2.5.0")
-    with patch("subprocess.run", return_value=fake_result) as mock_run:
-        with patch("forecastbox.utility.packages.get_fiabcore_version", return_value=Version("1.0.0")):
-            try_install("my-plugin", spec)
-    args = mock_run.call_args[0][0]
-    assert "my-plugin==2.5.0" in args
-
-
-def test_try_install_ignores_specifier_for_editable_source() -> None:
-    fake_result = MagicMock()
-    fake_result.returncode = 0
-    spec = SpecifierSet(">=1,<2")
-    with patch("subprocess.run", return_value=fake_result) as mock_run:
-        with patch("forecastbox.utility.packages.get_fiabcore_version", return_value=Version("1.0.0")):
-            try_install("-e /path/to/package", spec)
-    args = mock_run.call_args[0][0]
-    # specifier should NOT appear in the command for editable installs
-    assert not any(">=1" in a or "<2" in a for a in args)
-    assert "-e" in args
-    assert "/path/to/package" in args
 
 
 def test_try_install_logs_on_failure() -> None:
@@ -217,16 +153,14 @@ def test_try_install_logs_on_failure() -> None:
     fake_result.stdout = b""
     fake_result.args = []
     with patch("subprocess.run", return_value=fake_result):
-        with patch("forecastbox.utility.packages.get_fiabcore_version", return_value=Version("0.0.0")):
-            # Should not raise, only log
-            try_install("bad-package")
+        # Should not raise, only log
+        try_install(["bad-package"])
 
 
 def test_try_install_handles_uv_not_found() -> None:
     with patch("subprocess.run", side_effect=FileNotFoundError("uv not found")):
-        with patch("forecastbox.utility.packages.get_fiabcore_version", return_value=Version("0.0.0")):
-            # Should not raise
-            try_install("some-package")
+        # Should not raise
+        try_install(["some-package"])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Bit refactoring to fix the previous PR -- which made any plugin update run with "pip install ... fiab-core==current_version", but ignored editable installs, thus causing a possible downgrade. We fix by replacing current_version in case of editable installs