### PR TITLE
Feat/pkg update dt

### DIFF
--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -43,7 +43,7 @@ from pyrsistent.typing import PMap
 from forecastbox.domain.plugin.compatibility import install_plugin_compatibly
 from forecastbox.utility.concurrent import delayed_thread, timed_acquire
 from forecastbox.utility.config import PluginSettings, PluginsSettings, config, config_edit_lock
-from forecastbox.utility.packages import try_import, try_updatedate, try_version
+from forecastbox.utility.packages import try_import, try_updatedatetime, try_version
 from forecastbox.utility.pydantic import FiabBaseModel
 
 logger = logging.getLogger(__name__)
@@ -54,7 +54,7 @@ class PluginManager:
     plugins: PMap[PluginCompositeId, Plugin] = pmap()
     versions: PMap[PluginCompositeId, str] = pmap()
     errors: PMap[PluginCompositeId, str] = pmap()
-    updatedate: PMap[PluginCompositeId, str] = pmap()
+    updatedatetime: PMap[PluginCompositeId, str] = pmap()
     updater: threading.Thread | None = None
     updater_error: str | None = None
 
@@ -83,7 +83,7 @@ def load_plugins(plugins: PluginsSettings) -> None:
         lookup = {}
         errors = {}
         versions = {}
-        updatedate = {}
+        updatedatetime = {}
         for pluginKey, pluginSettings in plugins.items():
             if not pluginSettings.enabled:
                 continue
@@ -108,7 +108,7 @@ def load_plugins(plugins: PluginsSettings) -> None:
                 else:
                     assert_never(result)
                 versions[pluginKey] = try_version(pluginSettings.pip_source, pluginSettings.module_name)
-                updatedate[pluginKey] = try_updatedate(pluginSettings.pip_source)
+                updatedatetime[pluginKey] = try_updatedatetime(pluginSettings.pip_source)
 
         with timed_acquire(PluginManager.lock, 60) as result:
             if not result:
@@ -116,7 +116,7 @@ def load_plugins(plugins: PluginsSettings) -> None:
             PluginManager.plugins = pmap(lookup)
             PluginManager.errors = pmap(errors)
             PluginManager.versions = pmap(versions)
-            PluginManager.updatedate = pmap(updatedate)
+            PluginManager.updatedatetime = pmap(updatedatetime)
         logger.debug("global plugin loading finished")
     except Exception as e:
         logger.exception(f"updating thread failed with {repr(e)}")
@@ -146,7 +146,7 @@ def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, i
             PluginManager.versions = PluginManager.versions.set(
                 pluginId, try_version(pluginSettings.pip_source, pluginSettings.module_name)
             )
-            PluginManager.updatedate = PluginManager.updatedate.set(pluginId, try_updatedate(pluginSettings.pip_source))
+            PluginManager.updatedatetime = PluginManager.updatedatetime.set(pluginId, try_updatedatetime(pluginSettings.pip_source))
         logger.debug(f"single plugin loading finished: {pluginId}")
     except Exception as e:
         logger.exception(f"updating thread failed with {repr(e)}")
@@ -186,7 +186,7 @@ class PluginsStatus(FiabBaseModel):
     updater_status: Literal["ok", "running", "retrieving"] | str
     plugin_errors: dict[PluginCompositeId, str]
     plugin_versions: dict[PluginCompositeId, str]
-    plugin_updatedate: dict[PluginCompositeId, str]
+    plugin_updatedatetime: dict[PluginCompositeId, str]
 
 
 def status_brief() -> str:
@@ -209,17 +209,17 @@ def status_full() -> PluginsStatus:
             status = "retrieving"
             plugin_errors = {}
             plugin_versions = {}
-            plugin_updatedate = {}
+            plugin_updatedatetime = {}
         else:
             status = status_brief()
             plugin_errors = dict(PluginManager.errors)
             plugin_versions = dict(PluginManager.versions)
-            plugin_updatedate = dict(PluginManager.updatedate)
+            plugin_updatedatetime = dict(PluginManager.updatedatetime)
     return PluginsStatus(
         updater_status=status,
         plugin_errors=plugin_errors,
         plugin_versions=plugin_versions,
-        plugin_updatedate=plugin_updatedate,
+        plugin_updatedatetime=plugin_updatedatetime,
     )
 
 

--- a/backend/src/forecastbox/routes/plugins.py
+++ b/backend/src/forecastbox/routes/plugins.py
@@ -49,8 +49,8 @@ class PluginDetail(FiabBaseModel):
     """In case the plugin is errored, (eg installed but failed to load), this displays detail"""
     loaded_version: str | None = None
     """In case the plugin is loaded, this shows the version"""
-    update_date: str | None = None
-    """In case the plugin is installed, this shows the most recent update date"""
+    update_datetime: str | None = None
+    """In case the plugin is installed, this shows the most recent update datetime"""
 
 
 class PluginListing(FiabBaseModel):
@@ -102,7 +102,7 @@ def get_plugin_details(forceRefresh: bool = False) -> PluginListing:
             "status": status,
             "errored_detail": statuses.plugin_errors.get(pluginCompositeId, None),  # ty:ignore[no-matching-overload]
             "loaded_version": statuses.plugin_versions.get(pluginCompositeId, None),  # ty:ignore[no-matching-overload]
-            "update_date": statuses.plugin_updatedate.get(pluginCompositeId, None),  # ty:ignore[no-matching-overload]
+            "update_datetime": statuses.plugin_updatedatetime.get(pluginCompositeId, None),  # ty:ignore[no-matching-overload]
         }
         if pluginCompositeId not in rv:
             rv[pluginCompositeId] = PluginDetail(**update)  # ty:ignore[invalid-argument-type]

--- a/backend/src/forecastbox/utility/packages.py
+++ b/backend/src/forecastbox/utility/packages.py
@@ -80,8 +80,13 @@ def try_version(pip_source: str, module_name: str) -> str:
         return "unknown"
 
 
-def try_updatedate(pip_source: str) -> str:
-    """Return the install date of a package as ``YYYY/MM/DD``, or "unknown"."""
+def try_updatedatetime(pip_source: str) -> str:
+    """Return the install datetime of a package as ``YYYY-MM-DDTHH:MM:SS``, or "unknown".
+
+    Uses the ctime of the package's METADATA file as a proxy for the install time.
+    """
+    from forecastbox.utility.time import value_dt2str
+
     try:
         dist = importlib.metadata.distribution(pip_source)
     except importlib.metadata.PackageNotFoundError:
@@ -95,7 +100,7 @@ def try_updatedate(pip_source: str) -> str:
     try:
         path = pathlib.Path(mtdf.locate())
         install_time = dt.datetime.fromtimestamp(path.stat().st_ctime)
-        return install_time.strftime("%Y/%m/%d")
+        return value_dt2str(install_time)
     except Exception:  # too much could happen -- file not exist, no rights, malformed ts, etc
         return "unknown"
 

--- a/backend/tests/unit/utility/test_packages.py
+++ b/backend/tests/unit/utility/test_packages.py
@@ -20,7 +20,7 @@ from forecastbox.utility.packages import (
     get_package_versions,
     try_import,
     try_install,
-    try_updatedate,
+    try_updatedatetime,
     try_version,
 )
 
@@ -79,17 +79,17 @@ def test_try_version_returns_unknown_when_module_has_no_version_attribute() -> N
 
 
 # ---------------------------------------------------------------------------
-# try_updatedate
+# try_updatedatetime
 # ---------------------------------------------------------------------------
 
 
-def test_try_updatedate_package_not_found() -> None:
+def test_try_updatedatetime_package_not_found() -> None:
     with patch("importlib.metadata.distribution", side_effect=importlib.metadata.PackageNotFoundError):
-        result = try_updatedate("nonexistent-package")
+        result = try_updatedatetime("nonexistent-package")
     assert result == "unknown"
 
 
-def test_try_updatedate_success(tmp_path: pytest.TempPathFactory) -> None:
+def test_try_updatedatetime_success(tmp_path: pytest.TempPathFactory) -> None:
     metadata_file = tmp_path / "METADATA"  # type: ignore[operator]
     metadata_file.write_text("Metadata-Version: 2.1")
 
@@ -101,31 +101,74 @@ def test_try_updatedate_success(tmp_path: pytest.TempPathFactory) -> None:
     fake_dist.files = [fake_file]
 
     with patch("importlib.metadata.distribution", return_value=fake_dist):
-        result = try_updatedate("some-package")
+        result = try_updatedatetime("some-package")
 
     assert result != "unknown"
-    # Should be in YYYY/MM/DD format
-    parts = result.split("/")
-    assert len(parts) == 3
-    assert len(parts[0]) == 4  # year
+    # Should be in YYYY-MM-DDTHH:MM:SS format
+    import re
+
+    assert re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$", result), f"Unexpected format: {result!r}"
 
 
-def test_try_updatedate_no_metadata_file() -> None:
+def test_try_updatedatetime_success_uses_ctime(tmp_path: pytest.TempPathFactory) -> None:
+    import datetime
+    from unittest.mock import patch
+
+    metadata_file = tmp_path / "METADATA"  # type: ignore[operator]
+    metadata_file.write_text("Metadata-Version: 2.1")
+
+    fake_file = MagicMock()
+    fake_file.name = "METADATA"
+    fake_file.locate.return_value = metadata_file
+
+    fake_dist = MagicMock()
+    fake_dist.files = [fake_file]
+
+    fixed_ts = datetime.datetime(2024, 3, 15, 10, 30, 45).timestamp()
+    fake_stat = MagicMock()
+    fake_stat.st_ctime = fixed_ts
+
+    with patch("importlib.metadata.distribution", return_value=fake_dist):
+        with patch("pathlib.Path.stat", return_value=fake_stat):
+            result = try_updatedatetime("some-package")
+
+    assert result == "2024-03-15T10:30:45"
+
+
+def test_try_updatedatetime_no_metadata_file() -> None:
     fake_dist = MagicMock()
     fake_dist.files = []  # no METADATA file
 
     with patch("importlib.metadata.distribution", return_value=fake_dist):
-        result = try_updatedate("some-package")
+        result = try_updatedatetime("some-package")
 
     assert result == "unknown"
 
 
-def test_try_updatedate_dist_has_no_files() -> None:
+def test_try_updatedatetime_dist_has_no_files() -> None:
     fake_dist = MagicMock()
     fake_dist.files = None
 
     with patch("importlib.metadata.distribution", return_value=fake_dist):
-        result = try_updatedate("some-package")
+        result = try_updatedatetime("some-package")
+
+    assert result == "unknown"
+
+
+def test_try_updatedatetime_stat_raises_returns_unknown(tmp_path: pytest.TempPathFactory) -> None:
+    metadata_file = tmp_path / "METADATA"  # type: ignore[operator]
+    metadata_file.write_text("Metadata-Version: 2.1")
+
+    fake_file = MagicMock()
+    fake_file.name = "METADATA"
+    fake_file.locate.return_value = metadata_file
+
+    fake_dist = MagicMock()
+    fake_dist.files = [fake_file]
+
+    with patch("importlib.metadata.distribution", return_value=fake_dist):
+        with patch("pathlib.Path.stat", side_effect=OSError("permission denied")):
+            result = try_updatedatetime("some-package")
 
     assert result == "unknown"
 

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -50,6 +50,10 @@ Define success criteria. Loop until verified.
 
 For multi-step tasks, state a brief plan with verifiable checks.
 
+### 5. Correctness
+
+It is imperative formatting is correct and tests are passing. Make sure `npm run validate:fix` passes before you commit.
+
 ---
 
 ## Project Overview

--- a/frontend/mocks/data/plugins.data.ts
+++ b/frontend/mocks/data/plugins.data.ts
@@ -44,7 +44,7 @@ export const mockPluginListing: PluginListing = {
       remote_info: { version: '0.0.1' },
       errored_detail: null,
       loaded_version: '0.0.1',
-      update_date: '2026/02/03',
+      update_datetime: '2026-02-03T00:00:00',
     },
 
     // Disabled plugins (installed but not enabled)
@@ -62,7 +62,7 @@ export const mockPluginListing: PluginListing = {
       remote_info: { version: '1.0.0' },
       errored_detail: null,
       loaded_version: '1.0.0',
-      update_date: '2025/01/01',
+      update_datetime: '2025-01-01T00:00:00',
     },
     [createPluginKey('ecmwf', 'aifs-dataset')]: {
       status: 'disabled',
@@ -78,7 +78,7 @@ export const mockPluginListing: PluginListing = {
       remote_info: { version: '1.0.0' },
       errored_detail: null,
       loaded_version: '1.0.0',
-      update_date: '2025/01/01',
+      update_datetime: '2025-01-01T00:00:00',
     },
     [createPluginKey('ecmwf', 'regridding')]: {
       status: 'disabled',
@@ -94,7 +94,7 @@ export const mockPluginListing: PluginListing = {
       remote_info: { version: '2.0.5' },
       errored_detail: null,
       loaded_version: '2.0.5',
-      update_date: '2025/12/04',
+      update_datetime: '2025-12-04T00:00:00',
     },
     [createPluginKey('ecmwf', 'grib-export')]: {
       status: 'disabled',
@@ -110,7 +110,7 @@ export const mockPluginListing: PluginListing = {
       remote_info: { version: '2.1.0' },
       errored_detail: null,
       loaded_version: '2.1.0',
-      update_date: '2025/10/20',
+      update_datetime: '2025-10-20T00:00:00',
     },
     [createPluginKey('ecmwf', 'ensemble-forecast')]: {
       status: 'disabled',
@@ -126,7 +126,7 @@ export const mockPluginListing: PluginListing = {
       remote_info: { version: '2.4.0' },
       errored_detail: null,
       loaded_version: '2.1.0',
-      update_date: '2025/09/01',
+      update_datetime: '2025-09-01T00:00:00',
     },
     [createPluginKey('ecmwf', 'precipitation')]: {
       status: 'disabled',
@@ -141,7 +141,7 @@ export const mockPluginListing: PluginListing = {
       remote_info: { version: '1.2.0' },
       errored_detail: null,
       loaded_version: '1.2.0',
-      update_date: '2025/11/01',
+      update_datetime: '2025-11-01T00:00:00',
     },
 
     // Available plugins (not installed)
@@ -159,7 +159,7 @@ export const mockPluginListing: PluginListing = {
       remote_info: { version: '3.0.0' },
       errored_detail: null,
       loaded_version: null,
-      update_date: null,
+      update_datetime: null,
     },
     [createPluginKey('ecmwf', 'snow-analysis')]: {
       status: 'available',
@@ -174,7 +174,7 @@ export const mockPluginListing: PluginListing = {
       remote_info: { version: '2.0.0' },
       errored_detail: null,
       loaded_version: null,
-      update_date: null,
+      update_datetime: null,
     },
     [createPluginKey('ecmwf', 'netcdf-export')]: {
       status: 'available',
@@ -190,7 +190,7 @@ export const mockPluginListing: PluginListing = {
       remote_info: { version: '1.5.0' },
       errored_detail: null,
       loaded_version: null,
-      update_date: null,
+      update_datetime: null,
     },
     [createPluginKey('ecmwf', 'pdf-export')]: {
       status: 'available',
@@ -206,7 +206,7 @@ export const mockPluginListing: PluginListing = {
       remote_info: { version: '1.5.0' },
       errored_detail: null,
       loaded_version: null,
-      update_date: null,
+      update_datetime: null,
     },
   },
 }

--- a/frontend/mocks/handlers/plugins.handlers.ts
+++ b/frontend/mocks/handlers/plugins.handlers.ts
@@ -78,11 +78,12 @@ function createPluginKey(store: string, local: string): string {
 }
 
 /**
- * Get current date in backend format
+ * Get current datetime in backend format
  */
-function getCurrentDate(): string {
+function getCurrentDatetime(): string {
   const now = new Date()
-  return `${now.getFullYear()}/${String(now.getMonth() + 1).padStart(2, '0')}/${String(now.getDate()).padStart(2, '0')}`
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`
 }
 
 export const pluginsHandlers = [
@@ -95,7 +96,7 @@ export const pluginsHandlers = [
       updater_status: 'idle',
       plugin_errors: {},
       plugin_versions: {},
-      plugin_updatedate: {},
+      plugin_updatedatetime: {},
     }
 
     for (const [key, detail] of Object.entries(pluginsState.plugins)) {
@@ -105,8 +106,8 @@ export const pluginsHandlers = [
       if (detail.loaded_version) {
         status.plugin_versions[key] = detail.loaded_version
       }
-      if (detail.update_date) {
-        status.plugin_updatedate[key] = detail.update_date
+      if (detail.update_datetime) {
+        status.plugin_updatedatetime[key] = detail.update_datetime
       }
     }
 
@@ -158,7 +159,7 @@ export const pluginsHandlers = [
       ...plugin,
       status: 'loaded',
       loaded_version: plugin.remote_info?.version ?? '1.0.0',
-      update_date: getCurrentDate(),
+      update_datetime: getCurrentDatetime(),
     }
 
     // Simulate backend reload: catalogue will 503 once while plugins restart
@@ -196,7 +197,7 @@ export const pluginsHandlers = [
       ...plugin,
       status: 'available',
       loaded_version: null,
-      update_date: null,
+      update_datetime: null,
       errored_detail: null,
     }
 
@@ -243,7 +244,7 @@ export const pluginsHandlers = [
       ...plugin,
       status: 'loaded',
       loaded_version: newVersion,
-      update_date: getCurrentDate(),
+      update_datetime: getCurrentDatetime(),
       errored_detail: null,
     }
 

--- a/frontend/src/api/types/plugins.types.ts
+++ b/frontend/src/api/types/plugins.types.ts
@@ -136,7 +136,7 @@ export const PluginDetailSchema = z.object({
   remote_info: PluginRemoteInfoSchema.nullable(),
   errored_detail: z.string().nullable(),
   loaded_version: z.string().nullable(),
-  update_date: z.string().nullable(), // "YYYY/MM/DD" format
+  update_datetime: z.string().nullable(), // "YYYY-MM-DDTHH:MM:SS" format
 })
 
 export type PluginDetail = z.infer<typeof PluginDetailSchema>
@@ -157,7 +157,7 @@ export const PluginsStatusSchema = z.object({
   updater_status: z.string(),
   plugin_errors: z.record(z.string(), z.string()),
   plugin_versions: z.record(z.string(), z.string()),
-  plugin_updatedate: z.record(z.string(), z.string()),
+  plugin_updatedatetime: z.record(z.string(), z.string()),
 })
 
 export type PluginsStatus = z.infer<typeof PluginsStatusSchema>
@@ -195,7 +195,7 @@ export interface PluginInfo {
   isInstalled: boolean
   /** Whether an update is available (latestVersion > version) */
   hasUpdate: boolean
-  /** ISO date when last updated (from update_date) */
+  /** ISO datetime when last updated (from update_datetime) */
   updatedAt: string | null
   /** Error details if status is errored */
   errorDetail: string | null
@@ -247,8 +247,8 @@ export function toPluginInfo(
     isEnabled: detail.status === 'loaded' || detail.status === 'errored',
     isInstalled,
     hasUpdate,
-    updatedAt: detail.update_date
-      ? toValidDateOrNull(detail.update_date)
+    updatedAt: detail.update_datetime
+      ? toValidDateOrNull(detail.update_datetime)
       : null,
     errorDetail: detail.errored_detail,
     comment: detail.store_info?.comment ?? null,
@@ -258,24 +258,11 @@ export function toPluginInfo(
 }
 
 /**
- * Converts and validates a date string, returning null if unparseable.
+ * Converts and validates a datetime string, returning null if unparseable.
  */
 function toValidDateOrNull(dateStr: string): string | null {
-  const converted = convertUpdateDate(dateStr)
-  const date = new Date(converted)
-  return isNaN(date.getTime()) ? null : converted
-}
-
-/**
- * Convert backend date format (YYYY/MM/DD) to ISO format
- */
-function convertUpdateDate(dateStr: string): string {
-  // Convert "YYYY/MM/DD" to ISO format
-  const [year, month, day] = dateStr.split('/')
-  if (year && month && day) {
-    return `${year}-${month}-${day}T00:00:00Z`
-  }
-  return dateStr
+  const date = new Date(dateStr)
+  return isNaN(date.getTime()) ? null : dateStr
 }
 
 /**

--- a/frontend/tests/unit/api/endpoints/plugins.test.ts
+++ b/frontend/tests/unit/api/endpoints/plugins.test.ts
@@ -60,8 +60,8 @@ describe('getPluginStatus', () => {
       plugin_versions: {
         [createPluginKey('ecmwf', 'anemoi-inference')]: '1.0.0',
       },
-      plugin_updatedate: {
-        [createPluginKey('ecmwf', 'anemoi-inference')]: '2025/01/15',
+      plugin_updatedatetime: {
+        [createPluginKey('ecmwf', 'anemoi-inference')]: '2025-01-15T00:00:00',
       },
     }
 
@@ -99,7 +99,7 @@ describe('getPluginDetails', () => {
           remote_info: { version: '1.0.0' },
           errored_detail: null,
           loaded_version: '1.0.0',
-          update_date: '2025/01/15',
+          update_datetime: '2025-01-15T00:00:00',
         },
         [createPluginKey('ecmwf', 'storm-tracker')]: {
           status: 'available',
@@ -114,7 +114,7 @@ describe('getPluginDetails', () => {
           remote_info: { version: '2.0.0' },
           errored_detail: null,
           loaded_version: null,
-          update_date: null,
+          update_datetime: null,
         },
       },
     }


### PR DESCRIPTION
The plugin route now returns field `update_datetime` formatted as datetime, instead of `update_date`. This is to address a sort of frontend bug which originally took date and converted to utc midnight, leading to odd times being displayed. The frontend is simplified to treat the given datetime as is

Overall makes backend more consistent wrt how it reports dates and times

cc @liefra -- as always, the frontend impl is pure prompt, feel free to refuse/rewrite