### PR TITLE
[frontend+backend] feat(fable-builder): add edge qube lens for graph mode

### DIFF
--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -286,8 +286,8 @@ async def validate_expand(
         if not validate_only and isinstance(output_or_error.t, QubedOutput):
             try:
                 block_output_qubes[blockId] = output_or_error.t.dataqube.to_json()
-            except Exception as exc:  # noqa: BLE001 — viz extra, never fatal
-                logger.debug("Could not serialize output qube for block %s: %s", blockId, exc)
+            except Exception as exc:  # viz extra, never fatal
+                logger.error(f"Could not serialize output qube for {blockId=}: {repr(exc)}")
 
         if not validate_only:
             possible_expansions[blockId] = (

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -23,7 +23,7 @@ No HTTP exceptions are raised here; callers are responsible for mapping
 import logging
 from collections import defaultdict
 from itertools import groupby
-from typing import cast
+from typing import Any, cast
 
 from fiab_core.fable import (
     BlockFactoryId,
@@ -35,6 +35,7 @@ from fiab_core.fable import (
     NoOutput,
     PluginBlockExpansion,
     PluginBlockFactoryId,
+    QubedOutput,
 )
 from pydantic import Field
 
@@ -104,6 +105,10 @@ class BlueprintValidationExpansion(FiabBaseModel):
     configuration_restrictions: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = Field(default_factory=dict)
     resolved_configuration_options: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = Field(default_factory=dict)
     missing_glyphs: dict[BlockInstanceId, dict[ConfigurationOptionId, list[str]]] = Field(default_factory=dict)
+    block_output_qubes: dict[BlockInstanceId, dict[str, Any]] = Field(default_factory=dict)
+    """Per-block output qube serialized via ``Qube.to_json()`` (qubed node
+    tree), for visualizing the qube as it flows through the pipeline. Only
+    populated for the expand endpoint (``validate_only`` False)."""
 
 
 class BlueprintSaveCommand(FiabBaseModel):
@@ -156,6 +161,7 @@ async def validate_expand(
     resolved_configuration_options: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = {}
     block_errors: dict[BlockInstanceId, list[str]] = defaultdict(list)
     missing_glyphs_result: dict[BlockInstanceId, dict[ConfigurationOptionId, list[str]]] = {}
+    block_output_qubes: dict[BlockInstanceId, dict[str, Any]] = {}
     outputs = {}
 
     intrinsic_values = cast(dict[str, str], get_values_and_examples())
@@ -275,6 +281,14 @@ async def validate_expand(
             continue
         outputs[blockId] = output_or_error.t
 
+        # Serialize the block's output qube for the frontend qube lens. Best
+        # effort only — a malformed/edge-case qube must never fail validation.
+        if not validate_only and isinstance(output_or_error.t, QubedOutput):
+            try:
+                block_output_qubes[blockId] = output_or_error.t.dataqube.to_json()
+            except Exception as exc:  # noqa: BLE001 — viz extra, never fatal
+                logger.debug("Could not serialize output qube for block %s: %s", blockId, exc)
+
         if not validate_only:
             possible_expansions[blockId] = (
                 [
@@ -306,6 +320,7 @@ async def validate_expand(
         block_errors=block_errors,
         global_errors=global_errors,
         missing_glyphs=missing_glyphs_result,
+        block_output_qubes=block_output_qubes,
     )
 
 

--- a/backend/src/forecastbox/routes/blueprint.py
+++ b/backend/src/forecastbox/routes/blueprint.py
@@ -25,7 +25,7 @@ Glyph routes:
  - POST glyphs/global/delete  — delete a global glyph by id
 """
 
-from typing import Annotated, Literal, cast
+from typing import Annotated, Any, Literal, cast
 
 from cascade.low.func import assert_never
 from fastapi import APIRouter, Depends, status
@@ -170,6 +170,7 @@ class BlueprintValidationExpansionResponse(FiabBaseModel):
     configuration_restrictions: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = {}
     resolved_configuration_options: dict[BlockInstanceId, dict[ConfigurationOptionId, str]]
     missing_glyphs: dict[BlockInstanceId, dict[ConfigurationOptionId, list[str]]] = {}
+    block_output_qubes: dict[BlockInstanceId, dict[str, Any]] = {}
 
 
 GlyphType = Literal["intrinsic", "global"]
@@ -430,6 +431,7 @@ async def expand_blueprint(
         configuration_restrictions=result.configuration_restrictions,
         resolved_configuration_options=result.resolved_configuration_options,
         missing_glyphs=result.missing_glyphs,
+        block_output_qubes=result.block_output_qubes,
     )
 
 

--- a/frontend/src/api/types/fable.types.ts
+++ b/frontend/src/api/types/fable.types.ts
@@ -12,11 +12,13 @@ import { Cloud, Cog, Download, Shuffle } from 'lucide-react'
 import { z } from 'zod'
 import i18n from 'i18next'
 import { EnvironmentSpecificationSchema } from './job.types'
+import { QubeNodeSchema } from './artifacts.types'
 import {
   PluginCompositeIdSchema,
   parsePluginKey,
   toPluginDisplayId,
 } from './plugins.types'
+import type { QubeNode } from './artifacts.types'
 import type { LucideIcon } from 'lucide-react'
 import type { PluginCompositeId } from './plugins.types'
 
@@ -226,6 +228,11 @@ export const FableValidationExpansionSchema = z.object({
     .record(z.string(), z.record(z.string(), z.array(z.string())))
     .optional()
     .default({}),
+  /** Per-block output qube (qubed node tree) for the graph qube lens. */
+  block_output_qubes: z
+    .record(z.string(), QubeNodeSchema)
+    .optional()
+    .default({}),
 })
 
 export type FableValidationExpansion = z.infer<
@@ -375,6 +382,12 @@ export interface FableValidationState {
    * never resolves glyphs client-side.
    */
   resolvedConfigurationOptions: Record<BlockInstanceId, Record<string, string>>
+  /**
+   * Per-block output qube (qubed node tree), keyed by BlockInstanceId.
+   * The qube flowing out of a block — i.e. on every edge leaving it. Used by
+   * the graph qube lens; empty when the backend doesn't provide it.
+   */
+  blockOutputQubes: Record<BlockInstanceId, QubeNode>
 }
 
 export interface BlockKindMetadata {
@@ -690,6 +703,7 @@ export function toValidationState(
     blockStates,
     possibleSources: expansion.possible_sources,
     resolvedConfigurationOptions: expansion.resolved_configuration_options,
+    blockOutputQubes: expansion.block_output_qubes,
   }
 }
 

--- a/frontend/src/api/types/fable.types.ts
+++ b/frontend/src/api/types/fable.types.ts
@@ -228,11 +228,20 @@ export const FableValidationExpansionSchema = z.object({
     .record(z.string(), z.record(z.string(), z.array(z.string())))
     .optional()
     .default({}),
-  /** Per-block output qube (qubed node tree) for the graph qube lens. */
+  /** Per-block output qube for the graph lens; parsed per-block so one
+   * unparseable qube is dropped rather than failing the whole response. */
   block_output_qubes: z
-    .record(z.string(), QubeNodeSchema)
+    .record(z.string(), z.unknown())
     .optional()
-    .default({}),
+    .default({})
+    .transform((rec) => {
+      const out: Record<string, QubeNode> = {}
+      for (const [blockId, raw] of Object.entries(rec)) {
+        const parsed = QubeNodeSchema.safeParse(raw)
+        if (parsed.success) out[blockId] = parsed.data
+      }
+      return out
+    }),
 })
 
 export type FableValidationExpansion = z.infer<
@@ -655,6 +664,17 @@ export function getBlocksByKind(
     .map(([instanceId, instance]) => ({ instanceId, instance }))
 }
 
+/** Backend wraps validator failures with `repr(exc)`; unwrap that exact
+ * `Error('msg')` shape to the bare message, leaving clean strings untouched. */
+const PYTHON_EXCEPTION_REPR =
+  /^[A-Z]\w*(?:Error|Exception|Warning)\((['"])([\s\S]*)\1\)$/
+
+export function unwrapBackendError(message: string): string {
+  const match = PYTHON_EXCEPTION_REPR.exec(message)
+  if (!match) return message
+  return match[2].replace(/\\(['"\\])/g, '$1')
+}
+
 export function toValidationState(
   expansion: FableValidationExpansion,
   fable?: FableBuilderV1,
@@ -673,7 +693,9 @@ export function toValidationState(
   ])
 
   for (const blockId of allBlockIds) {
-    const backendErrors = expansion.block_errors[blockId] ?? []
+    const backendErrors = (expansion.block_errors[blockId] ?? []).map(
+      unwrapBackendError,
+    )
     const missingErrors = missingRequiredByBlock[blockId] ?? []
     const errors = [...backendErrors, ...missingErrors]
     const missingGlyphs = expansion.missing_glyphs[blockId] ?? {}

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -30,12 +30,13 @@ function TooltipContent({
   align = 'center',
   alignOffset = 0,
   children,
+  variant = 'default',
   ...props
 }: TooltipPrimitive.Popup.Props &
   Pick<
     TooltipPrimitive.Positioner.Props,
     'align' | 'alignOffset' | 'side' | 'sideOffset'
-  >) {
+  > & { variant?: 'default' | 'light' }) {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Positioner
@@ -49,12 +50,16 @@ function TooltipContent({
           data-slot="tooltip-content"
           className={cn(
             'z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+            variant === 'light' &&
+              'bg-popover text-popover-foreground shadow-md ring-1 ring-border',
             className,
           )}
           {...props}
         >
           {children}
-          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+          {variant === 'default' && (
+            <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+          )}
         </TooltipPrimitive.Popup>
       </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>

--- a/frontend/src/features/fable-builder/components/graph-mode/EdgeQubeLens.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/EdgeQubeLens.tsx
@@ -1,0 +1,161 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { memo, useMemo, useState } from 'react'
+import { Boxes } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { QubeInspector } from './QubeInspector'
+import type { QubeNode } from '@/api/types/artifacts.types'
+import type { BlockInstance, FableBuilderV1 } from '@/api/types/fable.types'
+import { computeQubeMetrics } from '@/features/fable-builder/lib/qube-metrics'
+import { computeEdgeNarrowing } from '@/features/fable-builder/lib/qube-narrowing'
+import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { cn } from '@/lib/utils'
+
+/** Popover side per layout direction — mirrors AddNodeButton so the panel opens
+ *  away from the flow rather than over the next block. */
+const POPOVER_SIDE: Record<string, 'top' | 'bottom' | 'left' | 'right'> = {
+  TB: 'bottom',
+  LR: 'right',
+  BT: 'top',
+  RL: 'left',
+}
+
+/** Short human label for a block: "Select <dim>" for selects, else the factory
+ *  id de-camel-cased (no catalogue needed). */
+function describeBlock(fable: FableBuilderV1, blockId: string): string {
+  const block = fable.blocks[blockId] as BlockInstance | undefined
+  if (!block) return blockId
+  const factory = block.factory_id.factory
+  if (factory === 'select') {
+    const dimension = block.configuration_values['dimension'] as
+      | string
+      | undefined
+    return dimension != null && dimension !== ''
+      ? `Select ${dimension}`
+      : 'Select'
+  }
+  const words = factory
+    .replace(/([A-Z])/g, ' $1')
+    .trim()
+    .toLowerCase()
+  return words.charAt(0).toUpperCase() + words.slice(1)
+}
+
+interface EdgeQubeLensProps {
+  sourceId: string
+  targetId: string
+  inputName: string
+  /** The wire is hovered (or otherwise emphasised) — emphasises the handle. */
+  hovered: boolean
+}
+
+/**
+ * The qube-lens handle on an edge midpoint: a chip with the qube's
+ * dimensionality (and a dot when an upstream Select narrowed it). Clicking opens
+ * the inspector. Renders nothing when the backend provides no qube for the edge.
+ */
+export const EdgeQubeLens = memo(function ({
+  sourceId,
+  targetId,
+  hovered,
+}: EdgeQubeLensProps) {
+  const { t } = useTranslation('configure')
+  const [open, setOpen] = useState(false)
+  const layoutDirection = useFableBuilderStore((store) => store.layoutDirection)
+  const fable = useFableBuilderStore((store) => store.fable)
+  const blockOutputQubes = useFableBuilderStore(
+    (store) => store.validationState?.blockOutputQubes,
+  )
+  // The qube on this edge is the source block's output cube.
+  const qube = blockOutputQubes
+    ? (blockOutputQubes[sourceId] as QubeNode | undefined)
+    : undefined
+
+  const dimensionCount = useMemo(
+    () => (qube ? computeQubeMetrics(qube).dimensionCount : 0),
+    [qube],
+  )
+  const narrowing = useMemo(
+    () =>
+      qube && blockOutputQubes
+        ? computeEdgeNarrowing(fable, blockOutputQubes, sourceId)
+        : [],
+    [qube, blockOutputQubes, fable, sourceId],
+  )
+  const edgeLabel = useMemo(
+    () =>
+      `${describeBlock(fable, sourceId)} → ${describeBlock(fable, targetId)}`,
+    [fable, sourceId, targetId],
+  )
+
+  // No backend qube for this edge → nothing to show.
+  if (!qube) return null
+
+  const active = hovered || open
+  const narrowed = narrowing.length > 0
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      {/* Subtle handle: dimensionality only; the rich view lives in the popover. */}
+      <PopoverTrigger
+        render={
+          <button
+            type="button"
+            aria-label={t('qubeLens.handleLabel')}
+            className={cn(
+              'nodrag nopan inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5',
+              'text-[0.65rem] leading-none font-medium transition-all',
+              'focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none',
+              active
+                ? 'border-border bg-background text-muted-foreground shadow-sm'
+                : 'border-transparent text-muted-foreground/40 hover:text-muted-foreground',
+            )}
+            onClick={(event) => event.stopPropagation()}
+          />
+        }
+      >
+        <Boxes className="size-3 shrink-0" />
+        {dimensionCount > 0 && (
+          <span className="font-mono">
+            {t('qubeLens.dimensionCount', { count: dimensionCount })}
+          </span>
+        )}
+        {narrowed && (
+          <span
+            className="size-1.5 shrink-0 rounded-full bg-primary"
+            aria-hidden
+          />
+        )}
+      </PopoverTrigger>
+
+      <PopoverContent
+        className="max-h-[30rem] w-[min(24rem,90vw)] overflow-y-auto"
+        side={POPOVER_SIDE[layoutDirection]}
+        align="center"
+        sideOffset={10}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <QubeInspector
+          node={qube}
+          narrowing={narrowing}
+          edgeLabel={edgeLabel}
+          onClose={() => setOpen(false)}
+        />
+      </PopoverContent>
+    </Popover>
+  )
+})

--- a/frontend/src/features/fable-builder/components/graph-mode/EdgeQubeLens.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/EdgeQubeLens.tsx
@@ -15,7 +15,6 @@ import { useTranslation } from 'react-i18next'
 import { QubeInspector } from './QubeInspector'
 import type { QubeNode } from '@/api/types/artifacts.types'
 import type { BlockInstance, FableBuilderV1 } from '@/api/types/fable.types'
-import { computeQubeMetrics } from '@/features/fable-builder/lib/qube-metrics'
 import { computeEdgeNarrowing } from '@/features/fable-builder/lib/qube-narrowing'
 import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
 import {
@@ -64,8 +63,7 @@ interface EdgeQubeLensProps {
 }
 
 /**
- * The qube-lens handle on an edge midpoint: a chip with the qube's
- * dimensionality (and a dot when an upstream Select narrowed it). Clicking opens
+ * The qube-lens handle on an edge midpoint: a small cube glyph. Clicking opens
  * the inspector. Renders nothing when the backend provides no qube for the edge.
  */
 export const EdgeQubeLens = memo(function ({
@@ -85,10 +83,6 @@ export const EdgeQubeLens = memo(function ({
     ? (blockOutputQubes[sourceId] as QubeNode | undefined)
     : undefined
 
-  const dimensionCount = useMemo(
-    () => (qube ? computeQubeMetrics(qube).dimensionCount : 0),
-    [qube],
-  )
   const narrowing = useMemo(
     () =>
       qube && blockOutputQubes
@@ -106,19 +100,17 @@ export const EdgeQubeLens = memo(function ({
   if (!qube) return null
 
   const active = hovered || open
-  const narrowed = narrowing.length > 0
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      {/* Subtle handle: dimensionality only; the rich view lives in the popover. */}
+      {/* Subtle handle: just a cube glyph; the rich view lives in the popover. */}
       <PopoverTrigger
         render={
           <button
             type="button"
             aria-label={t('qubeLens.handleLabel')}
             className={cn(
-              'nodrag nopan inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5',
-              'text-[0.65rem] leading-none font-medium transition-all',
+              'nodrag nopan inline-flex items-center justify-center rounded-full border px-3 py-1 transition-all',
               'focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none',
               active
                 ? 'border-border bg-background text-muted-foreground shadow-sm'
@@ -128,18 +120,7 @@ export const EdgeQubeLens = memo(function ({
           />
         }
       >
-        <Boxes className="size-3 shrink-0" />
-        {dimensionCount > 0 && (
-          <span className="font-mono">
-            {t('qubeLens.dimensionCount', { count: dimensionCount })}
-          </span>
-        )}
-        {narrowed && (
-          <span
-            className="size-1.5 shrink-0 rounded-full bg-primary"
-            aria-hidden
-          />
-        )}
+        <Boxes className="size-3.5 shrink-0" />
       </PopoverTrigger>
 
       <PopoverContent

--- a/frontend/src/features/fable-builder/components/graph-mode/FableEdge.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/FableEdge.tsx
@@ -15,7 +15,9 @@ import {
   Position,
   getBezierPath,
   getSmoothStepPath,
+  useStore,
 } from '@xyflow/react'
+import { EdgeQubeLens } from './EdgeQubeLens'
 import type { Edge, EdgeProps } from '@xyflow/react'
 
 import type { EdgeStyle } from '@/features/fable-builder/stores/fableBuilderStore'
@@ -32,6 +34,10 @@ export type FableEdge = Edge<FableEdgeData, 'fableEdge'>
 // Orthogonal edges draw straight (no jog) when their cross-axis gap is within
 // this many px; real fan-out/-in bends stay well above it.
 const STRAIGHT_THRESHOLD = 24
+
+// Below this zoom the faint qube-lens handle is hidden to avoid clutter; it
+// still appears on hover (hovering the wire forces it visible).
+const LENS_ZOOM_THRESHOLD = 0.5
 
 /** SVG path for the active edge style. Orthogonal styles collapse to a straight
  *  line when the endpoints are nearly aligned (see STRAIGHT_THRESHOLD). */
@@ -90,6 +96,8 @@ function getEdgePath({
 
 export const FableEdgeComponent = memo(function ({
   id,
+  source,
+  target,
   sourceX,
   sourceY,
   targetX,
@@ -100,6 +108,12 @@ export const FableEdgeComponent = memo(function ({
   selected,
 }: EdgeProps<FableEdge>) {
   const edgeStyle = useFableBuilderStore((state) => state.edgeStyle)
+  // Per-edge boolean selectors keep re-renders scoped to the edge whose state
+  // actually flips (a raw hoveredEdgeId/zoom subscription would re-render all).
+  const isHovered = useFableBuilderStore((state) => state.hoveredEdgeId === id)
+  const lensHiddenByZoom = useStore(
+    (state) => state.transform[2] < LENS_ZOOM_THRESHOLD,
+  )
 
   const [edgePath, labelX, labelY] = getEdgePath({
     type: edgeStyle,
@@ -113,6 +127,19 @@ export const FableEdgeComponent = memo(function ({
 
   const inputName = data?.inputName
   const labelTransform = `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`
+
+  // Offset the qube-lens handle off the input-name badge when both share the
+  // midpoint (multi-input edges). Cross-axis = Y for horizontal flow, else X.
+  const horizontalFlow =
+    sourcePosition === Position.Left || sourcePosition === Position.Right
+  const lensDx = data?.showLabel && !horizontalFlow ? -30 : 0
+  const lensDy = data?.showLabel && horizontalFlow ? -18 : 0
+  const lensTransform = `translate(-50%, -50%) translate(${labelX + lensDx}px, ${labelY + lensDy}px)`
+
+  // Faint by default; the hovered (or selected) wire reveals it. Hidden at far
+  // zoom unless hovered, so a dense graph stays uncluttered.
+  const lensActive = isHovered || Boolean(selected)
+  const showLens = !lensHiddenByZoom || isHovered
 
   return (
     <>
@@ -138,6 +165,25 @@ export const FableEdgeComponent = memo(function ({
             <span className="rounded border border-border bg-background px-1.5 py-0.5 text-sm text-muted-foreground">
               {inputName}
             </span>
+          </div>
+        </EdgeLabelRenderer>
+      )}
+      {showLens && (
+        <EdgeLabelRenderer>
+          <div
+            style={{
+              position: 'absolute',
+              transform: lensTransform,
+              pointerEvents: 'all',
+            }}
+            className="nodrag nopan"
+          >
+            <EdgeQubeLens
+              sourceId={source}
+              targetId={target}
+              inputName={inputName ?? 'dataset'}
+              hovered={lensActive}
+            />
           </div>
         </EdgeLabelRenderer>
       )}

--- a/frontend/src/features/fable-builder/components/graph-mode/FableGraphCanvas.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/FableGraphCanvas.tsx
@@ -75,6 +75,7 @@ function FableGraphCanvasInner({ catalogue }: FableGraphCanvasProps) {
   const fitViewTrigger = useFableBuilderStore((state) => state.fitViewTrigger)
   const connectBlocks = useFableBuilderStore((state) => state.connectBlocks)
   const selectBlock = useFableBuilderStore((state) => state.selectBlock)
+  const setHoveredEdge = useFableBuilderStore((state) => state.setHoveredEdge)
   const selectedBlockId = useFableBuilderStore((state) => state.selectedBlockId)
 
   const { fitView, setViewport, getNodesBounds } = useReactFlow()
@@ -322,6 +323,16 @@ function FableGraphCanvasInner({ catalogue }: FableGraphCanvasProps) {
     [selectBlock],
   )
 
+  // Hovering a wire reveals its qube-lens handle (ephemeral UI; see FableEdge).
+  const onEdgeMouseEnter = useCallback(
+    (_: React.MouseEvent, edge: Edge) => setHoveredEdge(edge.id),
+    [setHoveredEdge],
+  )
+  const onEdgeMouseLeave = useCallback(
+    () => setHoveredEdge(null),
+    [setHoveredEdge],
+  )
+
   // Clicking empty canvas intentionally does NOT deselect the node
   // The sidebar stays with the last-selected node's config. To
   // deselect, use the X button in the ConfigPanel header.
@@ -335,6 +346,8 @@ function FableGraphCanvasInner({ catalogue }: FableGraphCanvasProps) {
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}
         onNodeClick={onNodeClick}
+        onEdgeMouseEnter={onEdgeMouseEnter}
+        onEdgeMouseLeave={onEdgeMouseLeave}
         onDragOver={onDragOver}
         onDrop={onDrop}
         nodeTypes={nodeTypes}

--- a/frontend/src/features/fable-builder/components/graph-mode/QubeInspector.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/QubeInspector.tsx
@@ -16,10 +16,7 @@ import { QubeSpectrum } from './QubeSpectrum'
 import type { QubeNode } from '@/api/types/artifacts.types'
 import type { QubeDimension } from '@/features/fable-builder/lib/qube-matrix'
 import type { DimensionNarrowing } from '@/features/fable-builder/lib/qube-narrowing'
-import {
-  computeQubeMetrics,
-  formatBytes,
-} from '@/features/fable-builder/lib/qube-metrics'
+import { computeQubeMetrics } from '@/features/fable-builder/lib/qube-metrics'
 import { dimensionColor } from '@/features/fable-builder/lib/dimension-colors'
 import { qubeToRequest } from '@/features/fable-builder/lib/qube-to-request'
 import { Badge } from '@/components/ui/badge'
@@ -39,9 +36,19 @@ function ColorDot({ name }: { name: string }) {
   )
 }
 
-function Stat({ value, label }: { value: string; label: string }) {
+function Stat({
+  value,
+  label,
+  align = 'start',
+}: {
+  value: string
+  label: string
+  align?: 'start' | 'end'
+}) {
   return (
-    <div className="flex flex-col gap-0.5">
+    <div
+      className={cn('flex flex-col gap-0.5', align === 'end' && 'items-end')}
+    >
       <span className="text-xl leading-none font-semibold text-foreground">
         {value}
       </span>
@@ -167,7 +174,6 @@ export function QubeInspector({
   const [query, setQuery] = useState('')
   const [hideFixed, setHideFixed] = useState(false)
   const [highlighted, setHighlighted] = useState<string | null>(null)
-  const rootRef = useRef<HTMLDivElement>(null)
 
   const metrics = useMemo(() => computeQubeMetrics(node), [node])
   const narrowingByDim = useMemo(
@@ -194,10 +200,9 @@ export function QubeInspector({
     )
 
   const selectDimension = (key: string) => {
-    // Toggle: clicking the already-selected bar deselects it and scrolls back up.
+    // Toggle: clicking the already-selected bar clears the emphasis.
     if (highlighted === key) {
       setHighlighted(null)
-      rootRef.current?.scrollIntoView({ block: 'start' })
       return
     }
     setTab('dimensions')
@@ -207,7 +212,7 @@ export function QubeInspector({
   }
 
   return (
-    <div ref={rootRef} className="flex flex-col gap-3">
+    <div className="flex flex-col gap-3">
       <div className="flex items-start justify-between gap-2">
         <div className="flex flex-col gap-0.5">
           <span className="font-semibold text-foreground">
@@ -231,7 +236,7 @@ export function QubeInspector({
         )}
       </div>
 
-      <div className="grid grid-cols-3 gap-2">
+      <div className="flex items-start justify-between gap-2">
         <Stat
           value={t('qubeLens.dimensionCount', {
             count: metrics.dimensionCount,
@@ -241,10 +246,7 @@ export function QubeInspector({
         <Stat
           value={metrics.fieldCount.toLocaleString()}
           label={t('qubeLens.statFields')}
-        />
-        <Stat
-          value={`≈ ${formatBytes(metrics.estimatedBytes)}`}
-          label={t('qubeLens.statSize')}
+          align="end"
         />
       </div>
 

--- a/frontend/src/features/fable-builder/components/graph-mode/QubeInspector.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/QubeInspector.tsx
@@ -1,0 +1,350 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { ChevronDown, X } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+import { QubeSpectrum } from './QubeSpectrum'
+import type { QubeNode } from '@/api/types/artifacts.types'
+import type { QubeDimension } from '@/features/fable-builder/lib/qube-matrix'
+import type { DimensionNarrowing } from '@/features/fable-builder/lib/qube-narrowing'
+import {
+  computeQubeMetrics,
+  formatBytes,
+} from '@/features/fable-builder/lib/qube-metrics'
+import { dimensionColor } from '@/features/fable-builder/lib/dimension-colors'
+import { qubeToRequest } from '@/features/fable-builder/lib/qube-to-request'
+import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
+import { Switch } from '@/components/ui/switch'
+import { cn } from '@/lib/utils'
+
+type Tab = 'dimensions' | 'selection'
+
+function ColorDot({ name }: { name: string }) {
+  return (
+    <span
+      aria-hidden
+      className="size-2 shrink-0 rounded-full"
+      style={{ backgroundColor: dimensionColor(name) }}
+    />
+  )
+}
+
+function Stat({ value, label }: { value: string; label: string }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-xl leading-none font-semibold text-foreground">
+        {value}
+      </span>
+      <span className="text-[0.65rem] tracking-wide text-muted-foreground uppercase">
+        {label}
+      </span>
+    </div>
+  )
+}
+
+function DimensionRow({
+  dim,
+  narrowing,
+  highlighted,
+  search,
+}: {
+  dim: QubeDimension
+  narrowing: DimensionNarrowing | undefined
+  highlighted: boolean
+  search: string
+}) {
+  const { t } = useTranslation('configure')
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLLIElement>(null)
+  const count = dim.values.length
+  const fixedValue = count === 1 ? dim.values[0] : null
+  // Auto-reveal a dimension's values when the search matches one of them.
+  const valueMatch =
+    search !== '' &&
+    dim.values.some((value) => value.toLowerCase().includes(search))
+  const showValues = open || valueMatch
+
+  // Selecting this dimension's spectrum bar reveals and scrolls to its row.
+  useEffect(() => {
+    if (highlighted) {
+      setOpen(true)
+      ref.current?.scrollIntoView({ block: 'nearest' })
+    }
+  }, [highlighted])
+
+  return (
+    <li ref={ref} className={cn('rounded', highlighted && 'bg-primary/5')}>
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className={cn(
+          'flex w-full items-center gap-2 rounded px-1 py-1.5 text-left transition-colors hover:bg-muted/50',
+          highlighted && 'ring-2 ring-primary/40',
+        )}
+      >
+        <ColorDot name={dim.key} />
+        <span className="font-mono text-sm font-medium text-foreground">
+          {dim.key}
+        </span>
+        {fixedValue != null && (
+          <span className="truncate font-mono text-xs text-muted-foreground">
+            {fixedValue}
+          </span>
+        )}
+        <span className="ml-auto flex items-center gap-2">
+          {narrowing != null && (
+            <Badge
+              variant="outline"
+              className="border-primary/40 text-[0.6rem] tracking-wide text-primary uppercase"
+            >
+              {t('qubeLens.narrowedBadge')}
+            </Badge>
+          )}
+          <span className="font-mono text-xs text-muted-foreground">
+            {count}
+          </span>
+          <ChevronDown
+            className={cn(
+              'size-3.5 text-muted-foreground transition-transform',
+              showValues && 'rotate-180',
+            )}
+          />
+        </span>
+      </button>
+      {showValues && count > 0 && (
+        <div className="flex flex-wrap gap-1 px-3 pt-1 pb-2">
+          {dim.values.map((value) => {
+            const isMatch =
+              search !== '' && value.toLowerCase().includes(search)
+            return (
+              <Badge
+                key={value}
+                variant="secondary"
+                className={cn(
+                  'font-mono',
+                  isMatch &&
+                    'border border-primary/50 bg-primary/10 text-primary',
+                )}
+              >
+                {value}
+              </Badge>
+            )
+          })}
+        </div>
+      )}
+    </li>
+  )
+}
+
+/**
+ * "Qube at this edge" inspector: stats, the interactive spectrum, the upstream
+ * narrowing diff, a searchable dimension list, and a source-neutral selection
+ * view. Clicking a spectrum bar jumps to that dimension's row.
+ */
+export function QubeInspector({
+  node,
+  narrowing,
+  edgeLabel,
+  onClose,
+}: {
+  node: QubeNode
+  narrowing: ReadonlyArray<DimensionNarrowing>
+  edgeLabel?: string
+  onClose?: () => void
+}) {
+  const { t } = useTranslation('configure')
+  const [tab, setTab] = useState<Tab>('dimensions')
+  const [query, setQuery] = useState('')
+  const [hideFixed, setHideFixed] = useState(false)
+  const [highlighted, setHighlighted] = useState<string | null>(null)
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  const metrics = useMemo(() => computeQubeMetrics(node), [node])
+  const narrowingByDim = useMemo(
+    () => new Map(narrowing.map((item) => [item.dimension, item])),
+    [narrowing],
+  )
+
+  const hasFixed = metrics.dimensions.some((dim) => dim.values.length <= 1)
+  const search = query.trim().toLowerCase()
+  // Most-varying dimensions first, then alphabetical — the qube's tree order
+  // reads as arbitrary, and this sinks the size-1 context dims to the bottom.
+  const visibleDimensions = metrics.dimensions
+    .filter((dim) => {
+      if (hideFixed && dim.values.length <= 1) return false
+      if (search === '') return true
+      // Match the axis name or any of its coordinate values.
+      return (
+        dim.key.toLowerCase().includes(search) ||
+        dim.values.some((value) => value.toLowerCase().includes(search))
+      )
+    })
+    .sort(
+      (a, b) => b.values.length - a.values.length || a.key.localeCompare(b.key),
+    )
+
+  const selectDimension = (key: string) => {
+    // Toggle: clicking the already-selected bar deselects it and scrolls back up.
+    if (highlighted === key) {
+      setHighlighted(null)
+      rootRef.current?.scrollIntoView({ block: 'start' })
+      return
+    }
+    setTab('dimensions')
+    setQuery('')
+    setHideFixed(false)
+    setHighlighted(key)
+  }
+
+  return (
+    <div ref={rootRef} className="flex flex-col gap-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex flex-col gap-0.5">
+          <span className="font-semibold text-foreground">
+            {t('qubeLens.title')}
+          </span>
+          {edgeLabel != null && edgeLabel !== '' && (
+            <span className="font-mono text-xs text-muted-foreground">
+              {edgeLabel}
+            </span>
+          )}
+        </div>
+        {onClose != null && (
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={t('qubeLens.close')}
+            className="-mt-1 -mr-1 rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <X className="size-4" />
+          </button>
+        )}
+      </div>
+
+      <div className="grid grid-cols-3 gap-2">
+        <Stat
+          value={t('qubeLens.dimensionCount', {
+            count: metrics.dimensionCount,
+          })}
+          label={t('qubeLens.statDimensions')}
+        />
+        <Stat
+          value={metrics.fieldCount.toLocaleString()}
+          label={t('qubeLens.statFields')}
+        />
+        <Stat
+          value={`≈ ${formatBytes(metrics.estimatedBytes)}`}
+          label={t('qubeLens.statSize')}
+        />
+      </div>
+
+      <div className="flex justify-center py-1">
+        <QubeSpectrum
+          dimensions={metrics.dimensions}
+          size="lg"
+          onBarClick={selectDimension}
+          activeKey={highlighted}
+        />
+      </div>
+
+      {narrowing.length > 0 && (
+        <div className="flex flex-col gap-1 rounded-md border border-primary/30 bg-primary/5 px-3 py-2">
+          {narrowing.map((item) => (
+            <div
+              key={item.dimension}
+              className="flex items-center gap-2 text-sm"
+            >
+              <ColorDot name={item.dimension} />
+              <span className="font-mono font-medium text-foreground">
+                {item.dimension}
+              </span>
+              <span className="text-muted-foreground">
+                {t('qubeLens.narrowedDiff', {
+                  from: item.from,
+                  to: item.to,
+                })}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="flex gap-1 rounded-md bg-muted p-0.5 text-xs">
+        {(['dimensions', 'selection'] as const).map((option) => (
+          <button
+            key={option}
+            type="button"
+            onClick={() => setTab(option)}
+            className={cn(
+              'flex-1 rounded px-2 py-1 transition-colors',
+              tab === option
+                ? 'bg-background font-medium text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            {option === 'dimensions'
+              ? t('qubeLens.tabDimensions')
+              : t('qubeLens.tabSelection')}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'dimensions' ? (
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-2">
+            <Input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder={t('qubeLens.searchPlaceholder')}
+              className="h-8"
+            />
+            {hasFixed && (
+              <label className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
+                <Switch
+                  size="sm"
+                  checked={hideFixed}
+                  onCheckedChange={setHideFixed}
+                />
+                {t('qubeLens.hideFixed')}
+              </label>
+            )}
+          </div>
+
+          <ul className="flex flex-col">
+            {visibleDimensions.map((dim) => (
+              <DimensionRow
+                key={dim.key}
+                dim={dim}
+                narrowing={narrowingByDim.get(dim.key)}
+                highlighted={highlighted === dim.key}
+                search={search}
+              />
+            ))}
+          </ul>
+
+          <div className="border-t border-border pt-2 text-center font-mono text-xs text-muted-foreground">
+            {metrics.dimensions.map((dim) => dim.values.length).join(' × ')} ={' '}
+            <span className="font-semibold text-foreground">
+              {metrics.fieldCount.toLocaleString()}
+            </span>{' '}
+            {t('qubeLens.fieldsUnit')}
+          </div>
+        </div>
+      ) : (
+        <pre className="overflow-x-auto rounded-md bg-muted/50 p-3 font-mono text-xs text-foreground">
+          {qubeToRequest(node) || t('qubeLens.requestEmpty')}
+        </pre>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/fable-builder/components/graph-mode/QubeSpectrum.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/QubeSpectrum.tsx
@@ -1,0 +1,131 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { useTranslation } from 'react-i18next'
+
+import type { QubeDimension } from '@/features/fable-builder/lib/qube-matrix'
+import { dimensionColor } from '@/features/fable-builder/lib/dimension-colors'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+/**
+ * One colored bar per dimension, height (log-scaled) = cardinality; colors are
+ * shared with the inspector. With `onBarClick`, bars are interactive: hover
+ * shows a light tooltip, click selects (`activeKey` bar emphasised, rest fade).
+ */
+
+const SIZES = {
+  sm: { bar: 3, gap: 1.5, height: 16 },
+  lg: { bar: 9, gap: 4, height: 40 },
+} as const
+
+/** Smallest bar height fraction, so size-1 dimensions still show a stub. */
+const MIN_FRACTION = 0.18
+
+export function QubeSpectrum({
+  dimensions,
+  size = 'sm',
+  className,
+  onBarClick,
+  activeKey,
+}: {
+  dimensions: ReadonlyArray<QubeDimension>
+  size?: 'sm' | 'lg'
+  className?: string
+  onBarClick?: (key: string) => void
+  activeKey?: string | null
+}) {
+  const { t } = useTranslation('configure')
+
+  if (dimensions.length === 0) return null
+
+  const metrics = SIZES[size]
+  const interactive = onBarClick != null
+  const maxCount = Math.max(...dimensions.map((dim) => dim.values.length))
+  const denominator = Math.log(maxCount + 1) || 1
+
+  const barHeight = (dim: QubeDimension): number => {
+    const fraction =
+      MIN_FRACTION +
+      (1 - MIN_FRACTION) * (Math.log(dim.values.length + 1) / denominator)
+    return Math.max(2, fraction * metrics.height)
+  }
+
+  if (!interactive) {
+    return (
+      <div
+        className={cn('flex items-end', className)}
+        style={{ gap: metrics.gap, height: metrics.height }}
+        role="img"
+        aria-label={`Qube spectrum, ${dimensions.length} dimensions`}
+      >
+        {dimensions.map((dim) => (
+          <div
+            key={dim.key}
+            title={`${dim.key} (${dim.values.length})`}
+            className="shrink-0 rounded-[2px]"
+            style={{
+              width: metrics.bar,
+              height: barHeight(dim),
+              backgroundColor: dimensionColor(dim.key),
+            }}
+          />
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <TooltipProvider delay={120}>
+      <div
+        className={cn('flex items-end', className)}
+        style={{ gap: metrics.gap, height: metrics.height }}
+      >
+        {dimensions.map((dim) => {
+          const isActive = activeKey != null && dim.key === activeKey
+          const dimmed = activeKey != null && !isActive
+          return (
+            <Tooltip key={dim.key}>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
+                    aria-label={`${dim.key}: ${dim.values.length}`}
+                    onClick={() => onBarClick(dim.key)}
+                    className={cn(
+                      'shrink-0 cursor-pointer rounded-[2px] transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none',
+                      dimmed && 'opacity-30',
+                    )}
+                    style={{
+                      width: metrics.bar,
+                      height: barHeight(dim),
+                      backgroundColor: dimensionColor(dim.key),
+                    }}
+                  />
+                }
+              />
+              <TooltipContent variant="light" side="top" sideOffset={6}>
+                {t('qubeLens.barTooltip', {
+                  dimension: dim.key,
+                  count: dim.values.length,
+                })}
+              </TooltipContent>
+            </Tooltip>
+          )
+        })}
+      </div>
+    </TooltipProvider>
+  )
+}

--- a/frontend/src/features/fable-builder/lib/dimension-colors.ts
+++ b/frontend/src/features/fable-builder/lib/dimension-colors.ts
@@ -1,0 +1,66 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Stable dimension-name to hex-color mapping, so a given dimension is rendered
+ * in the same color everywhere (edge glyphs, inspector dots, ...). Common
+ * MARS/forecast dimensions are pinned to a hand-picked, visually-distinct
+ * palette; any other name is hashed deterministically into a fallback palette.
+ */
+
+/** Pinned colors for the common MARS/forecast dimensions (Tailwind-500-ish). */
+const PINNED: Record<string, string> = {
+  class: '#ef4444', // red
+  stream: '#f97316', // orange
+  expver: '#f59e0b', // amber
+  type: '#84cc16', // lime
+  levtype: '#14b8a6', // teal
+  levelist: '#10b981', // emerald
+  param: '#3b82f6', // blue
+  number: '#6366f1', // indigo
+  step: '#8b5cf6', // violet
+  time: '#d946ef', // fuchsia
+  domain: '#64748b', // slate
+}
+
+/** Fallback palette for unknown dimensions, kept clear of the pinned hues. */
+const FALLBACK: ReadonlyArray<string> = [
+  '#ec4899', // pink
+  '#06b6d4', // cyan
+  '#eab308', // yellow
+  '#a855f7', // purple
+  '#22c55e', // green
+  '#0ea5e9', // sky
+  '#f43f5e', // rose
+  '#0d9488', // teal-600
+  '#7c3aed', // violet-600
+  '#db2777', // pink-600
+]
+
+/** FNV-1a-ish stable string hash → non-negative 32-bit integer. */
+function hashName(name: string): number {
+  let hash = 2166136261
+  for (let i = 0; i < name.length; i += 1) {
+    hash ^= name.charCodeAt(i)
+    hash = Math.imul(hash, 16777619)
+  }
+  return hash >>> 0
+}
+
+/**
+ * Stable hex color for a dimension name. Pinned names always map to their
+ * curated hue; unknown names hash deterministically into the fallback palette,
+ * so the color is consistent across renders and sessions.
+ */
+export function dimensionColor(name: string): string {
+  const pinned = PINNED[name] as string | undefined
+  if (pinned !== undefined) return pinned
+  return FALLBACK[hashName(name) % FALLBACK.length]
+}

--- a/frontend/src/features/fable-builder/lib/qube-matrix.ts
+++ b/frontend/src/features/fable-builder/lib/qube-matrix.ts
@@ -1,0 +1,63 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Parse a qube into its dimensions. A qube is treated purely as a set of named
+ * dimensions, each with coordinate values — the foundation for the qube lens
+ * (spectrum glyph, metrics, inspector). Nothing here is specific to any
+ * dimension name.
+ */
+
+import type { QubeNode } from '@/api/types/artifacts.types'
+
+export interface QubeDimension {
+  key: string
+  values: Array<string>
+}
+
+/** Order a dimension's values numerically when they all parse as numbers,
+ *  otherwise leave them in first-seen order. */
+function sortValues(values: ReadonlyArray<string>): Array<string> {
+  const allNumeric = values.every(
+    (value) => value !== '' && !Number.isNaN(Number(value)),
+  )
+  if (!allNumeric) return [...values]
+  return [...values].sort((a, b) => Number(a) - Number(b))
+}
+
+/**
+ * Every dimension of the qube in tree order, each with the union of its
+ * coordinate values. A compressed qube node shares one set of children across
+ * all its values, so we recurse into children once per node — O(nodes), never
+ * expanding the cartesian product.
+ */
+export function parseQubeDimensions(root: QubeNode): Array<QubeDimension> {
+  const order: Array<string> = []
+  const byKey = new Map<string, Set<string>>()
+
+  const visit = (node: QubeNode, isRoot: boolean): void => {
+    if (!isRoot) {
+      let set = byKey.get(node.key)
+      if (!set) {
+        set = new Set<string>()
+        byKey.set(node.key, set)
+        order.push(node.key)
+      }
+      for (const value of node.values.values) set.add(String(value))
+    }
+    for (const child of node.children) visit(child, false)
+  }
+
+  visit(root, true)
+  return order.map((key) => ({
+    key,
+    values: sortValues([...(byKey.get(key) ?? new Set<string>())]),
+  }))
+}

--- a/frontend/src/features/fable-builder/lib/qube-metrics.ts
+++ b/frontend/src/features/fable-builder/lib/qube-metrics.ts
@@ -9,17 +9,13 @@
  */
 
 /**
- * Qube summary: dimension count, field count (exact product of dimension sizes),
- * and a rough size. The size is a demo estimate only — it assumes a fixed
- * per-field size; the real one needs the grid resolution (not carried here).
+ * Qube summary: dimension count and field count (the exact product of dimension
+ * sizes).
  */
 
 import { parseQubeDimensions } from './qube-matrix'
 import type { QubeNode } from '@/api/types/artifacts.types'
 import type { QubeDimension } from './qube-matrix'
-
-/** Rough size of one field (≈ one global lat/lon grid): ~1 MB. Demo estimate. */
-export const BYTES_PER_FIELD = 1_000_000
 
 export interface QubeMetrics {
   dimensions: Array<QubeDimension>
@@ -27,11 +23,9 @@ export interface QubeMetrics {
   dimensionCount: number
   /** Product of every dimension's value count; an empty/dimensionless qube is 1. */
   fieldCount: number
-  /** `fieldCount * BYTES_PER_FIELD` — indicative only (see file header). */
-  estimatedBytes: number
 }
 
-/** Summarize a qube as dimension count, (exact) field count, and rough size. */
+/** Summarize a qube as dimension count and (exact) field count. */
 export function computeQubeMetrics(node: QubeNode): QubeMetrics {
   const dimensions = parseQubeDimensions(node)
   const fieldCount = dimensions.reduce((acc, dim) => acc * dim.values.length, 1)
@@ -39,27 +33,5 @@ export function computeQubeMetrics(node: QubeNode): QubeMetrics {
     dimensions,
     dimensionCount: dimensions.length,
     fieldCount,
-    estimatedBytes: fieldCount * BYTES_PER_FIELD,
   }
-}
-
-/** Compact count for the small edge glyph: 8200 → "8.2k", 1500000 → "1.5M", 204 → "204". */
-export function formatCompactCount(n: number): string {
-  if (n < 1_000) return String(n)
-  if (n < 1_000_000) return `${(n / 1_000).toFixed(1)}k`
-  return `${(n / 1_000_000).toFixed(1)}M`
-}
-
-/** Human-readable byte size, stepping up to PB so large qubes stay short. */
-export function formatBytes(n: number): string {
-  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
-  let value = n
-  let unit = 0
-  while (value >= 1_000 && unit < units.length - 1) {
-    value /= 1_000
-    unit += 1
-  }
-  // Whole numbers up to MB, one decimal above (e.g. "920 KB", "13.6 TB").
-  const rounded = unit <= 2 ? Math.round(value) : Math.round(value * 10) / 10
-  return `${rounded} ${units[unit]}`
 }

--- a/frontend/src/features/fable-builder/lib/qube-metrics.ts
+++ b/frontend/src/features/fable-builder/lib/qube-metrics.ts
@@ -1,0 +1,65 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Qube summary: dimension count, field count (exact product of dimension sizes),
+ * and a rough size. The size is a demo estimate only — it assumes a fixed
+ * per-field size; the real one needs the grid resolution (not carried here).
+ */
+
+import { parseQubeDimensions } from './qube-matrix'
+import type { QubeNode } from '@/api/types/artifacts.types'
+import type { QubeDimension } from './qube-matrix'
+
+/** Rough size of one field (≈ one global lat/lon grid): ~1 MB. Demo estimate. */
+export const BYTES_PER_FIELD = 1_000_000
+
+export interface QubeMetrics {
+  dimensions: Array<QubeDimension>
+  /** Number of dimensions in the qube. */
+  dimensionCount: number
+  /** Product of every dimension's value count; an empty/dimensionless qube is 1. */
+  fieldCount: number
+  /** `fieldCount * BYTES_PER_FIELD` — indicative only (see file header). */
+  estimatedBytes: number
+}
+
+/** Summarize a qube as dimension count, (exact) field count, and rough size. */
+export function computeQubeMetrics(node: QubeNode): QubeMetrics {
+  const dimensions = parseQubeDimensions(node)
+  const fieldCount = dimensions.reduce((acc, dim) => acc * dim.values.length, 1)
+  return {
+    dimensions,
+    dimensionCount: dimensions.length,
+    fieldCount,
+    estimatedBytes: fieldCount * BYTES_PER_FIELD,
+  }
+}
+
+/** Compact count for the small edge glyph: 8200 → "8.2k", 1500000 → "1.5M", 204 → "204". */
+export function formatCompactCount(n: number): string {
+  if (n < 1_000) return String(n)
+  if (n < 1_000_000) return `${(n / 1_000).toFixed(1)}k`
+  return `${(n / 1_000_000).toFixed(1)}M`
+}
+
+/** Human-readable byte size, stepping up to PB so large qubes stay short. */
+export function formatBytes(n: number): string {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
+  let value = n
+  let unit = 0
+  while (value >= 1_000 && unit < units.length - 1) {
+    value /= 1_000
+    unit += 1
+  }
+  // Whole numbers up to MB, one decimal above (e.g. "920 KB", "13.6 TB").
+  const rounded = unit <= 2 ? Math.round(value) : Math.round(value * 10) / 10
+  return `${rounded} ${units[unit]}`
+}

--- a/frontend/src/features/fable-builder/lib/qube-narrowing.ts
+++ b/frontend/src/features/fable-builder/lib/qube-narrowing.ts
@@ -1,0 +1,87 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Detect which dimension(s) a block narrowed, by comparing the qube flowing
+ * into it (its upstream blocks' output) with the qube it emits. The diff is
+ * purely on per-dimension value counts, so it never expands the cartesian.
+ */
+
+import { parseQubeDimensions } from './qube-matrix'
+import type { QubeNode } from '@/api/types/artifacts.types'
+import type { FableBuilderV1 } from '@/api/types/fable.types'
+
+export interface DimensionNarrowing {
+  dimension: string
+  from: number
+  to: number
+}
+
+/** Per-dimension value counts for a qube, keyed by dimension name. */
+function dimensionCounts(root: QubeNode): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const dim of parseQubeDimensions(root)) {
+    counts.set(dim.key, dim.values.length)
+  }
+  return counts
+}
+
+/**
+ * Dimensions the source block deliberately narrowed (input → output count drop).
+ * For a Select, only its chosen dimension counts — other dims shrink merely as a
+ * side effect of pruning the qube. Sorted by largest drop; `[]` for an
+ * origin/missing qube.
+ */
+export function computeEdgeNarrowing(
+  fable: FableBuilderV1,
+  blockOutputQubes: Record<string, QubeNode>,
+  sourceBlockId: string,
+): Array<DimensionNarrowing> {
+  const outputQube = blockOutputQubes[sourceBlockId] as QubeNode | undefined
+  const block = fable.blocks[sourceBlockId] as
+    | FableBuilderV1['blocks'][string]
+    | undefined
+  if (!outputQube || !block) return []
+
+  const inputCounts = new Map<string, number>()
+  for (const upstreamId of Object.values(block.input_ids)) {
+    const upstreamQube = blockOutputQubes[upstreamId] as QubeNode | undefined
+    if (!upstreamQube) continue
+    for (const [dimension, count] of dimensionCounts(upstreamQube)) {
+      const existing = inputCounts.get(dimension)
+      // Union across upstream qubes: keep the widest count per dimension.
+      if (existing === undefined || count > existing) {
+        inputCounts.set(dimension, count)
+      }
+    }
+  }
+  if (inputCounts.size === 0) return []
+
+  const outputCounts = dimensionCounts(outputQube)
+  const narrowings: Array<DimensionNarrowing> = []
+  for (const [dimension, from] of inputCounts) {
+    const to = outputCounts.get(dimension)
+    if (to !== undefined && from > to) {
+      narrowings.push({ dimension, from, to })
+    }
+  }
+
+  // A Select only deliberately narrows its chosen dimension; keep just that one.
+  const isSelect = block.factory_id.factory === 'select'
+  const selectedDim = block.configuration_values['dimension'] as
+    | string
+    | undefined
+  const deliberate = isSelect
+    ? narrowings.filter((item) => item.dimension === selectedDim)
+    : narrowings
+
+  deliberate.sort((a, b) => b.from - b.to - (a.from - a.to))
+  return deliberate
+}

--- a/frontend/src/features/fable-builder/lib/qube-to-request.ts
+++ b/frontend/src/features/fable-builder/lib/qube-to-request.ts
@@ -1,0 +1,28 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Render a qube as a plain `key = v1, v2, …` selection (one line per dimension).
+ * Deliberately not MARS syntax — the qube can come from MARS, Anemoi or Open
+ * Data, so this is a source-neutral description of the selected coordinates.
+ */
+
+import { parseQubeDimensions } from './qube-matrix'
+import type { QubeNode } from '@/api/types/artifacts.types'
+
+/** A readable `key = values` selection, one dimension per line. Empty string
+ *  when the qube has no dimensions. */
+export function qubeToRequest(node: QubeNode): string {
+  const dimensions = parseQubeDimensions(node)
+  if (dimensions.length === 0) return ''
+  return dimensions
+    .map((dim) => `${dim.key} = ${dim.values.join(', ')}`)
+    .join('\n')
+}

--- a/frontend/src/features/fable-builder/stores/fableBuilderStore.ts
+++ b/frontend/src/features/fable-builder/stores/fableBuilderStore.ts
@@ -106,6 +106,9 @@ interface FableBuilderState {
   mode: BuilderMode
   step: BuilderStep
   selectedBlockId: BlockInstanceId | null
+  /** Edge currently hovered on the canvas; drives the qube-lens handle's
+   *  visibility. Ephemeral UI — never persisted, never part of undo history. */
+  hoveredEdgeId: string | null
   isPaletteOpen: boolean
   isConfigPanelOpen: boolean
   isMobilePaletteOpen: boolean
@@ -178,6 +181,7 @@ interface FableBuilderState {
   ) => void
   disconnectBlock: (targetBlockId: BlockInstanceId, inputName: string) => void
   selectBlock: (blockId: BlockInstanceId | null) => void
+  setHoveredEdge: (edgeId: string | null) => void
   setMode: (mode: BuilderMode) => void
   setStep: (step: BuilderStep) => void
   togglePalette: () => void
@@ -233,6 +237,7 @@ function createInitialState() {
     mode: 'graph' as BuilderMode,
     step: 'edit' as BuilderStep,
     selectedBlockId: null,
+    hoveredEdgeId: null as string | null,
     isPaletteOpen: true,
     isConfigPanelOpen: true,
     isMobilePaletteOpen: false,
@@ -633,6 +638,9 @@ export const useFableBuilderStore = create<FableBuilderState>()(
               // User closes it explicitly via toggleConfigPanel.
               isConfigPanelOpen: true,
             }),
+
+          // Pure ephemeral UI: no history, no dirty flag, no validation reset.
+          setHoveredEdge: (edgeId) => set({ hoveredEdgeId: edgeId }),
 
           setMode: (mode) => set({ mode }),
           setStep: (step) => set({ step }),

--- a/frontend/src/locales/en/configure.json
+++ b/frontend/src/locales/en/configure.json
@@ -205,7 +205,6 @@
     "handleLabel": "Inspect the qube on this edge",
     "statDimensions": "Dimensions",
     "statFields": "Fields",
-    "statSize": "Est. size",
     "narrowedDiff": "narrowed {{from}} → {{to}}",
     "tabDimensions": "Dimensions",
     "tabSelection": "Selection",

--- a/frontend/src/locales/en/configure.json
+++ b/frontend/src/locales/en/configure.json
@@ -198,6 +198,26 @@
     "dropInsert": "Slice & insert",
     "dropConnect": "Connect"
   },
+  "qubeLens": {
+    "title": "Qube at this edge",
+    "dimensionCount_one": "{{count}}D",
+    "dimensionCount_other": "{{count}}D",
+    "handleLabel": "Inspect the qube on this edge",
+    "statDimensions": "Dimensions",
+    "statFields": "Fields",
+    "statSize": "Est. size",
+    "narrowedDiff": "narrowed {{from}} → {{to}}",
+    "tabDimensions": "Dimensions",
+    "tabSelection": "Selection",
+    "requestEmpty": "No coordinates.",
+    "searchPlaceholder": "Search axes or values…",
+    "hideFixed": "Hide fixed",
+    "narrowedBadge": "narrowed",
+    "fieldsUnit": "fields",
+    "close": "Close",
+    "barTooltip_one": "{{dimension}} · {{count}} value",
+    "barTooltip_other": "{{dimension}} · {{count}} values"
+  },
   "blockNode": {
     "configureBlock": "Configure block",
     "deleteBlock": "Delete Block",

--- a/frontend/tests/unit/api/fable-types.test.ts
+++ b/frontend/tests/unit/api/fable-types.test.ts
@@ -15,9 +15,11 @@ import type {
   FableValidationExpansion,
 } from '@/api/types/fable.types'
 import {
+  FableValidationExpansionSchema,
   getBlockConfigurationRestrictions,
   partitionBlueprintTags,
   toValidationState,
+  unwrapBackendError,
 } from '@/api/types/fable.types'
 
 const mockCatalogue: BlockFactoryCatalogue = {
@@ -200,6 +202,104 @@ describe('toValidationState', () => {
     expect(
       getBlockConfigurationRestrictions(fable, validationState, 'b1'),
     ).toEqual({ param: 'list[enumClosed[2t,msl]]' })
+  })
+})
+
+describe('unwrapBackendError', () => {
+  it('unwraps a single-quoted Python exception repr to the bare message', () => {
+    expect(
+      unwrapBackendError(
+        "ValueError('param 2t is not in the input parameters: [msl]')",
+      ),
+    ).toBe('param 2t is not in the input parameters: [msl]')
+  })
+
+  it('unwraps a double-quoted repr and un-escapes the embedded quote', () => {
+    expect(unwrapBackendError('ValueError("can\'t resolve")')).toBe(
+      "can't resolve",
+    )
+  })
+
+  it('unwraps custom exception classes ending in Error/Exception', () => {
+    expect(
+      unwrapBackendError("BlockInstanceConfigurationError('missing input')"),
+    ).toBe('missing input')
+  })
+
+  it('leaves already-clean messages untouched', () => {
+    const clean =
+      'Invalid filepath: directory path can not contain template values'
+    expect(unwrapBackendError(clean)).toBe(clean)
+  })
+
+  it('does not strip text that merely looks function-like', () => {
+    expect(unwrapBackendError('select(dataset) returned nothing')).toBe(
+      'select(dataset) returned nothing',
+    )
+  })
+
+  it('cleans backend block errors through toValidationState', () => {
+    const result = toValidationState({
+      global_errors: [],
+      block_errors: { b1: ["ValueError('bad value')"] },
+      possible_sources: [],
+      possible_expansions: {},
+      configuration_restrictions: {},
+      resolved_configuration_options: {},
+      block_output_qubes: {},
+      missing_glyphs: {},
+    })
+    expect(result.blockStates.b1.errors).toEqual(['bad value'])
+  })
+})
+
+describe('FableValidationExpansionSchema block_output_qubes', () => {
+  const base = {
+    global_errors: [],
+    block_errors: {},
+    possible_sources: [],
+    possible_expansions: {},
+    configuration_restrictions: {},
+    resolved_configuration_options: {},
+    missing_glyphs: {},
+  }
+
+  /** A well-formed qubed node tree (enum value-groups only). */
+  const enumQube = {
+    key: 'root',
+    values: { type: 'enum', dtype: 'str', values: ['root'] },
+    metadata: {},
+    children: [
+      {
+        key: 'param',
+        values: { type: 'enum', dtype: 'str', values: ['2t', 'msl'] },
+        metadata: {},
+        children: [],
+      },
+    ],
+  }
+
+  /** Wildcard value-groups serialize as the bare string `"*"`, which QubeNodeSchema rejects. */
+  const wildcardQube = {
+    key: 'root',
+    values: { type: 'enum', dtype: 'str', values: ['root'] },
+    metadata: {},
+    children: [{ key: 'param', values: '*', metadata: {}, children: [] }],
+  }
+
+  it('keeps valid qubes and drops unmodellable ones without failing the response', () => {
+    const result = FableValidationExpansionSchema.parse({
+      ...base,
+      block_output_qubes: { good: enumQube, bad: wildcardQube },
+    })
+
+    expect(Object.keys(result.block_output_qubes)).toEqual(['good'])
+    expect(result.block_output_qubes.good).toEqual(enumQube)
+  })
+
+  it('defaults to an empty object when omitted', () => {
+    const result = FableValidationExpansionSchema.parse({ ...base })
+    expect(result.block_output_qubes).toEqual({})
   })
 })
 

--- a/frontend/tests/unit/api/fable-types.test.ts
+++ b/frontend/tests/unit/api/fable-types.test.ts
@@ -74,6 +74,7 @@ describe('toValidationState', () => {
       possible_expansions: {},
       configuration_restrictions: {},
       resolved_configuration_options: {},
+      block_output_qubes: {},
       missing_glyphs: {},
     }
 
@@ -94,6 +95,7 @@ describe('toValidationState', () => {
       possible_expansions: {},
       configuration_restrictions: {},
       resolved_configuration_options: {},
+      block_output_qubes: {},
       missing_glyphs: {
         sink_file: {
           fname: ['missingRoot'],
@@ -121,6 +123,7 @@ describe('toValidationState', () => {
       possible_expansions: {},
       configuration_restrictions: {},
       resolved_configuration_options: {},
+      block_output_qubes: {},
       missing_glyphs: { sink_file: {} },
     }
 
@@ -146,6 +149,7 @@ describe('toValidationState', () => {
       },
       configuration_restrictions: {},
       resolved_configuration_options: {},
+      block_output_qubes: {},
       missing_glyphs: {},
     }
 
@@ -184,6 +188,7 @@ describe('toValidationState', () => {
         b1: { param: 'list[enumClosed[2t,msl]]' },
       },
       resolved_configuration_options: {},
+      block_output_qubes: {},
       missing_glyphs: {},
     }
 

--- a/frontend/tests/unit/features/fable-builder/components/EdgeQubeLens.test.tsx
+++ b/frontend/tests/unit/features/fable-builder/components/EdgeQubeLens.test.tsx
@@ -8,7 +8,15 @@
  * does it submit to any jurisdiction.
  */
 
-import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
 import { act } from '@testing-library/react'
 import { renderWithProviders } from '@tests/utils/render'
 import type {
@@ -103,7 +111,11 @@ describe('EdgeQubeLens', () => {
     })
   })
 
-  it('shows the qube dimensionality on the handle', async () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows the qube dimensionality in the inspector', async () => {
     // Edge selParam → selStep carries selParam's 3-D output qube.
     act(() =>
       useFableBuilderStore.getState().setValidationState(
@@ -124,6 +136,10 @@ describe('EdgeQubeLens', () => {
         hovered={false}
       />,
     )
+    // The handle is just a cube glyph; the dimensionality lives in the inspector.
+    await screen
+      .getByRole('button', { name: 'Inspect the qube on this edge' })
+      .click()
     await expect.element(screen.getByText('3D')).toBeVisible()
   })
 
@@ -175,6 +191,41 @@ describe('EdgeQubeLens', () => {
       .toBeVisible()
     // The (source-neutral) selection tab is present.
     await expect.element(screen.getByText('Selection')).toBeVisible()
+  })
+
+  it('toggling a spectrum bar off does not scroll the page (regression: popup jump)', async () => {
+    const scrollSpy = vi.spyOn(HTMLElement.prototype, 'scrollIntoView')
+    act(() =>
+      useFableBuilderStore.getState().setValidationState(
+        validationWith({
+          selParam: linearQube([
+            ['param', ['2t']],
+            ['step', ['0', '24', '48']],
+          ]),
+        }),
+      ),
+    )
+    const screen = await renderWithProviders(
+      <EdgeQubeLens
+        sourceId="selParam"
+        targetId="selStep"
+        inputName="dataset"
+        hovered
+      />,
+    )
+    await screen
+      .getByRole('button', { name: 'Inspect the qube on this edge' })
+      .click()
+    // Select then deselect the 'step' bar in the spectrum.
+    const bar = screen.getByRole('button', { name: 'step: 3' })
+    await bar.click()
+    await bar.click()
+    // Deselecting must not force a page-level scroll to the inspector top.
+    expect(
+      scrollSpy.mock.calls.some(
+        ([opts]) => typeof opts === 'object' && opts.block === 'start',
+      ),
+    ).toBe(false)
   })
 
   it('shows the upstream narrowing diff from comparing input and output qubes', async () => {

--- a/frontend/tests/unit/features/fable-builder/components/EdgeQubeLens.test.tsx
+++ b/frontend/tests/unit/features/fable-builder/components/EdgeQubeLens.test.tsx
@@ -1,0 +1,222 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { act } from '@testing-library/react'
+import { renderWithProviders } from '@tests/utils/render'
+import type {
+  BlockInstance,
+  FableBuilderV1,
+  FableValidationState,
+} from '@/api/types/fable.types'
+import type { QubeNode } from '@/api/types/artifacts.types'
+import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
+import { EdgeQubeLens } from '@/features/fable-builder/components/graph-mode/EdgeQubeLens'
+
+const PLUGIN = { store: 'ecmwf', local: 'ecmwf-base' }
+
+const enumVals = (values: Array<string | number>) => ({
+  type: 'enum',
+  dtype: 'str',
+  values,
+})
+
+/** Build a linear qube (root → one node per dimension, in order). */
+function linearQube(dims: Array<[string, Array<string>]>): QubeNode {
+  let node: QubeNode | null = null
+  for (let i = dims.length - 1; i >= 0; i -= 1) {
+    const [key, values] = dims[i]
+    node = {
+      key,
+      values: enumVals(values),
+      metadata: {},
+      children: node ? [node] : [],
+    }
+  }
+  return {
+    key: 'root',
+    values: enumVals(['root']),
+    metadata: {},
+    children: node ? [node] : [],
+  }
+}
+
+function selectBlock(
+  input: string,
+  dimension: string,
+  values: string,
+): BlockInstance {
+  return {
+    factory_id: { plugin: PLUGIN, factory: 'select' },
+    configuration_values: { dimension, values },
+    input_ids: { dataset: input },
+  }
+}
+
+const FABLE: FableBuilderV1 = {
+  blocks: {
+    src: {
+      factory_id: { plugin: PLUGIN, factory: 'operationalForecastSource' },
+      configuration_values: {},
+      input_ids: {},
+    },
+    selParam: selectBlock('src', 'param', '2t'),
+    selStep: selectBlock('selParam', 'step', '24'),
+  },
+  local_glyphs: {},
+}
+
+/** A validation snapshot carrying only the per-block output qubes the lens reads. */
+function validationWith(
+  blockOutputQubes: Record<string, QubeNode>,
+): FableValidationState {
+  return {
+    isValid: true,
+    globalErrors: [],
+    possibleSources: [],
+    resolvedConfigurationOptions: {},
+    blockOutputQubes,
+    blockStates: {},
+  }
+}
+
+describe('EdgeQubeLens', () => {
+  // Browser-mode renders without the app stylesheet; restore the popover's
+  // production stacking so its click target isn't swallowed (see CommandPalette).
+  beforeAll(() => {
+    const style = document.createElement('style')
+    style.textContent =
+      '[data-slot="popover-content"]{position:fixed;z-index:50}'
+    document.head.appendChild(style)
+  })
+
+  beforeEach(() => {
+    act(() => {
+      useFableBuilderStore.getState().setFable(FABLE)
+    })
+  })
+
+  it('shows the qube dimensionality on the handle', async () => {
+    // Edge selParam → selStep carries selParam's 3-D output qube.
+    act(() =>
+      useFableBuilderStore.getState().setValidationState(
+        validationWith({
+          selParam: linearQube([
+            ['param', ['2t']],
+            ['step', ['0', '24']],
+            ['number', ['0', '1', '2']],
+          ]),
+        }),
+      ),
+    )
+    const screen = await renderWithProviders(
+      <EdgeQubeLens
+        sourceId="selParam"
+        targetId="selStep"
+        inputName="dataset"
+        hovered={false}
+      />,
+    )
+    await expect.element(screen.getByText('3D')).toBeVisible()
+  })
+
+  it('renders nothing when the backend sends no qube for the edge', async () => {
+    act(() =>
+      useFableBuilderStore.getState().setValidationState(validationWith({})),
+    )
+    const screen = await renderWithProviders(
+      <EdgeQubeLens
+        sourceId="selParam"
+        targetId="selStep"
+        inputName="dataset"
+        hovered={false}
+      />,
+    )
+    await expect
+      .element(
+        screen.getByRole('button', { name: 'Inspect the qube on this edge' }),
+      )
+      .not.toBeInTheDocument()
+  })
+
+  it('opens the inspector with stats and a Selection tab on click', async () => {
+    act(() =>
+      useFableBuilderStore.getState().setValidationState(
+        validationWith({
+          selParam: linearQube([
+            ['param', ['2t']],
+            ['step', ['24', '48']],
+          ]),
+        }),
+      ),
+    )
+    const screen = await renderWithProviders(
+      <EdgeQubeLens
+        sourceId="selParam"
+        targetId="selStep"
+        inputName="dataset"
+        hovered
+      />,
+    )
+    await screen
+      .getByRole('button', { name: 'Inspect the qube on this edge' })
+      .click()
+
+    await expect.element(screen.getByText('Qube at this edge')).toBeVisible()
+    await expect
+      .element(screen.getByText('Select param → Select step'))
+      .toBeVisible()
+    // The (source-neutral) selection tab is present.
+    await expect.element(screen.getByText('Selection')).toBeVisible()
+  })
+
+  it('shows the upstream narrowing diff from comparing input and output qubes', async () => {
+    act(() =>
+      useFableBuilderStore.getState().setValidationState(
+        validationWith({
+          src: linearQube([
+            ['param', ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']],
+          ]),
+          selParam: linearQube([['param', ['a']]]),
+        }),
+      ),
+    )
+    const screen = await renderWithProviders(
+      <EdgeQubeLens
+        sourceId="selParam"
+        targetId="selStep"
+        inputName="dataset"
+        hovered
+      />,
+    )
+    await screen
+      .getByRole('button', { name: 'Inspect the qube on this edge' })
+      .click()
+    // param dropped 8 → 1 between src's output and selParam's output.
+    await expect.element(screen.getByText('narrowed 8 → 1')).toBeVisible()
+  })
+
+  it('renders nothing without a validation snapshot', async () => {
+    act(() => useFableBuilderStore.getState().setValidationState(null))
+    const screen = await renderWithProviders(
+      <EdgeQubeLens
+        sourceId="selParam"
+        targetId="selStep"
+        inputName="dataset"
+        hovered={false}
+      />,
+    )
+    await expect
+      .element(
+        screen.getByRole('button', { name: 'Inspect the qube on this edge' }),
+      )
+      .not.toBeInTheDocument()
+  })
+})

--- a/frontend/tests/unit/features/fable-builder/lib/qube-matrix.test.ts
+++ b/frontend/tests/unit/features/fable-builder/lib/qube-matrix.test.ts
@@ -1,0 +1,67 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { QubeNode } from '@/api/types/artifacts.types'
+import { parseQubeDimensions } from '@/features/fable-builder/lib/qube-matrix'
+
+function node(
+  key: string,
+  values: Array<string | number>,
+  children: Array<QubeNode> = [],
+): QubeNode {
+  return {
+    key,
+    values: { type: 'enum', dtype: 'str', values },
+    metadata: {},
+    children,
+  }
+}
+
+// root → number[0,1] → param[t,q] → level[1000,500]
+const qube: QubeNode = node(
+  'root',
+  ['root'],
+  [
+    node(
+      'number',
+      [0, 1],
+      [node('param', ['t', 'q'], [node('level', [1000, 500], [])])],
+    ),
+  ],
+)
+
+describe('parseQubeDimensions', () => {
+  it('lists every dimension in tree order with its value union', () => {
+    const dims = parseQubeDimensions(qube)
+    expect(dims.map((d) => d.key)).toEqual(['number', 'param', 'level'])
+    // Numeric values are sorted ascending; string values keep first-seen order.
+    expect(dims.find((d) => d.key === 'level')?.values).toEqual(['500', '1000'])
+    expect(dims.find((d) => d.key === 'param')?.values).toEqual(['t', 'q'])
+  })
+
+  it('unions values across branches that share a dimension', () => {
+    // param=t carries level 1000; param=q carries level 500 → level union {500,1000}.
+    const sparse = node(
+      'root',
+      ['root'],
+      [
+        node('param', ['t'], [node('level', [1000], [])]),
+        node('param', ['q'], [node('level', [500], [])]),
+      ],
+    )
+    const level = parseQubeDimensions(sparse).find((d) => d.key === 'level')
+    expect(level?.values).toEqual(['500', '1000'])
+  })
+
+  it('returns no dimensions for a bare root', () => {
+    expect(parseQubeDimensions(node('root', ['root']))).toEqual([])
+  })
+})

--- a/frontend/tests/unit/features/fable-builder/lib/qube-narrowing.test.ts
+++ b/frontend/tests/unit/features/fable-builder/lib/qube-narrowing.test.ts
@@ -1,0 +1,114 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { QubeNode } from '@/api/types/artifacts.types'
+import type { BlockInstance, FableBuilderV1 } from '@/api/types/fable.types'
+import { computeEdgeNarrowing } from '@/features/fable-builder/lib/qube-narrowing'
+
+const PLUGIN = { store: 'ecmwf', local: 'ecmwf-base' }
+
+function leaf(key: string, values: Array<string>): QubeNode {
+  return {
+    key,
+    values: { type: 'enum', dtype: 'str', values },
+    metadata: {},
+    children: [],
+  }
+}
+
+function single(dims: Record<string, Array<string>>): QubeNode {
+  // Build a simple linear qube: one node per dimension, in object order.
+  const keys = Object.keys(dims)
+  let node: QubeNode = leaf(keys[keys.length - 1], dims[keys[keys.length - 1]])
+  for (let i = keys.length - 2; i >= 0; i -= 1) {
+    node = {
+      key: keys[i],
+      values: { type: 'enum', dtype: 'str', values: dims[keys[i]] },
+      metadata: {},
+      children: [node],
+    }
+  }
+  return {
+    key: 'root',
+    values: { type: 'enum', dtype: 'str', values: ['root'] },
+    metadata: {},
+    children: [node],
+  }
+}
+
+function fableWith(source: BlockInstance): FableBuilderV1 {
+  return {
+    blocks: {
+      src: {
+        factory_id: { plugin: PLUGIN, factory: 'operationalForecastSource' },
+        configuration_values: {},
+        input_ids: {},
+      },
+      sel: source,
+    },
+    local_glyphs: {},
+  }
+}
+
+describe('computeEdgeNarrowing', () => {
+  // Input has param=8, stream=2, levtype=2; selecting param=2t prunes all three.
+  const inputQube = single({
+    stream: ['enfo', 'oper'],
+    levtype: ['pl', 'sfc'],
+    param: ['a', 'b', 'c', 'd', 'e', 'f', 'g', '2t'],
+  })
+  const selOutput = single({
+    stream: ['enfo'],
+    levtype: ['sfc'],
+    param: ['2t'],
+  })
+
+  it('flags only the Select-chosen dimension, not pruned side effects', () => {
+    const fable = fableWith({
+      factory_id: { plugin: PLUGIN, factory: 'select' },
+      configuration_values: { dimension: 'param', values: '2t' },
+      input_ids: { dataset: 'src' },
+    })
+    const result = computeEdgeNarrowing(
+      fable,
+      { src: inputQube, sel: selOutput },
+      'sel',
+    )
+    expect(result).toEqual([{ dimension: 'param', from: 8, to: 1 }])
+  })
+
+  it('flags every shrunk dimension for a non-Select block', () => {
+    const fable = fableWith({
+      factory_id: { plugin: PLUGIN, factory: 'ensembleStatistics' },
+      configuration_values: {},
+      input_ids: { dataset: 'src' },
+    })
+    const result = computeEdgeNarrowing(
+      fable,
+      { src: inputQube, sel: selOutput },
+      'sel',
+    )
+    expect(result.map((r) => r.dimension).sort()).toEqual([
+      'levtype',
+      'param',
+      'stream',
+    ])
+  })
+
+  it('returns [] for an origin block with no upstream qube', () => {
+    const fable = fableWith({
+      factory_id: { plugin: PLUGIN, factory: 'select' },
+      configuration_values: { dimension: 'param', values: '2t' },
+      input_ids: { dataset: 'src' },
+    })
+    expect(computeEdgeNarrowing(fable, { sel: selOutput }, 'sel')).toEqual([])
+  })
+})

--- a/frontend/tests/unit/features/fable-builder/stores/fableBuilderStore.test.ts
+++ b/frontend/tests/unit/features/fable-builder/stores/fableBuilderStore.test.ts
@@ -65,6 +65,7 @@ function makeValidationState(
     blockStates,
     possibleSources: [],
     resolvedConfigurationOptions: {},
+    blockOutputQubes: {},
   }
 }
 
@@ -103,6 +104,32 @@ describe('useFableBuilderStore', () => {
     it('is not dirty initially', () => {
       expect(useFableBuilderStore.getState().isDirty).toBe(false)
     })
+
+    it('has no hovered edge initially', () => {
+      expect(useFableBuilderStore.getState().hoveredEdgeId).toBeNull()
+    })
+  })
+
+  describe('setHoveredEdge', () => {
+    it('sets and clears the hovered edge', () => {
+      act(() => useFableBuilderStore.getState().setHoveredEdge('a-b-dataset'))
+      expect(useFableBuilderStore.getState().hoveredEdgeId).toBe('a-b-dataset')
+      act(() => useFableBuilderStore.getState().setHoveredEdge(null))
+      expect(useFableBuilderStore.getState().hoveredEdgeId).toBeNull()
+    })
+
+    it('is pure ephemeral UI: no effect on selection, dirty flag or validation', () => {
+      act(() =>
+        useFableBuilderStore
+          .getState()
+          .setValidationState(makeValidationState()),
+      )
+      act(() => useFableBuilderStore.getState().setHoveredEdge('a-b-dataset'))
+      const state = useFableBuilderStore.getState()
+      expect(state.selectedBlockId).toBeNull()
+      expect(state.isDirty).toBe(false)
+      expect(state.validationState).not.toBeNull()
+    })
   })
 
   describe('setFable', () => {
@@ -132,6 +159,7 @@ describe('useFableBuilderStore', () => {
           blockStates: {},
           possibleSources: [],
           resolvedConfigurationOptions: {},
+          blockOutputQubes: {},
         }),
       )
       act(() => useFableBuilderStore.getState().setFable(mockFable))


### PR DESCRIPTION
## Summary

This PR adds the **Edge Qube Lens** to the Fable graph builder: selecting an edge now visualises the qube flowing between blocks, its dimensions, value spectrum, and how each block narrows it. It threads a new backend field (`block_output_qubes`) through `/blueprint/expand` and renders it client-side.

### Backend changes in this PR
- `domain/blueprint/service.py` + `routes/blueprint.py`: `validate_expand` now serialises each block's output qube via `Qube.to_json()` into a new `block_output_qubes` field on the expand response. It is best-effort (wrapped in try/except) and only runs on the expand path (`validate_only=False`), so a malformed qube does not stop validation.

@tmi, @HCookie : Could you please have a look at the backend changes in d5dcd18b if these changes are okay as is?

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
