### PR TITLE
[plugin] fix qube expand, from bug in anemoi qube step dim

### DIFF
--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/utils.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/utils.py
@@ -13,7 +13,7 @@ from copy import deepcopy
 from functools import reduce
 from operator import or_
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from fiab_core.artifacts import AnemoiCheckpoint, ArtifactsProvider, CompositeArtifactId
 from fiab_core.fable import QubedOutput
@@ -114,7 +114,8 @@ class CheckpointArtifact:
         steps = list(map(lambda x: x // 3600, range(model_step_seconds, lead_time_seconds + model_step_seconds, model_step_seconds)))
 
         if isinstance(qube, dict):
-            return {key: expand(q, {"step": steps}) for key, q in qube.items()}  # type: ignore
+            nested_qube = cast(dict[str, Qube], qube)
+            return {key: expand(q, {"step": steps}) for key, q in nested_qube.items()}
         return expand(qube, {"step": steps})
 
     def get_additional_kwargs(self) -> dict[str, Any]:

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -79,6 +79,10 @@ def _extract_dataset(inputs: dict[str, QubedOutput], name: str) -> QubedOutput:
     return input_dataset
 
 
+def _is_empty_qube(qube: Qube) -> bool:
+    return next(iter(qube.datacubes()), None) is None
+
+
 def _restriction_value_strings(axis_values: set[Any], item_python_type: type[str] | type[int]) -> list[str]:
     if item_python_type is str:
         return sorted(value for value in axis_values if isinstance(value, str))
@@ -398,6 +402,11 @@ class Select(Transform):
             )
 
         output = select(input_dataset, {dimension: selected_values})
+        if output.dataqube is None or _is_empty_qube(output.dataqube):
+            return BlockValidation(
+                Either.error(f"selection of values {selected_values} from dimension {dimension} produced an empty dataset"),
+                restrict,
+            )
 
         return BlockValidation(Either.ok(output), restrict)
 

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/qubed_utils.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/qubed_utils.py
@@ -29,6 +29,7 @@ import functools
 from collections.abc import Mapping
 from typing import Any, Callable, Concatenate, Iterable, ParamSpec, TypeVar, overload
 
+import numpy as np
 from fiab_core.fable import QubedOutput
 from qubed import Qube
 
@@ -93,6 +94,26 @@ def collapse(qube: Qube, axis: str | list[str]) -> Qube:
     return qube.remove_by_key(axes)
 
 
+def _broadcast_array_over_new_axis(value: np.ndarray, size: int) -> np.ndarray:
+    value = value.reshape((1,)) if value.ndim == 0 else value
+    expanded = np.expand_dims(value, axis=1)
+    return np.broadcast_to(expanded, (expanded.shape[0], size, *expanded.shape[2:]))
+
+
+def _broadcast_new_axis_metadata(qube: Qube, size: int) -> Qube:
+    metadata = {key: _broadcast_array_over_new_axis(value, size) for key, value in qube.metadata.items()}
+    children = tuple(_broadcast_new_axis_metadata(child, size) for child in qube.children)
+    return qube.replace(metadata=metadata, children=children)
+
+
+def _expand_axis(qube: Qube, key: str, values: Iterable[Any]) -> Qube:
+    axis_values = list(values)
+    value_group = Qube.from_datacube({key: axis_values}).children[0].values if axis_values else [None]
+    axis_size = len(axis_values) or 1
+    children = tuple(_broadcast_new_axis_metadata(child, axis_size) for child in qube.children)
+    return Qube.make_root([Qube.make_node(key, value_group, children)])
+
+
 @support_qubed_output
 def expand(qube: Qube, dimension: Mapping[str, Iterable[Any]]) -> Qube:
     """Return a new Qube with the dataqube expanded by adding the specified dimension(s).
@@ -119,11 +140,7 @@ def expand(qube: Qube, dimension: Mapping[str, Iterable[Any]]) -> Qube:
     >>> axes(expanded)
     {'ensemble': {'ens1', 'ens2'}, 'param': {'2t', 'tp'}, 'time': {0, 1, 2}}
     """
-    dataqube = functools.reduce(
-        lambda q, kv: Qube.make_root([Qube.make_node(kv[0], list(kv[1]) or [None], q.children)]), dimension.items(), qube
-    )
-
-    return dataqube
+    return functools.reduce(lambda q, kv: _expand_axis(q, kv[0], kv[1]), dimension.items(), qube)
 
 
 @support_qubed_output

--- a/backend/packages/fiab-plugin-ecmwf/tests/runtime/test_anemoi_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/runtime/test_anemoi_blocks.py
@@ -19,7 +19,7 @@ from qubed import Qube
 
 from fiab_plugin_ecmwf import plugin
 from fiab_plugin_ecmwf.anemoi.blocks import AnemoiInputSource, AnemoiSource, AnemoiTransform
-from fiab_plugin_ecmwf.anemoi.utils import get_checkpoint_enum_type
+from fiab_plugin_ecmwf.anemoi.utils import CheckpointArtifact, get_checkpoint_enum_type
 from fiab_plugin_ecmwf.qubed_utils import axes, collapse, contains, expand
 
 # ---------------------------------------------------------------------------
@@ -140,6 +140,16 @@ def anemoi_source_ensemble_output(anemoi_source_ensemble_configuration: BlockIns
 @pytest.fixture
 def anemoi_input_source_output(anemoi_input_source_configuration: BlockInstance) -> QubedOutput:
     return AnemoiInputSource().validate(block=anemoi_input_source_configuration, inputs={}).get_or_raise()  # type: ignore[return-value]
+
+
+class TestCheckpointArtifact:
+    def test_model_output_selects_multiple_steps_with_metadata(self, six_hour_dummy_checkpoint: str) -> None:
+        output = CheckpointArtifact(six_hour_dummy_checkpoint).get_model_output(lead_time=48)
+
+        assert isinstance(output, Qube)
+        selected = output.select({"step": lambda step: step in {6, 12, 30, 24}})
+        assert axes(selected)["step"] == {6, 12, 24, 30}
+        assert list(selected.leaves(metadata=True))
 
 
 # ===================================================================

--- a/backend/packages/fiab-plugin-ecmwf/tests/runtime/test_qubedinstanceoutput.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/runtime/test_qubedinstanceoutput.py
@@ -91,6 +91,31 @@ class TestQubedOutputExpand:
         assert set(axes(expanded)["ensemble"]) == {"ens1", "ens2"}
         assert set(axes(expanded)["level"]) == {1000, 850}
 
+    def test_expand_integer_dimension_can_be_selected(self) -> None:
+        expanded = expand(Qube.from_datacube({"param": ["2t"]}), {"step": [6, 12]})
+
+        selected = expanded.select({"step": 6})
+
+        assert axes(selected)["step"] == {6}
+        assert axes(selected)["param"] == {"2t"}
+
+    def test_expand_empty_values_uses_none(self) -> None:
+        expanded = expand(Qube.empty(), {"param": []})
+
+        assert axes(expanded)["param"] == {None}
+
+    def test_expand_broadcasts_metadata_to_new_dimension(self) -> None:
+        output = Qube.from_datacube({"levtype": ["pl", "sfc"], "param": ["t", "q"]}).add_metadata(
+            {"name": ["pl-q", "pl-t", "sfc-q", "sfc-t"]},
+            depth=2,
+        )
+        expanded = expand(output, {"step": [6, 12, 18, 24, 30, 36, 42, 48]})
+
+        selected = expanded.select({"step": [6, 12, 30, 24]})
+
+        assert axes(selected)["step"] == {6, 12, 24, 30}
+        assert list(selected.leaves(metadata=True))
+
     @pytest.mark.parametrize("fixture_name", ["empty_output", "simple_output", "complex_output"])
     def test_expand_preserves_original(
         self,

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -554,6 +554,17 @@ class TestSelect:
         assert isinstance(output, QubedOutput)
         assert axes(output)[STEP] == {0, 6}
 
+    def test_validate_rejects_empty_selection_after_axis_membership_passes(self, select_configuration: BlockInstance) -> None:
+        block = _select()
+        broken_qube = Qube.make_root([Qube.make_node("step", [6, 12], Qube.from_datacube({"param": ["2t"]}).children)])
+        input_dataset = QubedOutput(dataqube=broken_qube)
+        config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "step", "values": ["6"]})})
+
+        validation = block.validate(block=config, inputs={"dataset": input_dataset})
+
+        assert validation.e is not None
+        assert "produced an empty dataset" in validation.e
+
     def test_validate_rejects_unknown_dimension(
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
     ) -> None:


### PR DESCRIPTION
### Description
@HCookie, not sure if it's the right fix but the Qube expand function was broken for the steps, leading to an empty Qube when trying to select steps from the list, as reported by @liefra. This PR fixes that but feel free to suggest another way of fixing it.

This pull request introduces several improvements and bug fixes related to expanding and selecting dimensions in `Qube` objects, as well as better handling of empty selections and metadata broadcasting. The changes enhance the robustness of data manipulation utilities and provide more comprehensive test coverage for edge cases.

**Enhancements to Qube expansion and metadata handling:**

* Refactored the `expand` function in `qubed_utils.py` to use new helper functions that correctly broadcast metadata and handle new axes, ensuring that metadata is preserved and broadcasted when expanding dimensions. This also fixes issues with expanding over empty values by introducing `None` as a placeholder. [[1]](diffhunk://#diff-f061390536fc5c2584536e708d019a039b8ee981facc632eeeb7a69689754f5cR97-R116) [[2]](diffhunk://#diff-f061390536fc5c2584536e708d019a039b8ee981facc632eeeb7a69689754f5cL122-R143)
* Added tests to verify that expanding with integer dimensions, empty values, and metadata broadcasting works as expected, ensuring correct axis selection and metadata presence after expansion.

**Validation improvements and error handling:**

* Added a utility function `_is_empty_qube` and updated block validation logic to return a meaningful error if a selection results in an empty dataset, even if axis membership checks pass. [[1]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dR82-R85) [[2]](diffhunk://#diff-fce8f4d6b6c02218b392619848e18a04688978ee35800a509b445872f78a302dR405-R409) [[3]](diffhunk://#diff-e2aca903e02ed1c838dc135c2505f6e2ebead9543f46f466e1ab97877adacf4aR557-R567)
* Added tests to confirm that empty selections are properly rejected with clear error messages.

**Type safety and code quality:**

* Improved type safety in `get_model_output` by using `cast` instead of `type: ignore`, ensuring better static type checking. [[1]](diffhunk://#diff-be733c2f434eb142a49bf382f3c170b7eee6b58136db9a6d953c5987b4b733e4L16-R16) [[2]](diffhunk://#diff-be733c2f434eb142a49bf382f3c170b7eee6b58136db9a6d953c5987b4b733e4L117-R118)
* Added a test for `CheckpointArtifact.get_model_output` to verify correct selection and metadata propagation for multiple steps.

**Dependency and import updates:**

* Added missing imports (e.g., `numpy` and `CheckpointArtifact`) to support new functionality and tests. [[1]](diffhunk://#diff-f061390536fc5c2584536e708d019a039b8ee981facc632eeeb7a69689754f5cR32) [[2]](diffhunk://#diff-68d37e871f159cc3c517b28e1dc46c721c527e72dfdd8a6251f876409a6befe7L22-R22)

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
