### PR TITLE
[frontend] Tolerate null blueprint tag values, surface CoreVersionMismatch warning 

### DIFF
--- a/frontend/src/api/types/fable.types.ts
+++ b/frontend/src/api/types/fable.types.ts
@@ -247,26 +247,55 @@ export interface FableUpsertRequest {
   parent_id?: string
 }
 
-/**
- * A tag as returned by the backend: an object with a `key` and an optional
- * `value`. The `value` is intentionally ignored — existing functionality only
- * uses the key. The schema transforms the object to the key string so all
- * downstream code continues to work with plain strings.
- */
-const TagApiSchema = z
-  .object({ key: z.string(), value: z.string().optional() })
-  .transform((t) => t.key)
+/** Reserved tag (backend #494): value holds the version-mismatch detail
+ * (e.g. `"!3 != 4"`). Stripped from user tags, surfaced as a warning. */
+export const CORE_VERSION_MISMATCH_KEY = 'CoreVersionMismatch'
+
+/** Backend tag: `value` is null for plain labels, set for informational ones. */
+const TagObjectSchema = z.object({
+  key: z.string(),
+  value: z.string().nullish(),
+})
+
+export interface PartitionedTags {
+  /** User-facing tag keys (reserved keys removed). */
+  tags: Array<string>
+  /** `CoreVersionMismatch` detail, or null when versions agree. */
+  coreVersionMismatch: string | null
+}
+
+/** Split backend tags into plain keys (kept as `string[]` for existing
+ * save/search/group/display) and the extracted mismatch detail. */
+export function partitionBlueprintTags(
+  raw: ReadonlyArray<{ key: string; value?: string | null }>,
+): PartitionedTags {
+  let coreVersionMismatch: string | null = null
+  const tags: Array<string> = []
+  for (const tag of raw) {
+    if (tag.key === CORE_VERSION_MISMATCH_KEY) {
+      coreVersionMismatch = tag.value ?? null
+    } else {
+      tags.push(tag.key)
+    }
+  }
+  return { tags, coreVersionMismatch }
+}
 
 /** routes/blueprint.py: BlueprintListItem */
-export const BlueprintListItemSchema = z.object({
-  blueprint_id: z.string(),
-  version: z.number(),
-  display_name: z.string().nullable(),
-  display_description: z.string().nullable(),
-  tags: z.array(TagApiSchema).nullable(),
-  source: z.string().nullable(),
-  created_by: z.string().nullable(),
-})
+export const BlueprintListItemSchema = z
+  .object({
+    blueprint_id: z.string(),
+    version: z.number(),
+    display_name: z.string().nullable(),
+    display_description: z.string().nullable(),
+    tags: z.array(TagObjectSchema).nullable(),
+    source: z.string().nullable(),
+    created_by: z.string().nullable(),
+  })
+  .transform(({ tags, ...rest }) => ({
+    ...rest,
+    ...partitionBlueprintTags(tags ?? []),
+  }))
 
 export type BlueprintListItem = z.infer<typeof BlueprintListItemSchema>
 
@@ -297,15 +326,20 @@ export interface BlueprintDeleteRequest {
   version: number
 }
 
-export const FableRetrieveResponseSchema = z.object({
-  blueprint_id: z.string(),
-  version: z.number(),
-  builder: FableBuilderV1Schema,
-  display_name: z.string().nullable(),
-  display_description: z.string().nullable(),
-  tags: z.array(TagApiSchema),
-  parent_id: z.string().nullable().optional(),
-})
+export const FableRetrieveResponseSchema = z
+  .object({
+    blueprint_id: z.string(),
+    version: z.number(),
+    builder: FableBuilderV1Schema,
+    display_name: z.string().nullable(),
+    display_description: z.string().nullable(),
+    tags: z.array(TagObjectSchema),
+    parent_id: z.string().nullable().optional(),
+  })
+  .transform(({ tags, ...rest }) => ({
+    ...rest,
+    ...partitionBlueprintTags(tags),
+  }))
 
 export type FableRetrieveResponse = z.infer<typeof FableRetrieveResponseSchema>
 

--- a/frontend/src/components/common/CoreVersionMismatchBadge.tsx
+++ b/frontend/src/components/common/CoreVersionMismatchBadge.tsx
@@ -1,0 +1,68 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Soft warning for a blueprint built on a different fiab-core major
+ * (backend `CoreVersionMismatch` tag). Parses the detail (e.g. "!3 != 4")
+ * into a readable tooltip; falls back to a generic message.
+ */
+
+import { AlertTriangle } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+function parseMismatch(
+  detail: string,
+): { stored: string; current: string } | null {
+  const m = /(\d+)\s*!=\s*(\d+)/.exec(detail)
+  return m ? { stored: m[1], current: m[2] } : null
+}
+
+interface CoreVersionMismatchBadgeProps {
+  /** Backend `CoreVersionMismatch` tag value, e.g. "!3 != 4". */
+  detail: string
+  className?: string
+}
+
+export function CoreVersionMismatchBadge({
+  detail,
+  className,
+}: CoreVersionMismatchBadgeProps) {
+  const { t } = useTranslation('common')
+  const parsed = parseMismatch(detail)
+  const tooltip = parsed
+    ? t('coreVersionMismatch.detail', parsed)
+    : t('coreVersionMismatch.detailUnknown')
+
+  return (
+    <Tooltip>
+      <TooltipTrigger>
+        <span
+          className={cn(
+            'inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium',
+            'bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-300',
+            className,
+          )}
+        >
+          <AlertTriangle className="h-3.5 w-3.5" />
+          {t('coreVersionMismatch.label')}
+        </span>
+      </TooltipTrigger>
+      {/* Plain text: inherits the popup's light color; a <P> would force
+          dark `text-foreground` and vanish on the dark background. */}
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
+  )
+}

--- a/frontend/src/features/dashboard/components/PresetCard.tsx
+++ b/frontend/src/features/dashboard/components/PresetCard.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from 'react-i18next'
 import { Link } from '@tanstack/react-router'
 import type { PresetEntry } from '@/features/dashboard/hooks/useConfigPresets'
 import { useFableRetrieve } from '@/api/hooks/useFable'
+import { CoreVersionMismatchBadge } from '@/components/common/CoreVersionMismatchBadge'
 import { FableMiniFlow } from '@/features/journal/components/FableMiniFlow'
 import { JournalChip } from '@/features/journal/components/JournalChip'
 import { RunMetadataDialog } from '@/features/journal/components/RunMetadataDialog'
@@ -79,6 +80,13 @@ export function PresetCard({
       <p className="text-sm text-muted-foreground">
         {t('item.outputs', { count: outputCount })}
       </p>
+
+      {preset.coreVersionMismatch && (
+        <CoreVersionMismatchBadge
+          detail={preset.coreVersionMismatch}
+          className="self-start"
+        />
+      )}
 
       {(modelLabel || outputKinds.length > 0 || preset.tags.length > 0) && (
         <div className="flex flex-wrap gap-1.5">

--- a/frontend/src/features/dashboard/hooks/useConfigPresets.ts
+++ b/frontend/src/features/dashboard/hooks/useConfigPresets.ts
@@ -32,6 +32,8 @@ export interface PresetEntry {
   displayName: string | null
   displayDescription: string | null
   tags: Array<string>
+  /** Version-mismatch detail when built on a different fiab-core major, else null. */
+  coreVersionMismatch: string | null
   version: number
   isFavourite: boolean
   /** First source block's title — derived from the blueprint builder. */
@@ -81,6 +83,7 @@ export function useConfigPresets() {
           displayName: bp.display_name,
           displayDescription: bp.display_description,
           tags: stripSystemTags(bp.tags),
+          coreVersionMismatch: bp.coreVersionMismatch,
           version: bp.version,
           isFavourite: !!favourites[bp.blueprint_id],
           modelLabel: canDerive ? deriveModelLabel(builder, catalogue) : null,

--- a/frontend/src/features/executions/components/RunDetailPage.tsx
+++ b/frontend/src/features/executions/components/RunDetailPage.tsx
@@ -39,6 +39,7 @@ import { showToast } from '@/lib/toast'
 import { ApiClientError } from '@/api/client'
 import { useBlockCatalogue, useFableRetrieve } from '@/api/hooks/useFable'
 import { useDeleteJob, useJobStatus, useRestartJob } from '@/api/hooks/useJobs'
+import { CoreVersionMismatchBadge } from '@/components/common/CoreVersionMismatchBadge'
 import { LoadingSpinner } from '@/components/common/LoadingSpinner'
 import { Button } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -215,6 +216,10 @@ export function RunDetailPage() {
         completedBlockCount={jobData.completed_block_ids?.length ?? null}
         plannedBlockCount={jobData.planned_block_ids?.length ?? null}
       />
+
+      {fableData?.coreVersionMismatch && (
+        <CoreVersionMismatchBadge detail={fableData.coreVersionMismatch} />
+      )}
 
       {jobData.status === 'failed' && jobData.error && (
         <RunErrorBanner

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -191,5 +191,10 @@
   },
   "notificationBanner": {
     "dismiss": "Dismiss notification"
+  },
+  "coreVersionMismatch": {
+    "label": "Core version mismatch",
+    "detail": "Built with fiab-core v{{stored}}; you're running v{{current}}. It should still work, but may behave unexpectedly.",
+    "detailUnknown": "This configuration was created with a different fiab-core major version. It should still work, but may behave unexpectedly."
   }
 }

--- a/frontend/tests/unit/api/endpoints/fable.test.ts
+++ b/frontend/tests/unit/api/endpoints/fable.test.ts
@@ -199,6 +199,53 @@ describe('retrieveFable', () => {
     expect(result.display_name).toBe('My Config')
   })
 
+  it('parses label tags whose value is null (backend Tag.value: str | None)', async () => {
+    // Regression (#494): label tags serialise as { key, value: null }; if the
+    // schema rejects the null, the whole retrieve fails and the page loses its
+    // blueprint (no graph, untitled, raw block ids).
+    worker.use(
+      http.get(API_ENDPOINTS.fable.get, () =>
+        HttpResponse.json({
+          blueprint_id: 'fable-oneoff',
+          version: 1,
+          builder: mockFable,
+          display_name: 'One-off run',
+          display_description: null,
+          tags: [{ key: '__fiab:oneoff__', value: null }],
+        }),
+      ),
+    )
+
+    const result = await retrieveFable('fable-oneoff')
+    expect(result.tags).toEqual(['__fiab:oneoff__'])
+    expect(result.display_name).toBe('One-off run')
+    expect(result.coreVersionMismatch).toBeNull()
+  })
+
+  it('extracts the CoreVersionMismatch tag from the tag list (backend #494)', async () => {
+    // CoreVersionMismatch is reserved: stripped from user tags (else it would
+    // render as a chip and 422 on save), its value surfaced separately.
+    worker.use(
+      http.get(API_ENDPOINTS.fable.get, () =>
+        HttpResponse.json({
+          blueprint_id: 'fable-mismatch',
+          version: 1,
+          builder: mockFable,
+          display_name: 'Stale config',
+          display_description: null,
+          tags: [
+            { key: 'prod', value: null },
+            { key: 'CoreVersionMismatch', value: '!3 != 4' },
+          ],
+        }),
+      ),
+    )
+
+    const result = await retrieveFable('fable-mismatch')
+    expect(result.tags).toEqual(['prod'])
+    expect(result.coreVersionMismatch).toBe('!3 != 4')
+  })
+
   it('sends blueprint_id as query parameter', async () => {
     let capturedUrl: string | null = null
 

--- a/frontend/tests/unit/api/fable-types.test.ts
+++ b/frontend/tests/unit/api/fable-types.test.ts
@@ -16,6 +16,7 @@ import type {
 } from '@/api/types/fable.types'
 import {
   getBlockConfigurationRestrictions,
+  partitionBlueprintTags,
   toValidationState,
 } from '@/api/types/fable.types'
 
@@ -194,5 +195,29 @@ describe('toValidationState', () => {
     expect(
       getBlockConfigurationRestrictions(fable, validationState, 'b1'),
     ).toEqual({ param: 'list[enumClosed[2t,msl]]' })
+  })
+})
+
+describe('partitionBlueprintTags', () => {
+  it('returns plain keys and no mismatch for label tags', () => {
+    expect(
+      partitionBlueprintTags([{ key: 'prod', value: null }, { key: 'europe' }]),
+    ).toEqual({ tags: ['prod', 'europe'], coreVersionMismatch: null })
+  })
+
+  it('extracts CoreVersionMismatch and strips it from the key list', () => {
+    expect(
+      partitionBlueprintTags([
+        { key: 'prod', value: null },
+        { key: 'CoreVersionMismatch', value: '!3 != 4' },
+      ]),
+    ).toEqual({ tags: ['prod'], coreVersionMismatch: '!3 != 4' })
+  })
+
+  it('handles an empty list', () => {
+    expect(partitionBlueprintTags([])).toEqual({
+      tags: [],
+      coreVersionMismatch: null,
+    })
   })
 })

--- a/frontend/tests/unit/components/common/CoreVersionMismatchBadge.test.tsx
+++ b/frontend/tests/unit/components/common/CoreVersionMismatchBadge.test.tsx
@@ -1,0 +1,31 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { render } from 'vitest-browser-react'
+import { CoreVersionMismatchBadge } from '@/components/common/CoreVersionMismatchBadge'
+// Initialise i18next so the badge's t() calls resolve to real strings.
+import '@/lib/i18n'
+
+describe('CoreVersionMismatchBadge', () => {
+  it('renders the warning label for a backend mismatch value', async () => {
+    const screen = await render(<CoreVersionMismatchBadge detail="!3 != 4" />)
+    await expect
+      .element(screen.getByText('Core version mismatch'))
+      .toBeVisible()
+  })
+
+  it('renders for an unparseable detail without throwing', async () => {
+    const screen = await render(<CoreVersionMismatchBadge detail="garbage" />)
+    await expect
+      .element(screen.getByText('Core version mismatch'))
+      .toBeVisible()
+  })
+})

--- a/frontend/tests/unit/features/dashboard/hooks/useConfigPresets.test.ts
+++ b/frontend/tests/unit/features/dashboard/hooks/useConfigPresets.test.ts
@@ -61,15 +61,17 @@ const DEFAULT_BLUEPRINTS: Array<BlueprintListItem> = [
     tags: ['prod'],
     source: 'user_defined',
     created_by: null,
+    coreVersionMismatch: null,
   },
   {
     blueprint_id: 'bp-002',
     version: 2,
     display_name: 'Second Config',
     display_description: null,
-    tags: null,
+    tags: [],
     source: 'user_defined',
     created_by: null,
+    coreVersionMismatch: null,
   },
   {
     blueprint_id: 'bp-003',
@@ -79,6 +81,7 @@ const DEFAULT_BLUEPRINTS: Array<BlueprintListItem> = [
     tags: ['test', 'europe'],
     source: 'user_defined',
     created_by: null,
+    coreVersionMismatch: null,
   },
 ]
 
@@ -167,6 +170,7 @@ describe('useConfigPresets', () => {
           tags: ['europe', ONEOFF_TAG],
           source: 'user_defined',
           created_by: null,
+          coreVersionMismatch: null,
         },
       ]
 
@@ -186,9 +190,10 @@ describe('useConfigPresets', () => {
           version: 1,
           display_name: 'Plugin Template',
           display_description: null,
-          tags: null,
+          tags: [],
           source: 'plugin_template',
           created_by: null,
+          coreVersionMismatch: null,
         },
       ]
 
@@ -210,6 +215,7 @@ describe('useConfigPresets', () => {
           tags: [ONEOFF_TAG],
           source: 'user_defined',
           created_by: null,
+          coreVersionMismatch: null,
         },
       ]
 

--- a/frontend/tests/unit/features/journal/adapters.test.ts
+++ b/frontend/tests/unit/features/journal/adapters.test.ts
@@ -63,6 +63,7 @@ const blueprint: FableRetrieveResponse = {
   display_name: 'Europe Forecast',
   display_description: null,
   tags: ['europe', ONEOFF_TAG],
+  coreVersionMismatch: null,
 }
 
 const baseRun: JobExecutionDetail = {


### PR DESCRIPTION
## Summary

Aligns the frontend with the blueprint tag-contract change from backend #494. It fixes a regression that broke the one-off run's detail page, and adds the soft warning #494 asked the frontend to display. Frontend-only.

## Hotfix

#494 changed blueprint tags from `list[str]` to `list[{key, value}]`, where plain label tags (e.g. the frontend's own `__fiab:oneoff__` marker) serialise with `value: null`. The frontend tag schema accepted `{key, value?}` but not `value: null`, so `zod` rejected the entire blueprint-retrieve response. The result: any one-off run's detail page lost its blueprint — "Graph visualisation unavailable", "Untitled Job", and raw block ids (`sink_1`) instead of factory titles. The fix makes the tag value nullable (`z.string().nullish()`).

## CoreVersionMismatch warning

#494 injects a reserved `CoreVersionMismatch` tag on blueprint get/list when the stored fiab-core major differs from the running one, with a detail value like `"!3 != 4"`, intended for the frontend to display as a soft warning. This PR extracts that tag's value into a dedicated `coreVersionMismatch` field and strips the tag from the user-facing `tags` list, then renders it as a reusable amber warning badge (with a parsed "built with vX, running vY" tooltip) on the run-detail page and on saved-config preset cards.

Example with tooltip:

<img width="416" height="144" alt="2026-06-15_14-42-16" src="https://github.com/user-attachments/assets/8fbb18b7-4cfb-48cb-b586-cd4ca97062a2" />


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
