### PR TITLE
Feat/utc

### DIFF
--- a/backend/src/forecastbox/domain/admin.py
+++ b/backend/src/forecastbox/domain/admin.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import httpx
 
 from forecastbox.utility.config import fiab_home
+from forecastbox.utility.time import current_time
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +112,8 @@ def save_pylock(pylock: str, release: Release) -> None:
     fiab_home.mkdir(parents=True, exist_ok=True)
 
     pylock_file_path.write_text(pylock)
-    timestamp_file_path.write_text(f"{int(datetime.now().timestamp())}:v{release}")
+    pylock_time = current_time("pylock_save")
+    timestamp_file_path.write_text(f"{int(pylock_time.timestamp())}:v{release}")
 
 
 def mark_release(release: Release) -> None:

--- a/backend/src/forecastbox/domain/blueprint/db.py
+++ b/backend/src/forecastbox/domain/blueprint/db.py
@@ -28,6 +28,7 @@ from forecastbox.domain.plugin.compatibility import get_fiabcore_version
 from forecastbox.schemata.jobs import Blueprint, BlueprintSource
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.db import dbRetry, executeAndCommit, querySingle
+from forecastbox.utility.time import current_time
 
 
 async def upsert_blueprint(
@@ -54,7 +55,7 @@ async def upsert_blueprint(
     """
     id_provided = blueprint_id is not None
     blueprint_id = blueprint_id if blueprint_id is not None else BlueprintId(str(uuid.uuid4()))
-    ref_time = dt.datetime.now()
+    ref_time = current_time("dbref")
 
     async def function(i: int) -> int:
         async with _jobs_module.async_session_maker() as session:

--- a/backend/src/forecastbox/domain/experiment/db.py
+++ b/backend/src/forecastbox/domain/experiment/db.py
@@ -28,6 +28,7 @@ from forecastbox.domain.experiment.types import ExperimentDefinitionId
 from forecastbox.schemata.jobs import ExperimentDefinition, ExperimentType
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.db import dbRetry, executeAndCommit, querySingle
+from forecastbox.utility.time import current_time
 
 
 async def upsert_experiment_definition(
@@ -53,7 +54,7 @@ async def upsert_experiment_definition(
     """
     id_provided = experiment_definition_id is not None
     experiment_id = experiment_definition_id if experiment_definition_id is not None else ExperimentDefinitionId(str(uuid.uuid4()))
-    ref_time = dt.datetime.now()
+    ref_time = current_time("dbref")
 
     async def function(i: int) -> int:
         async with _jobs_module.async_session_maker() as session:

--- a/backend/src/forecastbox/domain/experiment/scheduling/background.py
+++ b/backend/src/forecastbox/domain/experiment/scheduling/background.py
@@ -60,7 +60,7 @@ class SchedulerThread(threading.Thread):
         return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
 
     def mark_alive(self) -> dt.datetime:
-        self.liveness_timestamp = dt.datetime.now()
+        self.liveness_timestamp = current_time("liveness")
         self.liveness_signal.set()
         return self.liveness_timestamp
 
@@ -127,7 +127,7 @@ class SchedulerThread(threading.Thread):
 
         sleep_duration = sleep_duration_min
         if next_schedulable_at:
-            time_to_next_schedulable_at = int((next_schedulable_at - current_time()).total_seconds())
+            time_to_next_schedulable_at = int((next_schedulable_at - current_time("scheduling")).total_seconds())
             if time_to_next_schedulable_at > 0:
                 sleep_duration = min(time_to_next_schedulable_at, sleep_duration_min)
             else:
@@ -209,7 +209,7 @@ def status_scheduler() -> str:
         logger.warning("scheduler reported down due to thread not being alive")
         return "down"
     Globals.scheduler.liveness_signal.wait(0)  # we do this just for ensuring a multithread sync
-    now = dt.datetime.now()
+    now = current_time("liveness")
     if (
         Globals.scheduler.liveness_timestamp is None
         or (now - Globals.scheduler.liveness_timestamp) > dt.timedelta(minutes=sleep_duration_min) * 2

--- a/backend/src/forecastbox/domain/experiment/scheduling/db.py
+++ b/backend/src/forecastbox/domain/experiment/scheduling/db.py
@@ -22,11 +22,12 @@ import forecastbox.schemata.jobs as _jobs_module
 from forecastbox.domain.experiment.types import ExperimentDefinitionId
 from forecastbox.schemata.jobs import ExperimentDefinition, ExperimentNext
 from forecastbox.utility.db import addAndCommit, dbRetry, executeAndCommit, querySingle
+from forecastbox.utility.time import current_time
 
 
 async def upsert_experiment_next(*, experiment_id: ExperimentDefinitionId, scheduled_at: dt.datetime) -> None:
     """Insert or update the next scheduled run time for an experiment."""
-    ref_time = dt.datetime.now()
+    ref_time = current_time("dbref")
     existing = await querySingle(
         select(ExperimentNext).where(ExperimentNext.experiment_id == experiment_id),
         _jobs_module.async_session_maker,

--- a/backend/src/forecastbox/domain/experiment/scheduling/dt_utils.py
+++ b/backend/src/forecastbox/domain/experiment/scheduling/dt_utils.py
@@ -103,7 +103,7 @@ def calculate_next_run(after: datetime, crontab: str) -> datetime:
 
                 for hour in crontab_values.hours:
                     for minute in crontab_values.minutes:
-                        candidate_run = datetime(year, month, day_of_month, hour, minute)
+                        candidate_run = datetime(year, month, day_of_month, hour, minute, tzinfo=after.tzinfo)
                         if candidate_run > after:
                             return candidate_run
     raise ValueError(f"cron next run failure for {after} and {crontab}")

--- a/backend/src/forecastbox/domain/experiment/service.py
+++ b/backend/src/forecastbox/domain/experiment/service.py
@@ -56,7 +56,7 @@ def resolve_next_run(
 
     Raises ValueError if first_run_override is provided but older than max_delay_hours.
     """
-    now = current_time()
+    now = current_time("scheduling")
     if first_run_override is not None:
         age_hours = (now - first_run_override).total_seconds() / 3600
         if age_hours > max_delay_hours:

--- a/backend/src/forecastbox/domain/glyphs/global_db.py
+++ b/backend/src/forecastbox/domain/glyphs/global_db.py
@@ -21,6 +21,7 @@ from forecastbox.domain.glyphs.types import GlobalGlyphId
 from forecastbox.schemata.jobs import GlobalGlyph
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.db import dbRetry, querySingle
+from forecastbox.utility.time import current_time
 
 
 @dataclass(frozen=True, eq=True, slots=True)
@@ -61,7 +62,7 @@ async def upsert_global_glyph(key: str, value: str, public: bool, overriddable: 
     ``overriddable`` must be ``None`` when ``public=False`` and a bool when ``public=True``.
     This invariant is enforced at the route layer; the domain layer trusts callers.
     """
-    ref_time = dt.datetime.now()
+    ref_time = current_time("dbref")
 
     async def function(i: int) -> GlobalGlyph:
         async with _jobs_module.async_session_maker() as session:

--- a/backend/src/forecastbox/domain/glyphs/intrinsic.py
+++ b/backend/src/forecastbox/domain/glyphs/intrinsic.py
@@ -24,7 +24,7 @@ AvailableIntrinsicGlyphs = Literal[
 ]
 # fmt: on
 
-_current_time_example = value_dt2str(current_time())
+_current_time_example = value_dt2str(current_time("glyph_resolution"))
 
 # TODO: replace with frozendict once available so that we have immutability
 _values_and_examples: dict[AvailableIntrinsicGlyphs, str] = {

--- a/backend/src/forecastbox/domain/glyphs/jinja_interpolation.py
+++ b/backend/src/forecastbox/domain/glyphs/jinja_interpolation.py
@@ -10,8 +10,10 @@
 """Jinja2-based string interpolation engine for ${...} glyph expressions.
 
 Uses ``${`` / ``}`` as variable delimiters instead of the Jinja2 default ``{{`` / ``}}``.
-Variables whose values match the canonical datetime format (``YYYY-MM-DD HH:MM:SS``) are
-auto-coerced to :class:`datetime` objects so that date filters and arithmetic work directly.
+Variables whose values match the canonical datetime format (``YYYY-MM-DD HH:MM:SS`` and tz-aware
+variants) are auto-coerced to :class:`datetime` objects so that date filters and arithmetic
+work directly. The auto-coercion is bound to fiab-core.types.DatetimeType, as they are
+inherently coupled.
 """
 
 import re
@@ -21,20 +23,20 @@ from datetime import datetime, timedelta
 from typing import Any, Literal
 
 from cascade.low.func import Either
+from fiab_core.types import DatetimeType, WrongType
 from jinja2 import Environment, StrictUndefined, TemplateSyntaxError
 from jinja2 import nodes as jnodes
 from jinja2.sandbox import SandboxedEnvironment
 
-# Only the canonical backend datetime format is auto-coerced; other date-like strings
-# (e.g. "2024-01-15") are intentionally kept as strings to avoid silent format changes.
-# We use the simple ISO 8601 format.
-_CANONICAL_DATETIME_FMT = "%Y-%m-%dT%H:%M:%S"
+from forecastbox.utility.time import value_dt2str
+
+_dt_instance = DatetimeType()
 
 
 def _try_parse_datetime(value: str) -> datetime | str:
     try:
-        return datetime.strptime(value, _CANONICAL_DATETIME_FMT)
-    except ValueError:
+        return _dt_instance.validate_convert(value)
+    except WrongType:
         return value
 
 
@@ -68,7 +70,7 @@ def _split(value: str, sep: str | None = None) -> list[str]:
 
 def _stringify_result(value: object) -> str:
     if isinstance(value, datetime):
-        return value.strftime(_CANONICAL_DATETIME_FMT)
+        return value_dt2str(value)
     return str(value)
 
 

--- a/backend/src/forecastbox/domain/run/background.py
+++ b/backend/src/forecastbox/domain/run/background.py
@@ -73,7 +73,7 @@ def execute_background(
         return asyncio.run_coroutine_threadsafe(coro, loop).result()  # type: ignore[arg-type]
 
     try:
-        start_time = current_time()
+        start_time = current_time("glyph_resolution")
         intrinsic_values: dict[str, str] = cast(
             dict[str, str],
             resolve_intrinsic_glyph_values(run_id, submit_time, start_time, attempt_count),

--- a/backend/src/forecastbox/domain/run/db.py
+++ b/backend/src/forecastbox/domain/run/db.py
@@ -34,6 +34,7 @@ from forecastbox.schemata.jobs import Run, RunStatus
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.db import dbRetry, executeAndCommit, querySingle
 from forecastbox.utility.pydantic import FiabBaseModel
+from forecastbox.utility.time import current_time
 
 
 class CompilerRuntimeContext(FiabBaseModel):
@@ -68,7 +69,7 @@ async def upsert_run(
     """
     supplied_run_id = run_id
     effective_run_id = run_id if run_id is not None else RunId(str(uuid.uuid4()))
-    ref_time = dt.datetime.now()
+    ref_time = current_time("dbref")
 
     async def function(i: int) -> int:
         async with _jobs_module.async_session_maker() as session:
@@ -134,7 +135,7 @@ async def update_run_runtime(run_id: RunId, attempt_count: int, **kwargs: object
 
     No actor-level auth; this is an internal system operation called during execution.
     """
-    ref_time = dt.datetime.now()
+    ref_time = current_time("dbref")
     stmt = update(Run).where(Run.run_id == run_id, Run.attempt_count == attempt_count).values(updated_at=ref_time, **kwargs)
     await executeAndCommit(stmt, _jobs_module.async_session_maker)
 

--- a/backend/src/forecastbox/routes/experiment.py
+++ b/backend/src/forecastbox/routes/experiment.py
@@ -35,7 +35,7 @@ from forecastbox.schemata.jobs import ExperimentDefinition
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.pagination import PaginationSpec
 from forecastbox.utility.pydantic import FiabBaseModel
-from forecastbox.utility.time import current_time
+from forecastbox.utility.time import current_time, value_dt2str
 
 PREFIX = "/api/v1/experiment"
 
@@ -346,7 +346,7 @@ async def get_next_experiment_run(
 @router.get("/operational/scheduler/current_time")
 async def get_scheduler_current_time() -> str:
     """Return the current time used for scheduling decisions (ISO 8601)."""
-    return current_time().isoformat()
+    return value_dt2str(current_time("scheduling"))
 
 
 @router.post("/operational/scheduler/restart")

--- a/backend/src/forecastbox/schemata/jobs.py
+++ b/backend/src/forecastbox/schemata/jobs.py
@@ -20,11 +20,12 @@ via automatic schemata iteration.
 
 from typing import Literal
 
-from sqlalchemy import JSON, Boolean, CheckConstraint, Column, DateTime, ForeignKeyConstraint, Integer, String, UniqueConstraint
+from sqlalchemy import JSON, Boolean, CheckConstraint, Column, ForeignKeyConstraint, Integer, String, UniqueConstraint
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase
 
 from forecastbox.utility.config import config
+from forecastbox.utility.time import UTCDateTime
 
 BlueprintSource = Literal["plugin_template", "user_defined", "oneoff_execution"]
 ExperimentType = Literal["cron_schedule", "batch_execution", "external_trigger"]
@@ -49,7 +50,7 @@ class Blueprint(Base):
     blueprint_id = Column(String(255), primary_key=True, nullable=False)
     version = Column(Integer, primary_key=True, nullable=False)
     created_by = Column(String(255), nullable=False)
-    created_at = Column(DateTime, nullable=False)
+    created_at = Column(UTCDateTime, nullable=False)
 
     # TODO later -- make sure entity validates this
     source = Column(String(64), nullable=False)
@@ -89,8 +90,8 @@ class GlobalGlyph(Base):
     public = Column(Boolean, nullable=False, default=False)
     overriddable = Column(Boolean, nullable=True)
     created_by = Column(String(255), nullable=False)
-    created_at = Column(DateTime, nullable=False)
-    updated_at = Column(DateTime, nullable=False)
+    created_at = Column(UTCDateTime, nullable=False)
+    updated_at = Column(UTCDateTime, nullable=False)
 
     __table_args__ = (
         UniqueConstraint("created_by", "key", name="uq_global_glyph_created_by_key"),
@@ -114,7 +115,7 @@ class ExperimentDefinition(Base):
     experiment_definition_id = Column(String(255), primary_key=True, nullable=False)
     version = Column(Integer, primary_key=True, nullable=False)
     created_by = Column(String(255), nullable=False)
-    created_at = Column(DateTime, nullable=False)
+    created_at = Column(UTCDateTime, nullable=False)
 
     display_name = Column(String(255), nullable=True)
     display_description = Column(String(1024), nullable=True)
@@ -152,8 +153,8 @@ class Run(Base):
     run_id = Column(String(255), primary_key=True, nullable=False)
     attempt_count = Column(Integer, primary_key=True, nullable=False)
     created_by = Column(String(255), nullable=False)
-    created_at = Column(DateTime, nullable=False)
-    updated_at = Column(DateTime, nullable=False)
+    created_at = Column(UTCDateTime, nullable=False)
+    updated_at = Column(UTCDateTime, nullable=False)
 
     blueprint_id = Column(String(255), nullable=False)
     blueprint_version = Column(Integer, nullable=False)
@@ -194,8 +195,8 @@ class ExperimentNext(Base):
 
     experiment_next_id = Column(String(255), primary_key=True, nullable=False)
     experiment_id = Column(String(255), nullable=False, unique=True)
-    scheduled_at = Column(DateTime, nullable=False)
-    updated_at = Column(DateTime, nullable=False)
+    scheduled_at = Column(UTCDateTime, nullable=False)
+    updated_at = Column(UTCDateTime, nullable=False)
 
 
 async_url = f"sqlite+aiosqlite:///{config.db.sqlite_jobdb_path}"

--- a/backend/src/forecastbox/utility/packages.py
+++ b/backend/src/forecastbox/utility/packages.py
@@ -27,6 +27,8 @@ import orjson
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
+from forecastbox.utility.time import from_timestamp, value_dt2str
+
 logger = logging.getLogger(__name__)
 
 
@@ -85,7 +87,6 @@ def try_updatedatetime(pip_source: str) -> str:
 
     Uses the ctime of the package's METADATA file as a proxy for the install time.
     """
-    from forecastbox.utility.time import value_dt2str
 
     try:
         dist = importlib.metadata.distribution(pip_source)
@@ -99,7 +100,7 @@ def try_updatedatetime(pip_source: str) -> str:
         return "unknown"
     try:
         path = pathlib.Path(mtdf.locate())
-        install_time = dt.datetime.fromtimestamp(path.stat().st_ctime)
+        install_time = from_timestamp(path.stat().st_ctime)
         return value_dt2str(install_time)
     except Exception:  # too much could happen -- file not exist, no rights, malformed ts, etc
         return "unknown"

--- a/backend/src/forecastbox/utility/time.py
+++ b/backend/src/forecastbox/utility/time.py
@@ -9,19 +9,38 @@
 
 """Time and Date related utilities"""
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
+from typing import Literal
 
 from sqlalchemy import Column
 
+TimeQueryReason = Literal[
+    "liveness",  # for deciding whether a given long running thread is still alive
+    "scheduling",  # for calculating next_run, and deciding whether a next_run should fire
+    "glyph_resolution",  # eg when a cascade job starts executing
+    "dbref",  # for db inserts and created_at/updated_at
+    "pylock_save",  # for creating the pylock.toml.timestamp file utilized by the installer
+]
 
-def current_time() -> datetime:
-    """Return the current time used for scheduling decisions or submit time derivation."""
-    # NOTE used by scheduler for scheduling decision, exposed to the users via endpoint
-    # *Not* used for internal liveness measurement etc. Primarily to ensure the same timezone
-    # etc are being used.
-    return datetime.now()
+
+def current_time(reason: TimeQueryReason) -> datetime:
+    """Return the current time, for the given reason. Sets the proper time zone
+    to ensure consistency and client compatibility"""
+    # NOTE we dont use the reason atm, but in case we would ever need to its
+    # more convenient than grepping around
+    return datetime.now(UTC)
+
+
+def from_timestamp(ts: float) -> datetime:
+    """The `ts` is to come from like file stat ctime"""
+    local_install_time = datetime.fromtimestamp(ts)
+    utc_install_time = local_install_time.astimezone(UTC)
+    return utc_install_time
+
+
+canonical_output_format = "%Y-%m-%dT%H:%M:%S%:z"
 
 
 def value_dt2str(value: datetime | Column) -> str:
     """Convert a datetime to the canonical string format used for all client-exposed serialization."""
-    return value.strftime("%Y-%m-%dT%H:%M:%S")
+    return value.strftime(canonical_output_format)

--- a/backend/src/forecastbox/utility/time.py
+++ b/backend/src/forecastbox/utility/time.py
@@ -9,6 +9,7 @@
 
 """Time and Date related utilities"""
 
+import sys
 from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
 
@@ -57,9 +58,19 @@ class UTCDateTime(TypeDecorator[datetime]):
         return value
 
 
-canonical_output_format = "%Y-%m-%dT%H:%M:%S%:z"
+# NOTE the value_dt2str is used for client-exposed datetimes via routes like current time
+# or plugin update datetime, but also in glyph resolution in jobs etc. We may want to
+# include the callsite motivation in the function similarly to how current_time is done
+if (sys.version_info.major, sys.version_info.minor) >= (3, 12):
 
+    def value_dt2str(value: datetime | Column) -> str:
+        """Convert a datetime to the canonical string format used for all serialization."""
+        canonical_output_format = "%Y-%m-%dT%H:%M:%S%:z"
+        return value.strftime(canonical_output_format)
+else:
 
-def value_dt2str(value: datetime | Column) -> str:
-    """Convert a datetime to the canonical string format used for all client-exposed serialization."""
-    return value.strftime(canonical_output_format)
+    def value_dt2str(value: datetime | Column) -> str:
+        """Convert a datetime to the canonical string format used for all serialization."""
+        # NOTE there is no %:z in those pythons. The `isoformat` generally returns %f as well, which
+        # we prefer not to, hence we replace it.
+        return value.replace(microsecond=0).isoformat()

--- a/backend/src/forecastbox/utility/time.py
+++ b/backend/src/forecastbox/utility/time.py
@@ -10,9 +10,10 @@
 """Time and Date related utilities"""
 
 from datetime import UTC, datetime, timedelta
-from typing import Literal
+from typing import Any, Literal
 
-from sqlalchemy import Column
+from sqlalchemy import Column, DateTime
+from sqlalchemy.types import TypeDecorator
 
 TimeQueryReason = Literal[
     "liveness",  # for deciding whether a given long running thread is still alive
@@ -36,6 +37,24 @@ def from_timestamp(ts: float) -> datetime:
     local_install_time = datetime.fromtimestamp(ts)
     utc_install_time = local_install_time.astimezone(UTC)
     return utc_install_time
+
+
+class UTCDateTime(TypeDecorator[datetime]):
+    """DateTime column that always returns UTC-aware datetimes.
+
+    SQLite has no native timezone support, so SQLAlchemy's DateTime returns naive
+    datetimes on read regardless of timezone=True. This decorator attaches UTC tzinfo
+    to any naive datetime value read from the database, ensuring all in-process
+    datetimes are consistently tz-aware.
+    """
+
+    impl = DateTime(timezone=True)
+    cache_ok = True
+
+    def process_result_value(self, value: datetime | None, dialect: Any) -> datetime | None:
+        if value is not None and value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value
 
 
 canonical_output_format = "%Y-%m-%dT%H:%M:%S%:z"

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -460,7 +460,8 @@ def test_blueprint_expand_missing_glyph_warnings(tmpdir: Any, backend_client_wit
     outputTime = pathlib.Path(f"{tmpdir}/output{run_id}.time.txt")
     # Both submitDatetime and startDatetime equal created_at on the first run.
     # created_at is at higher precision than the second-resolution glyph values.
-    created_at_sec = created_at.split(".", 1)[0]
+    # Use fromisoformat + replace to strip sub-second precision while preserving the UTC offset.
+    created_at_sec = _dt.fromisoformat(created_at).replace(microsecond=0).isoformat()
     _time_line = outputTime.read_text()
     _time_parts = _time_line.split(";")
     assert _time_parts[0] == created_at_sec
@@ -514,7 +515,7 @@ def test_blueprint_expand_missing_glyph_warnings(tmpdir: Any, backend_client_wit
     # the updated global value "changed_value".
     status_restarted_resp = backend_client_with_auth.get("/run/get", params={"run_id": run_id})
     assert status_restarted_resp.is_success, status_restarted_resp.text
-    created_at_restarted = status_restarted_resp.json()["created_at"].split(".", 1)[0]
+    created_at_restarted = _dt.fromisoformat(status_restarted_resp.json()["created_at"]).replace(microsecond=0).isoformat()
     _time_line_r = outputTime.read_text()
     _time_parts_r = _time_line_r.split(";")
     assert _time_parts_r[0] == created_at_sec
@@ -893,7 +894,7 @@ def test_blueprint_composite_glyph_expand(tmpdir: Any, backend_client_with_auth:
     assert glyphs_resp2.is_success, glyphs_resp2.text
     submit_example = next(g["valueExample"] for g in glyphs_resp2.json()["glyphs"] if g["name"] == "submitDatetime")
     # floor_day of the example value: strip time component
-    expected_floored = submit_example[:10] + "T00:00:00"
+    expected_floored = submit_example[:10] + "T00:00:00+00:00"
     source_jinja = BlockInstance(
         factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_text")),
         configuration_values=_config({"text": "${jinjaFilterGlyph}"}),

--- a/backend/tests/integration/test_schedule.py
+++ b/backend/tests/integration/test_schedule.py
@@ -24,7 +24,7 @@ from forecastbox.domain.blueprint.service import BlueprintSaveCommand as Bluepri
 from forecastbox.domain.blueprint.types import BlueprintId
 from forecastbox.domain.experiment.types import ExperimentDefinitionId
 from forecastbox.routes.experiment import ExperimentCreateRequest, ExperimentUpdateRequest
-from forecastbox.utility.time import value_dt2str
+from forecastbox.utility.time import current_time, value_dt2str
 
 from .conftest import testPluginId
 from .utils import (
@@ -394,7 +394,7 @@ def test_schedule_v2_execute(tmpdir: Any, backend_client_with_auth: httpx.Client
     time_output_path = str(pathlib.Path(str(tmpdir)) / "time_output")
     job_def_id, job_def_version = _save_full_blueprint(backend_client_with_auth, output_path, time_output_path)
 
-    first_run_override = dt.datetime.now() - dt.timedelta(minutes=5)
+    first_run_override = current_time("scheduling") - dt.timedelta(minutes=5)
     spec = ExperimentCreateRequest(
         blueprint_id=job_def_id,
         blueprint_version=job_def_version,

--- a/backend/tests/largeE2E/blueprint.py
+++ b/backend/tests/largeE2E/blueprint.py
@@ -20,6 +20,7 @@ from forecastbox.domain.blueprint.service import BlueprintBuilder
 from forecastbox.domain.run.cascade import ExecutionSpecification, RawCascadeJob
 from forecastbox.entrypoint.main import launch_all
 from forecastbox.utility.config import FIABConfig, UnmanagedGateway
+from forecastbox.utility.time import current_time
 
 
 def _config(values: dict[str, str]) -> dict[ConfigurationOptionId, str]:
@@ -74,7 +75,7 @@ if __name__ == "__main__":
                     configuration_values=_config(
                         {
                             "source": "ecmwf-open-data",
-                            "date": (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d"),
+                            "date": (current_time("scheduling") - timedelta(days=1)).strftime("%Y-%m-%d"),
                             "expver": "0001",
                         }
                     ),

--- a/backend/tests/unit/scheduling/test_dt_utils.py
+++ b/backend/tests/unit/scheduling/test_dt_utils.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -117,8 +117,8 @@ def test_next_run_endofyear() -> None:
 
 
 def test_current_scheduling_time() -> None:
-    before = datetime.now()
-    result = current_time()
-    after = datetime.now()
+    before = datetime.now(UTC)
+    result = current_time("scheduling")
+    after = datetime.now(UTC)
     assert isinstance(result, datetime)
     assert before <= result <= after

--- a/backend/tests/unit/scheduling/test_experiment_runnable.py
+++ b/backend/tests/unit/scheduling/test_experiment_runnable.py
@@ -17,6 +17,7 @@ import pytest
 from forecastbox.domain.experiment.scheduling.job_utils import RunnableExperiment, experiment2runnable
 from forecastbox.domain.experiment.types import ExperimentDefinitionId
 from forecastbox.domain.run.db import CompilerRuntimeContext
+from forecastbox.utility.time import current_time
 
 
 def _make_experiment(experiment_id: str = "exp-1", job_def_id: str = "jd-1", job_def_version: int = 1) -> MagicMock:
@@ -82,7 +83,7 @@ async def test_experiment2runnable_success(mock_get_jd: AsyncMock, mock_get_exp:
 async def test_experiment2runnable_not_found(mock_get_exp: AsyncMock) -> None:
     mock_get_exp.return_value = None
 
-    result = await experiment2runnable(ExperimentDefinitionId("does-not-exist"), dt.datetime.now())
+    result = await experiment2runnable(ExperimentDefinitionId("does-not-exist"), current_time("scheduling"))
 
     assert result.t is None
     assert result.e is not None
@@ -96,7 +97,7 @@ async def test_experiment2runnable_job_def_missing(mock_get_jd: AsyncMock, mock_
     mock_get_exp.return_value = _make_experiment()
     mock_get_jd.return_value = None
 
-    result = await experiment2runnable(ExperimentDefinitionId("exp-1"), dt.datetime.now())
+    result = await experiment2runnable(ExperimentDefinitionId("exp-1"), current_time("scheduling"))
 
     assert result.t is None
     assert result.e is not None

--- a/backend/tests/unit/test_jobs.py
+++ b/backend/tests/unit/test_jobs.py
@@ -565,7 +565,7 @@ async def test_jobs_experiment_next_upsert(mem_session_maker_both: async_session
         created_by="user1",
     )
 
-    t1 = dt.datetime(2026, 1, 1, 12, 0)
+    t1 = dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.timezone.utc)
     await scheduling_db.upsert_experiment_next(experiment_id=exp_id, scheduled_at=t1)
 
     result = await scheduling_db.get_experiment_next(exp_id)
@@ -573,7 +573,7 @@ async def test_jobs_experiment_next_upsert(mem_session_maker_both: async_session
     assert result.scheduled_at == t1
 
     # Upsert again should update the scheduled_at
-    t2 = dt.datetime(2026, 1, 2, 12, 0)
+    t2 = dt.datetime(2026, 1, 2, 12, 0, tzinfo=dt.timezone.utc)
     await scheduling_db.upsert_experiment_next(experiment_id=exp_id, scheduled_at=t2)
 
     result2 = await scheduling_db.get_experiment_next(exp_id)

--- a/backend/tests/unit/utility/test_packages.py
+++ b/backend/tests/unit/utility/test_packages.py
@@ -9,6 +9,7 @@
 
 import importlib.metadata
 import subprocess
+from datetime import UTC
 from types import ModuleType
 from unittest.mock import MagicMock, patch
 
@@ -23,6 +24,7 @@ from forecastbox.utility.packages import (
     try_updatedatetime,
     try_version,
 )
+from forecastbox.utility.time import value_dt2str
 
 # ---------------------------------------------------------------------------
 # try_import
@@ -107,7 +109,7 @@ def test_try_updatedatetime_success(tmp_path: pytest.TempPathFactory) -> None:
     # Should be in YYYY-MM-DDTHH:MM:SS format
     import re
 
-    assert re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$", result), f"Unexpected format: {result!r}"
+    assert re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00$", result), f"Unexpected format: {result!r}"
 
 
 def test_try_updatedatetime_success_uses_ctime(tmp_path: pytest.TempPathFactory) -> None:
@@ -124,7 +126,8 @@ def test_try_updatedatetime_success_uses_ctime(tmp_path: pytest.TempPathFactory)
     fake_dist = MagicMock()
     fake_dist.files = [fake_file]
 
-    fixed_ts = datetime.datetime(2024, 3, 15, 10, 30, 45).timestamp()
+    fixed_dt = datetime.datetime(2024, 3, 15, 10, 30, 45).astimezone(UTC)
+    fixed_ts = fixed_dt.timestamp()
     fake_stat = MagicMock()
     fake_stat.st_ctime = fixed_ts
 
@@ -132,7 +135,7 @@ def test_try_updatedatetime_success_uses_ctime(tmp_path: pytest.TempPathFactory)
         with patch("pathlib.Path.stat", return_value=fake_stat):
             result = try_updatedatetime("some-package")
 
-    assert result == "2024-03-15T10:30:45"
+    assert result == value_dt2str(fixed_dt)
 
 
 def test_try_updatedatetime_no_metadata_file() -> None:

--- a/backend/tests/unit/utility/test_time.py
+++ b/backend/tests/unit/utility/test_time.py
@@ -1,0 +1,13 @@
+import datetime
+
+import pytest
+from fiab_core.types import DatetimeType
+
+from forecastbox.utility.time import current_time, value_dt2str
+
+
+def test_fiabcore_compat() -> None:
+    now = current_time("glyph_resolution").replace(microsecond=0)
+    now_ser = value_dt2str(now)
+    parsed_now = DatetimeType().validate_convert(now_ser)
+    assert now == parsed_now

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -140,8 +140,8 @@ tests/                   # Unit, integration, E2E tests
 ## Dates & timezones
 
 A user-settable **application timezone** lives in `uiStore.timeZone` (default
-`UTC`). Forecast date/times are stored and transmitted as **canonical naive UTC**
-(`YYYY-MM-DDTHH:MM:SS`) — the forecast pipeline (anemoi, map plots) is UTC
+`UTC`). Forecast date/times are stored and transmitted as **UTC with explicit
+offset** (`YYYY-MM-DDTHH:MM:SS+00:00`) — the forecast pipeline (anemoi, map plots) is UTC
 end-to-end. The application timezone is a **presentation layer**; conversion
 happens only at the entry/display boundary.
 

--- a/frontend/mocks/data/fable.data.ts
+++ b/frontend/mocks/data/fable.data.ts
@@ -253,8 +253,8 @@ export const mockSavedFables: Record<
     name: 'European Temperature Forecast',
     tags: ['europe', 'temperature', 'daily'],
     user_id: 'user-123',
-    created_at: '2024-01-10T10:00:00Z',
-    updated_at: '2024-01-15T14:30:00Z',
+    created_at: '2024-01-10 10:00:00+00:00',
+    updated_at: '2024-01-15 14:30:00+00:00',
   },
 
   'fable-002': {
@@ -289,8 +289,8 @@ export const mockSavedFables: Record<
     name: 'Open Data Archive',
     tags: ['open-data', 'archive'],
     user_id: 'user-123',
-    created_at: '2024-01-12T08:00:00Z',
-    updated_at: '2024-01-12T08:00:00Z',
+    created_at: '2024-01-12 08:00:00+00:00',
+    updated_at: '2024-01-12 08:00:00+00:00',
   },
 }
 

--- a/frontend/mocks/data/job.data.ts
+++ b/frontend/mocks/data/job.data.ts
@@ -20,11 +20,15 @@ import type {
 } from '@/api/types/job.types'
 
 const now = new Date()
-const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000).toISOString()
-const twoHoursAgo = new Date(now.getTime() - 2 * 60 * 60 * 1000).toISOString()
-const threeDaysAgo = new Date(
-  now.getTime() - 3 * 24 * 60 * 60 * 1000,
-).toISOString()
+const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000)
+  .toISOString()
+  .replace(/\.\d{3}Z$/, '+00:00')
+const twoHoursAgo = new Date(now.getTime() - 2 * 60 * 60 * 1000)
+  .toISOString()
+  .replace(/\.\d{3}Z$/, '+00:00')
+const threeDaysAgo = new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000)
+  .toISOString()
+  .replace(/\.\d{3}Z$/, '+00:00')
 
 // ─── Execution mock state ─────────────────────────────────────────────────
 
@@ -111,8 +115,8 @@ const seedExecutions: Array<JobExecutionDetail> = [
     run_id: 'job-submitted-004',
     attempt_count: 1,
     status: 'submitted',
-    created_at: now.toISOString(),
-    updated_at: now.toISOString(),
+    created_at: now.toISOString().replace(/\.\d{3}Z$/, '+00:00'),
+    updated_at: now.toISOString().replace(/\.\d{3}Z$/, '+00:00'),
     blueprint_id: 'def-004',
     blueprint_version: 1,
     error: null,
@@ -222,7 +226,7 @@ export function getExecution(
 
 export function addExecution(request: JobExecuteRequest): JobExecuteResponse {
   const run_id = `exec-mock-${String(executionIdCounter++).padStart(3, '0')}`
-  const timestamp = new Date().toISOString()
+  const timestamp = new Date().toISOString().replace(/\.\d{3}Z$/, '+00:00')
   executionsState[run_id] = {
     run_id,
     attempt_count: 1,

--- a/frontend/mocks/data/plugins.data.ts
+++ b/frontend/mocks/data/plugins.data.ts
@@ -44,7 +44,7 @@ export const mockPluginListing: PluginListing = {
       remote_info: { version: '0.0.1' },
       errored_detail: null,
       loaded_version: '0.0.1',
-      update_datetime: '2026-02-03T00:00:00',
+      update_datetime: '2026-02-03T00:00:00+00:00',
     },
 
     // Disabled plugins (installed but not enabled)
@@ -62,7 +62,7 @@ export const mockPluginListing: PluginListing = {
       remote_info: { version: '1.0.0' },
       errored_detail: null,
       loaded_version: '1.0.0',
-      update_datetime: '2025-01-01T00:00:00',
+      update_datetime: '2025-01-01T00:00:00+00:00',
     },
     [createPluginKey('ecmwf', 'aifs-dataset')]: {
       status: 'disabled',
@@ -78,7 +78,7 @@ export const mockPluginListing: PluginListing = {
       remote_info: { version: '1.0.0' },
       errored_detail: null,
       loaded_version: '1.0.0',
-      update_datetime: '2025-01-01T00:00:00',
+      update_datetime: '2025-01-01T00:00:00+00:00',
     },
     [createPluginKey('ecmwf', 'regridding')]: {
       status: 'disabled',
@@ -94,7 +94,7 @@ export const mockPluginListing: PluginListing = {
       remote_info: { version: '2.0.5' },
       errored_detail: null,
       loaded_version: '2.0.5',
-      update_datetime: '2025-12-04T00:00:00',
+      update_datetime: '2025-12-04T00:00:00+00:00',
     },
     [createPluginKey('ecmwf', 'grib-export')]: {
       status: 'disabled',
@@ -110,7 +110,7 @@ export const mockPluginListing: PluginListing = {
       remote_info: { version: '2.1.0' },
       errored_detail: null,
       loaded_version: '2.1.0',
-      update_datetime: '2025-10-20T00:00:00',
+      update_datetime: '2025-10-20T00:00:00+00:00',
     },
     [createPluginKey('ecmwf', 'ensemble-forecast')]: {
       status: 'disabled',
@@ -126,7 +126,7 @@ export const mockPluginListing: PluginListing = {
       remote_info: { version: '2.4.0' },
       errored_detail: null,
       loaded_version: '2.1.0',
-      update_datetime: '2025-09-01T00:00:00',
+      update_datetime: '2025-09-01T00:00:00+00:00',
     },
     [createPluginKey('ecmwf', 'precipitation')]: {
       status: 'disabled',
@@ -141,7 +141,7 @@ export const mockPluginListing: PluginListing = {
       remote_info: { version: '1.2.0' },
       errored_detail: null,
       loaded_version: '1.2.0',
-      update_datetime: '2025-11-01T00:00:00',
+      update_datetime: '2025-11-01T00:00:00+00:00',
     },
 
     // Available plugins (not installed)

--- a/frontend/mocks/handlers/fable.handlers.ts
+++ b/frontend/mocks/handlers/fable.handlers.ts
@@ -179,7 +179,10 @@ export const fableHandlers = [
       }
     }
 
-    const now = new Date().toISOString()
+    const now = new Date()
+      .toISOString()
+      .replace('T', ' ')
+      .replace(/\.\d{3}Z$/, '+00:00')
 
     if (parent_id) {
       const existing = savedFablesState[parent_id]
@@ -427,7 +430,10 @@ export const fableHandlers = [
     }
 
     const existing = mockGlobalGlyphs.find((g) => g.key === body.key)
-    const now = new Date().toISOString()
+    const now = new Date()
+      .toISOString()
+      .replace('T', ' ')
+      .replace(/\.\d{3}Z$/, '+00:00')
     if (existing) {
       existing.value = body.value
       existing.public = isPublic

--- a/frontend/mocks/handlers/plugins.handlers.ts
+++ b/frontend/mocks/handlers/plugins.handlers.ts
@@ -78,12 +78,10 @@ function createPluginKey(store: string, local: string): string {
 }
 
 /**
- * Get current datetime in backend format
+ * Get current datetime in backend format: "YYYY-MM-DDTHH:MM:SS+00:00"
  */
 function getCurrentDatetime(): string {
-  const now = new Date()
-  const pad = (n: number) => String(n).padStart(2, '0')
-  return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`
+  return new Date().toISOString().replace(/\.\d{3}Z$/, '+00:00')
 }
 
 export const pluginsHandlers = [

--- a/frontend/mocks/handlers/schedule.handlers.ts
+++ b/frontend/mocks/handlers/schedule.handlers.ts
@@ -47,7 +47,9 @@ export const scheduleHandlers = [
   }),
 
   http.get(API_ENDPOINTS.schedule.currentTime, () => {
-    return HttpResponse.json(new Date().toISOString().slice(0, -1))
+    return HttpResponse.json(
+      new Date().toISOString().replace(/\.\d{3}Z$/, '+00:00'),
+    )
   }),
 
   // Mutation endpoints
@@ -66,7 +68,10 @@ export const scheduleHandlers = [
       cron_expr: '0 6 * * *',
       max_acceptable_delay_hours: 24,
       enabled: true,
-      created_at: new Date().toISOString(),
+      created_at: new Date()
+        .toISOString()
+        .replace('T', ' ')
+        .replace(/\.\d{3}Z$/, '+00:00'),
       created_by: null,
       display_name: 'Updated Schedule',
       display_description: null,

--- a/frontend/src/api/hooks/useSchedules.ts
+++ b/frontend/src/api/hooks/useSchedules.ts
@@ -151,12 +151,11 @@ export function useDeleteSchedule() {
 }
 
 /**
- * Parse a naive datetime string from the backend.
+ * Parse a datetime string from the backend.
  *
- * The backend's current_scheduling_time() uses datetime.now() which returns
- * a naive datetime in the server's local timezone (no timezone suffix).
- * We parse it consistently with new Date() — the offset calculation and
- * conversion both use the same parsing, so any timezone difference cancels out.
+ * The backend returns UTC datetimes with an explicit "+00:00" offset
+ * (e.g. "2024-01-15T10:30:45+00:00"). We parse consistently with new Date()
+ * so the offset calculation and conversion use the same parsing.
  */
 function parseServerTime(dateStr: string): number {
   return new Date(dateStr.trim()).getTime()
@@ -165,8 +164,8 @@ function parseServerTime(dateStr: string): number {
 /**
  * Fetches the scheduler's current time and computes the offset from the client clock.
  *
- * The offset lets us translate naive datetime strings returned by the server
- * (which are in the server's local timezone) into correct client-local Dates.
+ * The offset lets us translate UTC datetime strings returned by the server
+ * into correct client-local Dates.
  *
  * Formula: correctEpoch = new Date(serverTimeStr).getTime() - offsetMs
  */

--- a/frontend/src/features/dashboard/components/RunActivityPopover.tsx
+++ b/frontend/src/features/dashboard/components/RunActivityPopover.tsx
@@ -58,7 +58,7 @@ export function RunActivityPopover({
     const byKey = new Map(buckets.map((bucket) => [bucket.key, bucket]))
     let total = 0
     for (const run of runs) {
-      // created_at is naive server-local — correct it before bucketing.
+      // created_at is UTC with explicit offset — convert before bucketing.
       const date = serverTimeToLocal(run.created_at)
       const bucket = byKey.get(`${date.getFullYear()}-${date.getMonth()}`)
       if (bucket) {

--- a/frontend/src/features/dashboard/components/WelcomeCard.tsx
+++ b/frontend/src/features/dashboard/components/WelcomeCard.tsx
@@ -58,7 +58,7 @@ function getUserDisplayName(email?: string): string | null {
 /**
  * Month-over-month change in forecast count; null when last month had none.
  *
- * `created_at` is naive server-local — `toLocalDate` corrects it before bucketing.
+ * `created_at` is UTC with explicit offset — `toLocalDate` converts before bucketing.
  */
 function forecastTrend(
   runs: ReadonlyArray<{ created_at: string }>,

--- a/frontend/src/features/executions/components/RunStatusHeader.tsx
+++ b/frontend/src/features/executions/components/RunStatusHeader.tsx
@@ -80,8 +80,7 @@ function formatElapsed(ms: number): string {
 }
 
 function useElapsedTime(createdAt: string | null, isTerminal: boolean) {
-  // createdAt is naive server-local — `new Date(naive)` skews by the
-  // local TZ offset; route through the measured server/client offset.
+  // createdAt is UTC with explicit offset — route through the measured
   const { serverTimeToLocal } = useServerTime()
   const [elapsed, setElapsed] = useState<number | null>(null)
 

--- a/frontend/src/features/journal/components/ForecastRunRow.tsx
+++ b/frontend/src/features/journal/components/ForecastRunRow.tsx
@@ -53,7 +53,7 @@ export const ForecastRunRow = memo(function ({
   const [metadataOpen, setMetadataOpen] = useState(false)
 
   const title = run.displayName || t('item.untitled')
-  // created_at is naive server-local — correct it via the measured server-clock offset.
+  // created_at is UTC with explicit offset — convert via the measured server-clock offset.
   const startedInstant = serverTimeToLocal(run.createdAt)
   const startedAt =
     formatInZone(startedInstant, timeZone, 'yyyy-MM-dd HH:mm') +

--- a/frontend/tests/unit/api/endpoints/plugins.test.ts
+++ b/frontend/tests/unit/api/endpoints/plugins.test.ts
@@ -99,7 +99,7 @@ describe('getPluginDetails', () => {
           remote_info: { version: '1.0.0' },
           errored_detail: null,
           loaded_version: '1.0.0',
-          update_datetime: '2025-01-15T00:00:00',
+          update_datetime: '2025-01-15T00:00:00+00:00',
         },
         [createPluginKey('ecmwf', 'storm-tracker')]: {
           status: 'available',


### PR DESCRIPTION
Complete migration of all datetimes to UTC, including:
1/ descriptive routes (plugin update datetime, current scheduling time, glyph example value)
2/ glyph resolution (start_time)
3/ database entries for created_at, updated_at
4/ unified supported formats in jinja parsing and in datetime type parsing for fable configuration blocks -- they now all support the same 4 options. Two of them are *not* tz aware, so we will probably drop them? 

Unexpected were the lack of sqlite-sqlalchemy support for timezones, and formatting differences between 3.11 and 3.12+ python versions

Includes frontend update:
1/ updates stale comments about frontend being tz-naive to frontend being tz-aware, even though code itself apparently needed no change
2/ updates the mocks to match what the backend is now returning
cc @liefra , as always, feel free to update


