### PR TITLE
Refac/block validation

### DIFF
--- a/backend/packages/fiab-core/src/fiab_core/plugin.py
+++ b/backend/packages/fiab-core/src/fiab_core/plugin.py
@@ -34,17 +34,6 @@ class BlockValidation:
     result: Either[BlockInstanceOutput, Error]  # type:ignore[invalid-argument] # semigroup
     restrictions: ConfigurationOptionRestriction = field(default_factory=dict)
 
-    def get_or_raise(self) -> BlockInstanceOutput:
-        return self.result.get_or_raise()
-
-    @property
-    def t(self) -> BlockInstanceOutput | None:
-        return self.result.t
-
-    @property
-    def e(self) -> Error | None:
-        return self.result.e
-
 
 Validator = Callable[[BlockInstance, dict[str, BlockInstanceOutput]], BlockValidation]
 """Given a block instance and its inputs, return either error or output and configuration restrictions"""

--- a/backend/packages/fiab-core/src/fiab_core/plugin.py
+++ b/backend/packages/fiab-core/src/fiab_core/plugin.py
@@ -11,8 +11,8 @@
 Types pertaining to declaring FIAB Plugins, in particular their Fable-based interface.
 """
 
-from dataclasses import dataclass, field
-from typing import Callable
+from dataclasses import dataclass, field, replace
+from typing import Callable, Self
 
 from cascade.low.func import Either
 from earthkit.workflows.fluent import Action
@@ -34,10 +34,19 @@ class BlockValidationError:
     reason: str
     is_hard: bool
 
+    def __add__(self, other: Self) -> Self:
+        if not isinstance(other, BlockValidationError):
+            raise TypeError(other.__class__.__name__)
+        return replace(
+            self,
+            reason=self.reason + other.reason,
+            is_hard=self.is_hard or other.is_hard,
+        )
+
 
 @dataclass(frozen=True, eq=True, slots=True)
 class BlockValidation:
-    result: Either[BlockInstanceOutput, BlockValidationError]  # type:ignore[invalid-argument] # semigroup
+    result: Either[BlockInstanceOutput, BlockValidationError]
     restrictions: ConfigurationOptionRestriction = field(default_factory=dict)
 
 

--- a/backend/packages/fiab-core/src/fiab_core/plugin.py
+++ b/backend/packages/fiab-core/src/fiab_core/plugin.py
@@ -30,8 +30,14 @@ Error = str
 
 
 @dataclass(frozen=True, eq=True, slots=True)
+class BlockValidationError:
+    reason: str
+    is_hard: bool
+
+
+@dataclass(frozen=True, eq=True, slots=True)
 class BlockValidation:
-    result: Either[BlockInstanceOutput, Error]  # type:ignore[invalid-argument] # semigroup
+    result: Either[BlockInstanceOutput, BlockValidationError]  # type:ignore[invalid-argument] # semigroup
     restrictions: ConfigurationOptionRestriction = field(default_factory=dict)
 
 

--- a/backend/packages/fiab-core/src/fiab_core/tools/blocks.py
+++ b/backend/packages/fiab-core/src/fiab_core/tools/blocks.py
@@ -24,9 +24,10 @@ from fiab_core.fable import (
     BlockInstanceOutput,
     BlockKind,
     ConfigurationOptionId,
+    ConfigurationOptionRestriction,
     QubedOutput,
 )
-from fiab_core.plugin import BlockValidation, Error
+from fiab_core.plugin import Error
 from fiab_core.types import ClosedEnumType, DatetimeType, DateType, FloatType, IntType, ListType, OpenEnumType, StringType
 
 
@@ -172,7 +173,9 @@ class QubedBlockBuilder(abc.ABC):
     configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption]
     inputs: list[str]
 
-    def validate(self, block: BlockInstanceRich, inputs: dict[str, QubedOutput]) -> BlockValidation:
+    def validate(
+        self, block: BlockInstanceRich, inputs: dict[str, QubedOutput], restrictions: ConfigurationOptionRestriction
+    ) -> BlockInstanceOutput:
         raise NotImplementedError
 
     def compile(

--- a/backend/packages/fiab-core/src/fiab_core/tools/plugins.py
+++ b/backend/packages/fiab-core/src/fiab_core/tools/plugins.py
@@ -15,7 +15,7 @@ from fiab_core.fable import (
     BlockInstanceOutput,
     QubedOutput,
 )
-from fiab_core.plugin import BlockValidation, Error, Plugin
+from fiab_core.plugin import BlockValidation, BlockValidationError, Error, Plugin
 from fiab_core.tools.blocks import BlockInstanceConfigurationError, BlockInstanceRich, QubedBlockBuilder
 
 
@@ -58,7 +58,7 @@ class QubedPluginBuilder:
         try:
             return factory.validate(rich_block, inputs)
         except BlockInstanceConfigurationError as exc:
-            return BlockValidation(Either.error(str(exc)))
+            return BlockValidation(Either.error(BlockValidationError(reason=str(exc), is_hard=True)))
 
     def expand(self, output: QubedOutput) -> list[BlockExpansion]:
         """Given a block instance output (including from other plugin), provide which block factories from this plugin can expand it"""
@@ -92,7 +92,11 @@ class QubedPluginBuilder:
         def _generic_validate(block: BlockInstance, inputs: dict[str, BlockInstanceOutput]) -> BlockValidation:
             invalid = [f"{key}->{value.__class__.__name__}" for key, value in inputs.items() if not isinstance(value, QubedOutput)]
             if any(invalid):
-                return BlockValidation(Either.error(f"Expected only QubedOutputs in inputs, gotten {','.join(invalid)}"))
+                return BlockValidation(
+                    Either.error(
+                        BlockValidationError(reason=f"Expected only QubedOutputs in inputs, gotten {','.join(invalid)}", is_hard=True)
+                    )
+                )
             else:
                 inputs_validated = cast(dict[str, QubedOutput], inputs)
                 return self.validate(block, inputs_validated)

--- a/backend/packages/fiab-core/src/fiab_core/tools/plugins.py
+++ b/backend/packages/fiab-core/src/fiab_core/tools/plugins.py
@@ -13,6 +13,7 @@ from fiab_core.fable import (
     BlockFactoryId,
     BlockInstance,
     BlockInstanceOutput,
+    ConfigurationOptionRestriction,
     QubedOutput,
 )
 from fiab_core.plugin import BlockValidation, BlockValidationError, Error, Plugin
@@ -55,10 +56,12 @@ class QubedPluginBuilder:
         """Given a block instance and its inputs, return either error or output and configuration restrictions."""
         factory = self.block_builders[block.factory_id.factory]
         rich_block = BlockInstanceRich.from_block(block, factory.configuration_options)
+        restrictions: ConfigurationOptionRestriction = {}
         try:
-            return factory.validate(rich_block, inputs)
-        except BlockInstanceConfigurationError as exc:
-            return BlockValidation(Either.error(BlockValidationError(reason=str(exc), is_hard=True)))
+            result = factory.validate(rich_block, inputs, restrictions)
+            return BlockValidation(Either.ok(result), restrictions)
+        except Exception as exc:
+            return BlockValidation(Either.error(BlockValidationError(repr(exc), True)), restrictions)
 
     def expand(self, output: QubedOutput) -> list[BlockExpansion]:
         """Given a block instance output (including from other plugin), provide which block factories from this plugin can expand it"""

--- a/backend/packages/fiab-plugin-demo/src/fiab_plugin_demo/blocks.py
+++ b/backend/packages/fiab-plugin-demo/src/fiab_plugin_demo/blocks.py
@@ -15,10 +15,11 @@ from fiab_core.fable import (
     BlockInstance,
     BlockInstanceOutput,
     ConfigurationOptionId,
+    ConfigurationOptionRestriction,
     NoOutput,
     QubedOutput,
 )
-from fiab_core.plugin import BlockValidation, BlockValidationError, Error
+from fiab_core.plugin import Error
 from fiab_core.tools.blocks import Product, Sink, Transform
 
 DIR = ConfigurationOptionId("dir")
@@ -29,11 +30,13 @@ class _DemoTransform(Transform):
     configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {}
     inputs: list[str] = ["dataset"]
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
+    def validate(
+        self, block: BlockInstance, inputs: dict[str, QubedOutput], restrictions: ConfigurationOptionRestriction
+    ) -> BlockInstanceOutput:
         dataset = inputs.get("dataset")
         if dataset is None:
-            return BlockValidation(Either.error(BlockValidationError(reason="Missing input 'dataset'", is_hard=True)))
-        return BlockValidation(Either.ok(dataset))
+            raise ValueError("Missing input 'dataset'")
+        return dataset
 
     def compile(
         self,
@@ -50,11 +53,13 @@ class _DemoProduct(Product):
     configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {}
     inputs: list[str] = ["dataset"]
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
+    def validate(
+        self, block: BlockInstance, inputs: dict[str, QubedOutput], restrictions: ConfigurationOptionRestriction
+    ) -> BlockInstanceOutput:
         dataset = inputs.get("dataset")
         if dataset is None:
-            return BlockValidation(Either.error(BlockValidationError(reason="Missing input 'dataset'", is_hard=True)))
-        return BlockValidation(Either.ok(dataset))
+            raise ValueError("Missing input 'dataset'")
+        return dataset
 
     def compile(
         self,
@@ -71,10 +76,12 @@ class _DemoSink(Sink):
     configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {}
     inputs: list[str] = ["dataset"]
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
+    def validate(
+        self, block: BlockInstance, inputs: dict[str, QubedOutput], restrictions: ConfigurationOptionRestriction
+    ) -> BlockInstanceOutput:
         if "dataset" not in inputs:
-            return BlockValidation(Either.error(BlockValidationError(reason="Missing input 'dataset'", is_hard=True)))
-        return BlockValidation(Either.ok(NoOutput()))
+            raise ValueError("Missing input 'dataset'")
+        return NoOutput()
 
     def compile(
         self,

--- a/backend/packages/fiab-plugin-demo/src/fiab_plugin_demo/blocks.py
+++ b/backend/packages/fiab-plugin-demo/src/fiab_plugin_demo/blocks.py
@@ -18,7 +18,7 @@ from fiab_core.fable import (
     NoOutput,
     QubedOutput,
 )
-from fiab_core.plugin import BlockValidation, Error
+from fiab_core.plugin import BlockValidation, BlockValidationError, Error
 from fiab_core.tools.blocks import Product, Sink, Transform
 
 DIR = ConfigurationOptionId("dir")
@@ -32,7 +32,7 @@ class _DemoTransform(Transform):
     def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
         dataset = inputs.get("dataset")
         if dataset is None:
-            return BlockValidation(Either.error("Missing input 'dataset'"))
+            return BlockValidation(Either.error(BlockValidationError(reason="Missing input 'dataset'", is_hard=True)))
         return BlockValidation(Either.ok(dataset))
 
     def compile(
@@ -53,7 +53,7 @@ class _DemoProduct(Product):
     def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
         dataset = inputs.get("dataset")
         if dataset is None:
-            return BlockValidation(Either.error("Missing input 'dataset'"))
+            return BlockValidation(Either.error(BlockValidationError(reason="Missing input 'dataset'", is_hard=True)))
         return BlockValidation(Either.ok(dataset))
 
     def compile(
@@ -73,7 +73,7 @@ class _DemoSink(Sink):
 
     def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
         if "dataset" not in inputs:
-            return BlockValidation(Either.error("Missing input 'dataset'"))
+            return BlockValidation(Either.error(BlockValidationError(reason="Missing input 'dataset'", is_hard=True)))
         return BlockValidation(Either.ok(NoOutput()))
 
     def compile(

--- a/backend/packages/fiab-plugin-demo/tests/test_blocks.py
+++ b/backend/packages/fiab-plugin-demo/tests/test_blocks.py
@@ -80,7 +80,7 @@ def test_demo_blocks_pass_through_dataset(
     dummy_output: QubedOutput,
 ) -> None:
     block = _rich_block(factory_id, builder)
-    validated = builder.validate(block=block, inputs={"dataset": dummy_output}).result.get_or_raise()
+    validated = builder.validate(block=block, inputs={"dataset": dummy_output}, restrictions={})
     assert validated is dummy_output
 
 
@@ -93,7 +93,7 @@ def test_demo_blocks_pass_through_dataset(
 )
 def test_demo_sinks_return_no_output(factory_id: BlockFactoryId, builder: QubedBlockBuilder, dummy_output: QubedOutput) -> None:
     block = _rich_block(factory_id, builder)
-    validated = builder.validate(block=block, inputs={"dataset": dummy_output}).result.get_or_raise()
+    validated = builder.validate(block=block, inputs={"dataset": dummy_output}, restrictions={})
     assert isinstance(validated, NoOutput)
 
 
@@ -113,6 +113,5 @@ def test_demo_sinks_return_no_output(factory_id: BlockFactoryId, builder: QubedB
 )
 def test_demo_blocks_require_dataset(factory_id: BlockFactoryId, builder: QubedBlockBuilder) -> None:
     block = _rich_block(factory_id, builder)
-    result = builder.validate(block=block, inputs={})
     with pytest.raises(Exception, match="Missing input 'dataset'"):
-        result.result.get_or_raise()
+        builder.validate(block=block, inputs={}, restrictions={})

--- a/backend/packages/fiab-plugin-demo/tests/test_blocks.py
+++ b/backend/packages/fiab-plugin-demo/tests/test_blocks.py
@@ -80,7 +80,7 @@ def test_demo_blocks_pass_through_dataset(
     dummy_output: QubedOutput,
 ) -> None:
     block = _rich_block(factory_id, builder)
-    validated = builder.validate(block=block, inputs={"dataset": dummy_output}).get_or_raise()
+    validated = builder.validate(block=block, inputs={"dataset": dummy_output}).result.get_or_raise()
     assert validated is dummy_output
 
 
@@ -93,7 +93,7 @@ def test_demo_blocks_pass_through_dataset(
 )
 def test_demo_sinks_return_no_output(factory_id: BlockFactoryId, builder: QubedBlockBuilder, dummy_output: QubedOutput) -> None:
     block = _rich_block(factory_id, builder)
-    validated = builder.validate(block=block, inputs={"dataset": dummy_output}).get_or_raise()
+    validated = builder.validate(block=block, inputs={"dataset": dummy_output}).result.get_or_raise()
     assert isinstance(validated, NoOutput)
 
 
@@ -115,4 +115,4 @@ def test_demo_blocks_require_dataset(factory_id: BlockFactoryId, builder: QubedB
     block = _rich_block(factory_id, builder)
     result = builder.validate(block=block, inputs={})
     with pytest.raises(Exception, match="Missing input 'dataset'"):
-        result.get_or_raise()
+        result.result.get_or_raise()

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
@@ -18,10 +18,12 @@ from earthkit.workflows.plugins.anemoi.types import DATE
 from fiab_core.fable import (
     ActionLookup,
     BlockConfigurationOption,
+    BlockInstanceOutput,
     ConfigurationOptionId,
+    ConfigurationOptionRestriction,
     QubedOutput,
 )
-from fiab_core.plugin import BlockValidation, BlockValidationError, Error
+from fiab_core.plugin import Error
 from fiab_core.tools.blocks import BlockInstanceRich as BlockInstance
 from fiab_core.tools.blocks import Source, Transform
 from fiab_core.tools.validators import positive
@@ -138,24 +140,21 @@ class AnemoiSource(Source):
         ),
     }
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
+    def validate(
+        self, block: BlockInstance, inputs: dict[str, QubedOutput], restrictions: ConfigurationOptionRestriction
+    ) -> BlockInstanceOutput:
         ensemble_members = block.config_as_int(ENSEMBLE, validator=positive)
         checkpoint = CheckpointArtifact(block.config_as_str(CHECKPOINT))
         lead_time = block.config_as_int(LEAD_TIME, validator=positive)
-        if ensemble_members < 1:
-            return BlockValidation(
-                Either.error(BlockValidationError(reason="Ensemble members must be an int, positive and non zero.", is_hard=True))
-            )
 
         validation_error = checkpoint.validate_lead_time(lead_time)
         if validation_error is not None:
-            return BlockValidation(Either.error(BlockValidationError(reason=validation_error, is_hard=True)))
+            raise ValueError(validation_error)
 
         qubed_output = checkpoint.combine_if_nested_qube(checkpoint.get_model_output(lead_time))
         if ensemble_members > 1:
             qubed_output = expand(qubed_output, {"number": range(1, ensemble_members + 1)})
-        qubed_output = QubedOutput(dataqube=qubed_output)
-        return BlockValidation(Either.ok(qubed_output))
+        return QubedOutput(dataqube=qubed_output)
 
     def compile(  # type:ignore[invalid-argument] # semigroup
         self,
@@ -205,17 +204,14 @@ class AnemoiInputSource(Source):
         ),
     }
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
+    def validate(
+        self, block: BlockInstance, inputs: dict[str, QubedOutput], restrictions: ConfigurationOptionRestriction
+    ) -> BlockInstanceOutput:
         checkpoint = CheckpointArtifact(block.config_as_str(CHECKPOINT))
         number = block.config_as_int(ENSEMBLE, validator=positive)
-        if number < 1:
-            return BlockValidation(
-                Either.error(BlockValidationError(reason="Ensemble members must be an int, positive and non zero.", is_hard=True))
-            )
         model_input = checkpoint.combine_if_nested_qube(checkpoint.get_model_input())
         model_input = expand(model_input, {ENSEMBLE: [number]})
-
-        return BlockValidation(Either.ok(QubedOutput(dataqube=model_input)))
+        return QubedOutput(dataqube=model_input)
 
     def compile(  # type:ignore[invalid-argument] # semigroup
         self,
@@ -252,31 +248,25 @@ class AnemoiTransform(Transform):
         ),
     }
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
+    def validate(
+        self, block: BlockInstance, inputs: dict[str, QubedOutput], restrictions: ConfigurationOptionRestriction
+    ) -> BlockInstanceOutput:
         checkpoint = CheckpointArtifact(block.config_as_str(CHECKPOINT))
         lead_time = block.config_as_int(LEAD_TIME, validator=positive)
         qubed_input = checkpoint.combine_if_nested_qube(checkpoint.get_model_input())
         if not contains(inputs["dataset"], qubed_input):
             difference_qube = qubed_input ^ inputs["dataset"].dataqube
-            return BlockValidation(
-                Either.error(
-                    BlockValidationError(
-                        reason=f"Input dataset is not compatible with the model checkpoint. Difference in qubes: {difference_qube}",
-                        is_hard=True,
-                    )
-                )
-            )
+            raise ValueError(f"Input dataset is not compatible with the model checkpoint. Difference in qubes: {difference_qube}")
 
         validation_error = checkpoint.validate_lead_time(lead_time)
         if validation_error is not None:
-            return BlockValidation(Either.error(BlockValidationError(reason=validation_error, is_hard=True)))
+            raise ValueError(validation_error)
 
         qubed_output = checkpoint.combine_if_nested_qube(checkpoint.get_model_output(lead_time=lead_time))
-
         input_dataset = inputs["dataset"]
         if contains(input_dataset, ENSEMBLE):
             qubed_output = expand(qubed_output, {ENSEMBLE: axes(input_dataset)[ENSEMBLE]})
-        return BlockValidation(Either.ok(QubedOutput(dataqube=qubed_output)))
+        return QubedOutput(dataqube=qubed_output)
 
     def compile(  # type:ignore[invalid-argument] # semigroup
         self,

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
@@ -21,7 +21,7 @@ from fiab_core.fable import (
     ConfigurationOptionId,
     QubedOutput,
 )
-from fiab_core.plugin import BlockValidation, Error
+from fiab_core.plugin import BlockValidation, BlockValidationError, Error
 from fiab_core.tools.blocks import BlockInstanceRich as BlockInstance
 from fiab_core.tools.blocks import Source, Transform
 from fiab_core.tools.validators import positive
@@ -143,11 +143,13 @@ class AnemoiSource(Source):
         checkpoint = CheckpointArtifact(block.config_as_str(CHECKPOINT))
         lead_time = block.config_as_int(LEAD_TIME, validator=positive)
         if ensemble_members < 1:
-            return BlockValidation(Either.error("Ensemble members must be an int, positive and non zero."))
+            return BlockValidation(
+                Either.error(BlockValidationError(reason="Ensemble members must be an int, positive and non zero.", is_hard=True))
+            )
 
         validation_error = checkpoint.validate_lead_time(lead_time)
         if validation_error is not None:
-            return BlockValidation(Either.error(validation_error))
+            return BlockValidation(Either.error(BlockValidationError(reason=validation_error, is_hard=True)))
 
         qubed_output = checkpoint.combine_if_nested_qube(checkpoint.get_model_output(lead_time))
         if ensemble_members > 1:
@@ -207,7 +209,9 @@ class AnemoiInputSource(Source):
         checkpoint = CheckpointArtifact(block.config_as_str(CHECKPOINT))
         number = block.config_as_int(ENSEMBLE, validator=positive)
         if number < 1:
-            return BlockValidation(Either.error("Ensemble members must be an int, positive and non zero."))
+            return BlockValidation(
+                Either.error(BlockValidationError(reason="Ensemble members must be an int, positive and non zero.", is_hard=True))
+            )
         model_input = checkpoint.combine_if_nested_qube(checkpoint.get_model_input())
         model_input = expand(model_input, {ENSEMBLE: [number]})
 
@@ -255,12 +259,17 @@ class AnemoiTransform(Transform):
         if not contains(inputs["dataset"], qubed_input):
             difference_qube = qubed_input ^ inputs["dataset"].dataqube
             return BlockValidation(
-                Either.error(f"Input dataset is not compatible with the model checkpoint. Difference in qubes: {difference_qube}")
+                Either.error(
+                    BlockValidationError(
+                        reason=f"Input dataset is not compatible with the model checkpoint. Difference in qubes: {difference_qube}",
+                        is_hard=True,
+                    )
+                )
             )
 
         validation_error = checkpoint.validate_lead_time(lead_time)
         if validation_error is not None:
-            return BlockValidation(Either.error(validation_error))
+            return BlockValidation(Either.error(BlockValidationError(reason=validation_error, is_hard=True)))
 
         qubed_output = checkpoint.combine_if_nested_qube(checkpoint.get_model_output(lead_time=lead_time))
 

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -25,7 +25,7 @@ from fiab_core.fable import (
     QubedOutput,
     RawOutput,
 )
-from fiab_core.plugin import BlockValidation, BlockValidationError, Error
+from fiab_core.plugin import Error
 from fiab_core.tools.blocks import BlockInstanceConfigurationError, Product, Sink, Source, Transform
 from fiab_core.tools.blocks import BlockInstanceRich as BlockInstance
 from fiab_core.types import ClosedEnumType, ListType
@@ -133,18 +133,18 @@ class OperationalForecastSource(Source):
     def _convert_time(cls, time: int) -> str:
         return f"{time:02d}00"
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
+    def validate(
+        self, block: BlockInstance, inputs: dict[str, QubedOutput], restrictions: ConfigurationOptionRestriction
+    ) -> BlockInstanceOutput:
         forecast = block.config_as_str(FORECAST)
         basetime = block.config_as_datetime(BASETIME)
         time = self._convert_time(basetime.time().hour)
 
         ifs_qoutput = QubedOutput(dataqube=FORECAST_DATASETS[forecast].as_qube(ens_dim=ENSEMBLE, include_member_zero=True))
         if not contains(ifs_qoutput, {"time": time}):
-            return BlockValidation(
-                Either.error(BlockValidationError(reason=f"Invalid time: must be in {axes(ifs_qoutput)['time']}", is_hard=True))
-            )
+            raise ValueError(f"Invalid time: must be in {axes(ifs_qoutput)['time']}")
 
-        return BlockValidation(Either.ok(select(ifs_qoutput, {"time": time})))
+        return select(ifs_qoutput, {"time": time})
 
     def compile(
         self,
@@ -218,21 +218,17 @@ class EnsembleStatistics(Product):
     }
     inputs: list[str] = ["dataset"]
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
+    def validate(
+        self, block: BlockInstance, inputs: dict[str, QubedOutput], restrictions: ConfigurationOptionRestriction
+    ) -> BlockInstanceOutput:
         input_dataset = _extract_dataset(inputs, "dataset")
 
         param = block.config_as_str(PARAM)
         if not contains(input_dataset, {PARAM: param}):
-            return BlockValidation(
-                Either.error(
-                    BlockValidationError(
-                        reason=f"param {param} is not in the input parameters: {axes(input_dataset).get(PARAM, [])}", is_hard=True
-                    )
-                )
-            )
+            raise ValueError(f"param {param} is not in the input parameters: {axes(input_dataset).get(PARAM, [])}")
 
         output = coxpand(input_dataset, [PARAM, ENSEMBLE], {PARAM: [param]})
-        return BlockValidation(Either.ok(output))
+        return output
 
     def compile(
         self,
@@ -268,20 +264,16 @@ class TemporalStatistics(Product):
     }
     inputs: list[str] = ["dataset"]
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
+    def validate(
+        self, block: BlockInstance, inputs: dict[str, QubedOutput], restrictions: ConfigurationOptionRestriction
+    ) -> BlockInstanceOutput:
         input_dataset = _extract_dataset(inputs, "dataset")
 
         param = block.config_as_str(PARAM)
         if not contains(input_dataset, {PARAM: param}):
-            return BlockValidation(
-                Either.error(
-                    BlockValidationError(
-                        reason=f"param {param} is not in the input parameters: {axes(input_dataset).get(PARAM, [])}", is_hard=True
-                    )
-                )
-            )
+            raise ValueError(f"param {param} is not in the input parameters: {axes(input_dataset).get(PARAM, [])}")
         output = coxpand(input_dataset, [PARAM, STEP], {PARAM: [param]})
-        return BlockValidation(Either.ok(output))
+        return output
 
     def compile(
         self,
@@ -320,9 +312,11 @@ class ZarrSink(Sink):
     }
     inputs: list[str] = ["dataset"]
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
+    def validate(
+        self, block: BlockInstance, inputs: dict[str, QubedOutput], restrictions: ConfigurationOptionRestriction
+    ) -> BlockInstanceOutput:
         _extract_dataset(inputs, "dataset")
-        return BlockValidation(Either.ok(RawOutput(type_fqn="bytes", mime_type="text/plain")))
+        return RawOutput(type_fqn="bytes", mime_type="text/plain")
 
     def compile(
         self,
@@ -377,60 +371,37 @@ class Select(Transform):
     def _selected_values(self, block: BlockInstance) -> list[str]:
         return block.config_as_list(VALUES, str, allow_empty=False)
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
+    def validate(
+        self, block: BlockInstance, inputs: dict[str, QubedOutput], restrictions: ConfigurationOptionRestriction
+    ) -> BlockInstanceOutput:
         input_dataset = _extract_dataset(inputs, "dataset")
-
-        restrict: ConfigurationOptionRestriction = {}
 
         input_dimensions = sorted(dimensions(input_dataset))
         if input_dimensions:
-            restrict[DIMENSION] = ClosedEnumType(input_dimensions)
+            restrictions[DIMENSION] = ClosedEnumType(input_dimensions)
 
-        try:
-            dimension = self._selected_dimension(block)
-        except BlockInstanceConfigurationError as exc:
-            return BlockValidation(Either.error(BlockValidationError(reason=str(exc), is_hard=True)), restrict)
+        dimension = self._selected_dimension(block)
 
         input_axes = axes(input_dataset)
         axis_values = input_axes.get(dimension)
         if axis_values is None:
-            return BlockValidation(
-                Either.error(
-                    BlockValidationError(reason=f"dimension {dimension} is not in the input dimensions: {input_dimensions}", is_hard=True)
-                ),
-                restrict,
-            )
+            raise ValueError(f"dimension {dimension} is not in the input dimensions: {input_dimensions}")
 
         input_values = _axis_value_strings(axis_values)
         if input_values:
-            restrict[VALUES] = ListType(ClosedEnumType(input_values))
+            restrictions[VALUES] = ListType(ClosedEnumType(input_values))
 
-        try:
-            selected_values = [_parse_axis_value(value) for value in self._selected_values(block)]
-        except BlockInstanceConfigurationError as exc:
-            return BlockValidation(Either.error(BlockValidationError(reason=str(exc), is_hard=True)), restrict)
+        selected_values = [_parse_axis_value(value) for value in self._selected_values(block)]
 
         missing_values = [value for value in selected_values if value not in axis_values]
         if missing_values:
-            return BlockValidation(
-                Either.error(
-                    BlockValidationError(reason=f"values {missing_values} are not in dimension {dimension}: {input_values}", is_hard=True)
-                ),
-                restrict,
-            )
+            raise ValueError(f"values {missing_values} are not in dimension {dimension}: {input_values}")
 
         output = select(input_dataset, {dimension: selected_values})
         if output.dataqube is None or _is_empty_qube(output.dataqube):
-            return BlockValidation(
-                Either.error(
-                    BlockValidationError(
-                        reason=f"selection of values {selected_values} from dimension {dimension} produced an empty dataset", is_hard=True
-                    )
-                ),
-                restrict,
-            )
+            raise ValueError(f"selection of values {selected_values} from dimension {dimension} produced an empty dataset")
 
-        return BlockValidation(Either.ok(output), restrict)
+        return output
 
     def compile(
         self,
@@ -462,15 +433,15 @@ class GribSink(Sink):
     def _find_template_values(cls, path: str) -> list[str]:
         return re.findall(r"\[(.*?)\]", path)
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
+    def validate(
+        self, block: BlockInstance, inputs: dict[str, QubedOutput], restrictions: ConfigurationOptionRestriction
+    ) -> BlockInstanceOutput:
         _extract_dataset(inputs, "dataset")  # check format of input and existence of dataset
         path = block.config_as_str(PATH)
         dirname = os.path.dirname(path)
         if len(self._find_template_values(dirname)) != 0:
-            return BlockValidation(
-                Either.error(BlockValidationError(reason=f"Invalid filepath: directory path can not contain template values", is_hard=True))
-            )
-        return BlockValidation(Either.ok(RawOutput(type_fqn="bytes", mime_type=GRIB_MIME)))
+            raise ValueError("Invalid filepath: directory path can not contain template values")
+        return RawOutput(type_fqn="bytes", mime_type=GRIB_MIME)
 
     def compile(
         self,
@@ -548,54 +519,36 @@ class MapPlotSink(Sink):
     }
     inputs: list[str] = ["dataset"]
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
+    def validate(
+        self, block: BlockInstance, inputs: dict[str, QubedOutput], restrictions: ConfigurationOptionRestriction
+    ) -> BlockInstanceOutput:
         input_dataset = _extract_dataset(inputs, "dataset")
-
-        restrict: ConfigurationOptionRestriction = {}
 
         input_axes = axes(input_dataset)
         input_param_values = input_axes.get(PARAM, set())
         param_values = [value for value in input_param_values if isinstance(value, str)]
         if param_values:
-            restrict[PARAM] = ListType(ClosedEnumType(sorted(param_values)))
+            restrictions[PARAM] = ListType(ClosedEnumType(sorted(param_values)))
 
         common = common_dimensions(input_dataset).intersection({PARAM, STEP, ENSEMBLE, LEVEL})
         splitby = [x for x in common if len(input_axes[x]) > 1]
-        restrict[SPLITBY] = ListType(ClosedEnumType(sorted(splitby) + ["none"]))
+        restrictions[SPLITBY] = ListType(ClosedEnumType(sorted(splitby) + ["none"]))
 
-        try:
-            params = block.config_as_list(PARAM, str, allow_empty=False)
-            splitby_value = block.config_as_list(SPLITBY, str, allow_empty=True)
-            fmt = block.config_as_str(FORMAT)
-        except BlockInstanceConfigurationError as exc:
-            return BlockValidation(Either.error(BlockValidationError(reason=str(exc), is_hard=True)), restrict)
+        params = block.config_as_list(PARAM, str, allow_empty=False)
+        splitby_value = block.config_as_list(SPLITBY, str, allow_empty=True)
+        fmt = block.config_as_str(FORMAT)
 
         missing_params = [param for param in params if param not in input_param_values]
         if missing_params:
-            return BlockValidation(
-                Either.error(
-                    BlockValidationError(
-                        reason=f"params {missing_params} are not in the input parameters: {_axis_value_strings(input_param_values)}",
-                        is_hard=True,
-                    )
-                ),
-                restrict,
-            )
+            raise ValueError(f"params {missing_params} are not in the input parameters: {_axis_value_strings(input_param_values)}")
 
         if "none" in splitby_value and len(splitby_value) != 1:
-            return BlockValidation(
-                Either.error(
-                    BlockValidationError(
-                        reason=f"Invalid splitby value: if none is selected, no other dimensions can be present", is_hard=True
-                    )
-                ),
-                restrict,
-            )
+            raise ValueError("Invalid splitby value: if none is selected, no other dimensions can be present")
 
         mime_type = PLOT_FORMAT_TO_MIME.get(fmt)
         if mime_type is None:
-            return BlockValidation(Either.error(BlockValidationError(reason=f"Unsupported output format: {fmt}", is_hard=True)), restrict)
-        return BlockValidation(Either.ok(RawOutput(type_fqn="bytes", mime_type=mime_type)), restrict)
+            raise ValueError(f"Unsupported output format: {fmt}")
+        return RawOutput(type_fqn="bytes", mime_type=mime_type)
 
     def compile(
         self,

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -25,7 +25,7 @@ from fiab_core.fable import (
     QubedOutput,
     RawOutput,
 )
-from fiab_core.plugin import BlockValidation, Error
+from fiab_core.plugin import BlockValidation, BlockValidationError, Error
 from fiab_core.tools.blocks import BlockInstanceConfigurationError, Product, Sink, Source, Transform
 from fiab_core.tools.blocks import BlockInstanceRich as BlockInstance
 from fiab_core.types import ClosedEnumType, ListType
@@ -140,7 +140,9 @@ class OperationalForecastSource(Source):
 
         ifs_qoutput = QubedOutput(dataqube=FORECAST_DATASETS[forecast].as_qube(ens_dim=ENSEMBLE, include_member_zero=True))
         if not contains(ifs_qoutput, {"time": time}):
-            return BlockValidation(Either.error(f"Invalid time: must be in {axes(ifs_qoutput)['time']}"))
+            return BlockValidation(
+                Either.error(BlockValidationError(reason=f"Invalid time: must be in {axes(ifs_qoutput)['time']}", is_hard=True))
+            )
 
         return BlockValidation(Either.ok(select(ifs_qoutput, {"time": time})))
 
@@ -221,7 +223,13 @@ class EnsembleStatistics(Product):
 
         param = block.config_as_str(PARAM)
         if not contains(input_dataset, {PARAM: param}):
-            return BlockValidation(Either.error(f"param {param} is not in the input parameters: {axes(input_dataset).get(PARAM, [])}"))
+            return BlockValidation(
+                Either.error(
+                    BlockValidationError(
+                        reason=f"param {param} is not in the input parameters: {axes(input_dataset).get(PARAM, [])}", is_hard=True
+                    )
+                )
+            )
 
         output = coxpand(input_dataset, [PARAM, ENSEMBLE], {PARAM: [param]})
         return BlockValidation(Either.ok(output))
@@ -265,7 +273,13 @@ class TemporalStatistics(Product):
 
         param = block.config_as_str(PARAM)
         if not contains(input_dataset, {PARAM: param}):
-            return BlockValidation(Either.error(f"param {param} is not in the input parameters: {axes(input_dataset).get(PARAM, [])}"))
+            return BlockValidation(
+                Either.error(
+                    BlockValidationError(
+                        reason=f"param {param} is not in the input parameters: {axes(input_dataset).get(PARAM, [])}", is_hard=True
+                    )
+                )
+            )
         output = coxpand(input_dataset, [PARAM, STEP], {PARAM: [param]})
         return BlockValidation(Either.ok(output))
 
@@ -375,13 +389,15 @@ class Select(Transform):
         try:
             dimension = self._selected_dimension(block)
         except BlockInstanceConfigurationError as exc:
-            return BlockValidation(Either.error(str(exc)), restrict)
+            return BlockValidation(Either.error(BlockValidationError(reason=str(exc), is_hard=True)), restrict)
 
         input_axes = axes(input_dataset)
         axis_values = input_axes.get(dimension)
         if axis_values is None:
             return BlockValidation(
-                Either.error(f"dimension {dimension} is not in the input dimensions: {input_dimensions}"),
+                Either.error(
+                    BlockValidationError(reason=f"dimension {dimension} is not in the input dimensions: {input_dimensions}", is_hard=True)
+                ),
                 restrict,
             )
 
@@ -392,19 +408,25 @@ class Select(Transform):
         try:
             selected_values = [_parse_axis_value(value) for value in self._selected_values(block)]
         except BlockInstanceConfigurationError as exc:
-            return BlockValidation(Either.error(str(exc)), restrict)
+            return BlockValidation(Either.error(BlockValidationError(reason=str(exc), is_hard=True)), restrict)
 
         missing_values = [value for value in selected_values if value not in axis_values]
         if missing_values:
             return BlockValidation(
-                Either.error(f"values {missing_values} are not in dimension {dimension}: {input_values}"),
+                Either.error(
+                    BlockValidationError(reason=f"values {missing_values} are not in dimension {dimension}: {input_values}", is_hard=True)
+                ),
                 restrict,
             )
 
         output = select(input_dataset, {dimension: selected_values})
         if output.dataqube is None or _is_empty_qube(output.dataqube):
             return BlockValidation(
-                Either.error(f"selection of values {selected_values} from dimension {dimension} produced an empty dataset"),
+                Either.error(
+                    BlockValidationError(
+                        reason=f"selection of values {selected_values} from dimension {dimension} produced an empty dataset", is_hard=True
+                    )
+                ),
                 restrict,
             )
 
@@ -445,7 +467,9 @@ class GribSink(Sink):
         path = block.config_as_str(PATH)
         dirname = os.path.dirname(path)
         if len(self._find_template_values(dirname)) != 0:
-            return BlockValidation(Either.error(f"Invalid filepath: directory path can not contain template values"))
+            return BlockValidation(
+                Either.error(BlockValidationError(reason=f"Invalid filepath: directory path can not contain template values", is_hard=True))
+            )
         return BlockValidation(Either.ok(RawOutput(type_fqn="bytes", mime_type=GRIB_MIME)))
 
     def compile(
@@ -544,23 +568,33 @@ class MapPlotSink(Sink):
             splitby_value = block.config_as_list(SPLITBY, str, allow_empty=True)
             fmt = block.config_as_str(FORMAT)
         except BlockInstanceConfigurationError as exc:
-            return BlockValidation(Either.error(str(exc)), restrict)
+            return BlockValidation(Either.error(BlockValidationError(reason=str(exc), is_hard=True)), restrict)
 
         missing_params = [param for param in params if param not in input_param_values]
         if missing_params:
             return BlockValidation(
-                Either.error(f"params {missing_params} are not in the input parameters: {_axis_value_strings(input_param_values)}"),
+                Either.error(
+                    BlockValidationError(
+                        reason=f"params {missing_params} are not in the input parameters: {_axis_value_strings(input_param_values)}",
+                        is_hard=True,
+                    )
+                ),
                 restrict,
             )
 
         if "none" in splitby_value and len(splitby_value) != 1:
             return BlockValidation(
-                Either.error(f"Invalid splitby value: if none is selected, no other dimensions can be present"), restrict
+                Either.error(
+                    BlockValidationError(
+                        reason=f"Invalid splitby value: if none is selected, no other dimensions can be present", is_hard=True
+                    )
+                ),
+                restrict,
             )
 
         mime_type = PLOT_FORMAT_TO_MIME.get(fmt)
         if mime_type is None:
-            return BlockValidation(Either.error(f"Unsupported output format: {fmt}"), restrict)
+            return BlockValidation(Either.error(BlockValidationError(reason=f"Unsupported output format: {fmt}", is_hard=True)), restrict)
         return BlockValidation(Either.ok(RawOutput(type_fqn="bytes", mime_type=mime_type)), restrict)
 
     def compile(

--- a/backend/packages/fiab-plugin-ecmwf/tests/runtime/test_anemoi_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/runtime/test_anemoi_blocks.py
@@ -129,17 +129,17 @@ def anemoi_transform_configuration(dummy_checkpoint: str) -> BlockInstance:
 
 @pytest.fixture
 def anemoi_source_output(anemoi_source_configuration: BlockInstance) -> QubedOutput:
-    return AnemoiSource().validate(block=anemoi_source_configuration, inputs={}).result.get_or_raise()  # type: ignore[return-value]
+    return AnemoiSource().validate(block=anemoi_source_configuration, inputs={}, restrictions={})  # type: ignore[return-value]
 
 
 @pytest.fixture
 def anemoi_source_ensemble_output(anemoi_source_ensemble_configuration: BlockInstance) -> QubedOutput:
-    return AnemoiSource().validate(block=anemoi_source_ensemble_configuration, inputs={}).result.get_or_raise()  # type: ignore[return-value]
+    return AnemoiSource().validate(block=anemoi_source_ensemble_configuration, inputs={}, restrictions={})  # type: ignore[return-value]
 
 
 @pytest.fixture
 def anemoi_input_source_output(anemoi_input_source_configuration: BlockInstance) -> QubedOutput:
-    return AnemoiInputSource().validate(block=anemoi_input_source_configuration, inputs={}).result.get_or_raise()  # type: ignore[return-value]
+    return AnemoiInputSource().validate(block=anemoi_input_source_configuration, inputs={}, restrictions={})  # type: ignore[return-value]
 
 
 class TestCheckpointArtifact:
@@ -161,7 +161,7 @@ class TestAnemoiSourceValidate:
     """Validate method - happy paths and error paths."""
 
     def test_valid_deterministic(self, anemoi_source_configuration: BlockInstance) -> None:
-        output = AnemoiSource().validate(block=anemoi_source_configuration, inputs={}).result.get_or_raise()
+        output = AnemoiSource().validate(block=anemoi_source_configuration, inputs={}, restrictions={})
         assert isinstance(output, QubedOutput)
         assert output.dataqube is not None
 
@@ -187,7 +187,11 @@ class TestAnemoiSourceValidate:
             {"checkpoint": dummy_checkpoint, "lead_time": "abc", "base_time": "2024-01-01", "number": "1"},
         )
         with pytest.raises(BlockInstanceConfigurationError, match="expected int"):
-            AnemoiSource().validate(block=block, inputs={})
+            AnemoiSource().validate(
+                block=block,
+                inputs={},
+                restrictions={},
+            )
 
     def test_invalid_lead_time_negative(self, dummy_checkpoint: str) -> None:
         block = _make_block(
@@ -195,25 +199,27 @@ class TestAnemoiSourceValidate:
             {"checkpoint": dummy_checkpoint, "lead_time": -1, "base_time": datetime(2024, 1, 1), "number": 1},
         )
         with pytest.raises(BlockInstanceConfigurationError, match="must be positive"):
-            AnemoiSource().validate(block=block, inputs={})
+            AnemoiSource().validate(
+                block=block,
+                inputs={},
+                restrictions={},
+            )
 
     def test_invalid_lead_time_equal_to_timestep(self, dummy_checkpoint: str) -> None:
         block = _make_block(
             AnemoiSource,
             {"checkpoint": dummy_checkpoint, "lead_time": 1, "base_time": datetime(2024, 1, 1), "number": 1},
         )
-        result = AnemoiSource().validate(block=block, inputs={})
         with pytest.raises(Exception, match="must be greater than checkpoint timestep"):
-            result.result.get_or_raise()
+            AnemoiSource().validate(block=block, inputs={}, restrictions={})
 
     def test_invalid_lead_time_not_a_timestep_multiple(self, six_hour_dummy_checkpoint: str) -> None:
         block = _make_block(
             AnemoiSource,
             {"checkpoint": six_hour_dummy_checkpoint, "lead_time": 7, "base_time": datetime(2024, 1, 1), "number": 1},
         )
-        result = AnemoiSource().validate(block=block, inputs={})
         with pytest.raises(Exception, match="must be a multiple of checkpoint timestep"):
-            result.result.get_or_raise()
+            AnemoiSource().validate(block=block, inputs={}, restrictions={})
 
     def test_invalid_number_zero(self, dummy_checkpoint: str) -> None:
         block = _make_block(
@@ -221,7 +227,11 @@ class TestAnemoiSourceValidate:
             {"checkpoint": dummy_checkpoint, "lead_time": 24, "base_time": datetime(2024, 1, 1), "number": 0},
         )
         with pytest.raises(BlockInstanceConfigurationError, match="must be positive"):
-            AnemoiSource().validate(block=block, inputs={})
+            AnemoiSource().validate(
+                block=block,
+                inputs={},
+                restrictions={},
+            )
 
     def test_invalid_number_not_a_digit(self, dummy_checkpoint: str) -> None:
         block = _make_raw_block(
@@ -229,7 +239,11 @@ class TestAnemoiSourceValidate:
             {"checkpoint": dummy_checkpoint, "lead_time": "24", "base_time": "2024-01-01", "number": "two"},
         )
         with pytest.raises(BlockInstanceConfigurationError, match="expected int"):
-            AnemoiSource().validate(block=block, inputs={})
+            AnemoiSource().validate(
+                block=block,
+                inputs={},
+                restrictions={},
+            )
 
     def test_unknown_checkpoint(self, registered_provider: None) -> None:
         block = _make_block(
@@ -237,7 +251,7 @@ class TestAnemoiSourceValidate:
             {"checkpoint": "dummy_store:unknown", "lead_time": 24, "base_time": datetime(2024, 1, 1), "number": 1},
         )
         with pytest.raises(Exception):
-            AnemoiSource().validate(block=block, inputs={}).result.get_or_raise()
+            AnemoiSource().validate(block=block, inputs={}, restrictions={})
 
     def test_invalid_checkpoint_format(self) -> None:
         block = _make_block(
@@ -245,7 +259,7 @@ class TestAnemoiSourceValidate:
             {"checkpoint": "not-a-valid-id", "lead_time": 24, "base_time": datetime(2024, 1, 1), "number": 1},
         )
         with pytest.raises(ValueError, match="must be of the form"):
-            AnemoiSource().validate(block=block, inputs={}).result.get_or_raise()
+            AnemoiSource().validate(block=block, inputs={}, restrictions={})
 
 
 class TestAnemoiSourceIntersect:
@@ -268,7 +282,7 @@ class TestAnemoiSourceIntersect:
 
 class TestAnemoiInputSourceValidate:
     def test_valid_config(self, anemoi_input_source_configuration: BlockInstance) -> None:
-        output = AnemoiInputSource().validate(block=anemoi_input_source_configuration, inputs={}).result.get_or_raise()
+        output = AnemoiInputSource().validate(block=anemoi_input_source_configuration, inputs={}, restrictions={})
         assert isinstance(output, QubedOutput)
         assert output.dataqube is not None
 
@@ -297,13 +311,10 @@ class TestAnemoiInputSourceIntersect:
 
 class TestAnemoiTransformValidate:
     def test_valid_no_number_axis(self, anemoi_transform_configuration: BlockInstance, anemoi_input_source_output: QubedOutput) -> None:
-        output = (
-            AnemoiTransform()
-            .validate(
-                block=anemoi_transform_configuration,
-                inputs={"dataset": anemoi_input_source_output},
-            )
-            .result.get_or_raise()
+        output = AnemoiTransform().validate(
+            block=anemoi_transform_configuration,
+            inputs={"dataset": anemoi_input_source_output},
+            restrictions={},
         )
         assert isinstance(output, QubedOutput)
         assert contains(anemoi_input_source_output, "number")
@@ -315,37 +326,28 @@ class TestAnemoiTransformValidate:
         self, anemoi_transform_configuration: BlockInstance, anemoi_input_source_output: QubedOutput
     ) -> None:
         input_with_number = expand(anemoi_input_source_output, {"number": [1, 2, 3]})
-        output = (
-            AnemoiTransform()
-            .validate(
-                block=anemoi_transform_configuration,
-                inputs={"dataset": input_with_number},
-            )
-            .result.get_or_raise()
+        output = AnemoiTransform().validate(
+            block=anemoi_transform_configuration,
+            inputs={"dataset": input_with_number},
+            restrictions={},
         )
         assert isinstance(output, QubedOutput)
         assert contains(output, "number")
         assert set(axes(output)["number"]) == {1, 2, 3}
 
     def test_output_has_step_axis(self, anemoi_transform_configuration: BlockInstance, anemoi_input_source_output: QubedOutput) -> None:
-        output: QubedOutput = (
-            AnemoiTransform()
-            .validate(
-                block=anemoi_transform_configuration,
-                inputs={"dataset": anemoi_input_source_output},
-            )
-            .result.get_or_raise()
+        output: QubedOutput = AnemoiTransform().validate(
+            block=anemoi_transform_configuration,
+            inputs={"dataset": anemoi_input_source_output},
+            restrictions={},
         )  # type: ignore[assignment]
         assert contains(output, "step")
 
     def test_output_has_param_axis(self, anemoi_transform_configuration: BlockInstance, anemoi_input_source_output: QubedOutput) -> None:
-        output: QubedOutput = (
-            AnemoiTransform()
-            .validate(
-                block=anemoi_transform_configuration,
-                inputs={"dataset": anemoi_input_source_output},
-            )
-            .result.get_or_raise()
+        output: QubedOutput = AnemoiTransform().validate(
+            block=anemoi_transform_configuration,
+            inputs={"dataset": anemoi_input_source_output},
+            restrictions={},
         )  # type: ignore[assignment]
         assert contains(output, "param")
 
@@ -357,7 +359,11 @@ class TestAnemoiTransformValidate:
             input_ids={"dataset": "src"},
         )
         with pytest.raises(BlockInstanceConfigurationError, match="expected int"):
-            AnemoiTransform().validate(block=block, inputs={"dataset": input_dataset})
+            AnemoiTransform().validate(
+                block=block,
+                inputs={"dataset": input_dataset},
+                restrictions={},
+            )
 
     def test_invalid_lead_time_negative(self, dummy_checkpoint: str, dummy_qube: Qube) -> None:
         input_dataset = QubedOutput(dataqube=dummy_qube)
@@ -367,7 +373,11 @@ class TestAnemoiTransformValidate:
             input_ids={"dataset": "src"},
         )
         with pytest.raises(BlockInstanceConfigurationError, match="must be positive"):
-            AnemoiTransform().validate(block=block, inputs={"dataset": input_dataset})
+            AnemoiTransform().validate(
+                block=block,
+                inputs={"dataset": input_dataset},
+                restrictions={},
+            )
 
     def test_invalid_lead_time_not_a_timestep_multiple(self, six_hour_dummy_checkpoint: str, dummy_qube: Qube) -> None:
         input_dataset = QubedOutput(dataqube=dummy_qube)
@@ -376,9 +386,8 @@ class TestAnemoiTransformValidate:
             {"checkpoint": six_hour_dummy_checkpoint, "lead_time": 7},
             input_ids={"dataset": "src"},
         )
-        result = AnemoiTransform().validate(block=block, inputs={"dataset": input_dataset})
         with pytest.raises(Exception, match="must be a multiple of checkpoint timestep"):
-            result.result.get_or_raise()
+            AnemoiTransform().validate(block=block, inputs={"dataset": input_dataset}, restrictions={})
 
     def test_unknown_checkpoint(self, registered_provider: None, dummy_qube: Qube) -> None:
         input_dataset = QubedOutput(dataqube=dummy_qube)
@@ -388,7 +397,7 @@ class TestAnemoiTransformValidate:
             input_ids={"dataset": "src"},
         )
         with pytest.raises(Exception):
-            AnemoiTransform().validate(block=block, inputs={"dataset": input_dataset}).result.get_or_raise()
+            AnemoiTransform().validate(block=block, inputs={"dataset": input_dataset}, restrictions={})
 
     def test_incompatible_input_dataset(self, dummy_checkpoint: str) -> None:
         """If the input dataset does not contain the model's required input params, validate should error."""
@@ -398,9 +407,8 @@ class TestAnemoiTransformValidate:
             {"checkpoint": dummy_checkpoint, "lead_time": 24},
             input_ids={"dataset": "src"},
         )
-        result = AnemoiTransform().validate(block=block, inputs={"dataset": incompatible})
         with pytest.raises(Exception, match="not compatible"):
-            result.result.get_or_raise()
+            AnemoiTransform().validate(block=block, inputs={"dataset": incompatible}, restrictions={})
 
 
 class TestAnemoiTransformIntersect:
@@ -432,13 +440,10 @@ class TestFlowAnemoiSourceToTransform:
         anemoi_transform_configuration: BlockInstance,
     ) -> None:
         """The deterministic source output should be a valid input for the transform."""
-        output = (
-            AnemoiTransform()
-            .validate(
-                block=anemoi_transform_configuration,
-                inputs={"dataset": anemoi_source_output},
-            )
-            .result.get_or_raise()
+        output = AnemoiTransform().validate(
+            block=anemoi_transform_configuration,
+            inputs={"dataset": anemoi_source_output},
+            restrictions={},
         )
         assert isinstance(output, QubedOutput)
         assert contains(output, "param")
@@ -449,13 +454,10 @@ class TestFlowAnemoiSourceToTransform:
         anemoi_source_ensemble_output: QubedOutput,
         anemoi_transform_configuration: BlockInstance,
     ) -> None:
-        output: QubedOutput = (
-            AnemoiTransform()
-            .validate(
-                block=anemoi_transform_configuration,
-                inputs={"dataset": anemoi_source_ensemble_output},
-            )
-            .result.get_or_raise()
+        output: QubedOutput = AnemoiTransform().validate(
+            block=anemoi_transform_configuration,
+            inputs={"dataset": anemoi_source_ensemble_output},
+            restrictions={},
         )  # type: ignore[assignment]
         assert contains(output, "number")
         assert set(axes(output)["number"]) == {1, 2, 3}
@@ -469,13 +471,10 @@ class TestFlowAnemoiInputSourceToTransform:
         anemoi_input_source_output: QubedOutput,
         anemoi_transform_configuration: BlockInstance,
     ) -> None:
-        output = (
-            AnemoiTransform()
-            .validate(
-                block=anemoi_transform_configuration,
-                inputs={"dataset": anemoi_input_source_output},
-            )
-            .result.get_or_raise()
+        output = AnemoiTransform().validate(
+            block=anemoi_transform_configuration,
+            inputs={"dataset": anemoi_input_source_output},
+            restrictions={},
         )
         assert isinstance(output, QubedOutput)
         assert contains(output, "param")
@@ -493,13 +492,10 @@ class TestFlowChainedTransforms:
         anemoi_input_source_output: QubedOutput,
         anemoi_transform_configuration: BlockInstance,
     ) -> None:
-        first_output: QubedOutput = (
-            AnemoiTransform()
-            .validate(
-                block=anemoi_transform_configuration,
-                inputs={"dataset": anemoi_input_source_output},
-            )
-            .result.get_or_raise()
+        first_output: QubedOutput = AnemoiTransform().validate(
+            block=anemoi_transform_configuration,
+            inputs={"dataset": anemoi_input_source_output},
+            restrictions={},
         )  # type: ignore[assignment]
 
         second_config = _make_block(
@@ -507,13 +503,10 @@ class TestFlowChainedTransforms:
             {"checkpoint": dummy_checkpoint, "lead_time": 48},
             input_ids={"dataset": "first_transform"},
         )
-        second_output: QubedOutput = (
-            AnemoiTransform()
-            .validate(
-                block=second_config,
-                inputs={"dataset": first_output},
-            )
-            .result.get_or_raise()
+        second_output: QubedOutput = AnemoiTransform().validate(
+            block=second_config,
+            inputs={"dataset": first_output},
+            restrictions={},
         )  # type: ignore[assignment]
 
         assert isinstance(second_output, QubedOutput)
@@ -528,13 +521,10 @@ class TestFlowChainedTransforms:
     ) -> None:
         input_with_number = expand(anemoi_input_source_output, {"number": [1, 2]})
 
-        first_output: QubedOutput = (
-            AnemoiTransform()
-            .validate(
-                block=anemoi_transform_configuration,
-                inputs={"dataset": input_with_number},
-            )
-            .result.get_or_raise()
+        first_output: QubedOutput = AnemoiTransform().validate(
+            block=anemoi_transform_configuration,
+            inputs={"dataset": input_with_number},
+            restrictions={},
         )  # type: ignore[assignment]
         assert contains(first_output, "number")
 
@@ -543,13 +533,10 @@ class TestFlowChainedTransforms:
             {"checkpoint": dummy_checkpoint, "lead_time": 48},
             input_ids={"dataset": "first_transform"},
         )
-        second_output: QubedOutput = (
-            AnemoiTransform()
-            .validate(
-                block=second_config,
-                inputs={"dataset": first_output},
-            )
-            .result.get_or_raise()
+        second_output: QubedOutput = AnemoiTransform().validate(
+            block=second_config,
+            inputs={"dataset": first_output},
+            restrictions={},
         )  # type: ignore[assignment]
 
         assert contains(second_output, "number")

--- a/backend/packages/fiab-plugin-ecmwf/tests/runtime/test_anemoi_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/runtime/test_anemoi_blocks.py
@@ -129,17 +129,17 @@ def anemoi_transform_configuration(dummy_checkpoint: str) -> BlockInstance:
 
 @pytest.fixture
 def anemoi_source_output(anemoi_source_configuration: BlockInstance) -> QubedOutput:
-    return AnemoiSource().validate(block=anemoi_source_configuration, inputs={}).get_or_raise()  # type: ignore[return-value]
+    return AnemoiSource().validate(block=anemoi_source_configuration, inputs={}).result.get_or_raise()  # type: ignore[return-value]
 
 
 @pytest.fixture
 def anemoi_source_ensemble_output(anemoi_source_ensemble_configuration: BlockInstance) -> QubedOutput:
-    return AnemoiSource().validate(block=anemoi_source_ensemble_configuration, inputs={}).get_or_raise()  # type: ignore[return-value]
+    return AnemoiSource().validate(block=anemoi_source_ensemble_configuration, inputs={}).result.get_or_raise()  # type: ignore[return-value]
 
 
 @pytest.fixture
 def anemoi_input_source_output(anemoi_input_source_configuration: BlockInstance) -> QubedOutput:
-    return AnemoiInputSource().validate(block=anemoi_input_source_configuration, inputs={}).get_or_raise()  # type: ignore[return-value]
+    return AnemoiInputSource().validate(block=anemoi_input_source_configuration, inputs={}).result.get_or_raise()  # type: ignore[return-value]
 
 
 class TestCheckpointArtifact:
@@ -161,7 +161,7 @@ class TestAnemoiSourceValidate:
     """Validate method - happy paths and error paths."""
 
     def test_valid_deterministic(self, anemoi_source_configuration: BlockInstance) -> None:
-        output = AnemoiSource().validate(block=anemoi_source_configuration, inputs={}).get_or_raise()
+        output = AnemoiSource().validate(block=anemoi_source_configuration, inputs={}).result.get_or_raise()
         assert isinstance(output, QubedOutput)
         assert output.dataqube is not None
 
@@ -204,7 +204,7 @@ class TestAnemoiSourceValidate:
         )
         result = AnemoiSource().validate(block=block, inputs={})
         with pytest.raises(Exception, match="must be greater than checkpoint timestep"):
-            result.get_or_raise()
+            result.result.get_or_raise()
 
     def test_invalid_lead_time_not_a_timestep_multiple(self, six_hour_dummy_checkpoint: str) -> None:
         block = _make_block(
@@ -213,7 +213,7 @@ class TestAnemoiSourceValidate:
         )
         result = AnemoiSource().validate(block=block, inputs={})
         with pytest.raises(Exception, match="must be a multiple of checkpoint timestep"):
-            result.get_or_raise()
+            result.result.get_or_raise()
 
     def test_invalid_number_zero(self, dummy_checkpoint: str) -> None:
         block = _make_block(
@@ -237,7 +237,7 @@ class TestAnemoiSourceValidate:
             {"checkpoint": "dummy_store:unknown", "lead_time": 24, "base_time": datetime(2024, 1, 1), "number": 1},
         )
         with pytest.raises(Exception):
-            AnemoiSource().validate(block=block, inputs={}).get_or_raise()
+            AnemoiSource().validate(block=block, inputs={}).result.get_or_raise()
 
     def test_invalid_checkpoint_format(self) -> None:
         block = _make_block(
@@ -245,7 +245,7 @@ class TestAnemoiSourceValidate:
             {"checkpoint": "not-a-valid-id", "lead_time": 24, "base_time": datetime(2024, 1, 1), "number": 1},
         )
         with pytest.raises(ValueError, match="must be of the form"):
-            AnemoiSource().validate(block=block, inputs={}).get_or_raise()
+            AnemoiSource().validate(block=block, inputs={}).result.get_or_raise()
 
 
 class TestAnemoiSourceIntersect:
@@ -268,7 +268,7 @@ class TestAnemoiSourceIntersect:
 
 class TestAnemoiInputSourceValidate:
     def test_valid_config(self, anemoi_input_source_configuration: BlockInstance) -> None:
-        output = AnemoiInputSource().validate(block=anemoi_input_source_configuration, inputs={}).get_or_raise()
+        output = AnemoiInputSource().validate(block=anemoi_input_source_configuration, inputs={}).result.get_or_raise()
         assert isinstance(output, QubedOutput)
         assert output.dataqube is not None
 
@@ -303,7 +303,7 @@ class TestAnemoiTransformValidate:
                 block=anemoi_transform_configuration,
                 inputs={"dataset": anemoi_input_source_output},
             )
-            .get_or_raise()
+            .result.get_or_raise()
         )
         assert isinstance(output, QubedOutput)
         assert contains(anemoi_input_source_output, "number")
@@ -321,7 +321,7 @@ class TestAnemoiTransformValidate:
                 block=anemoi_transform_configuration,
                 inputs={"dataset": input_with_number},
             )
-            .get_or_raise()
+            .result.get_or_raise()
         )
         assert isinstance(output, QubedOutput)
         assert contains(output, "number")
@@ -334,7 +334,7 @@ class TestAnemoiTransformValidate:
                 block=anemoi_transform_configuration,
                 inputs={"dataset": anemoi_input_source_output},
             )
-            .get_or_raise()
+            .result.get_or_raise()
         )  # type: ignore[assignment]
         assert contains(output, "step")
 
@@ -345,7 +345,7 @@ class TestAnemoiTransformValidate:
                 block=anemoi_transform_configuration,
                 inputs={"dataset": anemoi_input_source_output},
             )
-            .get_or_raise()
+            .result.get_or_raise()
         )  # type: ignore[assignment]
         assert contains(output, "param")
 
@@ -378,7 +378,7 @@ class TestAnemoiTransformValidate:
         )
         result = AnemoiTransform().validate(block=block, inputs={"dataset": input_dataset})
         with pytest.raises(Exception, match="must be a multiple of checkpoint timestep"):
-            result.get_or_raise()
+            result.result.get_or_raise()
 
     def test_unknown_checkpoint(self, registered_provider: None, dummy_qube: Qube) -> None:
         input_dataset = QubedOutput(dataqube=dummy_qube)
@@ -388,7 +388,7 @@ class TestAnemoiTransformValidate:
             input_ids={"dataset": "src"},
         )
         with pytest.raises(Exception):
-            AnemoiTransform().validate(block=block, inputs={"dataset": input_dataset}).get_or_raise()
+            AnemoiTransform().validate(block=block, inputs={"dataset": input_dataset}).result.get_or_raise()
 
     def test_incompatible_input_dataset(self, dummy_checkpoint: str) -> None:
         """If the input dataset does not contain the model's required input params, validate should error."""
@@ -400,7 +400,7 @@ class TestAnemoiTransformValidate:
         )
         result = AnemoiTransform().validate(block=block, inputs={"dataset": incompatible})
         with pytest.raises(Exception, match="not compatible"):
-            result.get_or_raise()
+            result.result.get_or_raise()
 
 
 class TestAnemoiTransformIntersect:
@@ -438,7 +438,7 @@ class TestFlowAnemoiSourceToTransform:
                 block=anemoi_transform_configuration,
                 inputs={"dataset": anemoi_source_output},
             )
-            .get_or_raise()
+            .result.get_or_raise()
         )
         assert isinstance(output, QubedOutput)
         assert contains(output, "param")
@@ -455,7 +455,7 @@ class TestFlowAnemoiSourceToTransform:
                 block=anemoi_transform_configuration,
                 inputs={"dataset": anemoi_source_ensemble_output},
             )
-            .get_or_raise()
+            .result.get_or_raise()
         )  # type: ignore[assignment]
         assert contains(output, "number")
         assert set(axes(output)["number"]) == {1, 2, 3}
@@ -475,7 +475,7 @@ class TestFlowAnemoiInputSourceToTransform:
                 block=anemoi_transform_configuration,
                 inputs={"dataset": anemoi_input_source_output},
             )
-            .get_or_raise()
+            .result.get_or_raise()
         )
         assert isinstance(output, QubedOutput)
         assert contains(output, "param")
@@ -499,7 +499,7 @@ class TestFlowChainedTransforms:
                 block=anemoi_transform_configuration,
                 inputs={"dataset": anemoi_input_source_output},
             )
-            .get_or_raise()
+            .result.get_or_raise()
         )  # type: ignore[assignment]
 
         second_config = _make_block(
@@ -513,7 +513,7 @@ class TestFlowChainedTransforms:
                 block=second_config,
                 inputs={"dataset": first_output},
             )
-            .get_or_raise()
+            .result.get_or_raise()
         )  # type: ignore[assignment]
 
         assert isinstance(second_output, QubedOutput)
@@ -534,7 +534,7 @@ class TestFlowChainedTransforms:
                 block=anemoi_transform_configuration,
                 inputs={"dataset": input_with_number},
             )
-            .get_or_raise()
+            .result.get_or_raise()
         )  # type: ignore[assignment]
         assert contains(first_output, "number")
 
@@ -549,7 +549,7 @@ class TestFlowChainedTransforms:
                 block=second_config,
                 inputs={"dataset": first_output},
             )
-            .get_or_raise()
+            .result.get_or_raise()
         )  # type: ignore[assignment]
 
         assert contains(second_output, "number")

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -19,6 +19,7 @@ from fiab_core.fable import (
     BlockFactoryId,
     BlockInstanceId,
     ConfigurationOptionId,
+    ConfigurationOptionRestriction,
     PluginBlockFactoryId,
     PluginCompositeId,
     QubedOutput,
@@ -274,7 +275,7 @@ class TestOperationalForecastSource:
             ),
             OperationalForecastSource.configuration_options,
         )
-        output = block.validate(block=block_instance, inputs={}).result.get_or_raise()  # type: ignore[assignment]
+        output = block.validate(block=block_instance, inputs={}, restrictions={})  # type: ignore[assignment]
         assert isinstance(output, QubedOutput)
         assert output.dataqube is not None
         assert contains(output, "param")
@@ -327,7 +328,7 @@ class TestOperationalForecastSource:
             OperationalForecastSource.configuration_options,
         )
         with pytest.raises(Exception, match=error):
-            block.validate(block=block_instance, inputs={}).result.get_or_raise()  # type: ignore[assignment]
+            block.validate(block=block_instance, inputs={}, restrictions={})  # type: ignore[assignment]
 
     def test_catalogue_value_types_are_canonical(self) -> None:
         assert (
@@ -352,8 +353,9 @@ class TestEnsembleStatistics:
         assert block.intersect(other=operational_forecast_source_output)  # type: ignore[arg-type]
         output = block.validate(  # type: ignore[assignment]
             block=ensemble_statistics_configuration,
-            inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
-        ).result.get_or_raise()
+            inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item],
+            restrictions={},
+        )
         assert isinstance(output, QubedOutput)
         assert output.dataqube is not None
         assert contains(output, "param")
@@ -368,16 +370,17 @@ class TestEnsembleStatistics:
         temporal_block = TemporalStatistics()
         temporal_output = temporal_block.validate(  # type: ignore[assignment]
             block=temporal_statistics_configuration,
-            inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
-        ).result.get_or_raise()
-
+            inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item],
+            restrictions={},
+        )
         block = EnsembleStatistics()
 
         assert block.intersect(other=temporal_output)  # type: ignore[arg-type]
         output = block.validate(  # type: ignore[assignment]
             block=ensemble_statistics_configuration,
-            inputs={"dataset": temporal_output},  # type: ignore[dict-item]
-        ).result.get_or_raise()
+            inputs={"dataset": temporal_output},  # type: ignore[dict-item],
+            restrictions={},
+        )
         assert isinstance(output, QubedOutput)
         assert output.dataqube is not None
         assert contains(output, "param")
@@ -389,9 +392,8 @@ class TestEnsembleStatistics:
         modified_output = collapse(operational_forecast_source_output, "param")
 
         assert not block.intersect(other=modified_output)  # type: ignore[arg-type]
-        result = block.validate(block=ensemble_statistics_configuration, inputs={"dataset": modified_output})  # type: ignore[dict-item]
         with pytest.raises(Exception, match="param 2t is not in the input parameters"):
-            assert result.result.get_or_raise()
+            block.validate(block=ensemble_statistics_configuration, inputs={"dataset": modified_output}, restrictions={})  # type: ignore[dict-item]
 
 
 class TestTemporalStatistics:
@@ -409,8 +411,9 @@ class TestTemporalStatistics:
         assert block.intersect(other=operational_forecast_source_output)  # type: ignore[arg-type]
         output = block.validate(  # type: ignore[assignment]
             block=temporal_statistics_configuration,
-            inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
-        ).result.get_or_raise()
+            inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item],
+            restrictions={},
+        )
         assert isinstance(output, QubedOutput)
         assert output.dataqube is not None
         assert contains(output, "param")
@@ -425,16 +428,17 @@ class TestTemporalStatistics:
         ensemble_block = EnsembleStatistics()
         ensemble_output = ensemble_block.validate(  # type: ignore[assignment]
             block=ensemble_statistics_configuration,
-            inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
-        ).result.get_or_raise()
-
+            inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item],
+            restrictions={},
+        )
         block = TemporalStatistics()
 
         assert block.intersect(other=ensemble_output)  # type: ignore[arg-type]
         output = block.validate(  # type: ignore[assignment]
             block=temporal_statistics_configuration,
-            inputs={"dataset": ensemble_output},  # type: ignore[dict-item]
-        ).result.get_or_raise()
+            inputs={"dataset": ensemble_output},  # type: ignore[dict-item],
+            restrictions={},
+        )
         assert isinstance(output, QubedOutput)
         assert output.dataqube is not None
         assert contains(output, "param")
@@ -446,9 +450,8 @@ class TestTemporalStatistics:
         modified_output = collapse(operational_forecast_source_output, "param")
 
         assert not block.intersect(other=modified_output)  # type: ignore[arg-type]
-        result = block.validate(block=temporal_statistics_configuration, inputs={"dataset": modified_output})  # type: ignore[dict-item]
         with pytest.raises(Exception, match="param 2t is not in the input parameters"):
-            assert result.result.get_or_raise()
+            block.validate(block=temporal_statistics_configuration, inputs={"dataset": modified_output}, restrictions={})  # type: ignore[dict-item]
 
 
 class TestZarrSink:
@@ -460,8 +463,9 @@ class TestZarrSink:
         assert block.intersect(other=operational_forecast_source_output)  # type: ignore[arg-type]
         output = block.validate(  # type: ignore[assignment]
             block=zarr_sink_configuration,
-            inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
-        ).result.get_or_raise()
+            inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item],
+            restrictions={},
+        )
         assert isinstance(output, RawOutput)
 
     def test_from_ensemble_statistics(
@@ -473,16 +477,17 @@ class TestZarrSink:
         ensemble_block = EnsembleStatistics()
         ensemble_output = ensemble_block.validate(  # type: ignore[assignment]
             block=ensemble_statistics_configuration,
-            inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
-        ).result.get_or_raise()
-
+            inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item],
+            restrictions={},
+        )
         block = ZarrSink()
 
         assert block.intersect(other=ensemble_output)  # type: ignore[arg-type]
         output = block.validate(  # type: ignore[assignment]
             block=zarr_sink_configuration,
-            inputs={"dataset": ensemble_output},  # type: ignore[dict-item]
-        ).result.get_or_raise()
+            inputs={"dataset": ensemble_output},  # type: ignore[dict-item],
+            restrictions={},
+        )
         assert isinstance(output, RawOutput)
 
     def test_from_temporal_statistics(
@@ -494,16 +499,17 @@ class TestZarrSink:
         temporal_block = TemporalStatistics()
         temporal_output = temporal_block.validate(  # type: ignore[assignment]
             block=temporal_statistics_configuration,
-            inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
-        ).result.get_or_raise()
-
+            inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item],
+            restrictions={},
+        )
         block = ZarrSink()
 
         assert block.intersect(other=temporal_output)  # type: ignore[arg-type]
         output = block.validate(  # type: ignore[assignment]
             block=zarr_sink_configuration,
-            inputs={"dataset": temporal_output},  # type: ignore[dict-item]
-        ).result.get_or_raise()
+            inputs={"dataset": temporal_output},  # type: ignore[dict-item],
+            restrictions={},
+        )
         assert isinstance(output, RawOutput)
 
     def test_compile(
@@ -513,7 +519,7 @@ class TestZarrSink:
         zarr_sink_configuration: BlockInstance,
     ) -> None:
         block = ZarrSink()
-        block.validate(block=zarr_sink_configuration, inputs={"dataset": operational_forecast_source_output}).result.get_or_raise()  # type: ignore[dict-item]
+        block.validate(block=zarr_sink_configuration, inputs={"dataset": operational_forecast_source_output}, restrictions={})  # type: ignore[dict-item]
         action = block.compile(
             inputs={BlockInstanceId("source_output"): operational_forecast_source_action},
             block=zarr_sink_configuration,
@@ -531,7 +537,7 @@ class TestSelect:
     ) -> None:
         block = _select()
         assert block.intersect(other=operational_forecast_source_output)  # type: ignore[arg-type]
-        output = block.validate(block=select_configuration, inputs={"dataset": operational_forecast_source_output}).result.get_or_raise()  # type: ignore[dict-item]
+        output = block.validate(block=select_configuration, inputs={"dataset": operational_forecast_source_output}, restrictions={})  # type: ignore[dict-item]
         assert isinstance(output, QubedOutput)
         assert output.dataqube is not None
         assert axes(output)[PARAM] == {"2t"}
@@ -541,7 +547,7 @@ class TestSelect:
     ) -> None:
         block = _select()
         config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "param", "values": ["2t", "msl"]})})
-        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).result.get_or_raise()  # type: ignore[dict-item]
+        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}, restrictions={})  # type: ignore[dict-item]
         assert isinstance(output, QubedOutput)
         assert axes(output)[PARAM] == {"2t", "msl"}
 
@@ -550,7 +556,7 @@ class TestSelect:
     ) -> None:
         block = _select()
         config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "step", "values": ["0", "6"]})})
-        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).result.get_or_raise()  # type: ignore[dict-item]
+        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}, restrictions={})  # type: ignore[dict-item]
         assert isinstance(output, QubedOutput)
         assert axes(output)[STEP] == {0, 6}
 
@@ -560,34 +566,30 @@ class TestSelect:
         input_dataset = QubedOutput(dataqube=broken_qube)
         config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "step", "values": ["6"]})})
 
-        validation = block.validate(block=config, inputs={"dataset": input_dataset})
-
-        assert validation.result.e is not None
-        assert "produced an empty dataset" in validation.result.e.reason
+        with pytest.raises(Exception, match="produced an empty dataset"):
+            block.validate(block=config, inputs={"dataset": input_dataset}, restrictions={})
 
     def test_validate_rejects_unknown_dimension(
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
     ) -> None:
         block = _select()
         config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "missing", "values": ["2t"]})})
-        validation = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})  # type: ignore[dict-item]
-
-        assert validation.result.e is not None
-        assert "dimension missing is not in the input dimensions" in validation.result.e.reason
-        assert DIMENSION in validation.restrictions
-        assert VALUES not in validation.restrictions
+        restrictions: ConfigurationOptionRestriction = {}
+        with pytest.raises(Exception, match="dimension missing is not in the input dimensions"):
+            block.validate(block=config, inputs={"dataset": operational_forecast_source_output}, restrictions=restrictions)  # type: ignore[dict-item]
+        assert DIMENSION in restrictions
+        assert VALUES not in restrictions
 
     def test_validate_rejects_unknown_values(
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
     ) -> None:
         block = _select()
         config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "param", "values": ["missing"]})})
-        validation = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})  # type: ignore[dict-item]
-
-        assert validation.result.e is not None
-        assert "values ['missing'] are not in dimension param" in validation.result.e.reason
-        assert DIMENSION in validation.restrictions
-        assert VALUES in validation.restrictions
+        restrictions: ConfigurationOptionRestriction = {}
+        with pytest.raises(Exception, match="values.*are not in dimension param"):
+            block.validate(block=config, inputs={"dataset": operational_forecast_source_output}, restrictions=restrictions)  # type: ignore[dict-item]
+        assert DIMENSION in restrictions
+        assert VALUES in restrictions
 
     def test_validator_adds_dimension_restrictions(
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
@@ -655,8 +657,9 @@ class TestGribSink:
         assert block.intersect(other=operational_forecast_source_output)  # type: ignore[arg-type]
         output = block.validate(  # type: ignore[assignment]
             block=grib_sink_configuration,
-            inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
-        ).result.get_or_raise()
+            inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item],
+            restrictions={},
+        )
         assert isinstance(output, RawOutput)
 
     def test_from_ensemble_statistics(
@@ -668,16 +671,17 @@ class TestGribSink:
         ensemble_block = EnsembleStatistics()
         ensemble_output = ensemble_block.validate(  # type: ignore[assignment]
             block=ensemble_statistics_configuration,
-            inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
-        ).result.get_or_raise()
-
+            inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item],
+            restrictions={},
+        )
         block = GribSink()
 
         assert block.intersect(other=ensemble_output)  # type: ignore[arg-type]
         output = block.validate(  # type: ignore[assignment]
             block=grib_sink_configuration,
-            inputs={"dataset": ensemble_output},  # type: ignore[dict-item]
-        ).result.get_or_raise()
+            inputs={"dataset": ensemble_output},  # type: ignore[dict-item],
+            restrictions={},
+        )
         assert isinstance(output, RawOutput)
 
     def test_from_temporal_statistics(
@@ -689,16 +693,17 @@ class TestGribSink:
         temporal_block = TemporalStatistics()
         temporal_output = temporal_block.validate(  # type: ignore[assignment]
             block=temporal_statistics_configuration,
-            inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
-        ).result.get_or_raise()
-
+            inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item],
+            restrictions={},
+        )
         block = GribSink()
 
         assert block.intersect(other=temporal_output)  # type: ignore[arg-type]
         output = block.validate(  # type: ignore[assignment]
             block=grib_sink_configuration,
-            inputs={"dataset": temporal_output},  # type: ignore[dict-item]
-        ).result.get_or_raise()
+            inputs={"dataset": temporal_output},  # type: ignore[dict-item],
+            restrictions={},
+        )
         assert isinstance(output, RawOutput)
 
     @pytest.mark.parametrize(
@@ -727,7 +732,8 @@ class TestGribSink:
         output = block.validate(  # type: ignore[assignment]
             block=config,
             inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
-        ).result.get_or_raise()
+            restrictions={},
+        )
         assert isinstance(output, RawOutput)
 
     def test_invalid_path(self, operational_forecast_source_output: QubedOutput) -> None:
@@ -744,12 +750,12 @@ class TestGribSink:
             ),
             GribSink.configuration_options,
         )
-        output = block.validate(  # type: ignore[assignment]
-            block=config,
-            inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
-        )
         with pytest.raises(Exception, match="Invalid filepath: directory path can not contain template values"):
-            output.result.get_or_raise()
+            block.validate(
+                block=config,
+                inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
+                restrictions={},
+            )
 
     @pytest.mark.parametrize(
         "filepath, dims",
@@ -780,7 +786,7 @@ class TestGribSink:
             ),
             GribSink.configuration_options,
         )
-        block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).result.get_or_raise()  # type: ignore[dict-item]
+        block.validate(block=config, inputs={"dataset": operational_forecast_source_output}, restrictions={})  # type: ignore[dict-item]
         action = block.compile(inputs={BlockInstanceId("source_output"): operational_forecast_source_action}, block=config).get_or_raise()
         assert action.nodes.dims == dims
 
@@ -821,8 +827,10 @@ class TestMapPlotSink:
     ) -> None:
         block = MapPlotSink()
         output = block.validate(
-            block=map_plot_sink_configuration, inputs={"dataset": operational_forecast_source_output}
-        ).result.get_or_raise()  # type: ignore[dict-item]
+            block=map_plot_sink_configuration,
+            inputs={"dataset": operational_forecast_source_output},
+            restrictions={},  # type: ignore[dict-item]
+        )
         assert isinstance(output, RawOutput)
         assert output.type_fqn == "bytes"
         assert output.mime_type == "image/png"
@@ -853,7 +861,7 @@ class TestMapPlotSink:
             ),
             MapPlotSink.configuration_options,
         )
-        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).result.get_or_raise()  # type: ignore[dict-item]
+        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}, restrictions={})  # type: ignore[dict-item]
         assert isinstance(output, RawOutput)
         assert output.type_fqn == "bytes"
         assert output.mime_type == expected_mime
@@ -876,7 +884,7 @@ class TestMapPlotSink:
             ),
             MapPlotSink.configuration_options,
         )
-        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).result.get_or_raise()  # type: ignore[dict-item]
+        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}, restrictions={})  # type: ignore[dict-item]
         assert isinstance(output, RawOutput)
 
     def test_validate_rejects_unknown_param(self, operational_forecast_source_output: QubedOutput) -> None:
@@ -897,11 +905,10 @@ class TestMapPlotSink:
             ),
             MapPlotSink.configuration_options,
         )
-        validation = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})  # type: ignore[dict-item]
-
-        assert validation.result.e is not None
-        assert "params ['nonexistent'] are not in the input parameters" in validation.result.e.reason
-        assert PARAM in validation.restrictions
+        restrictions: ConfigurationOptionRestriction = {}
+        with pytest.raises(Exception, match="nonexistent"):
+            block.validate(block=config, inputs={"dataset": operational_forecast_source_output}, restrictions=restrictions)  # type: ignore[dict-item]
+        assert PARAM in restrictions
 
     def test_validate_rejects_partial_unknown_params(self, operational_forecast_source_output: QubedOutput) -> None:
         block = MapPlotSink()
@@ -921,11 +928,10 @@ class TestMapPlotSink:
             ),
             MapPlotSink.configuration_options,
         )
-        validation = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})  # type: ignore[dict-item]
-
-        assert validation.result.e is not None
-        assert "params ['nonexistent'] are not in the input parameters" in validation.result.e.reason
-        assert PARAM in validation.restrictions
+        restrictions: ConfigurationOptionRestriction = {}
+        with pytest.raises(Exception, match="nonexistent"):
+            block.validate(block=config, inputs={"dataset": operational_forecast_source_output}, restrictions=restrictions)  # type: ignore[dict-item]
+        assert PARAM in restrictions
 
     def test_validate_from_ensemble_statistics(
         self,
@@ -933,15 +939,15 @@ class TestMapPlotSink:
         ensemble_statistics_configuration: BlockInstance,
         operational_forecast_source_output: QubedOutput,
     ) -> None:
-        ensemble_output = (
-            EnsembleStatistics()
-            .validate(block=ensemble_statistics_configuration, inputs={"dataset": operational_forecast_source_output})
-            .result.get_or_raise()  # type: ignore[dict-item]
+        ensemble_output = EnsembleStatistics().validate(
+            block=ensemble_statistics_configuration,
+            inputs={"dataset": operational_forecast_source_output},
+            restrictions={},
         )
 
         block = MapPlotSink()
         assert block.intersect(other=ensemble_output)  # type: ignore[arg-type]
-        output = block.validate(block=map_plot_sink_configuration, inputs={"dataset": ensemble_output}).result.get_or_raise()  # type: ignore[dict-item]
+        output = block.validate(block=map_plot_sink_configuration, inputs={"dataset": ensemble_output}, restrictions={})  # type: ignore[dict-item]
         assert isinstance(output, RawOutput)
 
     @pytest.mark.parametrize("groupby", ["none", "number"])
@@ -965,7 +971,7 @@ class TestMapPlotSink:
             ),
             MapPlotSink.configuration_options,
         )
-        block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).result.get_or_raise()  # type: ignore[dict-item]
+        block.validate(block=config, inputs={"dataset": operational_forecast_source_output}, restrictions={})  # type: ignore[dict-item]
         action = block.compile(inputs={BlockInstanceId("source_output"): operational_forecast_source_action}, block=config).get_or_raise()
         assert action.nodes.dims == {}
 
@@ -988,7 +994,7 @@ class TestMapPlotSink:
             MapPlotSink.configuration_options,
         )
         with pytest.raises(Exception, match="Invalid splitby value: if none is selected, no other dimensions can be present"):
-            block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).result.get_or_raise()  # type: ignore[dict-item]
+            block.validate(block=config, inputs={"dataset": operational_forecast_source_output}, restrictions={})  # type: ignore[dict-item]
 
     @pytest.mark.parametrize(
         "splitby, dims", [[[], {}], [["none"], {}], [["number"], {"number": 5}], [["number", "step"], {"number": 5, "step": 3}]]
@@ -1017,6 +1023,6 @@ class TestMapPlotSink:
             ),
             MapPlotSink.configuration_options,
         )
-        block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).result.get_or_raise()  # type: ignore[dict-item]
+        block.validate(block=config, inputs={"dataset": operational_forecast_source_output}, restrictions={})  # type: ignore[dict-item]
         action = block.compile(inputs={BlockInstanceId("source_output"): operational_forecast_source_action}, block=config).get_or_raise()
         assert action.nodes.dims == dims

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -274,7 +274,7 @@ class TestOperationalForecastSource:
             ),
             OperationalForecastSource.configuration_options,
         )
-        output = block.validate(block=block_instance, inputs={}).get_or_raise()  # type: ignore[assignment]
+        output = block.validate(block=block_instance, inputs={}).result.get_or_raise()  # type: ignore[assignment]
         assert isinstance(output, QubedOutput)
         assert output.dataqube is not None
         assert contains(output, "param")
@@ -327,7 +327,7 @@ class TestOperationalForecastSource:
             OperationalForecastSource.configuration_options,
         )
         with pytest.raises(Exception, match=error):
-            block.validate(block=block_instance, inputs={}).get_or_raise()  # type: ignore[assignment]
+            block.validate(block=block_instance, inputs={}).result.get_or_raise()  # type: ignore[assignment]
 
     def test_catalogue_value_types_are_canonical(self) -> None:
         assert (
@@ -353,7 +353,7 @@ class TestEnsembleStatistics:
         output = block.validate(  # type: ignore[assignment]
             block=ensemble_statistics_configuration,
             inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
-        ).get_or_raise()
+        ).result.get_or_raise()
         assert isinstance(output, QubedOutput)
         assert output.dataqube is not None
         assert contains(output, "param")
@@ -369,7 +369,7 @@ class TestEnsembleStatistics:
         temporal_output = temporal_block.validate(  # type: ignore[assignment]
             block=temporal_statistics_configuration,
             inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
-        ).get_or_raise()
+        ).result.get_or_raise()
 
         block = EnsembleStatistics()
 
@@ -377,7 +377,7 @@ class TestEnsembleStatistics:
         output = block.validate(  # type: ignore[assignment]
             block=ensemble_statistics_configuration,
             inputs={"dataset": temporal_output},  # type: ignore[dict-item]
-        ).get_or_raise()
+        ).result.get_or_raise()
         assert isinstance(output, QubedOutput)
         assert output.dataqube is not None
         assert contains(output, "param")
@@ -391,7 +391,7 @@ class TestEnsembleStatistics:
         assert not block.intersect(other=modified_output)  # type: ignore[arg-type]
         result = block.validate(block=ensemble_statistics_configuration, inputs={"dataset": modified_output})  # type: ignore[dict-item]
         with pytest.raises(Exception, match="param 2t is not in the input parameters"):
-            assert result.get_or_raise()
+            assert result.result.get_or_raise()
 
 
 class TestTemporalStatistics:
@@ -410,7 +410,7 @@ class TestTemporalStatistics:
         output = block.validate(  # type: ignore[assignment]
             block=temporal_statistics_configuration,
             inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
-        ).get_or_raise()
+        ).result.get_or_raise()
         assert isinstance(output, QubedOutput)
         assert output.dataqube is not None
         assert contains(output, "param")
@@ -426,7 +426,7 @@ class TestTemporalStatistics:
         ensemble_output = ensemble_block.validate(  # type: ignore[assignment]
             block=ensemble_statistics_configuration,
             inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
-        ).get_or_raise()
+        ).result.get_or_raise()
 
         block = TemporalStatistics()
 
@@ -434,7 +434,7 @@ class TestTemporalStatistics:
         output = block.validate(  # type: ignore[assignment]
             block=temporal_statistics_configuration,
             inputs={"dataset": ensemble_output},  # type: ignore[dict-item]
-        ).get_or_raise()
+        ).result.get_or_raise()
         assert isinstance(output, QubedOutput)
         assert output.dataqube is not None
         assert contains(output, "param")
@@ -448,7 +448,7 @@ class TestTemporalStatistics:
         assert not block.intersect(other=modified_output)  # type: ignore[arg-type]
         result = block.validate(block=temporal_statistics_configuration, inputs={"dataset": modified_output})  # type: ignore[dict-item]
         with pytest.raises(Exception, match="param 2t is not in the input parameters"):
-            assert result.get_or_raise()
+            assert result.result.get_or_raise()
 
 
 class TestZarrSink:
@@ -461,7 +461,7 @@ class TestZarrSink:
         output = block.validate(  # type: ignore[assignment]
             block=zarr_sink_configuration,
             inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
-        ).get_or_raise()
+        ).result.get_or_raise()
         assert isinstance(output, RawOutput)
 
     def test_from_ensemble_statistics(
@@ -474,7 +474,7 @@ class TestZarrSink:
         ensemble_output = ensemble_block.validate(  # type: ignore[assignment]
             block=ensemble_statistics_configuration,
             inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
-        ).get_or_raise()
+        ).result.get_or_raise()
 
         block = ZarrSink()
 
@@ -482,7 +482,7 @@ class TestZarrSink:
         output = block.validate(  # type: ignore[assignment]
             block=zarr_sink_configuration,
             inputs={"dataset": ensemble_output},  # type: ignore[dict-item]
-        ).get_or_raise()
+        ).result.get_or_raise()
         assert isinstance(output, RawOutput)
 
     def test_from_temporal_statistics(
@@ -495,7 +495,7 @@ class TestZarrSink:
         temporal_output = temporal_block.validate(  # type: ignore[assignment]
             block=temporal_statistics_configuration,
             inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
-        ).get_or_raise()
+        ).result.get_or_raise()
 
         block = ZarrSink()
 
@@ -503,7 +503,7 @@ class TestZarrSink:
         output = block.validate(  # type: ignore[assignment]
             block=zarr_sink_configuration,
             inputs={"dataset": temporal_output},  # type: ignore[dict-item]
-        ).get_or_raise()
+        ).result.get_or_raise()
         assert isinstance(output, RawOutput)
 
     def test_compile(
@@ -513,7 +513,7 @@ class TestZarrSink:
         zarr_sink_configuration: BlockInstance,
     ) -> None:
         block = ZarrSink()
-        block.validate(block=zarr_sink_configuration, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
+        block.validate(block=zarr_sink_configuration, inputs={"dataset": operational_forecast_source_output}).result.get_or_raise()  # type: ignore[dict-item]
         action = block.compile(
             inputs={BlockInstanceId("source_output"): operational_forecast_source_action},
             block=zarr_sink_configuration,
@@ -531,7 +531,7 @@ class TestSelect:
     ) -> None:
         block = _select()
         assert block.intersect(other=operational_forecast_source_output)  # type: ignore[arg-type]
-        output = block.validate(block=select_configuration, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
+        output = block.validate(block=select_configuration, inputs={"dataset": operational_forecast_source_output}).result.get_or_raise()  # type: ignore[dict-item]
         assert isinstance(output, QubedOutput)
         assert output.dataqube is not None
         assert axes(output)[PARAM] == {"2t"}
@@ -541,7 +541,7 @@ class TestSelect:
     ) -> None:
         block = _select()
         config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "param", "values": ["2t", "msl"]})})
-        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
+        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).result.get_or_raise()  # type: ignore[dict-item]
         assert isinstance(output, QubedOutput)
         assert axes(output)[PARAM] == {"2t", "msl"}
 
@@ -550,7 +550,7 @@ class TestSelect:
     ) -> None:
         block = _select()
         config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "step", "values": ["0", "6"]})})
-        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
+        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).result.get_or_raise()  # type: ignore[dict-item]
         assert isinstance(output, QubedOutput)
         assert axes(output)[STEP] == {0, 6}
 
@@ -562,8 +562,8 @@ class TestSelect:
 
         validation = block.validate(block=config, inputs={"dataset": input_dataset})
 
-        assert validation.e is not None
-        assert "produced an empty dataset" in validation.e
+        assert validation.result.e is not None
+        assert "produced an empty dataset" in validation.result.e
 
     def test_validate_rejects_unknown_dimension(
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
@@ -572,8 +572,8 @@ class TestSelect:
         config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "missing", "values": ["2t"]})})
         validation = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})  # type: ignore[dict-item]
 
-        assert validation.e is not None
-        assert "dimension missing is not in the input dimensions" in validation.e
+        assert validation.result.e is not None
+        assert "dimension missing is not in the input dimensions" in validation.result.e
         assert DIMENSION in validation.restrictions
         assert VALUES not in validation.restrictions
 
@@ -584,8 +584,8 @@ class TestSelect:
         config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "param", "values": ["missing"]})})
         validation = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})  # type: ignore[dict-item]
 
-        assert validation.e is not None
-        assert "values ['missing'] are not in dimension param" in validation.e
+        assert validation.result.e is not None
+        assert "values ['missing'] are not in dimension param" in validation.result.e
         assert DIMENSION in validation.restrictions
         assert VALUES in validation.restrictions
 
@@ -611,7 +611,7 @@ class TestSelect:
     ) -> None:
         config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "step"})})
         validation = plugin().validator(config, {"dataset": operational_forecast_source_output})
-        assert validation.e is not None
+        assert validation.result.e is not None
         assert DIMENSION in validation.restrictions
         assert VALUES in validation.restrictions
 
@@ -656,7 +656,7 @@ class TestGribSink:
         output = block.validate(  # type: ignore[assignment]
             block=grib_sink_configuration,
             inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
-        ).get_or_raise()
+        ).result.get_or_raise()
         assert isinstance(output, RawOutput)
 
     def test_from_ensemble_statistics(
@@ -669,7 +669,7 @@ class TestGribSink:
         ensemble_output = ensemble_block.validate(  # type: ignore[assignment]
             block=ensemble_statistics_configuration,
             inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
-        ).get_or_raise()
+        ).result.get_or_raise()
 
         block = GribSink()
 
@@ -677,7 +677,7 @@ class TestGribSink:
         output = block.validate(  # type: ignore[assignment]
             block=grib_sink_configuration,
             inputs={"dataset": ensemble_output},  # type: ignore[dict-item]
-        ).get_or_raise()
+        ).result.get_or_raise()
         assert isinstance(output, RawOutput)
 
     def test_from_temporal_statistics(
@@ -690,7 +690,7 @@ class TestGribSink:
         temporal_output = temporal_block.validate(  # type: ignore[assignment]
             block=temporal_statistics_configuration,
             inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
-        ).get_or_raise()
+        ).result.get_or_raise()
 
         block = GribSink()
 
@@ -698,7 +698,7 @@ class TestGribSink:
         output = block.validate(  # type: ignore[assignment]
             block=grib_sink_configuration,
             inputs={"dataset": temporal_output},  # type: ignore[dict-item]
-        ).get_or_raise()
+        ).result.get_or_raise()
         assert isinstance(output, RawOutput)
 
     @pytest.mark.parametrize(
@@ -727,7 +727,7 @@ class TestGribSink:
         output = block.validate(  # type: ignore[assignment]
             block=config,
             inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
-        ).get_or_raise()
+        ).result.get_or_raise()
         assert isinstance(output, RawOutput)
 
     def test_invalid_path(self, operational_forecast_source_output: QubedOutput) -> None:
@@ -749,7 +749,7 @@ class TestGribSink:
             inputs={"dataset": operational_forecast_source_output},  # type: ignore[dict-item]
         )
         with pytest.raises(Exception, match="Invalid filepath: directory path can not contain template values"):
-            output.get_or_raise()
+            output.result.get_or_raise()
 
     @pytest.mark.parametrize(
         "filepath, dims",
@@ -780,7 +780,7 @@ class TestGribSink:
             ),
             GribSink.configuration_options,
         )
-        block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
+        block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).result.get_or_raise()  # type: ignore[dict-item]
         action = block.compile(inputs={BlockInstanceId("source_output"): operational_forecast_source_action}, block=config).get_or_raise()
         assert action.nodes.dims == dims
 
@@ -820,7 +820,9 @@ class TestMapPlotSink:
         self, map_plot_sink_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
     ) -> None:
         block = MapPlotSink()
-        output = block.validate(block=map_plot_sink_configuration, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
+        output = block.validate(
+            block=map_plot_sink_configuration, inputs={"dataset": operational_forecast_source_output}
+        ).result.get_or_raise()  # type: ignore[dict-item]
         assert isinstance(output, RawOutput)
         assert output.type_fqn == "bytes"
         assert output.mime_type == "image/png"
@@ -851,7 +853,7 @@ class TestMapPlotSink:
             ),
             MapPlotSink.configuration_options,
         )
-        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
+        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).result.get_or_raise()  # type: ignore[dict-item]
         assert isinstance(output, RawOutput)
         assert output.type_fqn == "bytes"
         assert output.mime_type == expected_mime
@@ -874,7 +876,7 @@ class TestMapPlotSink:
             ),
             MapPlotSink.configuration_options,
         )
-        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
+        output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).result.get_or_raise()  # type: ignore[dict-item]
         assert isinstance(output, RawOutput)
 
     def test_validate_rejects_unknown_param(self, operational_forecast_source_output: QubedOutput) -> None:
@@ -897,8 +899,8 @@ class TestMapPlotSink:
         )
         validation = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})  # type: ignore[dict-item]
 
-        assert validation.e is not None
-        assert "params ['nonexistent'] are not in the input parameters" in validation.e
+        assert validation.result.e is not None
+        assert "params ['nonexistent'] are not in the input parameters" in validation.result.e
         assert PARAM in validation.restrictions
 
     def test_validate_rejects_partial_unknown_params(self, operational_forecast_source_output: QubedOutput) -> None:
@@ -921,8 +923,8 @@ class TestMapPlotSink:
         )
         validation = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})  # type: ignore[dict-item]
 
-        assert validation.e is not None
-        assert "params ['nonexistent'] are not in the input parameters" in validation.e
+        assert validation.result.e is not None
+        assert "params ['nonexistent'] are not in the input parameters" in validation.result.e
         assert PARAM in validation.restrictions
 
     def test_validate_from_ensemble_statistics(
@@ -934,12 +936,12 @@ class TestMapPlotSink:
         ensemble_output = (
             EnsembleStatistics()
             .validate(block=ensemble_statistics_configuration, inputs={"dataset": operational_forecast_source_output})
-            .get_or_raise()  # type: ignore[dict-item]
+            .result.get_or_raise()  # type: ignore[dict-item]
         )
 
         block = MapPlotSink()
         assert block.intersect(other=ensemble_output)  # type: ignore[arg-type]
-        output = block.validate(block=map_plot_sink_configuration, inputs={"dataset": ensemble_output}).get_or_raise()  # type: ignore[dict-item]
+        output = block.validate(block=map_plot_sink_configuration, inputs={"dataset": ensemble_output}).result.get_or_raise()  # type: ignore[dict-item]
         assert isinstance(output, RawOutput)
 
     @pytest.mark.parametrize("groupby", ["none", "number"])
@@ -963,7 +965,7 @@ class TestMapPlotSink:
             ),
             MapPlotSink.configuration_options,
         )
-        block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
+        block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).result.get_or_raise()  # type: ignore[dict-item]
         action = block.compile(inputs={BlockInstanceId("source_output"): operational_forecast_source_action}, block=config).get_or_raise()
         assert action.nodes.dims == {}
 
@@ -986,7 +988,7 @@ class TestMapPlotSink:
             MapPlotSink.configuration_options,
         )
         with pytest.raises(Exception, match="Invalid splitby value: if none is selected, no other dimensions can be present"):
-            block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
+            block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).result.get_or_raise()  # type: ignore[dict-item]
 
     @pytest.mark.parametrize(
         "splitby, dims", [[[], {}], [["none"], {}], [["number"], {"number": 5}], [["number", "step"], {"number": 5, "step": 3}]]
@@ -1015,6 +1017,6 @@ class TestMapPlotSink:
             ),
             MapPlotSink.configuration_options,
         )
-        block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).get_or_raise()  # type: ignore[dict-item]
+        block.validate(block=config, inputs={"dataset": operational_forecast_source_output}).result.get_or_raise()  # type: ignore[dict-item]
         action = block.compile(inputs={BlockInstanceId("source_output"): operational_forecast_source_action}, block=config).get_or_raise()
         assert action.nodes.dims == dims

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -563,7 +563,7 @@ class TestSelect:
         validation = block.validate(block=config, inputs={"dataset": input_dataset})
 
         assert validation.result.e is not None
-        assert "produced an empty dataset" in validation.result.e
+        assert "produced an empty dataset" in validation.result.e.reason
 
     def test_validate_rejects_unknown_dimension(
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
@@ -573,7 +573,7 @@ class TestSelect:
         validation = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})  # type: ignore[dict-item]
 
         assert validation.result.e is not None
-        assert "dimension missing is not in the input dimensions" in validation.result.e
+        assert "dimension missing is not in the input dimensions" in validation.result.e.reason
         assert DIMENSION in validation.restrictions
         assert VALUES not in validation.restrictions
 
@@ -585,7 +585,7 @@ class TestSelect:
         validation = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})  # type: ignore[dict-item]
 
         assert validation.result.e is not None
-        assert "values ['missing'] are not in dimension param" in validation.result.e
+        assert "values ['missing'] are not in dimension param" in validation.result.e.reason
         assert DIMENSION in validation.restrictions
         assert VALUES in validation.restrictions
 
@@ -900,7 +900,7 @@ class TestMapPlotSink:
         validation = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})  # type: ignore[dict-item]
 
         assert validation.result.e is not None
-        assert "params ['nonexistent'] are not in the input parameters" in validation.result.e
+        assert "params ['nonexistent'] are not in the input parameters" in validation.result.e.reason
         assert PARAM in validation.restrictions
 
     def test_validate_rejects_partial_unknown_params(self, operational_forecast_source_output: QubedOutput) -> None:
@@ -924,7 +924,7 @@ class TestMapPlotSink:
         validation = block.validate(block=config, inputs={"dataset": operational_forecast_source_output})  # type: ignore[dict-item]
 
         assert validation.result.e is not None
-        assert "params ['nonexistent'] are not in the input parameters" in validation.result.e
+        assert "params ['nonexistent'] are not in the input parameters" in validation.result.e.reason
         assert PARAM in validation.restrictions
 
     def test_validate_from_ensemble_statistics(

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -270,7 +270,7 @@ async def validate_expand(
         if not validate_only and restrictions:
             configuration_restrictions[blockId] = {k: v.serialize() for k, v in restrictions.items()}
         if output_or_error.t is None:
-            block_errors[blockId] += [cast(str, output_or_error.e)]
+            block_errors[blockId] += [output_or_error.e.reason]
             invalidable.add(blockId)
             continue
         outputs[blockId] = output_or_error.t

--- a/backend/tests/unit/test_jobs.py
+++ b/backend/tests/unit/test_jobs.py
@@ -95,7 +95,7 @@ async def test_jobs_blueprint_insert_and_get(mem_session_maker_both: async_sessi
     assert result.version == 1
     assert result.source == "user_defined"
     assert result.display_name == "My job"
-    assert result.tags == ["tag1"]
+    assert result.tags == [{"tag1": None}]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_jobs.py
+++ b/backend/tests/unit/test_jobs.py
@@ -85,7 +85,7 @@ async def test_jobs_blueprint_insert_and_get(mem_session_maker_both: async_sessi
         created_by="user1",
         display_name="My job",
         builder={"blocks": {"source1": {}}, "environment": None, "local_glyphs": {}},
-        tags=["tag1"],
+        tags=[{"tag1": None}],
     )
     assert v1 == 1
 


### PR DESCRIPTION
1/ introduces error granularity -- soft and hard. We will need that in order to be able to save valid templates. But is not currently used
2/ makes the block validation a bit more convenient in the block factories. Original code:
```
restrictions = {}
...
... add restriction...
return BlockValidation(Either.ok(output), restrictions))
or
return BlockValidation(Either.error(...), restrictions)
```
now:
```
... add restriction to function's arg ...
return output
or
raise ValueError
```

this simplifies the code of the blocks a lot, I guess. Is this preferable for you @corentincarton  @HCookie @jinmannwong ?

But I'm not sure how we would handle the blueprint template saving. But thinking of it, even the soft error distinction won't save us. The whole `expand` thing fails, because we can't derive a legitimate output. What we could _probably_ do is that we'll be building templates by _forcing_ a completely valid configuration, and only marking somehow which configuration options are to be exposed (say like glyphs).