### PR TITLE
Move scripts.sh to scripts/cicd/ and add test suite

### DIFF
--- a/.github/workflows/cd-plugins.yaml
+++ b/.github/workflows/cd-plugins.yaml
@@ -33,7 +33,7 @@ jobs:
           git remote set-url origin https://$GH_USER:$GH_TOKEN@github.com/ecmwf/forecast-in-a-box.git
           git fetch --tags origin # NOTE dont use with: fetch-tags: true, the clone is still shallow
 
-          source .github/workflows/scripts.sh
+          source scripts/cicd/scripts.sh
           setupBash "${{ inputs.testpypi }}" 
 
           TAG_PREF="c"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,7 +34,7 @@ jobs:
           git remote set-url origin https://$GH_USER:$GH_TOKEN@github.com/ecmwf/forecast-in-a-box.git
           git fetch --tags origin # NOTE dont use with: fetch-tags: true, the clone is still shallow
 
-          source .github/workflows/scripts.sh
+          source scripts/cicd/scripts.sh
           setupBash "${{ inputs.testpypi }}" 
 
           # derive the tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ on:
       - 'backend/**'
       - 'frontend/**'
       - 'cli/**'
-      - '.github/workflows/ci.yml'
+      - '.github/**'
+      - 'scripts/cicd/**'
     tags-ignore:
       - '**'
 
@@ -19,7 +20,8 @@ on:
       - 'backend/**'
       - 'frontend/**'
       - 'cli/**'
-      - '.github/workflows/ci.yml'
+      - '.github/**'
+      - 'scripts/cicd/**'
 
   # Trigger the workflow manually
   workflow_dispatch: ~
@@ -39,6 +41,7 @@ jobs:
       backend: ${{ steps.filter.outputs.backend || steps.all-true.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend || steps.all-true.outputs.frontend }}
       cli: ${{ steps.filter.outputs.cli || steps.all-true.outputs.cli }}
+      cicd_scripts: ${{ steps.filter.outputs.cicd_scripts || steps.all-true.outputs.cicd_scripts }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -56,6 +59,9 @@ jobs:
             cli:
               - 'cli/**'
               - '.github/workflows/ci.yml'
+            cicd_scripts:
+              - '.github/**'
+              - 'scripts/cicd/**'
       # For workflow_dispatch and push events, set all outputs to true
       - name: Set outputs for non-PR events
         if: github.event_name != 'pull_request'
@@ -64,6 +70,7 @@ jobs:
           echo "backend=true" >> "$GITHUB_OUTPUT"
           echo "frontend=true" >> "$GITHUB_OUTPUT"
           echo "cli=true" >> "$GITHUB_OUTPUT"
+          echo "cicd_scripts=true" >> "$GITHUB_OUTPUT"
 
   macos:
     name: macos
@@ -182,3 +189,14 @@ jobs:
       # - uses: moonrepo/setup-rust@v1
       - name: Cargo tests
         run: echo "disabled until cargo fixed" # cargo test # TODO we actually have no tests, neither unit nor integration!
+
+  cicd-scripts:
+    name: CI/CD scripts
+    needs: changes
+    if: needs.changes.outputs.cicd_scripts == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v3
+      - run: just val-cicd-scripts

--- a/justfile
+++ b/justfile
@@ -37,6 +37,9 @@ clean:
 	find backend -name '__pycache__' -exec rm -fr {} +
 	find backend -name 'dist' -type d -exec rm -rf {} +
 
+val-cicd-scripts:
+    bash scripts/cicd/test_scripts.sh
+
 val:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/scripts/cicd/scripts.sh
+++ b/scripts/cicd/scripts.sh
@@ -37,9 +37,9 @@ function gitTagAndPush() {
     # args
     # $1 true => testpypi (no tag&push), false => regular pypi (do tag&push)
     # $2 <tag>
-    testypi=$1
+    testpypi=$1
     tag=$2
-    if [ "$testypi" = "false" ] ; then
+    if [ "$testpypi" = "false" ] ; then
         git tag "$tag"
         git push origin "$tag"
     fi
@@ -52,7 +52,7 @@ function getLatestTagAndIncrement() {
     # 1/ queries existing git tags starting with prefix and optionally droping fourth number
     # 2/ finds the num-highest with given prefix (or 0.0.0 if none found)
     # 3/ echo the result including prefix
-    # 
+    #
     tagPref=$1
     LATEST_TAG=$(
       git tag -l "${tagPref}*" \
@@ -95,7 +95,7 @@ function tagFromInputOrLatest() {
       validateTag "$input" "$tagPref"
       echo "$input"
     else
-      getLatestTagAndIncrement "$TAG_PREF"
+      getLatestTagAndIncrement "$tagPref"
     fi
 }
 
@@ -107,4 +107,3 @@ function preparePythonWheelVersion() {
     tag=$(echo "$tag_full" | sed -nE 's/^[a-zA-Z]*([0-9]+\.[0-9]+\.[0-9]+)(\.[0-9]+)?$/\1/p')
     export SETUPTOOLS_SCM_PRETEND_VERSION=$tag
 }
-

--- a/scripts/cicd/test_mocks/git
+++ b/scripts/cicd/test_mocks/git
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Mock for git. Records all calls to $MOCK_CALLS_FILE.
+#
+# Configurable env vars:
+#   MOCK_GIT_TAGS_LIST  - newline-separated tags returned by 'git tag -l ...'
+#   MOCK_GIT_TAGS_ALL   - newline-separated tags returned by 'git tag' (no args)
+#   MOCK_CALLS_FILE     - path to file where all calls are recorded
+
+echo "git $*" >> "${MOCK_CALLS_FILE:-/dev/null}"
+
+case "$1" in
+  tag)
+    if [[ "${2:-}" == "-l" ]]; then
+      echo "${MOCK_GIT_TAGS_LIST:-}"
+    elif [[ $# -eq 1 ]]; then
+      echo "${MOCK_GIT_TAGS_ALL:-}"
+    fi
+    # 'git tag <name>' -- creating a tag, just record (no output)
+    ;;
+  push)
+    # just record
+    ;;
+  *)
+    # passthrough for any other git commands not needed in tests
+    ;;
+esac

--- a/scripts/cicd/test_mocks/twine
+++ b/scripts/cicd/test_mocks/twine
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Mock for twine. Records all calls to $MOCK_CALLS_FILE.
+#
+# Always succeeds (exit 0).
+
+echo "twine $*" >> "${MOCK_CALLS_FILE:-/dev/null}"

--- a/scripts/cicd/test_scripts.sh
+++ b/scripts/cicd/test_scripts.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# Test suite for scripts/cicd/scripts.sh
+#
+# Strategy: prepend scripts/cicd/test_mocks/ to PATH so that external tools
+# (git, twine) are intercepted by mock scripts. Mocks record every call to
+# $MOCK_CALLS_FILE and return data controlled by environment variables.
+#
+# Run directly:   bash scripts/cicd/test_scripts.sh
+# Run via just:   just val-cicd-scripts
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MOCKS_DIR="$SCRIPT_DIR/test_mocks"
+
+# Prepend mocks to PATH so they shadow real git/twine
+export PATH="$MOCKS_DIR:$PATH"
+
+# Source the script under test (defines functions, no side effects at source time)
+# shellcheck source=scripts/cicd/scripts.sh
+source "$SCRIPT_DIR/scripts.sh"
+
+# ---------------------------------------------------------------------------
+# Minimal test framework
+# ---------------------------------------------------------------------------
+TESTS_RUN=0
+TESTS_FAILED=0
+
+MOCK_CALLS_FILE=$(mktemp)
+export MOCK_CALLS_FILE
+trap 'rm -f "$MOCK_CALLS_FILE"' EXIT
+
+_pass() { echo "  PASS: $1"; ((TESTS_RUN++)); }
+_fail() { echo "  FAIL: $1 -- $2"; ((TESTS_RUN++)); ((TESTS_FAILED++)); }
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        _pass "$desc"
+    else
+        _fail "$desc" "expected='$expected' actual='$actual'"
+    fi
+}
+
+assert_contains() {
+    local desc="$1" pattern="$2" actual="$3"
+    if echo "$actual" | grep -qF -- "$pattern"; then
+        _pass "$desc"
+    else
+        _fail "$desc" "expected to contain '$pattern', got: $actual"
+    fi
+}
+
+assert_not_contains() {
+    local desc="$1" pattern="$2" actual="$3"
+    if ! echo "$actual" | grep -qF -- "$pattern"; then
+        _pass "$desc"
+    else
+        _fail "$desc" "expected NOT to contain '$pattern', got: $actual"
+    fi
+}
+
+# assert_fails <desc> <cmd> [args...]  -- passes if the command exits non-zero
+assert_fails() {
+    local desc="$1"; shift
+    if ( "$@" ) 2>/dev/null; then
+        _fail "$desc" "expected command to fail but it succeeded"
+    else
+        _pass "$desc"
+    fi
+}
+
+calls_file_contains() { grep -qF "$1" "$MOCK_CALLS_FILE"; }
+
+reset_mocks() {
+    : > "$MOCK_CALLS_FILE"
+    unset MOCK_GIT_TAGS_LIST 2>/dev/null || true
+    unset MOCK_GIT_TAGS_ALL  2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Tests: preparePythonWheelVersion
+# ---------------------------------------------------------------------------
+test_prepare_python_wheel_version() {
+    echo "--- preparePythonWheelVersion ---"
+
+    preparePythonWheelVersion "v1.2.3"
+    assert_eq "strips v prefix" "1.2.3" "$SETUPTOOLS_SCM_PRETEND_VERSION"
+
+    preparePythonWheelVersion "v1.2.3.4"
+    assert_eq "strips 4th version number" "1.2.3" "$SETUPTOOLS_SCM_PRETEND_VERSION"
+
+    preparePythonWheelVersion "1.2.3"
+    assert_eq "no prefix" "1.2.3" "$SETUPTOOLS_SCM_PRETEND_VERSION"
+
+    preparePythonWheelVersion "abc1.2.3"
+    assert_eq "multi-char prefix" "1.2.3" "$SETUPTOOLS_SCM_PRETEND_VERSION"
+
+    preparePythonWheelVersion "c1.0.0.4"
+    assert_eq "letter prefix with 4-part version" "1.0.0" "$SETUPTOOLS_SCM_PRETEND_VERSION"
+}
+
+# ---------------------------------------------------------------------------
+# Tests: getLatestTagAndIncrement
+# ---------------------------------------------------------------------------
+test_get_latest_tag_and_increment() {
+    echo "--- getLatestTagAndIncrement ---"
+
+    reset_mocks
+    export MOCK_GIT_TAGS_LIST=""
+    result=$(getLatestTagAndIncrement "v")
+    assert_eq "no existing tags returns v0.0.1" "v0.0.1" "$result"
+
+    reset_mocks
+    export MOCK_GIT_TAGS_LIST="v1.2.3"
+    result=$(getLatestTagAndIncrement "v")
+    assert_eq "single tag: increments patch" "v1.2.4" "$result"
+
+    reset_mocks
+    export MOCK_GIT_TAGS_LIST=$'v1.0.0\nv0.9.9\nv1.0.5'
+    result=$(getLatestTagAndIncrement "v")
+    assert_eq "multiple tags: uses highest, increments patch" "v1.0.6" "$result"
+
+    reset_mocks
+    export MOCK_GIT_TAGS_LIST=$'v2.0.0\nv2.0.1'
+    result=$(getLatestTagAndIncrement "v")
+    assert_eq "respects major.minor across patches" "v2.0.2" "$result"
+
+    reset_mocks
+    # 4-part tags: sed strips 4th part, so v1.2.3.4 becomes 1.2.3 in sort pipeline
+    export MOCK_GIT_TAGS_LIST="v1.2.3.4"
+    result=$(getLatestTagAndIncrement "v")
+    assert_eq "4-part tag: 4th part stripped, patch incremented" "v1.2.4" "$result"
+
+    reset_mocks
+    export MOCK_GIT_TAGS_LIST=$'c0.1.0\nc0.2.0'
+    result=$(getLatestTagAndIncrement "c")
+    assert_eq "non-v prefix" "c0.2.1" "$result"
+}
+
+# ---------------------------------------------------------------------------
+# Tests: validateTag
+# ---------------------------------------------------------------------------
+test_validate_tag() {
+    echo "--- validateTag ---"
+
+    reset_mocks
+    export MOCK_GIT_TAGS_ALL=""
+    validateTag "v1.2.3" "v"
+    _pass "valid tag not in git succeeds"
+
+    reset_mocks
+    export MOCK_GIT_TAGS_ALL=""
+    assert_fails "wrong format (letters only)" validateTag "vbadtag" "v"
+
+    reset_mocks
+    export MOCK_GIT_TAGS_ALL=""
+    assert_fails "4-part version rejected" validateTag "v1.2.3.4" "v"
+
+    reset_mocks
+    export MOCK_GIT_TAGS_ALL=""
+    assert_fails "wrong prefix rejected" validateTag "c1.2.3" "v"
+
+    reset_mocks
+    export MOCK_GIT_TAGS_ALL="v1.2.3"
+    assert_fails "existing tag rejected" validateTag "v1.2.3" "v"
+
+    reset_mocks
+    export MOCK_GIT_TAGS_ALL=$'v1.0.0\nv2.0.0'
+    validateTag "v1.2.3" "v"
+    _pass "new tag among existing ones succeeds"
+}
+
+# ---------------------------------------------------------------------------
+# Tests: tagFromInputOrLatest
+# ---------------------------------------------------------------------------
+test_tag_from_input_or_latest() {
+    echo "--- tagFromInputOrLatest ---"
+
+    reset_mocks
+    export MOCK_GIT_TAGS_ALL=""
+    result=$(tagFromInputOrLatest "v3.0.0" "v")
+    assert_eq "explicit valid tag is returned as-is" "v3.0.0" "$result"
+
+    reset_mocks
+    export MOCK_GIT_TAGS_ALL=""
+    assert_fails "explicit tag with wrong prefix fails" tagFromInputOrLatest "c1.0.0" "v"
+
+    reset_mocks
+    export MOCK_GIT_TAGS_LIST=$'v1.0.0\nv1.0.1'
+    result=$(tagFromInputOrLatest "" "v")
+    assert_eq "empty input triggers auto-increment" "v1.0.2" "$result"
+
+    reset_mocks
+    export MOCK_GIT_TAGS_LIST=""
+    result=$(tagFromInputOrLatest "" "v")
+    assert_eq "empty input with no existing tags returns v0.0.1" "v0.0.1" "$result"
+}
+
+# ---------------------------------------------------------------------------
+# Tests: uploadPypi
+# ---------------------------------------------------------------------------
+test_upload_pypi() {
+    echo "--- uploadPypi ---"
+
+    export TWINE_PASSWORD_TEST="test-secret"
+    export TWINE_PASSWORD_PROD="prod-secret"
+
+    reset_mocks
+    uploadPypi "true" "some/wheel*.whl"
+    calls=$(cat "$MOCK_CALLS_FILE")
+    assert_contains "testpypi: twine check called" "twine check" "$calls"
+    assert_contains "testpypi: twine upload called" "twine upload" "$calls"
+    assert_contains "testpypi: --repository testpypi flag present" "--repository testpypi" "$calls"
+    assert_contains "testpypi: --skip-existing flag present" "--skip-existing" "$calls"
+
+    reset_mocks
+    uploadPypi "false" "some/wheel*.whl"
+    calls=$(cat "$MOCK_CALLS_FILE")
+    assert_contains "prod: twine check called" "twine check" "$calls"
+    assert_contains "prod: twine upload called" "twine upload" "$calls"
+    assert_not_contains "prod: no --repository testpypi flag" "--repository testpypi" "$calls"
+    assert_not_contains "prod: no --skip-existing flag" "--skip-existing" "$calls"
+}
+
+# ---------------------------------------------------------------------------
+# Tests: gitTagAndPush
+# ---------------------------------------------------------------------------
+test_git_tag_and_push() {
+    echo "--- gitTagAndPush ---"
+
+    reset_mocks
+    gitTagAndPush "false" "v1.2.3"
+    calls=$(cat "$MOCK_CALLS_FILE")
+    assert_contains "prod: git tag called" "git tag v1.2.3" "$calls"
+    assert_contains "prod: git push called" "git push origin v1.2.3" "$calls"
+
+    reset_mocks
+    gitTagAndPush "true" "v1.2.3"
+    calls=$(cat "$MOCK_CALLS_FILE")
+    if [[ -z "$calls" ]]; then
+        _pass "testpypi: no git calls made"
+    else
+        _fail "testpypi: no git calls made" "unexpected calls: $calls"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+echo "Running tests for scripts/cicd/scripts.sh"
+echo ""
+
+test_prepare_python_wheel_version
+test_get_latest_tag_and_increment
+test_validate_tag
+test_tag_from_input_or_latest
+test_upload_pypi
+test_git_tag_and_push
+
+echo ""
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    echo "FAILED: $TESTS_FAILED/$TESTS_RUN tests failed"
+    exit 1
+else
+    echo "OK: $TESTS_RUN/$TESTS_RUN tests passed"
+fi


### PR DESCRIPTION
- Add scripts/cicd/test_scripts.sh: 32 tests covering all functions using PATH-based mocking (test_mocks/git, test_mocks/twine)
- Move .github/workflows/scripts.sh -> scripts/cicd/scripts.sh
- Fix bug in tagFromInputOrLatest: use local $tagPref instead of $TAG_PREF
- Rename gitTagAndPush local var typo (testypi -> testpypi) for clarity
- Update source paths in cd.yml and cd-plugins.yaml
- Add `just val-cicd-scripts` recipe to justfile
- Add cicd-scripts job to ci.yml triggered by changes to .github/** or scripts/cicd/**