### PR TITLE
[frontend] fix: WMS viewer fix to allow CSP lens ports in production

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,8 +12,8 @@
         default-src 'self';
         script-src 'self';
         style-src 'self' 'unsafe-inline' https://*.basemaps.cartocdn.com https://basemaps.cartocdn.com https://cdn.jsdelivr.net;
-        img-src 'self' data: blob: https://*.basemaps.cartocdn.com https://basemaps.cartocdn.com <!--CSP_DEV_HOSTS-->;
-        connect-src 'self' https://*.basemaps.cartocdn.com https://basemaps.cartocdn.com https://cdn.jsdelivr.net <!--CSP_DEV_HOSTS-->;
+        img-src 'self' data: blob: https://*.basemaps.cartocdn.com https://basemaps.cartocdn.com <!--CSP_LOOPBACK_HOSTS-->;
+        connect-src 'self' https://*.basemaps.cartocdn.com https://basemaps.cartocdn.com https://cdn.jsdelivr.net <!--CSP_LOOPBACK_HOSTS-->;
         frame-src 'self';
         font-src 'self' https://*.basemaps.cartocdn.com https://basemaps.cartocdn.com https://cdn.jsdelivr.net;
       "

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -30,13 +30,14 @@ export default defineConfig(({ mode }) => {
       }),
       viteReact(),
       tailwindcss(),
-      // Inject localhost CSP allowlist only in dev — prod CSP stays clean.
+      // The WMS lens runs on a dynamic loopback port; CSP must let the page
+      // reach it in all builds, not just dev.
       {
-        name: 'csp-dev-hosts',
+        name: 'csp-loopback-hosts',
         transformIndexHtml(html) {
           return html.replaceAll(
-            '<!--CSP_DEV_HOSTS-->',
-            isDev ? 'http://localhost:* http://127.0.0.1:*' : '',
+            '<!--CSP_LOOPBACK_HOSTS-->',
+            'http://localhost:* http://127.0.0.1:*',
           )
         },
       },


### PR DESCRIPTION
### Description

The WMS map viewer (SkinnyWMS lens) failed in production builds with "Load failed"/"Failed to fetch" because the CSP loopback allowlist (http://localhost:* http://127.0.0.1:*) was injected only in dev, so prod blocked every cross-port request to the lens. The lens runs on a dynamic loopback port, so this injects the wildcards in all builds (connect-src + img-src). Purely additive; the lens stays loopback-only/single-host.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
