### PR TITLE
feat(fiab-core): add BlueprintTemplate entity and expose on Plugin co…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@
 
 # General
 * do not use fancy unicode or emoji characters when creating text/markdown files
+* do not use double space after `.` when writing comments and doc strings
 * when asked to fetch PR review comments, use the GitHub GraphQL API to fetch only **unresolved** threads:
   ```bash
   gh api graphql -f query='

--- a/backend/development.md
+++ b/backend/development.md
@@ -21,7 +21,7 @@
   * for simple immutable data transfer objects, use `@dataclass(frozen=True, eq=True, slots=True)` directly for best type checker support -- provides immutability, hashability, and memory efficiency via slots. We set `eq=True` explicitly, despite being a default, for clarity.
   * a convenience decorator `frozendc` exists in `forecastbox.utility.structural` but direct decorator syntax is preferred for type safety
   * when using a primitive type in a semantically restricted context, utilize typing.NewType -- for example, dont do `user_id: str` but `UserId = typing.NewType("UserId", str); user_id: UserId`, because not every string is a valid UserId. This prevents a mixture of ids and gives a stronger type validity
-* use comments sparingly, for non-obvious code only. Add docstrings to functions called from other modules only. When adding docstring, use compact style -- dont separate out Args and Returns, describe everything in one or two paragraphs
+* use comments sparingly, for non-obvious code only. Add docstrings to functions called from other modules only. When adding docstring, use compact style -- dont separate out Args and Returns, describe everything in one or two paragraphs. Do not make two spaces after a dot.
 * all imports belong to top level of the file, dont import inside function definitions unless necessiated by runtime
 * dont alias in imports unless there is a name collision, or unless its a standard shortcut: `datetime as dt`, `multiprocessing as mp`, `numpy as np`, `xarray as xr`, `earthkit.data as ekd`
 * never use python keywords and builtins as variable names -- for example, don't use `id` variable, prefer `id_<something>` or `id_`

--- a/backend/packages/fiab-core/src/fiab_core/fable.py
+++ b/backend/packages/fiab-core/src/fiab_core/fable.py
@@ -201,3 +201,11 @@ class BlueprintTemplate(FiabCoreBaseModel):
     local_glyphs: dict[str, str] = Field(default_factory=dict)
     example_values: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = Field(default_factory=dict)
     example_glyphs: dict[str, str] = Field(default_factory=dict)
+
+
+SelfPluginId = PluginCompositeId(store=PluginStoreId("__self__"), local=PluginId("__self__"))
+"""Use this when building the blueprint templates shipped by a plugin.
+
+The backend substitutes the real plugin composite ID at install time.
+"""
+# TODO this class shows some awkwardness -- ideally, we'll make the existence of PluginCompositeId completely unknown to the insides of the plugins, at the expense of the backend mutating the classes at the routing time

--- a/backend/packages/fiab-core/src/fiab_core/fable.py
+++ b/backend/packages/fiab-core/src/fiab_core/fable.py
@@ -179,3 +179,25 @@ class NoOutput(FiabCoreBaseModel):
 BlockInstanceOutput = QubedOutput | RawOutput | NoOutput
 
 ActionLookup = dict[BlockInstanceId, Action]
+
+
+class BlueprintTemplateEnvironment(FiabCoreBaseModel):
+    environment_variables: dict[str, str] = Field(default_factory=dict)
+
+
+class BlueprintTemplate(FiabCoreBaseModel):
+    """A partial, ready-to-customise blueprint shipped by a plugin.
+
+    Exposes the public subset of a blueprint builder plus separate guiding
+    example values/glyphs the user is expected to override. `display_name` is the
+    stable key used by the backend for upsert and exclusion; it must be unique
+    within a plugin.
+    """
+
+    display_name: str
+    display_description: str
+    blocks: dict[BlockInstanceId, BlockInstance]
+    environment: BlueprintTemplateEnvironment | None = None
+    local_glyphs: dict[str, str] = Field(default_factory=dict)
+    example_values: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = Field(default_factory=dict)
+    example_glyphs: dict[str, str] = Field(default_factory=dict)

--- a/backend/packages/fiab-core/src/fiab_core/plugin.py
+++ b/backend/packages/fiab-core/src/fiab_core/plugin.py
@@ -23,6 +23,7 @@ from fiab_core.fable import (
     BlockFactoryCatalogue,
     BlockInstance,
     BlockInstanceOutput,
+    BlueprintTemplate,
     ConfigurationOptionRestriction,
 )
 
@@ -72,3 +73,4 @@ class Plugin:
     validator: Validator
     expander: Expander
     compiler: Compiler
+    blueprint_templates: tuple[BlueprintTemplate, ...] = field(default_factory=tuple)

--- a/backend/packages/fiab-core/tests/test_fable.py
+++ b/backend/packages/fiab-core/tests/test_fable.py
@@ -10,7 +10,19 @@
 import pytest
 from pydantic import ValidationError
 
-from fiab_core.fable import BlockConfigurationOption
+from fiab_core.fable import (
+    BlockConfigurationOption,
+    BlockFactoryId,
+    BlockInstance,
+    BlockInstanceId,
+    BlueprintTemplate,
+    BlueprintTemplateEnvironment,
+    ConfigurationOptionId,
+    PluginBlockFactoryId,
+    PluginCompositeId,
+    PluginId,
+    PluginStoreId,
+)
 from fiab_core.types import FableType, StringType
 
 
@@ -35,3 +47,71 @@ def test_block_configuration_option_excludes_cached_value_type_from_serializatio
 def test_block_configuration_option_rejects_invalid_value_type() -> None:
     with pytest.raises(ValidationError, match="Invalid type expression"):
         BlockConfigurationOption(title="Title", description="Description", value_type="not-a-fable-type")
+
+
+# ---------------------------------------------------------------------------
+# BlueprintTemplate
+# ---------------------------------------------------------------------------
+
+_PLUGIN_ID = PluginCompositeId(store=PluginStoreId("s"), local=PluginId("p"))
+_BLOCK_ID = BlockInstanceId("b1")
+_TEXT = ConfigurationOptionId("text")
+
+
+def _make_block() -> BlockInstance:
+    return BlockInstance(
+        factory_id=PluginBlockFactoryId(plugin=_PLUGIN_ID, factory=BlockFactoryId("source_text")),
+        configuration_values={_TEXT: "hello"},
+        input_ids={},
+    )
+
+
+def _make_template(**overrides: object) -> BlueprintTemplate:
+    defaults: dict = dict(
+        display_name="myTemplate",
+        display_description="A template",
+        blocks={_BLOCK_ID: _make_block()},
+    )
+    defaults.update(overrides)
+    return BlueprintTemplate(**defaults)  # type: ignore[arg-type]
+
+
+def test_blueprint_template_constructs() -> None:
+    tmpl = _make_template()
+
+    assert tmpl.display_name == "myTemplate"
+    assert tmpl.display_description == "A template"
+    assert _BLOCK_ID in tmpl.blocks
+    assert tmpl.environment is None
+    assert tmpl.local_glyphs == {}
+    assert tmpl.example_values == {}
+    assert tmpl.example_glyphs == {}
+
+
+def test_blueprint_template_rejects_unknown_field() -> None:
+    with pytest.raises(ValidationError):
+        _make_template(unknown_field="oops")
+
+
+def test_blueprint_template_round_trips_model_dump() -> None:
+    tmpl = _make_template(
+        environment=BlueprintTemplateEnvironment(environment_variables={"K": "V"}),
+        local_glyphs={"g": "v"},
+        example_values={_BLOCK_ID: {_TEXT: "world"}},
+        example_glyphs={"g": "world"},
+    )
+
+    dumped = tmpl.model_dump()
+    restored = BlueprintTemplate.model_validate(dumped)
+
+    assert restored.display_name == tmpl.display_name
+    assert restored.environment is not None
+    assert restored.environment.environment_variables == {"K": "V"}
+    assert restored.local_glyphs == {"g": "v"}
+    assert restored.example_values == {_BLOCK_ID: {_TEXT: "world"}}
+    assert restored.example_glyphs == {"g": "world"}
+
+
+def test_blueprint_template_environment_rejects_unknown_field() -> None:
+    with pytest.raises(ValidationError):
+        BlueprintTemplateEnvironment(environment_variables={}, unexpected="x")  # type: ignore[call-arg]

--- a/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
+++ b/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
@@ -18,10 +18,8 @@ from fiab_core.fable import (
     ConfigurationOptionRestriction,
     NoOutput,
     PluginBlockFactoryId,
-    PluginCompositeId,
-    PluginId,
-    PluginStoreId,
     RawOutput,
+    SelfPluginId,
 )
 from fiab_core.plugin import BlockValidation, Error, Plugin
 from fiab_core.types import FableType
@@ -198,26 +196,34 @@ def compiler(lookup: ActionLookup, instance: BlockInstance) -> Either[Action, Er
 plugin = lambda: Plugin(catalogue=catalogue(), validator=validator, expander=expander, compiler=compiler)
 
 
-_SELF_PLUGIN_ID = PluginCompositeId(store=PluginStoreId("__self__"), local=PluginId("__self__"))
+def _make_source_text_block(text: str) -> BlockInstance:
+    return BlockInstance(
+        factory_id=PluginBlockFactoryId(plugin=SelfPluginId, factory=BlockFactoryId("source_text")),
+        configuration_values={TEXT: text} if text else {},
+        input_ids={},
+    )
 
-_BASIC_BLOCK_ID = BlockInstanceId("text_source")
+
+_BLOCK_FIXED = BlockInstanceId("text_fixed")
+_BLOCK_GLYPHS = BlockInstanceId("text_glyphs")
+_BLOCK_EXAMPLE = BlockInstanceId("text_example")
 
 _testBasic = BlueprintTemplate(
     display_name="testBasic",
-    display_description="A minimal test template with a single source_text block.",
+    display_description="A minimal test template demonstrating fixed values, glyph substitution, and example values.",
     blocks={
-        _BASIC_BLOCK_ID: BlockInstance(
-            factory_id=PluginBlockFactoryId(
-                plugin=_SELF_PLUGIN_ID,
-                factory=BlockFactoryId("source_text"),
-            ),
-            configuration_values={TEXT: "{{ example_text }}"},
-            input_ids={},
-        ),
+        # Fixed: configuration value is a literal string -- no glyphs, no example override needed.
+        _BLOCK_FIXED: _make_source_text_block("fixed text"),
+        # Glyphs: value references two glyphs; greeting is pinned in local_glyphs,
+        # name is provided only as an example the user should override.
+        _BLOCK_GLYPHS: _make_source_text_block("${greeting} ${name}"),
+        # Example only: no value in configuration_values; example_values shows
+        # what a user might start with.
+        _BLOCK_EXAMPLE: _make_source_text_block(""),
     },
-    local_glyphs={"example_text": "hello world"},
-    example_values={_BASIC_BLOCK_ID: {TEXT: "hello world"}},
-    example_glyphs={"example_text": "hello world"},
+    local_glyphs={"greeting": "hello"},
+    example_values={_BLOCK_EXAMPLE: {TEXT: "text from example values"}},
+    example_glyphs={"name": "world"},
 )
 
 plugin = lambda: Plugin(

--- a/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
+++ b/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
@@ -236,10 +236,21 @@ _testExclusion = BlueprintTemplate(
     },
 )
 
+_BLOCK_REMAP = BlockInstanceId("text_remap")
+
+_testRemapping = BlueprintTemplate(
+    display_name="testRemapping",
+    display_description="A minimal template used to verify glyph-name remapping at install time.",
+    blocks={
+        _BLOCK_REMAP: _make_source_text_block("${pluginGlyphOld}"),
+    },
+    local_glyphs={"localOld": "${pluginGlyphOld}"},
+)
+
 plugin = lambda: Plugin(
     catalogue=catalogue(),
     validator=validator,
     expander=expander,
     compiler=compiler,
-    blueprint_templates=(_testBasic, _testExclusion),
+    blueprint_templates=(_testBasic, _testExclusion, _testRemapping),
 )

--- a/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
+++ b/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
@@ -247,10 +247,24 @@ _testRemapping = BlueprintTemplate(
     local_glyphs={"localOld": "${pluginGlyphOld}"},
 )
 
+_BLOCK_FAIL_VAL = BlockInstanceId("fail_val_block")
+
+_testFailValidation = BlueprintTemplate(
+    display_name="testFailValidation",
+    display_description="A template that references a non-existent factory and always fails validation.",
+    blocks={
+        _BLOCK_FAIL_VAL: BlockInstance(
+            factory_id=PluginBlockFactoryId(plugin=SelfPluginId, factory=BlockFactoryId("nonexistent_factory")),
+            configuration_values={},
+            input_ids={},
+        ),
+    },
+)
+
 plugin = lambda: Plugin(
     catalogue=catalogue(),
     validator=validator,
     expander=expander,
     compiler=compiler,
-    blueprint_templates=(_testBasic, _testExclusion, _testRemapping),
+    blueprint_templates=(_testBasic, _testExclusion, _testRemapping, _testFailValidation),
 )

--- a/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
+++ b/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
@@ -11,10 +11,16 @@ from fiab_core.fable import (
     BlockFactoryCatalogue,
     BlockFactoryId,
     BlockInstance,
+    BlockInstanceId,
     BlockInstanceOutput,
+    BlueprintTemplate,
     ConfigurationOptionId,
     ConfigurationOptionRestriction,
     NoOutput,
+    PluginBlockFactoryId,
+    PluginCompositeId,
+    PluginId,
+    PluginStoreId,
     RawOutput,
 )
 from fiab_core.plugin import BlockValidation, Error, Plugin
@@ -190,3 +196,34 @@ def compiler(lookup: ActionLookup, instance: BlockInstance) -> Either[Action, Er
 
 
 plugin = lambda: Plugin(catalogue=catalogue(), validator=validator, expander=expander, compiler=compiler)
+
+
+_SELF_PLUGIN_ID = PluginCompositeId(store=PluginStoreId("__self__"), local=PluginId("__self__"))
+
+_BASIC_BLOCK_ID = BlockInstanceId("text_source")
+
+_testBasic = BlueprintTemplate(
+    display_name="testBasic",
+    display_description="A minimal test template with a single source_text block.",
+    blocks={
+        _BASIC_BLOCK_ID: BlockInstance(
+            factory_id=PluginBlockFactoryId(
+                plugin=_SELF_PLUGIN_ID,
+                factory=BlockFactoryId("source_text"),
+            ),
+            configuration_values={TEXT: "{{ example_text }}"},
+            input_ids={},
+        ),
+    },
+    local_glyphs={"example_text": "hello world"},
+    example_values={_BASIC_BLOCK_ID: {TEXT: "hello world"}},
+    example_glyphs={"example_text": "hello world"},
+)
+
+plugin = lambda: Plugin(
+    catalogue=catalogue(),
+    validator=validator,
+    expander=expander,
+    compiler=compiler,
+    blueprint_templates=(_testBasic,),
+)

--- a/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
+++ b/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
@@ -226,10 +226,20 @@ _testBasic = BlueprintTemplate(
     example_glyphs={"name": "world"},
 )
 
+_BLOCK_EXCL = BlockInstanceId("text_excl")
+
+_testExclusion = BlueprintTemplate(
+    display_name="testExclusion",
+    display_description="A minimal template used to verify admin exclusion via the settings route.",
+    blocks={
+        _BLOCK_EXCL: _make_source_text_block("exclusion test"),
+    },
+)
+
 plugin = lambda: Plugin(
     catalogue=catalogue(),
     validator=validator,
     expander=expander,
     compiler=compiler,
-    blueprint_templates=(_testBasic,),
+    blueprint_templates=(_testBasic, _testExclusion),
 )

--- a/backend/packages/fiab-plugin-test/tests/test_base.py
+++ b/backend/packages/fiab-plugin-test/tests/test_base.py
@@ -173,3 +173,23 @@ def test_sink_file_returns_bytes_locator(tmp_path: pathlib.Path) -> None:
     locator = sink_file("hello", str(tmp_path / "out.txt"))
     assert isinstance(locator, bytes)
     assert locator.startswith(b"file://")
+
+
+# ---------------------------------------------------------------------------
+# blueprint_templates
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_has_testBasic_template() -> None:
+    from fiab_plugin_test import plugin
+
+    templates = plugin().blueprint_templates
+    names = [t.display_name for t in templates]
+    assert "testBasic" in names
+
+
+def test_testBasic_template_display_name() -> None:
+    from fiab_plugin_test import plugin
+
+    tmpl = next(t for t in plugin().blueprint_templates if t.display_name == "testBasic")
+    assert tmpl.display_name == "testBasic"

--- a/backend/src/forecastbox/domain/blueprint/__init__.py
+++ b/backend/src/forecastbox/domain/blueprint/__init__.py
@@ -15,5 +15,5 @@ Depends on the Glyph domain, to resolve and validate Glyphs.
 Depends on the Plugin domain, to determine fiab-core compatibility and retrieve plugin factories for validation.
 Depended on by Run and Experiment domains.
 
-Note: there is a dependency circularity where this domain is *depended on* by Plugin, for validating imported blueprint templates. This will be fixed later by refactoring into events.
+Note: there is a dependency circularity where this domain is *depended on* by Plugin, for validating imported blueprint templates and for remapping glyph names in those templates. This will be fixed later by refactoring into events.
 """

--- a/backend/src/forecastbox/domain/blueprint/__init__.py
+++ b/backend/src/forecastbox/domain/blueprint/__init__.py
@@ -12,6 +12,8 @@ Manages the Blueprint domain -- user-created entities that capture computation i
 Used to create Runs and Experiments.
 
 Depends on the Glyph domain, to resolve and validate Glyphs.
-Depends on the Plugin domain, to determine fiab-core compatibility.
+Depends on the Plugin domain, to determine fiab-core compatibility and retrieve plugin factories for validation.
 Depended on by Run and Experiment domains.
+
+Note: there is a dependency circularity where this domain is *depended on* by Plugin, for validating imported blueprint templates. This will be fixed later by refactoring into events.
 """

--- a/backend/src/forecastbox/domain/blueprint/db.py
+++ b/backend/src/forecastbox/domain/blueprint/db.py
@@ -244,3 +244,21 @@ async def soft_delete_blueprint(blueprint_id: BlueprintId, *, expected_version: 
         raise BlueprintAccessDenied(f"User {auth_context.user_id!r} is not allowed to delete Blueprint {blueprint_id!r}.")
     stmt = update(Blueprint).where(Blueprint.blueprint_id == blueprint_id).values(is_deleted=True)
     await executeAndCommit(stmt, _jobs_module.async_session_maker)
+
+
+async def soft_delete_plugin_template(*, created_by: str, display_name: str) -> None:
+    """Mark all ``plugin_template`` rows owned by a plugin with a given display name as deleted.
+
+    Performs a bulk update keyed on ``(created_by, display_name)`` without
+    version or auth checks because the calling plugin owns these rows.
+    """
+    stmt = (
+        update(Blueprint)
+        .where(
+            Blueprint.source == "plugin_template",
+            Blueprint.created_by == created_by,
+            Blueprint.display_name == display_name,
+        )
+        .values(is_deleted=True)
+    )
+    await executeAndCommit(stmt, _jobs_module.async_session_maker)

--- a/backend/src/forecastbox/domain/blueprint/db.py
+++ b/backend/src/forecastbox/domain/blueprint/db.py
@@ -262,3 +262,21 @@ async def soft_delete_plugin_template(*, created_by: str, display_name: str) -> 
         .values(is_deleted=True)
     )
     await executeAndCommit(stmt, _jobs_module.async_session_maker)
+
+
+async def soft_delete_all_plugin_templates(*, created_by: str) -> None:
+    """Mark all ``plugin_template`` rows owned by a plugin as deleted, regardless of display name.
+
+    Used when a plugin is disabled to remove all its blueprint templates at once.
+    Performs a bulk update without version or auth checks because the calling plugin
+    owns these rows.
+    """
+    stmt = (
+        update(Blueprint)
+        .where(
+            Blueprint.source == "plugin_template",
+            Blueprint.created_by == created_by,
+        )
+        .values(is_deleted=True)
+    )
+    await executeAndCommit(stmt, _jobs_module.async_session_maker)

--- a/backend/src/forecastbox/domain/blueprint/db.py
+++ b/backend/src/forecastbox/domain/blueprint/db.py
@@ -197,6 +197,34 @@ async def count_blueprints(*, auth_context: AuthContext) -> int:
     return await dbRetry(function)
 
 
+async def find_plugin_template_id(*, created_by: str, display_name: str) -> BlueprintId | None:
+    """Return the blueprint_id of the latest non-deleted ``plugin_template`` row owned by a plugin.
+
+    Returns ``None`` if no matching row exists.  Used by template ingestion to
+    decide whether to append a new version to an existing blueprint or create a
+    fresh one.
+    """
+    query = (
+        select(Blueprint.blueprint_id)
+        .where(
+            Blueprint.source == "plugin_template",
+            Blueprint.created_by == created_by,
+            Blueprint.display_name == display_name,
+            Blueprint.is_deleted.is_(False),
+        )
+        .order_by(Blueprint.version.desc())
+        .limit(1)
+    )
+
+    async def function(i: int) -> BlueprintId | None:
+        async with _jobs_module.async_session_maker() as session:
+            result = await session.execute(query)
+            row = result.first()
+            return BlueprintId(str(row[0])) if row is not None else None
+
+    return await dbRetry(function)
+
+
 async def soft_delete_blueprint(blueprint_id: BlueprintId, *, expected_version: int, auth_context: AuthContext) -> None:
     """Mark all versions of a Blueprint as deleted.
 

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -51,7 +51,7 @@ from forecastbox.domain.blueprint.types import BlueprintId
 from forecastbox.domain.glyphs import global_db, resolution
 from forecastbox.domain.glyphs.exceptions import GlyphCircularReferenceError
 from forecastbox.domain.glyphs.intrinsic import get_values_and_examples
-from forecastbox.domain.glyphs.resolution import ExtractedGlyphs, expand_glyph_values, merge_glyph_values
+from forecastbox.domain.glyphs.resolution import ExtractedGlyphs, expand_glyph_values, merge_glyph_values, remap_glyph_names
 from forecastbox.domain.plugin.manager import PluginManager
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.graph import topological_order
@@ -355,6 +355,36 @@ def template_to_builder(template: BlueprintTemplate, plugin_id: PluginCompositeI
         environment=environment,
         local_glyphs=dict(template.local_glyphs),
     )
+
+
+def remap_builder_glyphs(builder: BlueprintBuilder, mapping: dict[str, str]) -> BlueprintBuilder:
+    """Return a copy of *builder* with all glyph identifier references renamed per *mapping*.
+
+    Applied in a single non-recursive pass to:
+
+    * every configuration option value string in every block (``${name}``
+      references inside ``${...}`` expressions);
+    * every local-glyph value string (same rename inside ``${...}``);
+    * every local-glyph key: if the key itself is present in *mapping*, it is
+      renamed to the mapped value.
+
+    Returns *builder* unchanged (same object) when *mapping* is empty.
+    """
+    if not mapping:
+        return builder
+
+    new_blocks: dict[BlockInstanceId, BlockInstance] = {}
+    for block_id, block in builder.blocks.items():
+        new_config = {opt_id: remap_glyph_names(val, mapping) for opt_id, val in block.configuration_values.items()}
+        new_blocks[block_id] = block.model_copy(update={"configuration_values": new_config})
+
+    new_local_glyphs: dict[str, str] = {}
+    for key, val in builder.local_glyphs.items():
+        new_key = mapping.get(key, key)
+        new_val = remap_glyph_names(val, mapping)
+        new_local_glyphs[new_key] = new_val
+
+    return builder.model_copy(update={"blocks": new_blocks, "local_glyphs": new_local_glyphs})
 
 
 # ---------------------------------------------------------------------------

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -357,6 +357,42 @@ def template_to_builder(template: BlueprintTemplate, plugin_id: PluginCompositeI
     )
 
 
+def resolve_builder_with_examples(
+    builder: BlueprintBuilder,
+    example_values: dict[BlockInstanceId, dict[ConfigurationOptionId, str]],
+    example_glyphs: dict[str, str],
+) -> BlueprintBuilder:
+    """Return a copy of ``builder`` with example values/glyphs overlaid for validation only.
+
+    Example configuration values fill in (without overwriting) the per-block
+    ``configuration_values``; example glyphs are merged into ``local_glyphs``.
+    The result is fed to ``validate_expand(validate_only=True)``; it is never persisted.
+
+    Overlay precedence: example values and glyphs only fill keys that are absent in
+    the builder -- they never overwrite an explicit template value.  This matches the
+    intended semantics: example values are defaults that the user is expected to
+    override, so anything already set in the template takes priority.
+
+    The function is pure: it operates on a deep copy of ``builder`` and never
+    mutates the caller's object.
+    """
+    copy = builder.model_copy(deep=True)
+
+    new_blocks: dict[BlockInstanceId, BlockInstance] = {}
+    for block_id, block in copy.blocks.items():
+        if block_id in example_values:
+            # Merge: example fills gaps; existing template values take precedence.
+            merged_config = {**example_values[block_id], **block.configuration_values}
+            new_blocks[block_id] = block.model_copy(update={"configuration_values": merged_config})
+        else:
+            new_blocks[block_id] = block
+
+    # Merge example_glyphs into local_glyphs; existing template glyphs take precedence.
+    merged_local_glyphs: dict[str, str] = {**example_glyphs, **copy.local_glyphs}
+
+    return copy.model_copy(update={"blocks": new_blocks, "local_glyphs": merged_local_glyphs})
+
+
 def remap_builder_glyphs(builder: BlueprintBuilder, mapping: dict[str, str]) -> BlueprintBuilder:
     """Return a copy of *builder* with all glyph identifier references renamed per *mapping*.
 

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -364,14 +364,15 @@ def resolve_builder_with_examples(
 ) -> BlueprintBuilder:
     """Return a copy of ``builder`` with example values/glyphs overlaid for validation only.
 
-    Example configuration values fill in (without overwriting) the per-block
-    ``configuration_values``; example glyphs are merged into ``local_glyphs``.
-    The result is fed to ``validate_expand(validate_only=True)``; it is never persisted.
+    Example configuration values overlay the per-block ``configuration_values``;
+    example glyphs are merged into ``local_glyphs``.  The result is fed to
+    ``validate_expand(validate_only=True)``; it is never persisted.
 
-    Overlay precedence: example values and glyphs only fill keys that are absent in
-    the builder -- they never overwrite an explicit template value.  This matches the
-    intended semantics: example values are defaults that the user is expected to
-    override, so anything already set in the template takes priority.
+    Overlay precedence: example values and glyphs **win** over any existing
+    template value.  Templates are validated at install time, before the user
+    has had a chance to fill in any values.  Template defaults (if any) may not
+    be valid examples on their own, so example values are allowed to override
+    them to produce a builder that passes validation.
 
     The function is pure: it operates on a deep copy of ``builder`` and never
     mutates the caller's object.
@@ -381,14 +382,14 @@ def resolve_builder_with_examples(
     new_blocks: dict[BlockInstanceId, BlockInstance] = {}
     for block_id, block in copy.blocks.items():
         if block_id in example_values:
-            # Merge: example fills gaps; existing template values take precedence.
-            merged_config = {**example_values[block_id], **block.configuration_values}
+            # Merge: example values override existing template configuration values.
+            merged_config = {**block.configuration_values, **example_values[block_id]}
             new_blocks[block_id] = block.model_copy(update={"configuration_values": merged_config})
         else:
             new_blocks[block_id] = block
 
-    # Merge example_glyphs into local_glyphs; existing template glyphs take precedence.
-    merged_local_glyphs: dict[str, str] = {**example_glyphs, **copy.local_glyphs}
+    # Merge example_glyphs into local_glyphs; example glyphs take precedence.
+    merged_local_glyphs: dict[str, str] = {**copy.local_glyphs, **example_glyphs}
 
     return copy.model_copy(update={"blocks": new_blocks, "local_glyphs": merged_local_glyphs})
 

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -31,11 +31,14 @@ from fiab_core.fable import (
     BlockInstanceId,
     BlockInstanceOutput,
     BlockKind,
+    BlueprintTemplate,
     ConfigurationOptionId,
     NoOutput,
     PluginBlockExpansion,
     PluginBlockFactoryId,
+    PluginCompositeId,
     QubedOutput,
+    SelfPluginId,
 )
 from pydantic import Field
 
@@ -321,6 +324,36 @@ async def validate_expand(
         global_errors=global_errors,
         missing_glyphs=missing_glyphs_result,
         block_output_qubes=block_output_qubes,
+    )
+
+
+def template_to_builder(template: BlueprintTemplate, plugin_id: PluginCompositeId) -> BlueprintBuilder:
+    """Convert a ``BlueprintTemplate`` to a ``BlueprintBuilder`` suitable for persistence.
+
+    ``SelfPluginId`` sentinels in block factory IDs are replaced with the real
+    plugin composite ID.  ``example_values`` and ``example_glyphs`` are
+    intentionally not copied -- they are guiding-only data and must not appear
+    in ``configuration_values``.
+    """
+    blocks: dict[BlockInstanceId, BlockInstance] = {}
+    for block_id, block in template.blocks.items():
+        factory = block.factory_id
+        if factory.plugin == SelfPluginId:
+            factory = PluginBlockFactoryId(plugin=plugin_id, factory=factory.factory)
+        blocks[block_id] = BlockInstance(
+            factory_id=factory,
+            configuration_values=dict(block.configuration_values),
+            input_ids=dict(block.input_ids),
+        )
+    environment: EnvironmentSpecification | None = None
+    if template.environment is not None:
+        environment = EnvironmentSpecification(
+            environment_variables=template.environment.environment_variables,
+        )
+    return BlueprintBuilder(
+        blocks=blocks,
+        environment=environment,
+        local_glyphs=dict(template.local_glyphs),
     )
 
 

--- a/backend/src/forecastbox/domain/glyphs/resolution.py
+++ b/backend/src/forecastbox/domain/glyphs/resolution.py
@@ -16,6 +16,7 @@
 # (resolution, error, missing), etc
 
 import datetime as dt
+import re
 from dataclasses import dataclass
 
 from cascade.low.func import Either
@@ -194,3 +195,54 @@ def expand_glyph_values(glyph_values: dict[str, str], roots: set[str] | None = N
             _expand(key, frozenset())
 
     return dict(memo) if roots is not None else {k: memo[k] for k in source}
+
+
+_EXPR_RE = re.compile(r"\$\{([^}]+)\}")
+
+
+def remap_glyph_names(value: str, mapping: dict[str, str]) -> str:
+    """Rewrite glyph identifier names referenced inside ``${...}`` expressions.
+
+    ``mapping`` is a flat old-name -> new-name dict.  Only names reported by
+    ``extract_glyph_names`` (AST-level variable identifiers, excluding filter
+    and global names) are candidates for renaming.  Names absent from
+    ``mapping`` are left untouched.
+
+    The substitution is a single non-recursive pass: every ``${...}``
+    expression in ``value`` is processed once and the result is not
+    re-scanned.  This means that if ``mapping`` contains ``{"a": "b",
+    "b": "c"}``, an expression ``${a}`` is rewritten to ``${b}`` -- never
+    to ``${c}`` -- guaranteeing no double-application.
+
+    Identifiers are matched at word boundaries so that, for example, renaming
+    ``root`` does not affect ``rootDir``.  Filter and global names (e.g.
+    ``floor_day``, ``timedelta``) are excluded by ``extract_glyph_names`` and
+    are therefore never touched.
+
+    Returns ``value`` unchanged when ``mapping`` is empty, when ``value``
+    contains no ``${...}`` expressions, or when no referenced name is a key
+    in ``mapping``.  Malformed expressions are also returned unchanged.
+    """
+    if not mapping or "${" not in value:
+        return value
+
+    names_result = extract_glyph_names(value)
+    if names_result.e is not None:
+        return value
+
+    referenced: set[str] = names_result.t  # type: ignore[assignment]
+    to_rename = {n: mapping[n] for n in referenced if n in mapping}
+    if not to_rename:
+        return value
+
+    # Build a pattern that matches any of the names to rename as whole words,
+    # sorted longest-first to avoid prefix-match ambiguity in alternation.
+    sorted_names: list[str] = sorted(to_rename.keys(), key=lambda n: len(n), reverse=True)
+    names_pattern = "|".join(re.escape(n) for n in sorted_names)
+    ident_re = re.compile(rf"\b({names_pattern})\b")
+
+    def _replace_in_expr(m: re.Match) -> str:  # type: ignore[type-arg]
+        renamed_body = ident_re.sub(lambda nm: to_rename[nm.group(0)], m.group(1))
+        return "${" + renamed_body + "}"
+
+    return _EXPR_RE.sub(_replace_in_expr, value)

--- a/backend/src/forecastbox/domain/plugin/__init__.py
+++ b/backend/src/forecastbox/domain/plugin/__init__.py
@@ -8,5 +8,5 @@ install error) is recorded in the ``plugin_state`` DB table via ``domain/plugin/
 Depends on no other domain.
 Depended on by Blueprint and Run domains -- they need to extract individual plugin validations and compilers, and to validate fiab-core version.
 
-Note: there is a dependency circularity where this domain *depends on* Blueprint, for validating imported blueprint templates. This will be fixed later by refactoring into events.
+Note: there is a dependency circularity where this domain *depends on* Blueprint, for validating imported blueprint templates and for remapping glyph names in those templates. This will be fixed later by refactoring into events.
 """

--- a/backend/src/forecastbox/domain/plugin/__init__.py
+++ b/backend/src/forecastbox/domain/plugin/__init__.py
@@ -2,6 +2,9 @@
 Manages Plugin domain -- python packages (wheels) that expose a concrete interface used for Blueprint
 building and validation, and Run execution.
 
+Now also owns persisted install state: each configured plugin's install outcome (version, timestamp,
+install error) is recorded in the ``plugin_state`` DB table via ``domain/plugin/db.py``.
+
 Depends on no other domain.
 Depended on by Blueprint and Run domains -- they need to extract individual plugin validations and compilers.
 """

--- a/backend/src/forecastbox/domain/plugin/__init__.py
+++ b/backend/src/forecastbox/domain/plugin/__init__.py
@@ -6,5 +6,7 @@ Now also owns persisted install state: each configured plugin's install outcome 
 install error) is recorded in the ``plugin_state`` DB table via ``domain/plugin/db.py``.
 
 Depends on no other domain.
-Depended on by Blueprint and Run domains -- they need to extract individual plugin validations and compilers.
+Depended on by Blueprint and Run domains -- they need to extract individual plugin validations and compilers, and to validate fiab-core version.
+
+Note: there is a dependency circularity where this domain *depends on* Blueprint, for validating imported blueprint templates. This will be fixed later by refactoring into events.
 """

--- a/backend/src/forecastbox/domain/plugin/compatibility.py
+++ b/backend/src/forecastbox/domain/plugin/compatibility.py
@@ -67,7 +67,11 @@ def get_compatible_versions(plugin_settings: PluginSettings, available_versions:
             yield version_str
 
 
-def install_plugin_compatibly(pip_source: str, version: Version | None) -> None:
+def install_plugin_compatibly(pip_source: str, version: Version | None) -> str | None:
+    """Install a plugin with compatibility constraints.
+
+    Returns ``None`` on success or an error string on failure.  Never raises.
+    """
     if pip_source.startswith("-e"):
         pkgs = pip_source.split(" ", 1)
     else:
@@ -77,4 +81,4 @@ def install_plugin_compatibly(pip_source: str, version: Version | None) -> None:
             pkgs = [f"{pip_source}{plugin_default_specifier()}"]
     # TODO -- include the whole pylock.toml
     pkgs += get_existing_install_pin("fiab-core")
-    try_install(pkgs)
+    return try_install(pkgs)

--- a/backend/src/forecastbox/domain/plugin/compatibility.py
+++ b/backend/src/forecastbox/domain/plugin/compatibility.py
@@ -28,6 +28,7 @@ import importlib
 import logging
 from collections.abc import Iterator
 
+from cascade.low.func import Either
 from packaging.specifiers import SpecifierSet
 from packaging.version import InvalidVersion, Version
 
@@ -67,10 +68,12 @@ def get_compatible_versions(plugin_settings: PluginSettings, available_versions:
             yield version_str
 
 
-def install_plugin_compatibly(pip_source: str, version: Version | None) -> str | None:
+def install_plugin_compatibly(pip_source: str, version: Version | None) -> Either[dict[str, str], str]:  # type: ignore[type-arg]
     """Install a plugin with compatibility constraints.
 
-    Returns ``None`` on success or an error string on failure.  Never raises.
+    Returns ``Either.ok(versions)`` on success, where ``versions`` maps newly-installed
+    package names to their version strings, or ``Either.error(msg)`` on failure.
+    Never raises.
     """
     if pip_source.startswith("-e"):
         pkgs = pip_source.split(" ", 1)

--- a/backend/src/forecastbox/domain/plugin/db.py
+++ b/backend/src/forecastbox/domain/plugin/db.py
@@ -36,7 +36,7 @@ from forecastbox.utility.time import current_time
 logger = logging.getLogger(__name__)
 
 
-async def upsert_plugin_state(*, plugin_id: str, version: str | None, enabled: bool, install_error: str | None) -> None:
+async def upsert_plugin_state(*, plugin_id: str, version: str | None = None, enabled: bool, install_error: str | None = None) -> None:
     """Insert or update the PluginState row for ``plugin_id``.
 
     On first install: creates a row with empty ``excluded_templates`` / ``glyph_remapping``
@@ -123,11 +123,11 @@ async def update_plugin_settings(
     "leave the stored value unchanged".  An empty list or empty dict
     is a valid value meaning "explicitly clear".
 
-    Always sets ``asset_ingest_needed=True`` when any setting is changed (or on
-    insert), so the next load cycle re-applies the updated exclusions/remapping.
+    Sets ``asset_ingest_needed=True`` when any setting actually changes value,
+    so the next load cycle re-applies the updated exclusions/remapping.
 
-    If no row exists yet (plugin configured but never installed), a new row is
-    inserted with the provided settings and a sentinel ``plugin_version``.
+    Raises ``RuntimeError`` if no row exists for ``plugin_id``; settings can
+    only be updated after the plugin has been installed at least once.
     """
 
     async def function(i: int) -> None:
@@ -135,24 +135,12 @@ async def update_plugin_settings(
             result = await session.execute(select(PluginState).where(PluginState.plugin_id == plugin_id))
             existing = result.scalar_one_or_none()
             if existing is None:
-                session.add(
-                    PluginState(
-                        plugin_id=plugin_id,
-                        plugin_version="not installed",
-                        updated_at=current_time("dbref"),
-                        install_error=None,
-                        excluded_templates=excluded_templates if excluded_templates is not None else [],
-                        glyph_remapping=glyph_remapping if glyph_remapping is not None else {},
-                        template_errors=None,
-                        enabled=True,
-                        asset_ingest_needed=True,
-                    )
-                )
+                raise RuntimeError(f"update_plugin_settings called for plugin that is not installed: {plugin_id!r}")
             else:
                 values: dict[str, object] = {}
-                if excluded_templates is not None:
+                if excluded_templates is not None and excluded_templates != existing.excluded_templates:
                     values["excluded_templates"] = excluded_templates
-                if glyph_remapping is not None:
+                if glyph_remapping is not None and glyph_remapping != existing.glyph_remapping:
                     values["glyph_remapping"] = glyph_remapping
                 if values:
                     values["asset_ingest_needed"] = True
@@ -179,21 +167,6 @@ async def update_template_errors(*, plugin_id: str, template_errors: dict[str, s
             if result.scalar_one_or_none() is not None:
                 await session.execute(update(PluginState).where(PluginState.plugin_id == plugin_id).values(template_errors=template_errors))
                 await session.commit()
-
-    await dbRetry(function)
-
-
-async def set_plugin_enabled_state(*, plugin_id: str, enabled: bool) -> None:
-    """Set the ``enabled`` flag for an existing PluginState row without touching any other field.
-
-    Used by ``unload_single`` to persist the disabled state after removing the plugin
-    from the in-memory maps.  If no row exists the call is a no-op.
-    """
-
-    async def function(i: int) -> None:
-        async with _jobs_module.async_session_maker() as session:
-            await session.execute(update(PluginState).where(PluginState.plugin_id == plugin_id).values(enabled=enabled))
-            await session.commit()
 
     await dbRetry(function)
 

--- a/backend/src/forecastbox/domain/plugin/db.py
+++ b/backend/src/forecastbox/domain/plugin/db.py
@@ -15,9 +15,9 @@ share a single SQLite connection pool and in-process tests can monkeypatch
 
 This table records unversioned app state (install history, per-plugin config).
 Writes are idempotent: insert on first install with empty-default columns for
-excluded_templates / glyph_remapping / template_errors; update version /
-updated_at / error on subsequent installs without clobbering the columns owned
-by later tasks (04/05/06).
+excluded_templates / glyph_remapping / template_errors; update plugin_version /
+updated_at / install_error on subsequent installs without clobbering the columns
+owned by other subsystems.
 """
 
 import logging
@@ -32,13 +32,13 @@ from forecastbox.utility.time import current_time
 logger = logging.getLogger(__name__)
 
 
-async def upsert_plugin_state(*, plugin_id: str, version: str | None, error: str | None) -> None:
+async def upsert_plugin_state(*, plugin_id: str, version: str, install_error: str | None) -> None:
     """Insert or update the PluginState row for ``plugin_id``.
 
     On first install: creates a row with empty ``excluded_templates`` / ``glyph_remapping``
     defaults and ``template_errors=None``.
-    On subsequent installs: updates ``version``, ``updated_at``, and ``error`` only --
-    ``excluded_templates`` and ``glyph_remapping`` are not touched (owned by tasks 04/05).
+    On subsequent installs: updates ``plugin_version``, ``updated_at``, and ``install_error``
+    only -- ``excluded_templates`` and ``glyph_remapping`` are not touched.
     """
     ref_time = current_time("dbref")
 
@@ -50,9 +50,9 @@ async def upsert_plugin_state(*, plugin_id: str, version: str | None, error: str
                 session.add(
                     PluginState(
                         plugin_id=plugin_id,
-                        version=version,
+                        plugin_version=version,
                         updated_at=ref_time,
-                        error=error,
+                        install_error=install_error,
                         excluded_templates=[],
                         glyph_remapping={},
                         template_errors=None,
@@ -60,7 +60,9 @@ async def upsert_plugin_state(*, plugin_id: str, version: str | None, error: str
                 )
             else:
                 await session.execute(
-                    update(PluginState).where(PluginState.plugin_id == plugin_id).values(version=version, updated_at=ref_time, error=error)
+                    update(PluginState)
+                    .where(PluginState.plugin_id == plugin_id)
+                    .values(plugin_version=version, updated_at=ref_time, install_error=install_error)
                 )
             await session.commit()
 

--- a/backend/src/forecastbox/domain/plugin/db.py
+++ b/backend/src/forecastbox/domain/plugin/db.py
@@ -18,6 +18,10 @@ Writes are idempotent: insert on first install with empty-default columns for
 excluded_templates / glyph_remapping / template_errors; update plugin_version /
 updated_at / install_error on subsequent installs without clobbering the columns
 owned by other subsystems.
+
+The ``update_plugin_settings`` helper owns the settings columns
+(``excluded_templates``, ``glyph_remapping``) and does a partial update that
+leaves unspecified fields unchanged.
 """
 
 import logging
@@ -84,3 +88,61 @@ async def get_all_plugin_states() -> list[PluginState]:
             return [row[0] for row in result.all()]
 
     return await dbRetry(function)
+
+
+async def update_plugin_settings(
+    *,
+    plugin_id: str,
+    excluded_templates: list[str] | None,
+    glyph_remapping: dict[str, str] | None,
+) -> None:
+    """Partially update the settings columns of the PluginState row for ``plugin_id``.
+
+    Only the fields that are not ``None`` are written; ``None`` means
+    "leave the stored value unchanged".  An empty list or empty dict
+    is a valid value meaning "explicitly clear".
+
+    If no row exists yet (plugin configured but never installed), a new row is
+    inserted with the provided settings and a sentinel ``plugin_version``.
+    """
+
+    async def function(i: int) -> None:
+        async with _jobs_module.async_session_maker() as session:
+            result = await session.execute(select(PluginState).where(PluginState.plugin_id == plugin_id))
+            existing = result.scalar_one_or_none()
+            if existing is None:
+                session.add(
+                    PluginState(
+                        plugin_id=plugin_id,
+                        plugin_version="not installed",
+                        updated_at=current_time("dbref"),
+                        install_error=None,
+                        excluded_templates=excluded_templates if excluded_templates is not None else [],
+                        glyph_remapping=glyph_remapping if glyph_remapping is not None else {},
+                        template_errors=None,
+                    )
+                )
+            else:
+                values: dict[str, object] = {}
+                if excluded_templates is not None:
+                    values["excluded_templates"] = excluded_templates
+                if glyph_remapping is not None:
+                    values["glyph_remapping"] = glyph_remapping
+                if values:
+                    await session.execute(update(PluginState).where(PluginState.plugin_id == plugin_id).values(**values))
+            await session.commit()
+
+    await dbRetry(function)
+
+
+async def get_plugin_settings(plugin_id: str) -> tuple[list[str], dict[str, str]]:
+    """Return ``(excluded_templates, glyph_remapping)`` for ``plugin_id``.
+
+    Returns empty defaults if the plugin has no persisted state yet.
+    """
+    state = await get_plugin_state(plugin_id)
+    if state is None:
+        return [], {}
+    excluded: list[str] = list(state.excluded_templates) if state.excluded_templates else []  # type: ignore[arg-type]
+    remapping: dict[str, str] = dict(state.glyph_remapping) if state.glyph_remapping else {}  # type: ignore[arg-type]
+    return excluded, remapping

--- a/backend/src/forecastbox/domain/plugin/db.py
+++ b/backend/src/forecastbox/domain/plugin/db.py
@@ -1,0 +1,84 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Persistence layer for plugin install state.
+
+Uses the same session maker as ``forecastbox.schemata.jobs`` so that all tables
+share a single SQLite connection pool and in-process tests can monkeypatch
+``async_session_maker`` to inject an in-memory database.
+
+This table records unversioned app state (install history, per-plugin config).
+Writes are idempotent: insert on first install with empty-default columns for
+excluded_templates / glyph_remapping / template_errors; update version /
+updated_at / error on subsequent installs without clobbering the columns owned
+by later tasks (04/05/06).
+"""
+
+import logging
+
+from sqlalchemy import select, update
+
+import forecastbox.schemata.jobs as _jobs_module
+from forecastbox.schemata.jobs import PluginState
+from forecastbox.utility.db import dbRetry, querySingle
+from forecastbox.utility.time import current_time
+
+logger = logging.getLogger(__name__)
+
+
+async def upsert_plugin_state(*, plugin_id: str, version: str | None, error: str | None) -> None:
+    """Insert or update the PluginState row for ``plugin_id``.
+
+    On first install: creates a row with empty ``excluded_templates`` / ``glyph_remapping``
+    defaults and ``template_errors=None``.
+    On subsequent installs: updates ``version``, ``updated_at``, and ``error`` only --
+    ``excluded_templates`` and ``glyph_remapping`` are not touched (owned by tasks 04/05).
+    """
+    ref_time = current_time("dbref")
+
+    async def function(i: int) -> None:
+        async with _jobs_module.async_session_maker() as session:
+            result = await session.execute(select(PluginState).where(PluginState.plugin_id == plugin_id))
+            existing = result.scalar_one_or_none()
+            if existing is None:
+                session.add(
+                    PluginState(
+                        plugin_id=plugin_id,
+                        version=version,
+                        updated_at=ref_time,
+                        error=error,
+                        excluded_templates=[],
+                        glyph_remapping={},
+                        template_errors=None,
+                    )
+                )
+            else:
+                await session.execute(
+                    update(PluginState).where(PluginState.plugin_id == plugin_id).values(version=version, updated_at=ref_time, error=error)
+                )
+            await session.commit()
+
+    await dbRetry(function)
+
+
+async def get_plugin_state(plugin_id: str) -> PluginState | None:
+    """Return the PluginState row for ``plugin_id``, or ``None`` if not yet installed."""
+    query = select(PluginState).where(PluginState.plugin_id == plugin_id)
+    return await querySingle(query, _jobs_module.async_session_maker)
+
+
+async def get_all_plugin_states() -> list[PluginState]:
+    """Return all PluginState rows."""
+
+    async def function(i: int) -> list[PluginState]:
+        async with _jobs_module.async_session_maker() as session:
+            result = await session.execute(select(PluginState))
+            return [row[0] for row in result.all()]
+
+    return await dbRetry(function)

--- a/backend/src/forecastbox/domain/plugin/db.py
+++ b/backend/src/forecastbox/domain/plugin/db.py
@@ -36,13 +36,20 @@ from forecastbox.utility.time import current_time
 logger = logging.getLogger(__name__)
 
 
-async def upsert_plugin_state(*, plugin_id: str, version: str, install_error: str | None) -> None:
+async def upsert_plugin_state(*, plugin_id: str, version: str | None, enabled: bool, install_error: str | None) -> None:
     """Insert or update the PluginState row for ``plugin_id``.
 
     On first install: creates a row with empty ``excluded_templates`` / ``glyph_remapping``
-    defaults and ``template_errors=None``.
-    On subsequent installs: updates ``plugin_version``, ``updated_at``, and ``install_error``
-    only -- ``excluded_templates`` and ``glyph_remapping`` are not touched.
+    defaults, ``template_errors=None``, and ``asset_ingest_needed=True``.
+    On subsequent calls: updates ``plugin_version`` (if provided), ``updated_at``,
+    ``install_error``, and ``enabled``.  ``excluded_templates`` and ``glyph_remapping``
+    are never touched.
+
+    Sets ``asset_ingest_needed=True`` when the version changes or when ``enabled``
+    transitions from ``False`` to ``True``.
+
+    Raises ``RuntimeError`` if ``version`` is ``None`` and no existing row is found,
+    as that indicates a programming error (re-enabling a plugin that was never installed).
     """
     ref_time = current_time("dbref")
 
@@ -51,6 +58,11 @@ async def upsert_plugin_state(*, plugin_id: str, version: str, install_error: st
             result = await session.execute(select(PluginState).where(PluginState.plugin_id == plugin_id))
             existing = result.scalar_one_or_none()
             if existing is None:
+                if version is None:
+                    raise RuntimeError(
+                        f"upsert_plugin_state called with version=None for unknown plugin {plugin_id!r}; "
+                        "this plugin has no prior DB row and cannot be upserted without a version"
+                    )
                 session.add(
                     PluginState(
                         plugin_id=plugin_id,
@@ -60,14 +72,23 @@ async def upsert_plugin_state(*, plugin_id: str, version: str, install_error: st
                         excluded_templates=[],
                         glyph_remapping={},
                         template_errors=None,
+                        asset_ingest_needed=True,
+                        enabled=enabled,
                     )
                 )
             else:
-                await session.execute(
-                    update(PluginState)
-                    .where(PluginState.plugin_id == plugin_id)
-                    .values(plugin_version=version, updated_at=ref_time, install_error=install_error)
-                )
+                version_changed = version is not None and version != existing.plugin_version
+                enabling = enabled and not existing.enabled
+                new_ingest_needed = bool(existing.asset_ingest_needed) or version_changed or enabling
+                values: dict[str, object] = {
+                    "updated_at": ref_time,
+                    "install_error": install_error,
+                    "enabled": enabled,
+                    "asset_ingest_needed": new_ingest_needed,
+                }
+                if version is not None:
+                    values["plugin_version"] = version
+                await session.execute(update(PluginState).where(PluginState.plugin_id == plugin_id).values(**values))
             await session.commit()
 
     await dbRetry(function)
@@ -102,6 +123,9 @@ async def update_plugin_settings(
     "leave the stored value unchanged".  An empty list or empty dict
     is a valid value meaning "explicitly clear".
 
+    Always sets ``asset_ingest_needed=True`` when any setting is changed (or on
+    insert), so the next load cycle re-applies the updated exclusions/remapping.
+
     If no row exists yet (plugin configured but never installed), a new row is
     inserted with the provided settings and a sentinel ``plugin_version``.
     """
@@ -120,6 +144,8 @@ async def update_plugin_settings(
                         excluded_templates=excluded_templates if excluded_templates is not None else [],
                         glyph_remapping=glyph_remapping if glyph_remapping is not None else {},
                         template_errors=None,
+                        enabled=True,
+                        asset_ingest_needed=True,
                     )
                 )
             else:
@@ -129,6 +155,7 @@ async def update_plugin_settings(
                 if glyph_remapping is not None:
                     values["glyph_remapping"] = glyph_remapping
                 if values:
+                    values["asset_ingest_needed"] = True
                     await session.execute(update(PluginState).where(PluginState.plugin_id == plugin_id).values(**values))
             await session.commit()
 
@@ -156,14 +183,32 @@ async def update_template_errors(*, plugin_id: str, template_errors: dict[str, s
     await dbRetry(function)
 
 
-async def get_plugin_settings(plugin_id: str) -> tuple[list[str], dict[str, str]]:
-    """Return ``(excluded_templates, glyph_remapping)`` for ``plugin_id``.
+async def set_plugin_enabled_state(*, plugin_id: str, enabled: bool) -> None:
+    """Set the ``enabled`` flag for an existing PluginState row without touching any other field.
 
-    Returns empty defaults if the plugin has no persisted state yet.
+    Used by ``unload_single`` to persist the disabled state after removing the plugin
+    from the in-memory maps.  If no row exists the call is a no-op.
     """
-    state = await get_plugin_state(plugin_id)
-    if state is None:
-        return [], {}
-    excluded: list[str] = list(state.excluded_templates) if state.excluded_templates else []  # type: ignore[arg-type]
-    remapping: dict[str, str] = dict(state.glyph_remapping) if state.glyph_remapping else {}  # type: ignore[arg-type]
-    return excluded, remapping
+
+    async def function(i: int) -> None:
+        async with _jobs_module.async_session_maker() as session:
+            await session.execute(update(PluginState).where(PluginState.plugin_id == plugin_id).values(enabled=enabled))
+            await session.commit()
+
+    await dbRetry(function)
+
+
+async def clear_asset_ingest_needed(*, plugin_id: str) -> None:
+    """Clear the ``asset_ingest_needed`` flag immediately before starting template ingestion.
+
+    Clearing before (not after) ingestion means a partial failure does not leave the
+    flag set and trigger a spurious re-ingest; the per-template errors are already
+    persisted via ``update_template_errors``.  If no row exists the call is a no-op.
+    """
+
+    async def function(i: int) -> None:
+        async with _jobs_module.async_session_maker() as session:
+            await session.execute(update(PluginState).where(PluginState.plugin_id == plugin_id).values(asset_ingest_needed=False))
+            await session.commit()
+
+    await dbRetry(function)

--- a/backend/src/forecastbox/domain/plugin/db.py
+++ b/backend/src/forecastbox/domain/plugin/db.py
@@ -135,6 +135,27 @@ async def update_plugin_settings(
     await dbRetry(function)
 
 
+async def update_template_errors(*, plugin_id: str, template_errors: dict[str, str] | None) -> None:
+    """Persist per-template validation errors for ``plugin_id``.
+
+    ``None`` clears any recorded errors (all templates passed).  A non-empty
+    dict maps ``display_name`` to the error string for that template.  Call
+    this after each ingestion pass so the status surface reflects the latest result.
+
+    If no PluginState row exists yet the call is silently skipped; the row will
+    be created by ``upsert_plugin_state`` which defaults ``template_errors`` to ``None``.
+    """
+
+    async def function(i: int) -> None:
+        async with _jobs_module.async_session_maker() as session:
+            result = await session.execute(select(PluginState).where(PluginState.plugin_id == plugin_id))
+            if result.scalar_one_or_none() is not None:
+                await session.execute(update(PluginState).where(PluginState.plugin_id == plugin_id).values(template_errors=template_errors))
+                await session.commit()
+
+    await dbRetry(function)
+
+
 async def get_plugin_settings(plugin_id: str) -> tuple[list[str], dict[str, str]]:
     """Return ``(excluded_templates, glyph_remapping)`` for ``plugin_id``.
 

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -14,9 +14,10 @@ Assumed to be invoked from the plugins router in API, and during application
 startup.
 
 The synchronization logic is handled by a PluginManager with a single lock.
-Pyrsistent immutable structures are used for shared state (plugins, versions,
-errors, updatedate), making reads safe without locks. The lock is only acquired
-when swapping the top-level structure pointers on writes.
+Pyrsistent immutable structures are used for shared state (plugins, errors),
+making reads safe without locks. The lock is only acquired when swapping the
+top-level structure pointers on writes. Plugin versions and timestamps are
+persisted in the DB and read back by status_full; they are not held in memory.
 
 There is at most one thread at any time doing any pip/importlib operations,
 thus inside these updater threads we don't need any other critical sections.
@@ -32,12 +33,11 @@ import re
 import threading
 import time
 from concurrent.futures import Future
-from typing import Iterator, Literal
+from typing import Literal
 
 from cascade.low.func import Either, assert_never
 from fiab_core.fable import BlockFactoryCatalogue, PluginCompositeId
 from fiab_core.plugin import Plugin
-from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 from pyrsistent import pmap
 from pyrsistent.typing import PMap
@@ -56,7 +56,6 @@ logger = logging.getLogger(__name__)
 class PluginManager:
     lock: threading.Lock = threading.Lock()
     plugins: PMap[PluginCompositeId, Plugin] = pmap()
-    versions: PMap[PluginCompositeId, str] = pmap()
     errors: PMap[PluginCompositeId, str] = pmap()
     updater: threading.Thread | None = None
     updater_error: str | None = None
@@ -108,7 +107,6 @@ def load_plugins(plugins: PluginsSettings) -> None:
     try:
         lookup = {}
         errors = {}
-        versions = {}
         for pluginKey, pluginSettings in plugins.items():
             if not pluginSettings.enabled:
                 continue
@@ -134,13 +132,7 @@ def load_plugins(plugins: PluginsSettings) -> None:
 
             if install_error is not None:
                 logger.error(f"install failed for {pluginKey}: {install_error}")
-                _run_async_from_thread(
-                    upsert_plugin_state(
-                        plugin_id=plugin_id_str,
-                        version=try_version(pluginSettings.pip_source, pluginSettings.module_name),
-                        install_error=install_error,
-                    )
-                )
+                _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version="install failed", install_error=install_error))
                 errors[pluginKey] = install_error
                 continue
 
@@ -158,7 +150,6 @@ def load_plugins(plugins: PluginsSettings) -> None:
                 version_str = _version_from_install(installed_versions, pluginSettings.module_name) or try_version(
                     pluginSettings.pip_source, pluginSettings.module_name
                 )
-                versions[pluginKey] = version_str
                 _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_str, install_error=None))
 
         with timed_acquire(PluginManager.lock, 60) as lock_result:
@@ -166,7 +157,6 @@ def load_plugins(plugins: PluginsSettings) -> None:
                 raise ValueError("failed to acquire the shared lock")
             PluginManager.plugins = pmap(lookup)
             PluginManager.errors = pmap(errors)
-            PluginManager.versions = pmap(versions)
         logger.debug("global plugin loading finished")
     except Exception as e:
         logger.exception(f"updating thread failed with {repr(e)}")
@@ -183,11 +173,7 @@ def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, i
             install_result = install_plugin_compatibly(pluginSettings.pip_source, version)
             if install_result.e:
                 _run_async_from_thread(
-                    upsert_plugin_state(
-                        plugin_id=plugin_id_str,
-                        version=try_version(pluginSettings.pip_source, pluginSettings.module_name),
-                        install_error=install_result.e,
-                    )
+                    upsert_plugin_state(plugin_id=plugin_id_str, version="install failed", install_error=install_result.e)
                 )
                 raise RuntimeError(f"install failed for {pluginId}: {install_result.e}")
             installed_versions = install_result.t or {}
@@ -208,7 +194,6 @@ def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, i
                 PluginManager.errors = PluginManager.errors.set(pluginId, result)
             else:
                 assert_never(result)
-            PluginManager.versions = PluginManager.versions.set(pluginId, version_str)
         _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_str, install_error=None))
         logger.debug(f"single plugin loading finished: {pluginId}")
     except Exception as e:
@@ -227,8 +212,6 @@ def unload_single(pluginId: PluginCompositeId) -> None:
             PluginManager.plugins = PluginManager.plugins.remove(pluginId)
         if pluginId in PluginManager.errors:
             PluginManager.errors = PluginManager.errors.remove(pluginId)
-        if pluginId in PluginManager.versions:
-            PluginManager.versions = PluginManager.versions.remove(pluginId)
 
 
 def submit_load_plugins(start_after: Future[None]) -> None:
@@ -272,11 +255,10 @@ async def status_full() -> PluginsStatus:
         if not result:
             status = "retrieving"
             plugin_errors: dict[PluginCompositeId, str] = {}
-            plugin_versions: dict[PluginCompositeId, str] = {}
         else:
             status = status_brief()
             plugin_errors = dict(PluginManager.errors)
-            plugin_versions = dict(PluginManager.versions)
+    plugin_versions: dict[PluginCompositeId, str] = {}
     plugin_updatedatetime: dict[PluginCompositeId, str] = {}
     try:
         states = await get_all_plugin_states()
@@ -291,6 +273,7 @@ async def status_full() -> PluginsStatus:
                 plugin_errors[plugin_id] = (
                     f"{existing}; {state.install_error}" if existing else state.install_error  # type: ignore[misc]
                 )
+            plugin_versions[plugin_id] = state.plugin_version  # type: ignore[assignment]
             plugin_updatedatetime[plugin_id] = value_dt2str(state.updated_at)  # type: ignore[arg-type]
     except Exception:
         logger.warning("failed to load plugin states from DB; status may be incomplete", exc_info=True)

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -39,7 +39,6 @@ from cascade.low.func import Either, assert_never
 from fiab_core.fable import BlockFactoryCatalogue, PluginCompositeId
 from fiab_core.plugin import Plugin
 from packaging.version import Version
-from pydantic import Field
 from pyrsistent import pmap
 from pyrsistent.typing import PMap
 
@@ -314,9 +313,6 @@ class PluginsStatus(FiabBaseModel):
     plugin_errors: dict[PluginCompositeId, str]
     plugin_versions: dict[PluginCompositeId, str]
     plugin_updatedatetime: dict[PluginCompositeId, str]
-    plugin_template_errors: dict[PluginCompositeId, dict[str, str]] = Field(default_factory=dict)
-    """Per-plugin map of template ``display_name`` to validation error string for
-    templates that failed validation during the most recent ingestion pass."""
 
 
 def status_brief() -> str:
@@ -343,7 +339,6 @@ async def status_full() -> PluginsStatus:
             plugin_errors = dict(PluginManager.errors)
     plugin_versions: dict[PluginCompositeId, str] = {}
     plugin_updatedatetime: dict[PluginCompositeId, str] = {}
-    plugin_template_errors: dict[PluginCompositeId, dict[str, str]] = {}
     try:
         states = await get_all_plugin_states()
         for state in states:
@@ -360,7 +355,14 @@ async def status_full() -> PluginsStatus:
             plugin_versions[plugin_id] = state.plugin_version  # type: ignore[assignment]
             plugin_updatedatetime[plugin_id] = value_dt2str(state.updated_at)  # type: ignore[arg-type]
             if state.template_errors:  # type: ignore[truthy-bool]
-                plugin_template_errors[plugin_id] = dict(state.template_errors)  # type: ignore[arg-type]
+                # Format per-template errors as a single string and merge into plugin_errors,
+                # consistent with the existing install_error merge above.
+                template_err_str = "; ".join(
+                    f"template {name!r}: {msg}"
+                    for name, msg in state.template_errors.items()  # type: ignore[union-attr]
+                )
+                existing = plugin_errors.get(plugin_id)
+                plugin_errors[plugin_id] = f"{existing}; {template_err_str}" if existing else template_err_str
     except Exception:
         logger.warning("failed to load plugin states from DB; status may be incomplete", exc_info=True)
     return PluginsStatus(
@@ -368,7 +370,6 @@ async def status_full() -> PluginsStatus:
         plugin_errors=plugin_errors,
         plugin_versions=plugin_versions,
         plugin_updatedatetime=plugin_updatedatetime,
-        plugin_template_errors=plugin_template_errors,
     )
 
 

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -47,7 +47,6 @@ from forecastbox.domain.plugin.db import (
     clear_asset_ingest_needed,
     get_all_plugin_states,
     get_plugin_state,
-    set_plugin_enabled_state,
     update_template_errors,
     upsert_plugin_state,
 )
@@ -254,18 +253,21 @@ def load_plugins(plugins: PluginsSettings) -> None:
                     version_imported = try_version(pluginSettings.pip_source, pluginSettings.module_name)
                     logger.debug(f"plugin {pluginKey} loaded with success: True and version {version_imported}")
                     fresh_state = _run_async_from_thread(get_plugin_state(plugin_id_str))
-                    if fresh_state is not None:
+                    if fresh_state is None:
+                        # NOTE this is unexpected state -- it is either developer editable install, or db wipe. We prefer to report,
+                        # but dont prevent template ingest
+                        err_msg = f"plugin {pluginKey} state not found -- install originally failed?"
+                        logger.error(err_msg)
+                        errors[pluginKey] = err_msg
+                        _run_async_from_thread(
+                            upsert_plugin_state(plugin_id=plugin_id_str, version=version_imported, enabled=True, install_error=None)
+                        )
+                    else:
                         db_ver: str = fresh_state.plugin_version  # type: ignore[assignment]
                         if db_ver != version_imported:
                             mismatch_msg = f"version mismatch: DB has {db_ver!r} but {version_imported!r} is imported"
                             logger.warning(f"plugin {pluginKey}: {mismatch_msg}")
                             errors[pluginKey] = mismatch_msg
-                    else:
-                        # No DB row yet (e.g. fresh DB with already-importable plugin).
-                        # Create a row so that _ingest_plugin_templates can proceed.
-                        _run_async_from_thread(
-                            upsert_plugin_state(plugin_id=plugin_id_str, version=version_imported, enabled=True, install_error=None)
-                        )
                 else:
                     logger.debug(f"plugin {pluginKey} loaded with success: False")
                     errors[pluginKey] = plugin_result.e
@@ -323,7 +325,10 @@ def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, i
                 PluginManager.errors = PluginManager.errors.set(
                     pluginId, f"{existing_err}; {version_mismatch}" if existing_err else version_mismatch
                 )
-        _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_install, enabled=True, install_error=None))
+        if version_install is not None:
+            _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_install, enabled=True, install_error=None))
+        else:
+            _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, enabled=True, install_error=None))
         if result.t is not None:
             _run_async_from_thread(_ingest_plugin_templates(pluginId, result.t))
         logger.debug(f"single plugin loading finished: {pluginId}")
@@ -349,7 +354,7 @@ def unload_single(pluginId: PluginCompositeId) -> None:
     # on blueprint domain), and will be fixed later by refactoring into events.
     from forecastbox.domain.blueprint.db import soft_delete_all_plugin_templates
 
-    _run_async_from_thread(set_plugin_enabled_state(plugin_id=plugin_id_str, enabled=False))
+    _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, enabled=False))
     _run_async_from_thread(soft_delete_all_plugin_templates(created_by=plugin_id_str))
 
 

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -62,7 +62,7 @@ class PluginManager:
     loop: asyncio.AbstractEventLoop | None = None
 
 
-def load_single(plugin: PluginSettings) -> Plugin | str:
+def load_single(plugin: PluginSettings) -> Either[Plugin, str]:
     errors = []
     plugin_impl = try_import(plugin.module_name)
     if plugin_impl is None:
@@ -74,10 +74,10 @@ def load_single(plugin: PluginSettings) -> Plugin | str:
         if not isinstance(maybe_plugin, Plugin):
             errors.append(f"plugin {plugin.module_name}'s `plugin()` does not give a Plugin")
         else:
-            return maybe_plugin
+            return Either.ok(maybe_plugin)
     except Exception as e:
         errors.append("failed to invoke plugin(): {repr(e)}")
-    return "\n".join(errors)
+    return Either.error("\n".join(errors))
 
 
 def _run_async_from_thread(coro: object) -> object:  # type: ignore[type-arg]
@@ -204,24 +204,26 @@ def load_plugins(plugins: PluginsSettings) -> None:
             if install_error is not None:
                 logger.error(f"install failed for {pluginKey}: {install_error}")
                 _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version="install failed", install_error=install_error))
-                errors[pluginKey] = install_error
                 continue
+            if installed_versions is not None:
+                version_str = _version_from_install(installed_versions, pluginSettings.module_name)
+                if version_str is not None:
+                    _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_str, install_error=None))
+                else:
+                    # pip does not report the version if it isn't changed -> this branch is not necessarily a bug
+                    logger.warning(f"pip install of plugin {plugin_id_str} did not produce a version, assuming no change")
 
             if pluginKey in lookup:
                 errors[pluginKey] = f"plugin {pluginKey} is provided by more than just {pluginSettings.pip_source}"
             else:
                 plugin_result = load_single(pluginSettings)
-                logger.debug(f"plugin {pluginKey} loaded with success: {isinstance(plugin_result, Plugin)}")
-                if isinstance(plugin_result, Plugin):
-                    lookup[pluginKey] = plugin_result
-                elif isinstance(plugin_result, str):
-                    errors[pluginKey] = plugin_result
+                logger.debug(f"plugin {pluginKey} loaded with success: {plugin_result.t is not None} and version {version_imported}")
+                if plugin_result.t is not None:
+                    lookup[pluginKey] = plugin_result.t
+                    version_imported = try_version(pluginSettings.pip_source, pluginSettings.module_name)
+                    # TODO validate version with database, if mismatch append to errors but dont drop from lookup
                 else:
-                    assert_never(plugin_result)
-                version_str = _version_from_install(installed_versions, pluginSettings.module_name) or try_version(
-                    pluginSettings.pip_source, pluginSettings.module_name
-                )
-                _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_str, install_error=None))
+                    errors[pluginKey] = plugin_result.e
 
         # Publish all loaded plugins before running template ingestion so that
         # validate_expand can resolve factory references during validation.
@@ -256,22 +258,19 @@ def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, i
             installed_versions = install_result.t or {}
         # NOTE we need to recommend in the docs to re-launch app after this change, this wont cover all cases
         importlib.reload(importlib.import_module(pluginSettings.module_name))
-        plugin_impl = try_import(pluginSettings.module_name)
         result = load_single(pluginSettings)
-        logger.debug(f"plugin {pluginId} loaded with success: {isinstance(result, Plugin)}")
-        version_str = _version_from_install(installed_versions, pluginSettings.module_name) or try_version(
-            pluginSettings.pip_source, pluginSettings.module_name
-        )
+        logger.debug(f"plugin {pluginId} loaded with success: {result.t is not None}")
+        version_install = _version_from_install(installed_versions, pluginSettings.module_name)
+        version_imported = try_version(pluginSettings.pip_source, pluginSettings.module_name)
+        # TODO compare versions, if mismatch, append to errors but dont unload
         with timed_acquire(PluginManager.lock, 60) as acquire_result:
             if not acquire_result:
                 raise ValueError("failed to acquire the shared lock")
-            if isinstance(result, Plugin):
-                PluginManager.plugins = PluginManager.plugins.set(pluginId, result)
-            elif isinstance(result, str):
-                PluginManager.errors = PluginManager.errors.set(pluginId, result)
+            if result.t is not None:
+                PluginManager.plugins = PluginManager.plugins.set(pluginId, result.t)
             else:
-                assert_never(result)
-        _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_str, install_error=None))
+                PluginManager.errors = PluginManager.errors.set(pluginId, result.e)
+        _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_installed, install_error=None))
         if isinstance(result, Plugin):
             _run_async_from_thread(_ingest_plugin_templates(pluginId, result))
         logger.debug(f"single plugin loading finished: {pluginId}")

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -39,6 +39,7 @@ from cascade.low.func import Either, assert_never
 from fiab_core.fable import BlockFactoryCatalogue, PluginCompositeId
 from fiab_core.plugin import Plugin
 from packaging.version import Version
+from pydantic import Field
 from pyrsistent import pmap
 from pyrsistent.typing import PMap
 
@@ -118,8 +119,13 @@ async def _ingest_plugin_templates(plugin_id: PluginCompositeId, plugin: Plugin)
     depending on blueprint domain), and will be fixed later by refactoring into events.
     """
     from forecastbox.domain.blueprint.db import find_plugin_template_id, soft_delete_plugin_template, upsert_blueprint
-    from forecastbox.domain.blueprint.service import remap_builder_glyphs, template_to_builder
-    from forecastbox.domain.plugin.db import get_plugin_settings
+    from forecastbox.domain.blueprint.service import (
+        remap_builder_glyphs,
+        resolve_builder_with_examples,
+        template_to_builder,
+        validate_expand,
+    )
+    from forecastbox.domain.plugin.db import get_plugin_settings, update_template_errors
     from forecastbox.utility.auth import AuthContext
 
     plugin_id_str = PluginCompositeId.to_str(plugin_id)
@@ -127,6 +133,8 @@ async def _ingest_plugin_templates(plugin_id: PluginCompositeId, plugin: Plugin)
 
     excluded_templates, glyph_remapping = await get_plugin_settings(plugin_id_str)
     excluded_set = set(excluded_templates)
+
+    template_errors: dict[str, str] = {}
 
     for template in plugin.blueprint_templates:
         try:
@@ -138,6 +146,17 @@ async def _ingest_plugin_templates(plugin_id: PluginCompositeId, plugin: Plugin)
             builder = template_to_builder(template, plugin_id)
             if glyph_remapping:
                 builder = remap_builder_glyphs(builder, glyph_remapping)
+            validation_builder = resolve_builder_with_examples(builder, template.example_values, template.example_glyphs)
+            result = await validate_expand(validation_builder, auth, validate_only=True)
+            all_errors: list[str] = list(result.global_errors)
+            for block_errs in result.block_errors.values():
+                all_errors.extend(block_errs)
+            if all_errors:
+                template_errors[template.display_name] = "; ".join(all_errors)
+                logger.warning(
+                    f"template {template.display_name!r} from plugin {plugin_id_str!r} failed validation, skipping upsert: {all_errors}"
+                )
+                continue
             await upsert_blueprint(
                 auth_context=auth,
                 blueprint_id=existing_id,
@@ -149,7 +168,10 @@ async def _ingest_plugin_templates(plugin_id: PluginCompositeId, plugin: Plugin)
             )
             logger.debug(f"ingested template {template.display_name!r} from plugin {plugin_id_str!r}")
         except Exception as e:
+            template_errors[template.display_name] = repr(e)
             logger.error(f"failed to ingest template {template.display_name!r} from plugin {plugin_id_str!r}: {repr(e)}")
+
+    await update_template_errors(plugin_id=plugin_id_str, template_errors=template_errors if template_errors else None)
 
 
 def load_plugins(plugins: PluginsSettings) -> None:
@@ -201,14 +223,18 @@ def load_plugins(plugins: PluginsSettings) -> None:
                     pluginSettings.pip_source, pluginSettings.module_name
                 )
                 _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_str, install_error=None))
-                if isinstance(plugin_result, Plugin):
-                    _run_async_from_thread(_ingest_plugin_templates(pluginKey, plugin_result))
 
+        # Publish all loaded plugins before running template ingestion so that
+        # validate_expand can resolve factory references during validation.
         with timed_acquire(PluginManager.lock, 60) as lock_result:
             if not lock_result:
                 raise ValueError("failed to acquire the shared lock")
             PluginManager.plugins = pmap(lookup)
             PluginManager.errors = pmap(errors)
+
+        for pluginKey, plugin_result in lookup.items():
+            _run_async_from_thread(_ingest_plugin_templates(pluginKey, plugin_result))
+
         logger.debug("global plugin loading finished")
     except Exception as e:
         logger.exception(f"updating thread failed with {repr(e)}")
@@ -288,6 +314,9 @@ class PluginsStatus(FiabBaseModel):
     plugin_errors: dict[PluginCompositeId, str]
     plugin_versions: dict[PluginCompositeId, str]
     plugin_updatedatetime: dict[PluginCompositeId, str]
+    plugin_template_errors: dict[PluginCompositeId, dict[str, str]] = Field(default_factory=dict)
+    """Per-plugin map of template ``display_name`` to validation error string for
+    templates that failed validation during the most recent ingestion pass."""
 
 
 def status_brief() -> str:
@@ -314,6 +343,7 @@ async def status_full() -> PluginsStatus:
             plugin_errors = dict(PluginManager.errors)
     plugin_versions: dict[PluginCompositeId, str] = {}
     plugin_updatedatetime: dict[PluginCompositeId, str] = {}
+    plugin_template_errors: dict[PluginCompositeId, dict[str, str]] = {}
     try:
         states = await get_all_plugin_states()
         for state in states:
@@ -329,6 +359,8 @@ async def status_full() -> PluginsStatus:
                 )
             plugin_versions[plugin_id] = state.plugin_version  # type: ignore[assignment]
             plugin_updatedatetime[plugin_id] = value_dt2str(state.updated_at)  # type: ignore[arg-type]
+            if state.template_errors:  # type: ignore[truthy-bool]
+                plugin_template_errors[plugin_id] = dict(state.template_errors)  # type: ignore[arg-type]
     except Exception:
         logger.warning("failed to load plugin states from DB; status may be incomplete", exc_info=True)
     return PluginsStatus(
@@ -336,6 +368,7 @@ async def status_full() -> PluginsStatus:
         plugin_errors=plugin_errors,
         plugin_versions=plugin_versions,
         plugin_updatedatetime=plugin_updatedatetime,
+        plugin_template_errors=plugin_template_errors,
     )
 
 

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -221,14 +221,13 @@ def load_plugins(plugins: PluginsSettings) -> None:
                     lookup[pluginKey] = plugin_result.t
                     version_imported = try_version(pluginSettings.pip_source, pluginSettings.module_name)
                     logger.debug(f"plugin {pluginKey} loaded with success: True and version {version_imported}")
-                    if not installed_versions:
-                        db_state = _run_async_from_thread(get_plugin_state(plugin_id_str))
-                        if db_state is not None:
-                            db_ver: str = db_state.plugin_version  # type: ignore[assignment]
-                            if db_ver not in ("install failed", "not installed") and db_ver != version_imported:
-                                mismatch_msg = f"version mismatch: DB has {db_ver!r} but {version_imported!r} is imported"
-                                logger.warning(f"plugin {pluginKey}: {mismatch_msg}")
-                                errors[pluginKey] = mismatch_msg
+                    db_state = _run_async_from_thread(get_plugin_state(plugin_id_str))
+                    if db_state is not None:
+                        db_ver: str = db_state.plugin_version  # type: ignore[assignment]
+                        if db_ver != version_imported:
+                            mismatch_msg = f"version mismatch: DB has {db_ver!r} but {version_imported!r} is imported"
+                            logger.warning(f"plugin {pluginKey}: {mismatch_msg}")
+                            errors[pluginKey] = mismatch_msg
                 else:
                     logger.debug(f"plugin {pluginKey} loaded with success: False")
                     errors[pluginKey] = plugin_result.e
@@ -286,9 +285,8 @@ def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, i
                 PluginManager.errors = PluginManager.errors.set(
                     pluginId, f"{existing_err}; {version_mismatch}" if existing_err else version_mismatch
                 )
-        _run_async_from_thread(
-            upsert_plugin_state(plugin_id=plugin_id_str, version=version_install or version_imported, install_error=None)
-        )
+        if version_install is not None:
+            _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_install, install_error=None))
         if result.t is not None:
             _run_async_from_thread(_ingest_plugin_templates(pluginId, result.t))
         logger.debug(f"single plugin loading finished: {pluginId}")

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -105,18 +105,34 @@ def _version_from_install(installed: dict[str, str], module_name: str) -> str | 
 async def _ingest_plugin_templates(plugin_id: PluginCompositeId, plugin: Plugin) -> None:
     """Upsert each blueprint template exposed by the plugin into the DB.
 
+    Excluded templates (per ``PluginState.excluded_templates``) are skipped and
+    any existing plugin-owned blueprint row with that ``display_name`` is
+    soft-deleted.  Non-excluded templates are upserted as normal.
+
     Uses lazy imports to avoid a circular dependency between the plugin and
     blueprint domains.  A failure on any single template is logged and skipped
     so the remaining templates are still ingested.
+
+    Glyph remapping is loaded from state but not applied here; that seam is
+    left for a later task.
     """
-    from forecastbox.domain.blueprint.db import find_plugin_template_id, upsert_blueprint
+    from forecastbox.domain.blueprint.db import find_plugin_template_id, soft_delete_plugin_template, upsert_blueprint
     from forecastbox.domain.blueprint.service import template_to_builder
+    from forecastbox.domain.plugin.db import get_plugin_settings
     from forecastbox.utility.auth import AuthContext
 
     plugin_id_str = PluginCompositeId.to_str(plugin_id)
     auth = AuthContext(user_id=plugin_id_str, is_admin=True)
+
+    excluded_templates, _glyph_remapping = await get_plugin_settings(plugin_id_str)
+    excluded_set = set(excluded_templates)
+
     for template in plugin.blueprint_templates:
         try:
+            if template.display_name in excluded_set:
+                await soft_delete_plugin_template(created_by=plugin_id_str, display_name=template.display_name)
+                logger.debug(f"soft-deleted excluded template {template.display_name!r} from plugin {plugin_id_str!r}")
+                continue
             existing_id = await find_plugin_template_id(created_by=plugin_id_str, display_name=template.display_name)
             builder = template_to_builder(template, plugin_id)
             await upsert_blueprint(

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -33,7 +33,7 @@ import re
 import threading
 import time
 from concurrent.futures import Future
-from typing import Literal
+from typing import Literal, cast
 
 from cascade.low.func import Either, assert_never
 from fiab_core.fable import BlockFactoryCatalogue, PluginCompositeId
@@ -43,7 +43,7 @@ from pyrsistent import pmap
 from pyrsistent.typing import PMap
 
 from forecastbox.domain.plugin.compatibility import install_plugin_compatibly
-from forecastbox.domain.plugin.db import get_all_plugin_states, upsert_plugin_state
+from forecastbox.domain.plugin.db import get_all_plugin_states, get_plugin_state, upsert_plugin_state
 from forecastbox.utility.concurrent import delayed_thread, timed_acquire
 from forecastbox.utility.config import PluginSettings, PluginsSettings, config, config_edit_lock
 from forecastbox.utility.packages import try_import, try_version
@@ -62,7 +62,7 @@ class PluginManager:
     loop: asyncio.AbstractEventLoop | None = None
 
 
-def load_single(plugin: PluginSettings) -> Either[Plugin, str]:
+def load_single(plugin: PluginSettings) -> Either[Plugin, str]:  # type: ignore[invalid-argument]
     errors = []
     plugin_impl = try_import(plugin.module_name)
     if plugin_impl is None:
@@ -205,7 +205,7 @@ def load_plugins(plugins: PluginsSettings) -> None:
                 logger.error(f"install failed for {pluginKey}: {install_error}")
                 _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version="install failed", install_error=install_error))
                 continue
-            if installed_versions is not None:
+            if installed_versions:
                 version_str = _version_from_install(installed_versions, pluginSettings.module_name)
                 if version_str is not None:
                     _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_str, install_error=None))
@@ -217,12 +217,20 @@ def load_plugins(plugins: PluginsSettings) -> None:
                 errors[pluginKey] = f"plugin {pluginKey} is provided by more than just {pluginSettings.pip_source}"
             else:
                 plugin_result = load_single(pluginSettings)
-                logger.debug(f"plugin {pluginKey} loaded with success: {plugin_result.t is not None} and version {version_imported}")
                 if plugin_result.t is not None:
                     lookup[pluginKey] = plugin_result.t
                     version_imported = try_version(pluginSettings.pip_source, pluginSettings.module_name)
-                    # TODO validate version with database, if mismatch append to errors but dont drop from lookup
+                    logger.debug(f"plugin {pluginKey} loaded with success: True and version {version_imported}")
+                    if not installed_versions:
+                        db_state = _run_async_from_thread(get_plugin_state(plugin_id_str))
+                        if db_state is not None:
+                            db_ver: str = db_state.plugin_version  # type: ignore[assignment]
+                            if db_ver not in ("install failed", "not installed") and db_ver != version_imported:
+                                mismatch_msg = f"version mismatch: DB has {db_ver!r} but {version_imported!r} is imported"
+                                logger.warning(f"plugin {pluginKey}: {mismatch_msg}")
+                                errors[pluginKey] = mismatch_msg
                 else:
+                    logger.debug(f"plugin {pluginKey} loaded with success: False")
                     errors[pluginKey] = plugin_result.e
 
         # Publish all loaded plugins before running template ingestion so that
@@ -262,17 +270,27 @@ def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, i
         logger.debug(f"plugin {pluginId} loaded with success: {result.t is not None}")
         version_install = _version_from_install(installed_versions, pluginSettings.module_name)
         version_imported = try_version(pluginSettings.pip_source, pluginSettings.module_name)
-        # TODO compare versions, if mismatch, append to errors but dont unload
+        version_mismatch: str | None = None
+        if version_install is not None and version_install != version_imported:
+            version_mismatch = f"version mismatch: pip installed {version_install!r} but {version_imported!r} is imported"
+            logger.warning(f"plugin {pluginId}: {version_mismatch}")
         with timed_acquire(PluginManager.lock, 60) as acquire_result:
             if not acquire_result:
                 raise ValueError("failed to acquire the shared lock")
             if result.t is not None:
                 PluginManager.plugins = PluginManager.plugins.set(pluginId, result.t)
             else:
-                PluginManager.errors = PluginManager.errors.set(pluginId, result.e)
-        _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_installed, install_error=None))
-        if isinstance(result, Plugin):
-            _run_async_from_thread(_ingest_plugin_templates(pluginId, result))
+                PluginManager.errors = PluginManager.errors.set(pluginId, cast(str, result.e))
+            if version_mismatch is not None:
+                existing_err = PluginManager.errors.get(pluginId)
+                PluginManager.errors = PluginManager.errors.set(
+                    pluginId, f"{existing_err}; {version_mismatch}" if existing_err else version_mismatch
+                )
+        _run_async_from_thread(
+            upsert_plugin_state(plugin_id=plugin_id_str, version=version_install or version_imported, install_error=None)
+        )
+        if result.t is not None:
+            _run_async_from_thread(_ingest_plugin_templates(pluginId, result.t))
         logger.debug(f"single plugin loading finished: {pluginId}")
     except Exception as e:
         logger.exception(f"updating thread failed with {repr(e)}")

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -112,6 +112,7 @@ async def _ingest_plugin_templates(plugin_id: PluginCompositeId, plugin: Plugin)
     Uses lazy imports to avoid a circular dependency between the plugin and
     blueprint domains.  A failure on any single template is logged and skipped
     so the remaining templates are still ingested.
+    Note: this import is a breach of dependency hierarchy, and will be fixed later.
 
     Glyph remapping is loaded from state but not applied here; that seam is
     left for a later task.

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -107,25 +107,25 @@ async def _ingest_plugin_templates(plugin_id: PluginCompositeId, plugin: Plugin)
 
     Excluded templates (per ``PluginState.excluded_templates``) are skipped and
     any existing plugin-owned blueprint row with that ``display_name`` is
-    soft-deleted.  Non-excluded templates are upserted as normal.
+    soft-deleted.  Non-excluded templates have their glyph names rewritten by
+    ``remap_builder_glyphs`` when a non-empty ``glyph_remapping`` is stored for
+    the plugin, then are upserted as normal.
 
-    Uses lazy imports to avoid a circular dependency between the plugin and
+    Uses lazy imports to avoid circular dependencies between the plugin and
     blueprint domains.  A failure on any single template is logged and skipped
     so the remaining templates are still ingested.
-    Note: this import is a breach of dependency hierarchy, and will be fixed later.
-
-    Glyph remapping is loaded from state but not applied here; that seam is
-    left for a later task.
+    Note: these imports are a breach of the dependency hierarchy (plugin domain
+    depending on blueprint domain), and will be fixed later by refactoring into events.
     """
     from forecastbox.domain.blueprint.db import find_plugin_template_id, soft_delete_plugin_template, upsert_blueprint
-    from forecastbox.domain.blueprint.service import template_to_builder
+    from forecastbox.domain.blueprint.service import remap_builder_glyphs, template_to_builder
     from forecastbox.domain.plugin.db import get_plugin_settings
     from forecastbox.utility.auth import AuthContext
 
     plugin_id_str = PluginCompositeId.to_str(plugin_id)
     auth = AuthContext(user_id=plugin_id_str, is_admin=True)
 
-    excluded_templates, _glyph_remapping = await get_plugin_settings(plugin_id_str)
+    excluded_templates, glyph_remapping = await get_plugin_settings(plugin_id_str)
     excluded_set = set(excluded_templates)
 
     for template in plugin.blueprint_templates:
@@ -136,6 +136,8 @@ async def _ingest_plugin_templates(plugin_id: PluginCompositeId, plugin: Plugin)
                 continue
             existing_id = await find_plugin_template_id(created_by=plugin_id_str, display_name=template.display_name)
             builder = template_to_builder(template, plugin_id)
+            if glyph_remapping:
+                builder = remap_builder_glyphs(builder, glyph_remapping)
             await upsert_blueprint(
                 auth_context=auth,
                 blueprint_id=existing_id,

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -102,6 +102,37 @@ def _version_from_install(installed: dict[str, str], module_name: str) -> str | 
     return None
 
 
+async def _ingest_plugin_templates(plugin_id: PluginCompositeId, plugin: Plugin) -> None:
+    """Upsert each blueprint template exposed by the plugin into the DB.
+
+    Uses lazy imports to avoid a circular dependency between the plugin and
+    blueprint domains.  A failure on any single template is logged and skipped
+    so the remaining templates are still ingested.
+    """
+    from forecastbox.domain.blueprint.db import find_plugin_template_id, upsert_blueprint
+    from forecastbox.domain.blueprint.service import template_to_builder
+    from forecastbox.utility.auth import AuthContext
+
+    plugin_id_str = PluginCompositeId.to_str(plugin_id)
+    auth = AuthContext(user_id=plugin_id_str, is_admin=True)
+    for template in plugin.blueprint_templates:
+        try:
+            existing_id = await find_plugin_template_id(created_by=plugin_id_str, display_name=template.display_name)
+            builder = template_to_builder(template, plugin_id)
+            await upsert_blueprint(
+                auth_context=auth,
+                blueprint_id=existing_id,
+                source="plugin_template",
+                created_by=plugin_id_str,
+                builder=builder.model_dump(mode="json"),
+                display_name=template.display_name,
+                display_description=template.display_description,
+            )
+            logger.debug(f"ingested template {template.display_name!r} from plugin {plugin_id_str!r}")
+        except Exception as e:
+            logger.error(f"failed to ingest template {template.display_name!r} from plugin {plugin_id_str!r}: {repr(e)}")
+
+
 def load_plugins(plugins: PluginsSettings) -> None:
     logger.info("starting initial plugin load")
     try:
@@ -151,6 +182,8 @@ def load_plugins(plugins: PluginsSettings) -> None:
                     pluginSettings.pip_source, pluginSettings.module_name
                 )
                 _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_str, install_error=None))
+                if isinstance(plugin_result, Plugin):
+                    _run_async_from_thread(_ingest_plugin_templates(pluginKey, plugin_result))
 
         with timed_acquire(PluginManager.lock, 60) as lock_result:
             if not lock_result:
@@ -195,6 +228,8 @@ def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, i
             else:
                 assert_never(result)
         _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_str, install_error=None))
+        if isinstance(result, Plugin):
+            _run_async_from_thread(_ingest_plugin_templates(pluginId, result))
         logger.debug(f"single plugin loading finished: {pluginId}")
     except Exception as e:
         logger.exception(f"updating thread failed with {repr(e)}")

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -25,6 +25,7 @@ or when running the initial plugin load -- but inside the updater threads,
 we lock for longer.
 """
 
+import asyncio
 import importlib
 import logging
 import threading
@@ -41,6 +42,7 @@ from pyrsistent import pmap
 from pyrsistent.typing import PMap
 
 from forecastbox.domain.plugin.compatibility import install_plugin_compatibly
+from forecastbox.domain.plugin.db import get_all_plugin_states, upsert_plugin_state
 from forecastbox.utility.concurrent import delayed_thread, timed_acquire
 from forecastbox.utility.config import PluginSettings, PluginsSettings, config, config_edit_lock
 from forecastbox.utility.packages import try_import, try_updatedatetime, try_version
@@ -57,6 +59,7 @@ class PluginManager:
     updatedatetime: PMap[PluginCompositeId, str] = pmap()
     updater: threading.Thread | None = None
     updater_error: str | None = None
+    loop: asyncio.AbstractEventLoop | None = None
 
 
 def load_single(plugin: PluginSettings) -> Plugin | str:
@@ -77,6 +80,15 @@ def load_single(plugin: PluginSettings) -> Plugin | str:
     return "\n".join(errors)
 
 
+def _run_async_from_thread(coro: object) -> object:  # type: ignore[type-arg]
+    """Dispatch *coro* to the event loop stashed on PluginManager and block until done."""
+    loop = PluginManager.loop
+    if loop is None:
+        logger.warning("PluginManager.loop is not set; skipping DB write")
+        return None
+    return asyncio.run_coroutine_threadsafe(coro, loop).result()  # type: ignore[arg-type]
+
+
 def load_plugins(plugins: PluginsSettings) -> None:
     logger.info("starting initial plugin load")
     try:
@@ -87,14 +99,25 @@ def load_plugins(plugins: PluginsSettings) -> None:
         for pluginKey, pluginSettings in plugins.items():
             if not pluginSettings.enabled:
                 continue
+            plugin_id_str = PluginCompositeId.to_str(pluginKey)
+            install_error: str | None = None
             # NOTE consider running all pip invocations at once -- worse error reporting but better perf
-            if pluginSettings.update_strategy == "auto":
-                logger.info(f"auto-updating {pluginSettings.module_name}")
-                install_plugin_compatibly(pluginSettings.pip_source, None)
-            else:
-                if try_import(pluginSettings.module_name) is None:
-                    logger.info(f"installing {pluginSettings.module_name} for the first time")
+            try:
+                if pluginSettings.update_strategy == "auto":
+                    logger.info(f"auto-updating {pluginSettings.module_name}")
                     install_plugin_compatibly(pluginSettings.pip_source, None)
+                else:
+                    if try_import(pluginSettings.module_name) is None:
+                        logger.info(f"installing {pluginSettings.module_name} for the first time")
+                        install_plugin_compatibly(pluginSettings.pip_source, None)
+            except Exception as e:
+                install_error = repr(e)
+                logger.exception(f"install failed for {pluginKey}: {repr(e)}")
+
+            if install_error is not None:
+                _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=None, error=install_error))
+                errors[pluginKey] = install_error
+                continue
 
             if pluginKey in lookup:
                 errors[pluginKey] = f"plugin {pluginKey} is provided by more than just {pluginSettings.pip_source}"
@@ -109,6 +132,7 @@ def load_plugins(plugins: PluginsSettings) -> None:
                     assert_never(result)
                 versions[pluginKey] = try_version(pluginSettings.pip_source, pluginSettings.module_name)
                 updatedatetime[pluginKey] = try_updatedatetime(pluginSettings.pip_source)
+                _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=versions[pluginKey], error=None))
 
         with timed_acquire(PluginManager.lock, 60) as result:
             if not result:
@@ -126,14 +150,20 @@ def load_plugins(plugins: PluginsSettings) -> None:
 
 
 def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, install: bool, version: Version | None) -> None:
+    plugin_id_str = PluginCompositeId.to_str(pluginId)
     try:
         if install:
-            install_plugin_compatibly(pluginSettings.pip_source, version)
+            try:
+                install_plugin_compatibly(pluginSettings.pip_source, version)
+            except Exception as install_exc:
+                _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=None, error=repr(install_exc)))
+                raise
         # NOTE we need to recommend in the docs to re-launch app after this change, this wont cover all cases
         importlib.reload(importlib.import_module(pluginSettings.module_name))
         plugin_impl = try_import(pluginSettings.module_name)
         result = load_single(pluginSettings)
         logger.debug(f"plugin {pluginId} loaded with success: {isinstance(result, Plugin)}")
+        version_str = try_version(pluginSettings.pip_source, pluginSettings.module_name)
         with timed_acquire(PluginManager.lock, 60) as acquire_result:
             if not acquire_result:
                 raise ValueError("failed to acquire the shared lock")
@@ -143,10 +173,9 @@ def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, i
                 PluginManager.errors = PluginManager.errors.set(pluginId, result)
             else:
                 assert_never(result)
-            PluginManager.versions = PluginManager.versions.set(
-                pluginId, try_version(pluginSettings.pip_source, pluginSettings.module_name)
-            )
+            PluginManager.versions = PluginManager.versions.set(pluginId, version_str)
             PluginManager.updatedatetime = PluginManager.updatedatetime.set(pluginId, try_updatedatetime(pluginSettings.pip_source))
+        _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_str, error=None))
         logger.debug(f"single plugin loading finished: {pluginId}")
     except Exception as e:
         logger.exception(f"updating thread failed with {repr(e)}")
@@ -188,6 +217,7 @@ class PluginsStatus(FiabBaseModel):
     plugin_errors: dict[PluginCompositeId, str]
     plugin_versions: dict[PluginCompositeId, str]
     plugin_updatedatetime: dict[PluginCompositeId, str]
+    plugin_install_errors: dict[str, str] = {}
 
 
 def status_brief() -> str:
@@ -204,7 +234,7 @@ def plugins_ready() -> bool:
     return status_brief() == "ok"
 
 
-def status_full() -> PluginsStatus:
+async def status_full() -> PluginsStatus:
     with timed_acquire(PluginManager.lock, 0.2) as result:
         if not result:
             status = "retrieving"
@@ -216,11 +246,18 @@ def status_full() -> PluginsStatus:
             plugin_errors = dict(PluginManager.errors)
             plugin_versions = dict(PluginManager.versions)
             plugin_updatedatetime = dict(PluginManager.updatedatetime)
+    plugin_install_errors: dict[str, str] = {}
+    try:
+        states = await get_all_plugin_states()
+        plugin_install_errors = {s.plugin_id: s.error for s in states if s.error is not None}  # type: ignore[misc]
+    except Exception:
+        logger.warning("failed to load plugin install states from DB; returning empty", exc_info=True)
     return PluginsStatus(
         updater_status=status,
         plugin_errors=plugin_errors,
         plugin_versions=plugin_versions,
         plugin_updatedatetime=plugin_updatedatetime,
+        plugin_install_errors=plugin_install_errors,
     )
 
 

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -43,7 +43,14 @@ from pyrsistent import pmap
 from pyrsistent.typing import PMap
 
 from forecastbox.domain.plugin.compatibility import install_plugin_compatibly
-from forecastbox.domain.plugin.db import get_all_plugin_states, get_plugin_state, upsert_plugin_state
+from forecastbox.domain.plugin.db import (
+    clear_asset_ingest_needed,
+    get_all_plugin_states,
+    get_plugin_state,
+    set_plugin_enabled_state,
+    update_template_errors,
+    upsert_plugin_state,
+)
 from forecastbox.utility.concurrent import delayed_thread, timed_acquire
 from forecastbox.utility.config import PluginSettings, PluginsSettings, config, config_edit_lock
 from forecastbox.utility.packages import try_import, try_version
@@ -69,14 +76,15 @@ def load_single(plugin: PluginSettings) -> Either[Plugin, str]:  # type: ignore[
         errors.append(f"failed to import plugin {plugin.module_name}")
     elif not hasattr(plugin_impl, "plugin"):
         errors.append(f"plugin {plugin.module_name} does not have a `plugin` attribute")
-    try:
-        maybe_plugin = getattr(plugin_impl, "plugin")()
-        if not isinstance(maybe_plugin, Plugin):
-            errors.append(f"plugin {plugin.module_name}'s `plugin()` does not give a Plugin")
-        else:
-            return Either.ok(maybe_plugin)
-    except Exception as e:
-        errors.append("failed to invoke plugin(): {repr(e)}")
+    else:
+        try:
+            maybe_plugin = getattr(plugin_impl, "plugin")()
+            if not isinstance(maybe_plugin, Plugin):
+                errors.append(f"plugin {plugin.module_name}'s `plugin()` does not give a Plugin")
+            else:
+                return Either.ok(maybe_plugin)
+        except Exception as e:
+            errors.append(f"failed to invoke plugin(): {repr(e)}")
     return Either.error("\n".join(errors))
 
 
@@ -105,6 +113,11 @@ def _version_from_install(installed: dict[str, str], module_name: str) -> str | 
 async def _ingest_plugin_templates(plugin_id: PluginCompositeId, plugin: Plugin) -> None:
     """Upsert each blueprint template exposed by the plugin into the DB.
 
+    Skips ingestion entirely if ``asset_ingest_needed`` is not set on the plugin's
+    DB state row.  When ingestion does run, the flag is cleared *before* ingesting so
+    that a partial failure does not trigger a spurious re-ingest; per-template errors
+    are persisted via ``update_template_errors`` regardless.
+
     Excluded templates (per ``PluginState.excluded_templates``) are skipped and
     any existing plugin-owned blueprint row with that ``display_name`` is
     soft-deleted.  Non-excluded templates have their glyph names rewritten by
@@ -124,14 +137,26 @@ async def _ingest_plugin_templates(plugin_id: PluginCompositeId, plugin: Plugin)
         template_to_builder,
         validate_expand,
     )
-    from forecastbox.domain.plugin.db import get_plugin_settings, update_template_errors
     from forecastbox.utility.auth import AuthContext
 
     plugin_id_str = PluginCompositeId.to_str(plugin_id)
+
+    state = await get_plugin_state(plugin_id_str)
+    if state is None:
+        raise RuntimeError(
+            f"_ingest_plugin_templates called for {plugin_id_str!r} but no PluginState row exists; "
+            "this is a programming error -- upsert_plugin_state must be called before ingestion"
+        )
+    if not state.asset_ingest_needed:
+        logger.debug(f"skipping template ingestion for {plugin_id_str!r}: asset_ingest_needed is False")
+        return
+
+    await clear_asset_ingest_needed(plugin_id=plugin_id_str)
+
     auth = AuthContext(user_id=plugin_id_str, is_admin=True)
 
-    excluded_templates, glyph_remapping = await get_plugin_settings(plugin_id_str)
-    excluded_set = set(excluded_templates)
+    excluded_set = set(state.excluded_templates) if state.excluded_templates else set()  # type: ignore[arg-type]
+    glyph_remapping: dict[str, str] = dict(state.glyph_remapping) if state.glyph_remapping else {}  # type: ignore[arg-type]
 
     template_errors: dict[str, str] = {}
 
@@ -179,9 +204,11 @@ def load_plugins(plugins: PluginsSettings) -> None:
         lookup = {}
         errors = {}
         for pluginKey, pluginSettings in plugins.items():
-            if not pluginSettings.enabled:
-                continue
             plugin_id_str = PluginCompositeId.to_str(pluginKey)
+            db_state = _run_async_from_thread(get_plugin_state(plugin_id_str))
+            if db_state is not None and not db_state.enabled:  # type: ignore[union-attr]
+                logger.info(f"skipping disabled plugin {pluginKey}")
+                continue
             installed_versions: dict[str, str] = {}
             install_error: str | None = None
             # NOTE consider running all pip invocations at once -- worse error reporting but better perf
@@ -203,31 +230,42 @@ def load_plugins(plugins: PluginsSettings) -> None:
 
             if install_error is not None:
                 logger.error(f"install failed for {pluginKey}: {install_error}")
-                _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version="install failed", install_error=install_error))
+                _run_async_from_thread(
+                    upsert_plugin_state(plugin_id=plugin_id_str, version="install failed", enabled=True, install_error=install_error)
+                )
                 continue
             if installed_versions:
                 version_str = _version_from_install(installed_versions, pluginSettings.module_name)
                 if version_str is not None:
-                    _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_str, install_error=None))
+                    _run_async_from_thread(
+                        upsert_plugin_state(plugin_id=plugin_id_str, version=version_str, enabled=True, install_error=None)
+                    )
                 else:
                     # pip does not report the version if it isn't changed -> this branch is not necessarily a bug
                     logger.warning(f"pip install of plugin {plugin_id_str} did not produce a version, assuming no change")
 
             if pluginKey in lookup:
                 errors[pluginKey] = f"plugin {pluginKey} is provided by more than just {pluginSettings.pip_source}"
+                continue
             else:
                 plugin_result = load_single(pluginSettings)
                 if plugin_result.t is not None:
                     lookup[pluginKey] = plugin_result.t
                     version_imported = try_version(pluginSettings.pip_source, pluginSettings.module_name)
                     logger.debug(f"plugin {pluginKey} loaded with success: True and version {version_imported}")
-                    db_state = _run_async_from_thread(get_plugin_state(plugin_id_str))
-                    if db_state is not None:
-                        db_ver: str = db_state.plugin_version  # type: ignore[assignment]
+                    fresh_state = _run_async_from_thread(get_plugin_state(plugin_id_str))
+                    if fresh_state is not None:
+                        db_ver: str = fresh_state.plugin_version  # type: ignore[assignment]
                         if db_ver != version_imported:
                             mismatch_msg = f"version mismatch: DB has {db_ver!r} but {version_imported!r} is imported"
                             logger.warning(f"plugin {pluginKey}: {mismatch_msg}")
                             errors[pluginKey] = mismatch_msg
+                    else:
+                        # No DB row yet (e.g. fresh DB with already-importable plugin).
+                        # Create a row so that _ingest_plugin_templates can proceed.
+                        _run_async_from_thread(
+                            upsert_plugin_state(plugin_id=plugin_id_str, version=version_imported, enabled=True, install_error=None)
+                        )
                 else:
                     logger.debug(f"plugin {pluginKey} loaded with success: False")
                     errors[pluginKey] = plugin_result.e
@@ -259,7 +297,7 @@ def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, i
             install_result = install_plugin_compatibly(pluginSettings.pip_source, version)
             if install_result.e:
                 _run_async_from_thread(
-                    upsert_plugin_state(plugin_id=plugin_id_str, version="install failed", install_error=install_result.e)
+                    upsert_plugin_state(plugin_id=plugin_id_str, version="install failed", enabled=True, install_error=install_result.e)
                 )
                 raise RuntimeError(f"install failed for {pluginId}: {install_result.e}")
             installed_versions = install_result.t or {}
@@ -285,8 +323,7 @@ def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, i
                 PluginManager.errors = PluginManager.errors.set(
                     pluginId, f"{existing_err}; {version_mismatch}" if existing_err else version_mismatch
                 )
-        if version_install is not None:
-            _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_install, install_error=None))
+        _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_install, enabled=True, install_error=None))
         if result.t is not None:
             _run_async_from_thread(_ingest_plugin_templates(pluginId, result.t))
         logger.debug(f"single plugin loading finished: {pluginId}")
@@ -298,6 +335,7 @@ def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, i
 
 
 def unload_single(pluginId: PluginCompositeId) -> None:
+    plugin_id_str = PluginCompositeId.to_str(pluginId)
     with timed_acquire(PluginManager.lock, 5) as result:
         if not result:
             logger.warning("failed to acquire lock for unload_single")
@@ -306,6 +344,13 @@ def unload_single(pluginId: PluginCompositeId) -> None:
             PluginManager.plugins = PluginManager.plugins.remove(pluginId)
         if pluginId in PluginManager.errors:
             PluginManager.errors = PluginManager.errors.remove(pluginId)
+    # DB writes outside the lock: persist disabled state and remove blueprint templates.
+    # Note: these imports are a breach of the dependency hierarchy (plugin domain depending
+    # on blueprint domain), and will be fixed later by refactoring into events.
+    from forecastbox.domain.blueprint.db import soft_delete_all_plugin_templates
+
+    _run_async_from_thread(set_plugin_enabled_state(plugin_id=plugin_id_str, enabled=False))
+    _run_async_from_thread(soft_delete_all_plugin_templates(created_by=plugin_id_str))
 
 
 def submit_load_plugins(start_after: Future[None]) -> None:
@@ -328,6 +373,9 @@ class PluginsStatus(FiabBaseModel):
     plugin_errors: dict[PluginCompositeId, str]
     plugin_versions: dict[PluginCompositeId, str]
     plugin_updatedatetime: dict[PluginCompositeId, str]
+    plugin_enabled: dict[PluginCompositeId, bool]
+    plugin_excluded_templates: dict[PluginCompositeId, list[str]]
+    plugin_glyph_remapping: dict[PluginCompositeId, dict[str, str]]
 
 
 def status_brief() -> str:
@@ -354,6 +402,9 @@ async def status_full() -> PluginsStatus:
             plugin_errors = dict(PluginManager.errors)
     plugin_versions: dict[PluginCompositeId, str] = {}
     plugin_updatedatetime: dict[PluginCompositeId, str] = {}
+    plugin_enabled: dict[PluginCompositeId, bool] = {}
+    plugin_excluded_templates: dict[PluginCompositeId, list[str]] = {}
+    plugin_glyph_remapping: dict[PluginCompositeId, dict[str, str]] = {}
     try:
         states = await get_all_plugin_states()
         for state in states:
@@ -369,6 +420,9 @@ async def status_full() -> PluginsStatus:
                 )
             plugin_versions[plugin_id] = state.plugin_version  # type: ignore[assignment]
             plugin_updatedatetime[plugin_id] = value_dt2str(state.updated_at)  # type: ignore[arg-type]
+            plugin_enabled[plugin_id] = bool(state.enabled)
+            plugin_excluded_templates[plugin_id] = list(state.excluded_templates) if state.excluded_templates else []  # type: ignore[arg-type]
+            plugin_glyph_remapping[plugin_id] = dict(state.glyph_remapping) if state.glyph_remapping else {}  # type: ignore[arg-type]
             if state.template_errors:  # type: ignore[truthy-bool]
                 # Format per-template errors as a single string and merge into plugin_errors,
                 # consistent with the existing install_error merge above.
@@ -385,6 +439,9 @@ async def status_full() -> PluginsStatus:
         plugin_errors=plugin_errors,
         plugin_versions=plugin_versions,
         plugin_updatedatetime=plugin_updatedatetime,
+        plugin_enabled=plugin_enabled,
+        plugin_excluded_templates=plugin_excluded_templates,
+        plugin_glyph_remapping=plugin_glyph_remapping,
     )
 
 
@@ -430,11 +487,6 @@ def uninstall_plugin(pluginId: PluginCompositeId) -> None:
 
 
 def modify_enabled(pluginId: PluginCompositeId, isEnabled: bool) -> None:
-    with timed_acquire(config_edit_lock, 5) as result:
-        if not result:
-            raise ValueError("failed to acquire the shared lock")
-        config.external.plugins[pluginId].enabled = isEnabled
-        config.save_to_file()
     if not isEnabled:
         unload_single(pluginId)
     else:

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -47,6 +47,7 @@ from forecastbox.utility.concurrent import delayed_thread, timed_acquire
 from forecastbox.utility.config import PluginSettings, PluginsSettings, config, config_edit_lock
 from forecastbox.utility.packages import try_import, try_updatedatetime, try_version
 from forecastbox.utility.pydantic import FiabBaseModel
+from forecastbox.utility.time import value_dt2str
 
 logger = logging.getLogger(__name__)
 
@@ -84,8 +85,8 @@ def _run_async_from_thread(coro: object) -> object:  # type: ignore[type-arg]
     """Dispatch *coro* to the event loop stashed on PluginManager and block until done."""
     loop = PluginManager.loop
     if loop is None:
-        logger.warning("PluginManager.loop is not set; skipping DB write")
-        return None
+        # TODO -- send an event to bring down the whole app, not just the thread in question
+        raise RuntimeError("PluginManager.loop is not set; cannot dispatch DB write from updater thread")
     return asyncio.run_coroutine_threadsafe(coro, loop).result()  # type: ignore[arg-type]
 
 
@@ -102,20 +103,17 @@ def load_plugins(plugins: PluginsSettings) -> None:
             plugin_id_str = PluginCompositeId.to_str(pluginKey)
             install_error: str | None = None
             # NOTE consider running all pip invocations at once -- worse error reporting but better perf
-            try:
-                if pluginSettings.update_strategy == "auto":
-                    logger.info(f"auto-updating {pluginSettings.module_name}")
-                    install_plugin_compatibly(pluginSettings.pip_source, None)
-                else:
-                    if try_import(pluginSettings.module_name) is None:
-                        logger.info(f"installing {pluginSettings.module_name} for the first time")
-                        install_plugin_compatibly(pluginSettings.pip_source, None)
-            except Exception as e:
-                install_error = repr(e)
-                logger.exception(f"install failed for {pluginKey}: {repr(e)}")
+            if pluginSettings.update_strategy == "auto":
+                logger.info(f"auto-updating {pluginSettings.module_name}")
+                install_error = install_plugin_compatibly(pluginSettings.pip_source, None)
+            else:
+                if try_import(pluginSettings.module_name) is None:
+                    logger.info(f"installing {pluginSettings.module_name} for the first time")
+                    install_error = install_plugin_compatibly(pluginSettings.pip_source, None)
 
             if install_error is not None:
-                _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=None, error=install_error))
+                logger.error(f"install failed for {pluginKey}: {install_error}")
+                _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version="unknown", install_error=install_error))
                 errors[pluginKey] = install_error
                 continue
 
@@ -132,7 +130,7 @@ def load_plugins(plugins: PluginsSettings) -> None:
                     assert_never(result)
                 versions[pluginKey] = try_version(pluginSettings.pip_source, pluginSettings.module_name)
                 updatedatetime[pluginKey] = try_updatedatetime(pluginSettings.pip_source)
-                _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=versions[pluginKey], error=None))
+                _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=versions[pluginKey], install_error=None))
 
         with timed_acquire(PluginManager.lock, 60) as result:
             if not result:
@@ -153,11 +151,10 @@ def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, i
     plugin_id_str = PluginCompositeId.to_str(pluginId)
     try:
         if install:
-            try:
-                install_plugin_compatibly(pluginSettings.pip_source, version)
-            except Exception as install_exc:
-                _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=None, error=repr(install_exc)))
-                raise
+            install_error = install_plugin_compatibly(pluginSettings.pip_source, version)
+            if install_error is not None:
+                _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version="unknown", install_error=install_error))
+                raise RuntimeError(f"install failed for {pluginId}: {install_error}")
         # NOTE we need to recommend in the docs to re-launch app after this change, this wont cover all cases
         importlib.reload(importlib.import_module(pluginSettings.module_name))
         plugin_impl = try_import(pluginSettings.module_name)
@@ -175,7 +172,7 @@ def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, i
                 assert_never(result)
             PluginManager.versions = PluginManager.versions.set(pluginId, version_str)
             PluginManager.updatedatetime = PluginManager.updatedatetime.set(pluginId, try_updatedatetime(pluginSettings.pip_source))
-        _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_str, error=None))
+        _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_str, install_error=None))
         logger.debug(f"single plugin loading finished: {pluginId}")
     except Exception as e:
         logger.exception(f"updating thread failed with {repr(e)}")
@@ -217,7 +214,6 @@ class PluginsStatus(FiabBaseModel):
     plugin_errors: dict[PluginCompositeId, str]
     plugin_versions: dict[PluginCompositeId, str]
     plugin_updatedatetime: dict[PluginCompositeId, str]
-    plugin_install_errors: dict[str, str] = {}
 
 
 def status_brief() -> str:
@@ -238,26 +234,36 @@ async def status_full() -> PluginsStatus:
     with timed_acquire(PluginManager.lock, 0.2) as result:
         if not result:
             status = "retrieving"
-            plugin_errors = {}
-            plugin_versions = {}
-            plugin_updatedatetime = {}
+            plugin_errors: dict[PluginCompositeId, str] = {}
+            plugin_versions: dict[PluginCompositeId, str] = {}
+            plugin_updatedatetime: dict[PluginCompositeId, str] = {}
         else:
             status = status_brief()
             plugin_errors = dict(PluginManager.errors)
             plugin_versions = dict(PluginManager.versions)
             plugin_updatedatetime = dict(PluginManager.updatedatetime)
-    plugin_install_errors: dict[str, str] = {}
     try:
         states = await get_all_plugin_states()
-        plugin_install_errors = {s.plugin_id: s.error for s in states if s.error is not None}  # type: ignore[misc]
+        for state in states:
+            try:
+                plugin_id = PluginCompositeId.from_str(state.plugin_id)  # type: ignore[arg-type]
+            except Exception:
+                logger.warning(f"could not parse plugin_id {state.plugin_id!r} from DB; skipping")
+                continue
+            if state.install_error is not None:  # type: ignore[misc]
+                existing = plugin_errors.get(plugin_id)
+                plugin_errors[plugin_id] = (
+                    f"{existing}; {state.install_error}" if existing else state.install_error  # type: ignore[misc]
+                )
+            if state.updated_at is not None:
+                plugin_updatedatetime[plugin_id] = value_dt2str(state.updated_at)  # type: ignore[arg-type]
     except Exception:
-        logger.warning("failed to load plugin install states from DB; returning empty", exc_info=True)
+        logger.warning("failed to load plugin states from DB; status may be incomplete", exc_info=True)
     return PluginsStatus(
         updater_status=status,
         plugin_errors=plugin_errors,
         plugin_versions=plugin_versions,
         plugin_updatedatetime=plugin_updatedatetime,
-        plugin_install_errors=plugin_install_errors,
     )
 
 

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -28,12 +28,13 @@ we lock for longer.
 import asyncio
 import importlib
 import logging
+import re
 import threading
 import time
 from concurrent.futures import Future
 from typing import Iterator, Literal
 
-from cascade.low.func import assert_never
+from cascade.low.func import Either, assert_never
 from fiab_core.fable import BlockFactoryCatalogue, PluginCompositeId
 from fiab_core.plugin import Plugin
 from packaging.specifiers import SpecifierSet
@@ -45,7 +46,7 @@ from forecastbox.domain.plugin.compatibility import install_plugin_compatibly
 from forecastbox.domain.plugin.db import get_all_plugin_states, upsert_plugin_state
 from forecastbox.utility.concurrent import delayed_thread, timed_acquire
 from forecastbox.utility.config import PluginSettings, PluginsSettings, config, config_edit_lock
-from forecastbox.utility.packages import try_import, try_updatedatetime, try_version
+from forecastbox.utility.packages import try_import, try_version
 from forecastbox.utility.pydantic import FiabBaseModel
 from forecastbox.utility.time import value_dt2str
 
@@ -57,7 +58,6 @@ class PluginManager:
     plugins: PMap[PluginCompositeId, Plugin] = pmap()
     versions: PMap[PluginCompositeId, str] = pmap()
     errors: PMap[PluginCompositeId, str] = pmap()
-    updatedatetime: PMap[PluginCompositeId, str] = pmap()
     updater: threading.Thread | None = None
     updater_error: str | None = None
     loop: asyncio.AbstractEventLoop | None = None
@@ -90,55 +90,83 @@ def _run_async_from_thread(coro: object) -> object:  # type: ignore[type-arg]
     return asyncio.run_coroutine_threadsafe(coro, loop).result()  # type: ignore[arg-type]
 
 
+def _version_from_install(installed: dict[str, str], module_name: str) -> str | None:
+    """Look up a plugin's newly-installed version from the pip install output dict.
+
+    Normalises names per PEP 503 (``[-_.]+`` → ``-``, lowercase) before comparing,
+    so ``fiab_plugin_test`` matches ``fiab-plugin-test`` in the pip output.
+    """
+    target = re.sub(r"[-_.]+", "-", module_name).lower()
+    for name, ver in installed.items():
+        if re.sub(r"[-_.]+", "-", name).lower() == target:
+            return ver
+    return None
+
+
 def load_plugins(plugins: PluginsSettings) -> None:
     logger.info("starting initial plugin load")
     try:
         lookup = {}
         errors = {}
         versions = {}
-        updatedatetime = {}
         for pluginKey, pluginSettings in plugins.items():
             if not pluginSettings.enabled:
                 continue
             plugin_id_str = PluginCompositeId.to_str(pluginKey)
+            installed_versions: dict[str, str] = {}
             install_error: str | None = None
             # NOTE consider running all pip invocations at once -- worse error reporting but better perf
             if pluginSettings.update_strategy == "auto":
                 logger.info(f"auto-updating {pluginSettings.module_name}")
-                install_error = install_plugin_compatibly(pluginSettings.pip_source, None)
+                result = install_plugin_compatibly(pluginSettings.pip_source, None)
+                if result.e:
+                    install_error = result.e
+                else:
+                    installed_versions = result.t or {}
             else:
                 if try_import(pluginSettings.module_name) is None:
                     logger.info(f"installing {pluginSettings.module_name} for the first time")
-                    install_error = install_plugin_compatibly(pluginSettings.pip_source, None)
+                    result = install_plugin_compatibly(pluginSettings.pip_source, None)
+                    if result.e:
+                        install_error = result.e
+                    else:
+                        installed_versions = result.t or {}
 
             if install_error is not None:
                 logger.error(f"install failed for {pluginKey}: {install_error}")
-                _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version="unknown", install_error=install_error))
+                _run_async_from_thread(
+                    upsert_plugin_state(
+                        plugin_id=plugin_id_str,
+                        version=try_version(pluginSettings.pip_source, pluginSettings.module_name),
+                        install_error=install_error,
+                    )
+                )
                 errors[pluginKey] = install_error
                 continue
 
             if pluginKey in lookup:
                 errors[pluginKey] = f"plugin {pluginKey} is provided by more than just {pluginSettings.pip_source}"
             else:
-                result = load_single(pluginSettings)
-                logger.debug(f"plugin {pluginKey} loaded with success: {isinstance(result, Plugin)}")
-                if isinstance(result, Plugin):
-                    lookup[pluginKey] = result
-                elif isinstance(result, str):
-                    errors[pluginKey] = result
+                plugin_result = load_single(pluginSettings)
+                logger.debug(f"plugin {pluginKey} loaded with success: {isinstance(plugin_result, Plugin)}")
+                if isinstance(plugin_result, Plugin):
+                    lookup[pluginKey] = plugin_result
+                elif isinstance(plugin_result, str):
+                    errors[pluginKey] = plugin_result
                 else:
-                    assert_never(result)
-                versions[pluginKey] = try_version(pluginSettings.pip_source, pluginSettings.module_name)
-                updatedatetime[pluginKey] = try_updatedatetime(pluginSettings.pip_source)
-                _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=versions[pluginKey], install_error=None))
+                    assert_never(plugin_result)
+                version_str = _version_from_install(installed_versions, pluginSettings.module_name) or try_version(
+                    pluginSettings.pip_source, pluginSettings.module_name
+                )
+                versions[pluginKey] = version_str
+                _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_str, install_error=None))
 
-        with timed_acquire(PluginManager.lock, 60) as result:
-            if not result:
+        with timed_acquire(PluginManager.lock, 60) as lock_result:
+            if not lock_result:
                 raise ValueError("failed to acquire the shared lock")
             PluginManager.plugins = pmap(lookup)
             PluginManager.errors = pmap(errors)
             PluginManager.versions = pmap(versions)
-            PluginManager.updatedatetime = pmap(updatedatetime)
         logger.debug("global plugin loading finished")
     except Exception as e:
         logger.exception(f"updating thread failed with {repr(e)}")
@@ -150,17 +178,27 @@ def load_plugins(plugins: PluginsSettings) -> None:
 def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, install: bool, version: Version | None) -> None:
     plugin_id_str = PluginCompositeId.to_str(pluginId)
     try:
+        installed_versions: dict[str, str] = {}
         if install:
-            install_error = install_plugin_compatibly(pluginSettings.pip_source, version)
-            if install_error is not None:
-                _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version="unknown", install_error=install_error))
-                raise RuntimeError(f"install failed for {pluginId}: {install_error}")
+            install_result = install_plugin_compatibly(pluginSettings.pip_source, version)
+            if install_result.e:
+                _run_async_from_thread(
+                    upsert_plugin_state(
+                        plugin_id=plugin_id_str,
+                        version=try_version(pluginSettings.pip_source, pluginSettings.module_name),
+                        install_error=install_result.e,
+                    )
+                )
+                raise RuntimeError(f"install failed for {pluginId}: {install_result.e}")
+            installed_versions = install_result.t or {}
         # NOTE we need to recommend in the docs to re-launch app after this change, this wont cover all cases
         importlib.reload(importlib.import_module(pluginSettings.module_name))
         plugin_impl = try_import(pluginSettings.module_name)
         result = load_single(pluginSettings)
         logger.debug(f"plugin {pluginId} loaded with success: {isinstance(result, Plugin)}")
-        version_str = try_version(pluginSettings.pip_source, pluginSettings.module_name)
+        version_str = _version_from_install(installed_versions, pluginSettings.module_name) or try_version(
+            pluginSettings.pip_source, pluginSettings.module_name
+        )
         with timed_acquire(PluginManager.lock, 60) as acquire_result:
             if not acquire_result:
                 raise ValueError("failed to acquire the shared lock")
@@ -171,7 +209,6 @@ def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, i
             else:
                 assert_never(result)
             PluginManager.versions = PluginManager.versions.set(pluginId, version_str)
-            PluginManager.updatedatetime = PluginManager.updatedatetime.set(pluginId, try_updatedatetime(pluginSettings.pip_source))
         _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_str, install_error=None))
         logger.debug(f"single plugin loading finished: {pluginId}")
     except Exception as e:
@@ -236,12 +273,11 @@ async def status_full() -> PluginsStatus:
             status = "retrieving"
             plugin_errors: dict[PluginCompositeId, str] = {}
             plugin_versions: dict[PluginCompositeId, str] = {}
-            plugin_updatedatetime: dict[PluginCompositeId, str] = {}
         else:
             status = status_brief()
             plugin_errors = dict(PluginManager.errors)
             plugin_versions = dict(PluginManager.versions)
-            plugin_updatedatetime = dict(PluginManager.updatedatetime)
+    plugin_updatedatetime: dict[PluginCompositeId, str] = {}
     try:
         states = await get_all_plugin_states()
         for state in states:
@@ -255,8 +291,7 @@ async def status_full() -> PluginsStatus:
                 plugin_errors[plugin_id] = (
                     f"{existing}; {state.install_error}" if existing else state.install_error  # type: ignore[misc]
                 )
-            if state.updated_at is not None:
-                plugin_updatedatetime[plugin_id] = value_dt2str(state.updated_at)  # type: ignore[arg-type]
+            plugin_updatedatetime[plugin_id] = value_dt2str(state.updated_at)  # type: ignore[arg-type]
     except Exception:
         logger.warning("failed to load plugin states from DB; status may be incomplete", exc_info=True)
     return PluginsStatus(

--- a/backend/src/forecastbox/domain/plugin/store.py
+++ b/backend/src/forecastbox/domain/plugin/store.py
@@ -53,14 +53,14 @@ class PluginRemoteInfo(FiabBaseModel):
 
 def get_latest_version(package_name: str, client: httpx.Client) -> str:
     url = f"https://pypi.org/pypi/{package_name}/json"
-    response = client.get(url)
-    if response.status_code == 200:
-        try:
+    try:
+        response = client.get(url)
+        if response.status_code == 200:
             return response.json()["info"]["version"]
-        except Exception:
-            logger.exception(f"getting version of {package_name=} => failure {response=}")
-    else:
-        logger.warning(f"getting version of {package_name=} => failure {response=}")
+        else:
+            logger.warning(f"getting version of {package_name=} => failure {response=}")
+    except Exception:
+        logger.exception(f"getting version of {package_name=} => failure {response=}")
     return "unknown"
 
 

--- a/backend/src/forecastbox/entrypoint/app.py
+++ b/backend/src/forecastbox/entrypoint/app.py
@@ -35,7 +35,7 @@ from forecastbox.domain.artifact.manager import ArtifactManager, join_artifact_m
 from forecastbox.domain.experiment.scheduling.background import start_scheduler, stop_scheduler
 from forecastbox.domain.gateway.service import shutdown_processes
 from forecastbox.domain.lens.manager import shutdown_all_lens_instances
-from forecastbox.domain.plugin.manager import join_updater_thread, submit_load_plugins
+from forecastbox.domain.plugin.manager import PluginManager, join_updater_thread, submit_load_plugins
 from forecastbox.domain.plugin.store import join_stores_thread, submit_initialize_stores
 from forecastbox.utility.config import config
 from forecastbox.utility.tunnel import shutdown as shutdown_tunnels
@@ -45,6 +45,8 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+    import asyncio
+
     logger.debug(f"Starting FIAB with config: {config}")
     for module_info in pkgutil.iter_modules(forecastbox.schemata.__path__):
         module = importlib.import_module(f"forecastbox.schemata.{module_info.name}")
@@ -58,6 +60,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     ArtifactsProvider.register_get_artifacts_lookup(lambda: ArtifactManager.catalog)
     ArtifactsProvider.register_get_artifact_local_path(lambda composite_id: get_artifact_local_path(composite_id, config.backend.data_path))
     catalog_ready = submit_refresh_catalog()
+    PluginManager.loop = asyncio.get_running_loop()
     submit_load_plugins(start_after=catalog_ready)
     yield
     if config.backend.allow_scheduler:

--- a/backend/src/forecastbox/entrypoint/app.py
+++ b/backend/src/forecastbox/entrypoint/app.py
@@ -9,6 +9,7 @@
 
 """FastAPI Entrypoint"""
 
+import asyncio
 import importlib
 import logging
 import os
@@ -45,8 +46,6 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
-    import asyncio
-
     logger.debug(f"Starting FIAB with config: {config}")
     for module_info in pkgutil.iter_modules(forecastbox.schemata.__path__):
         module = importlib.import_module(f"forecastbox.schemata.{module_info.name}")

--- a/backend/src/forecastbox/routes/blueprint.py
+++ b/backend/src/forecastbox/routes/blueprint.py
@@ -25,6 +25,7 @@ Glyph routes:
  - POST glyphs/global/delete  — delete a global glyph by id
 """
 
+import logging
 from typing import Annotated, Any, Literal, cast
 
 from cascade.low.func import assert_never
@@ -59,6 +60,7 @@ from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.pagination import PaginationSpec
 from forecastbox.utility.pydantic import FiabBaseModel
 
+logger = logging.getLogger(__name__)
 PREFIX = "/api/v1/blueprint"
 
 router = APIRouter(

--- a/backend/src/forecastbox/routes/plugins.py
+++ b/backend/src/forecastbox/routes/plugins.py
@@ -80,7 +80,7 @@ async def get_plugin_details(forceRefresh: bool = False) -> PluginListing:
         raise NotImplementedError
     rv = {}
     statuses = await status_full()
-    disabled = {pluginCompositeId for pluginCompositeId, pluginSettings in config.external.plugins.items() if not pluginSettings.enabled}
+    disabled = {plugin_id for plugin_id, enabled in statuses.plugin_enabled.items() if not enabled}
     errored = set(statuses.plugin_errors.keys())
     loaded = set(statuses.plugin_versions.keys())
     installed = errored.union(loaded).union(disabled)

--- a/backend/src/forecastbox/routes/plugins.py
+++ b/backend/src/forecastbox/routes/plugins.py
@@ -63,8 +63,8 @@ class PluginListing(FiabBaseModel):
 
 
 @router.get("/status")
-def get_plugins_status_full() -> PluginsStatus:
-    return status_full()
+async def get_plugins_status_full() -> PluginsStatus:
+    return await status_full()
 
 
 # ---------------------------------------------------------------------------
@@ -73,12 +73,12 @@ def get_plugins_status_full() -> PluginsStatus:
 
 
 @router.get("/details")
-def get_plugin_details(forceRefresh: bool = False) -> PluginListing:
+async def get_plugin_details(forceRefresh: bool = False) -> PluginListing:
     # TODO implement forceRefresh -- we would need to prod the thread to update the store, but await its completion here
     if forceRefresh:
         raise NotImplementedError
     rv = {}
-    statuses = status_full()
+    statuses = await status_full()
     disabled = {pluginCompositeId for pluginCompositeId, pluginSettings in config.external.plugins.items() if not pluginSettings.enabled}
     errored = set(statuses.plugin_errors.keys())
     loaded = set(statuses.plugin_versions.keys())

--- a/backend/src/forecastbox/routes/plugins.py
+++ b/backend/src/forecastbox/routes/plugins.py
@@ -52,6 +52,7 @@ class PluginDetail(FiabBaseModel):
     """In case the plugin is loaded, this shows the version"""
     update_datetime: str | None = None
     """In case the plugin is installed, this shows the most recent update datetime"""
+    # TODO add here the remapping/exclusion data
 
 
 class PluginListing(FiabBaseModel):

--- a/backend/src/forecastbox/routes/plugins.py
+++ b/backend/src/forecastbox/routes/plugins.py
@@ -23,6 +23,7 @@ from packaging.version import InvalidVersion, Version
 
 from forecastbox.domain.auth.users import UserRead
 from forecastbox.domain.plugin.compatibility import get_compatible_versions
+from forecastbox.domain.plugin.db import update_plugin_settings
 from forecastbox.domain.plugin.manager import PluginsStatus, modify_enabled, status_full, submit_update_single, uninstall_plugin
 from forecastbox.domain.plugin.store import PluginRemoteInfo, PluginStoreEntry, get_plugins_detail, submit_install_plugin
 from forecastbox.routes.admin import get_admin_user
@@ -197,4 +198,32 @@ def modify_enabled_endpoint(
     request: Request, pluginCompositeId: PluginCompositeId, isEnabled: bool, admin: UserRead | None = Depends(get_admin_user)
 ) -> Response:
     modify_enabled(pluginCompositeId, isEnabled)
+    return get_catalogue_redirect(request)
+
+
+class PluginSettingsUpdateRequest(FiabBaseModel):
+    pluginCompositeId: PluginCompositeId
+    excluded_templates: list[str] | None = None
+    """Names of templates to exclude.  ``None`` leaves the stored list unchanged;
+    an empty list explicitly clears all exclusions."""
+    glyph_remapping: dict[str, str] | None = None
+    """Glyph rename map to persist.  ``None`` leaves the stored map unchanged;
+    an empty dict explicitly clears all remappings."""
+
+
+@router.post("/settings")
+async def update_plugin_settings_endpoint(
+    request: Request,
+    body: PluginSettingsUpdateRequest,
+    admin: UserRead | None = Depends(get_admin_user),
+) -> Response:
+    """Persist plugin install settings and trigger a re-ingest so exclusions take effect immediately."""
+    await update_plugin_settings(
+        plugin_id=PluginCompositeId.to_str(body.pluginCompositeId),
+        excluded_templates=body.excluded_templates,
+        glyph_remapping=body.glyph_remapping,
+    )
+    result = submit_update_single(body.pluginCompositeId, install=False, version=None)
+    if result:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=result)
     return get_catalogue_redirect(request)

--- a/backend/src/forecastbox/schemata/jobs.py
+++ b/backend/src/forecastbox/schemata/jobs.py
@@ -215,6 +215,8 @@ class PluginState(Base):
     excluded_templates = Column(JSON, nullable=False, default=list)
     glyph_remapping = Column(JSON, nullable=False, default=dict)
     template_errors = Column(JSON, nullable=True)
+    asset_ingest_needed = Column(Boolean, nullable=False, default=True)
+    enabled = Column(Boolean, nullable=False, default=True)
 
 
 async_url = f"sqlite+aiosqlite:///{config.db.sqlite_jobdb_path}"

--- a/backend/src/forecastbox/schemata/jobs.py
+++ b/backend/src/forecastbox/schemata/jobs.py
@@ -199,6 +199,27 @@ class ExperimentNext(Base):
     updated_at = Column(UTCDateTime, nullable=False)
 
 
+class PluginState(Base):
+    """Persisted install state for each configured plugin.
+
+    One row per plugin, keyed by the PluginCompositeId rendered as ``store:local``.
+    Written and updated during plugin install; never versioned.
+
+    Columns owned by later tasks (excluded_templates, glyph_remapping, template_errors)
+    are defined here with safe defaults to avoid schema changes later (no migrations).
+    """
+
+    __tablename__ = "plugin_state"
+
+    plugin_id = Column(String(255), primary_key=True, nullable=False)
+    version = Column(String(255), nullable=True)
+    updated_at = Column(UTCDateTime, nullable=False)
+    error = Column(String(4096), nullable=True)
+    excluded_templates = Column(JSON, nullable=False, default=list)
+    glyph_remapping = Column(JSON, nullable=False, default=dict)
+    template_errors = Column(JSON, nullable=True)
+
+
 async_url = f"sqlite+aiosqlite:///{config.db.sqlite_jobdb_path}"
 async_engine = create_async_engine(async_url, pool_pre_ping=True)
 async_session_maker = async_sessionmaker(async_engine, expire_on_commit=False)

--- a/backend/src/forecastbox/schemata/jobs.py
+++ b/backend/src/forecastbox/schemata/jobs.py
@@ -204,17 +204,14 @@ class PluginState(Base):
 
     One row per plugin, keyed by the PluginCompositeId rendered as ``store:local``.
     Written and updated during plugin install; never versioned.
-
-    Columns owned by later tasks (excluded_templates, glyph_remapping, template_errors)
-    are defined here with safe defaults to avoid schema changes later (no migrations).
     """
 
     __tablename__ = "plugin_state"
 
     plugin_id = Column(String(255), primary_key=True, nullable=False)
-    version = Column(String(255), nullable=True)
+    plugin_version = Column(String(255), nullable=False)
     updated_at = Column(UTCDateTime, nullable=False)
-    error = Column(String(4096), nullable=True)
+    install_error = Column(String(4096), nullable=True)
     excluded_templates = Column(JSON, nullable=False, default=list)
     glyph_remapping = Column(JSON, nullable=False, default=dict)
     template_errors = Column(JSON, nullable=True)

--- a/backend/src/forecastbox/utility/config.py
+++ b/backend/src/forecastbox/utility/config.py
@@ -114,8 +114,6 @@ class PluginSettings(FiabBaseModel):
     """A string such that `importlib.import_module(module_name)` gives a module that has a `plugin` attribute of type fiab_core.plugin.Plugin`"""
     update_strategy: PluginRefreshStrategy = "manual"
     """Whether we should invoke `pip install --update <plugin>` on every launch, or let user handle that manually or via API"""
-    enabled: bool = True
-    """Whether the plugin should be considered when loading"""
 
 
 PluginCompositeIdReadable = Annotated[

--- a/backend/src/forecastbox/utility/packages.py
+++ b/backend/src/forecastbox/utility/packages.py
@@ -18,7 +18,6 @@ import importlib
 import importlib.metadata
 import logging
 import pathlib
-import re
 import subprocess
 from collections.abc import Iterator
 from types import ModuleType
@@ -155,7 +154,7 @@ def try_install(packages: list[str]) -> Either[dict[str, str], str]:  # type: ig
         logger.error(msg)
         return Either.error(msg)
     logger.debug(f"install finished with {result.stdout=}, {result.stderr=}")
-    return Either.ok(_parse_pip_install(result.stdout))
+    return Either.ok(_parse_pip_install(result.stderr))
 
 
 def get_existing_install_pin(distname: str) -> list[str]:

--- a/backend/src/forecastbox/utility/packages.py
+++ b/backend/src/forecastbox/utility/packages.py
@@ -106,19 +106,26 @@ def try_updatedatetime(pip_source: str) -> str:
         return "unknown"
 
 
-def try_install(packages: list[str]) -> None:
-    """Run ``uv pip install`` with the given pkg specs."""
+def try_install(packages: list[str]) -> str | None:
+    """Run ``uv pip install`` with the given pkg specs.
+
+    Returns ``None`` on success or an error string describing the failure.
+    Never raises.
+    """
     install_command = ["uv", "pip", "install"] + packages
     logger.debug(f"will run {install_command}")
     try:
         result = subprocess.run(install_command, check=False, capture_output=True)
     except FileNotFoundError as ex:
-        logger.error(f"installing {packages} failure: {repr(ex)}")
-        return
+        msg = f"installing {packages} failure: {repr(ex)}"
+        logger.error(msg)
+        return msg
     if result.returncode != 0:
         msg = f"installing {packages} failure: {result.returncode}. Stderr: {result.stderr}, Stdout: {result.stdout}, Args: {result.args}"
         logger.error(msg)
+        return msg
     logger.debug(f"install finished with {result.stdout=}, {result.stderr=}")
+    return None
 
 
 def get_existing_install_pin(distname: str) -> list[str]:

--- a/backend/src/forecastbox/utility/packages.py
+++ b/backend/src/forecastbox/utility/packages.py
@@ -18,12 +18,14 @@ import importlib
 import importlib.metadata
 import logging
 import pathlib
+import re
 import subprocess
 from collections.abc import Iterator
 from types import ModuleType
 
 import httpx
 import orjson
+from cascade.low.func import Either
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
@@ -106,26 +108,54 @@ def try_updatedatetime(pip_source: str) -> str:
         return "unknown"
 
 
-def try_install(packages: list[str]) -> str | None:
+def _parse_pip_install(pip_output: str) -> dict[str, str]:
+    """Parse ``uv pip install`` stdout to extract newly-installed packages and their versions.
+
+    Lines starting with `` + `` are newly-installed entries, e.g.:
+    ``  + fiab-plugin-test==0.1.0 (from file:///path/to/package)``
+
+    Returns a dict mapping package name to version string.
+    """
+    rv: dict[str, str] = {}
+    for line in pip_output.splitlines():
+        clean = line.strip()
+        if not clean.startswith("+"):
+            continue
+        parts = clean.lstrip("+ ").split("==")
+        if len(parts) != 2:
+            logger.warning(f"Suspicious pip output line: {clean!r} -- ignoring")
+            continue
+        name = parts[0].strip()
+        version_raw = parts[1].split(" ", 1)[0].strip()
+        try:
+            Version(version_raw)
+            rv[name] = version_raw
+        except Exception as e:
+            logger.warning(f"failed to parse version for {name!r}: {version_raw!r} -- {repr(e)}")
+    return rv
+
+
+def try_install(packages: list[str]) -> Either[dict[str, str], str]:  # type: ignore[type-arg]
     """Run ``uv pip install`` with the given pkg specs.
 
-    Returns ``None`` on success or an error string describing the failure.
+    Returns ``Either.ok(versions)`` on success, where ``versions`` maps newly-installed
+    package names to their version strings, or ``Either.error(msg)`` on failure.
     Never raises.
     """
     install_command = ["uv", "pip", "install"] + packages
     logger.debug(f"will run {install_command}")
     try:
-        result = subprocess.run(install_command, check=False, capture_output=True)
+        result = subprocess.run(install_command, check=False, capture_output=True, text=True)
     except FileNotFoundError as ex:
         msg = f"installing {packages} failure: {repr(ex)}"
         logger.error(msg)
-        return msg
+        return Either.error(msg)
     if result.returncode != 0:
         msg = f"installing {packages} failure: {result.returncode}. Stderr: {result.stderr}, Stdout: {result.stdout}, Args: {result.args}"
         logger.error(msg)
-        return msg
+        return Either.error(msg)
     logger.debug(f"install finished with {result.stdout=}, {result.stderr=}")
-    return None
+    return Either.ok(_parse_pip_install(result.stdout))
 
 
 def get_existing_install_pin(distname: str) -> list[str]:

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -226,3 +226,32 @@ def backend_client_with_auth(backend_client: httpx.Client) -> Generator[httpx.Cl
     response = backend_client.get("/users/me")
     assert response.is_success, "Failed to authenticate user"
     yield backend_client
+
+
+@pytest.fixture(scope="session")
+def backend_admin_client(backend_client: httpx.Client) -> Generator[httpx.Client, None, None]:
+    """A separate httpx.Client authenticated as the admin user (admin@somewhere.org).
+
+    Registers the user if not already present (note: the first registered user
+    becomes the superuser, so test_admin_flows.py must have run first).
+    Uses a dedicated client so that its auth cookies do not interfere with
+    backend_client or backend_client_with_auth.
+    """
+    admin_email = "admin@somewhere.org"
+    admin_password = "something"
+    admin_client = httpx.Client(base_url=str(backend_client.base_url), follow_redirects=True)
+    try:
+        # Try registering; ignore errors (user may already exist from test_admin_flows).
+        backend_client.post(
+            "/auth/register",
+            headers={"Content-Type": "application/json"},
+            json={"email": admin_email, "password": admin_password},
+        )
+        response = admin_client.post("/auth/jwt/login", data={"username": admin_email, "password": admin_password})
+        assert response.is_success, f"Admin login failed: {response.text}"
+        token = extract_auth_token_from_response(response)
+        assert token is not None, "Admin token should not be None"
+        admin_client.cookies.set(**prepare_cookie_with_auth_token(token))
+        yield admin_client
+    finally:
+        admin_client.close()

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -277,6 +277,38 @@ def test_plugin_template_exclusion(backend_client_with_auth: httpx.Client, backe
     assert "pluginGlyphNew" in local_glyphs.get("localNew", ""), f"Expected localNew value to reference pluginGlyphNew, got: {local_glyphs}"
 
 
+def test_plugin_template_validation_failure(backend_client_with_auth: httpx.Client) -> None:
+    """Templates that fail validation with their example values are absent from the blueprint list
+    and are reported under plugin_template_errors in the plugin status."""
+    from .conftest import testPluginId
+
+    # Wait for the initial plugin load to finish.
+    def do_action() -> dict:
+        response = backend_client_with_auth.get("/plugin/status", timeout=10)
+        assert response.is_success
+        return response.json()
+
+    def verify_ok(data: dict) -> dict | None:
+        return data if data.get("updater_status") == "ok" else None
+
+    status = retry_until(do_action, verify_ok, attempts=30, sleep=1.0, error_msg="Plugin loader did not reach 'ok' status")
+
+    # testFailValidation must NOT appear in the blueprint list.
+    response = backend_client_with_auth.get("/blueprint/list", timeout=10)
+    assert response.is_success, response.text
+    blueprints = response.json()["blueprints"]
+    names = [b.get("display_name") for b in blueprints if b.get("source") == "plugin_template"]
+    assert "testFailValidation" not in names, f"testFailValidation should have been rejected but found in: {names}"
+
+    # Its error must be reported under plugin_template_errors in the status response.
+    # PluginsStatus dict keys for PluginCompositeId are serialized via str(), which gives
+    # the Pydantic model repr (e.g. "store='localTest' local='single'").
+    plugin_id_key = str(testPluginId)
+    template_errors_map = status.get("plugin_template_errors", {})
+    plugin_te = template_errors_map.get(plugin_id_key, {})
+    assert "testFailValidation" in plugin_te, f"Expected testFailValidation in plugin_template_errors[{plugin_id_key!r}], got: {plugin_te}"
+
+
 def test_blueprint_expand(tmpdir: Any, backend_client_with_auth: httpx.Client) -> None:
     response = backend_client_with_auth.get("/blueprint/catalogue").raise_for_status()
     assert len(response.json()) > 0

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -279,7 +279,7 @@ def test_plugin_template_exclusion(backend_client_with_auth: httpx.Client, backe
 
 def test_plugin_template_validation_failure(backend_client_with_auth: httpx.Client) -> None:
     """Templates that fail validation with their example values are absent from the blueprint list
-    and are reported under plugin_template_errors in the plugin status."""
+    and their error is reported in plugin_errors in the plugin status."""
     from .conftest import testPluginId
 
     # Wait for the initial plugin load to finish.
@@ -300,13 +300,14 @@ def test_plugin_template_validation_failure(backend_client_with_auth: httpx.Clie
     names = [b.get("display_name") for b in blueprints if b.get("source") == "plugin_template"]
     assert "testFailValidation" not in names, f"testFailValidation should have been rejected but found in: {names}"
 
-    # Its error must be reported under plugin_template_errors in the status response.
-    # PluginsStatus dict keys for PluginCompositeId are serialized via str(), which gives
-    # the Pydantic model repr (e.g. "store='localTest' local='single'").
+    # Its error must be reported in plugin_errors (merged alongside install errors).
+    # PluginsStatus dict keys for PluginCompositeId are serialized via str(plugin_id).
     plugin_id_key = str(testPluginId)
-    template_errors_map = status.get("plugin_template_errors", {})
-    plugin_te = template_errors_map.get(plugin_id_key, {})
-    assert "testFailValidation" in plugin_te, f"Expected testFailValidation in plugin_template_errors[{plugin_id_key!r}], got: {plugin_te}"
+    plugin_errors = status.get("plugin_errors", {})
+    plugin_error_str = plugin_errors.get(plugin_id_key, "")
+    assert "testFailValidation" in plugin_error_str, (
+        f"Expected 'testFailValidation' in plugin_errors[{plugin_id_key!r}], got: {plugin_error_str!r}"
+    )
 
 
 def test_blueprint_expand(tmpdir: Any, backend_client_with_auth: httpx.Client) -> None:

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -207,6 +207,46 @@ def test_plugin_template_in_blueprint_list(backend_client_with_auth: httpx.Clien
     assert len(matches) == 1, f"Expected exactly one 'testBasic' plugin_template blueprint in the list, got: {blueprints}"
 
 
+def test_plugin_template_exclusion(backend_client_with_auth: httpx.Client, backend_admin_client: httpx.Client) -> None:
+    """Excluding a template via POST /plugin/settings removes it from the blueprint list."""
+    from .conftest import testPluginId
+
+    # Verify testExclusion is initially present.
+    response = backend_client_with_auth.get("/blueprint/list", timeout=10)
+    assert response.is_success, response.text
+    blueprints = response.json()["blueprints"]
+    assert any(b.get("display_name") == "testExclusion" for b in blueprints), (
+        f"testExclusion should be present before exclusion, got: {[b.get('display_name') for b in blueprints]}"
+    )
+
+    # Exclude testExclusion via the admin settings route.
+    response = backend_admin_client.post(
+        "/plugin/settings",
+        json={"pluginCompositeId": testPluginId.model_dump(), "excluded_templates": ["testExclusion"]},
+        timeout=10,
+    )
+    assert response.status_code in (200, 202), f"Unexpected status from /plugin/settings: {response.status_code} {response.text}"
+
+    # Wait for the re-ingest to complete.
+    def do_action() -> dict:
+        resp = backend_client_with_auth.get("/plugin/status", timeout=10)
+        assert resp.is_success
+        return resp.json()
+
+    def verify_ok(data: dict) -> dict | None:
+        return data if data.get("updater_status") == "ok" else None
+
+    retry_until(do_action, verify_ok, attempts=30, sleep=1.0, error_msg="Plugin re-ingest did not reach 'ok' status")
+
+    # testExclusion must be gone; testBasic must remain.
+    response = backend_client_with_auth.get("/blueprint/list", timeout=10)
+    assert response.is_success, response.text
+    blueprints = response.json()["blueprints"]
+    names = [b.get("display_name") for b in blueprints if b.get("source") == "plugin_template"]
+    assert "testExclusion" not in names, f"testExclusion should have been excluded, but found: {names}"
+    assert "testBasic" in names, f"testBasic should still be present, but found: {names}"
+
+
 def test_blueprint_expand(tmpdir: Any, backend_client_with_auth: httpx.Client) -> None:
     response = backend_client_with_auth.get("/blueprint/catalogue").raise_for_status()
     assert len(response.json()) > 0

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -208,21 +208,30 @@ def test_plugin_template_in_blueprint_list(backend_client_with_auth: httpx.Clien
 
 
 def test_plugin_template_exclusion(backend_client_with_auth: httpx.Client, backend_admin_client: httpx.Client) -> None:
-    """Excluding a template via POST /plugin/settings removes it from the blueprint list."""
+    """Excluding a template via POST /plugin/settings removes it from the blueprint list.
+    Also verifies that glyph_remapping renames glyph references in testRemapping after re-ingest.
+    """
     from .conftest import testPluginId
 
-    # Verify testExclusion is initially present.
+    # Verify testExclusion and testRemapping are initially present.
     response = backend_client_with_auth.get("/blueprint/list", timeout=10)
     assert response.is_success, response.text
     blueprints = response.json()["blueprints"]
     assert any(b.get("display_name") == "testExclusion" for b in blueprints), (
         f"testExclusion should be present before exclusion, got: {[b.get('display_name') for b in blueprints]}"
     )
+    assert any(b.get("display_name") == "testRemapping" for b in blueprints), (
+        f"testRemapping should be present before remapping, got: {[b.get('display_name') for b in blueprints]}"
+    )
 
-    # Exclude testExclusion via the admin settings route.
+    # Exclude testExclusion and set a glyph remapping for testRemapping via the admin settings route.
     response = backend_admin_client.post(
         "/plugin/settings",
-        json={"pluginCompositeId": testPluginId.model_dump(), "excluded_templates": ["testExclusion"]},
+        json={
+            "pluginCompositeId": testPluginId.model_dump(),
+            "excluded_templates": ["testExclusion"],
+            "glyph_remapping": {"pluginGlyphOld": "pluginGlyphNew", "localOld": "localNew"},
+        },
         timeout=10,
     )
     assert response.status_code in (200, 202), f"Unexpected status from /plugin/settings: {response.status_code} {response.text}"
@@ -238,13 +247,34 @@ def test_plugin_template_exclusion(backend_client_with_auth: httpx.Client, backe
 
     retry_until(do_action, verify_ok, attempts=30, sleep=1.0, error_msg="Plugin re-ingest did not reach 'ok' status")
 
-    # testExclusion must be gone; testBasic must remain.
+    # testExclusion must be gone; testBasic and testRemapping must remain.
     response = backend_client_with_auth.get("/blueprint/list", timeout=10)
     assert response.is_success, response.text
     blueprints = response.json()["blueprints"]
     names = [b.get("display_name") for b in blueprints if b.get("source") == "plugin_template"]
     assert "testExclusion" not in names, f"testExclusion should have been excluded, but found: {names}"
     assert "testBasic" in names, f"testBasic should still be present, but found: {names}"
+    assert "testRemapping" in names, f"testRemapping should be present, but found: {names}"
+
+    # Verify that the glyph remapping was applied to testRemapping.
+    remap_item = next(b for b in blueprints if b.get("display_name") == "testRemapping")
+    remap_id = remap_item["blueprint_id"]
+    response = backend_client_with_auth.get(f"/blueprint/get?blueprint_id={remap_id}", timeout=10)
+    assert response.is_success, response.text
+    builder_data = response.json()["builder"]
+    # The block config value must reference the renamed glyph.
+    config_values = list(builder_data["blocks"].values())[0]["configuration_values"]
+    assert any("pluginGlyphNew" in v for v in config_values.values()), (
+        f"Expected pluginGlyphNew in config values after remapping, got: {config_values}"
+    )
+    assert not any("pluginGlyphOld" in v for v in config_values.values()), (
+        f"pluginGlyphOld should have been renamed, but found in config values: {config_values}"
+    )
+    # The local glyph key and value must also be renamed.
+    local_glyphs = builder_data["local_glyphs"]
+    assert "localNew" in local_glyphs, f"Expected localNew in local_glyphs after remapping, got: {local_glyphs}"
+    assert "localOld" not in local_glyphs, f"localOld should have been renamed, got: {local_glyphs}"
+    assert "pluginGlyphNew" in local_glyphs.get("localNew", ""), f"Expected localNew value to reference pluginGlyphNew, got: {local_glyphs}"
 
 
 def test_blueprint_expand(tmpdir: Any, backend_client_with_auth: httpx.Client) -> None:

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -187,6 +187,26 @@ def test_blueprint_upsert_nonexistent_id(backend_client_with_auth: httpx.Client)
     assert response.status_code == 404
 
 
+def test_plugin_template_in_blueprint_list(backend_client_with_auth: httpx.Client) -> None:
+    """Verify that the testBasic plugin template appears in the blueprint list after startup."""
+
+    def do_action() -> dict:
+        response = backend_client_with_auth.get("/plugin/status", timeout=10)
+        assert response.is_success
+        return response.json()
+
+    def verify_ok(data: dict) -> dict | None:
+        return data if data.get("updater_status") == "ok" else None
+
+    retry_until(do_action, verify_ok, attempts=30, sleep=1.0, error_msg="Plugin loader did not reach 'ok' status")
+
+    response = backend_client_with_auth.get("/blueprint/list", timeout=10)
+    assert response.is_success, response.text
+    blueprints = response.json()["blueprints"]
+    matches = [b for b in blueprints if b.get("source") == "plugin_template" and b.get("display_name") == "testBasic"]
+    assert len(matches) == 1, f"Expected exactly one 'testBasic' plugin_template blueprint in the list, got: {blueprints}"
+
+
 def test_blueprint_expand(tmpdir: Any, backend_client_with_auth: httpx.Client) -> None:
     response = backend_client_with_auth.get("/blueprint/catalogue").raise_for_status()
     assert len(response.json()) > 0

--- a/backend/tests/integration/test_db_startup.py
+++ b/backend/tests/integration/test_db_startup.py
@@ -8,8 +8,11 @@
 # nor does it submit to any jurisdiction.
 
 import pathlib
+import time
 
 import httpx
+
+from .utils import retry_until
 
 
 def test_dbs_created(backend_client: httpx.Client) -> None:
@@ -19,3 +22,22 @@ def test_dbs_created(backend_client: httpx.Client) -> None:
     fiab_root = forecastbox.utility.config.fiab_home
     assert (pathlib.Path(fiab_root) / "user.db").exists(), "user.db was not created on startup"
     assert (pathlib.Path(fiab_root) / "job.db").exists(), "job.db was not created on startup"
+
+
+def test_plugin_install_state_persisted(backend_client: httpx.Client) -> None:
+    """Verify the test plugin install is reported via /plugin/status with no install error."""
+
+    def do_action() -> dict:
+        response = backend_client.get("/plugin/status", timeout=10)
+        assert response.is_success
+        return response.json()
+
+    def verify_ok(data: dict) -> dict | None:
+        return data if data.get("updater_status") == "ok" else None
+
+    status = retry_until(do_action, verify_ok, attempts=30, sleep=1.0, error_msg="Plugin loader did not reach 'ok' status")
+
+    assert "plugin_install_errors" in status, "plugin_install_errors field missing from /plugin/status response"
+    assert "localTest:single" not in status["plugin_install_errors"], (
+        f"Test plugin reported an install error: {status['plugin_install_errors'].get('localTest:single')}"
+    )

--- a/backend/tests/integration/test_db_startup.py
+++ b/backend/tests/integration/test_db_startup.py
@@ -8,7 +8,6 @@
 # nor does it submit to any jurisdiction.
 
 import pathlib
-import time
 
 import httpx
 
@@ -37,7 +36,5 @@ def test_plugin_install_state_persisted(backend_client: httpx.Client) -> None:
 
     status = retry_until(do_action, verify_ok, attempts=30, sleep=1.0, error_msg="Plugin loader did not reach 'ok' status")
 
-    assert "plugin_install_errors" in status, "plugin_install_errors field missing from /plugin/status response"
-    assert "localTest:single" not in status["plugin_install_errors"], (
-        f"Test plugin reported an install error: {status['plugin_install_errors'].get('localTest:single')}"
-    )
+    plugin_errors = status.get("plugin_errors", {})
+    assert "localTest:single" not in plugin_errors, f"Test plugin reported an error: {plugin_errors.get('localTest:single')}"

--- a/backend/tests/unit/domain/blueprint/test_blueprint_db.py
+++ b/backend/tests/unit/domain/blueprint/test_blueprint_db.py
@@ -1,0 +1,82 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Unit tests for domain/blueprint/db.py helpers."""
+
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+import forecastbox.domain.blueprint.db as blueprint_db
+import forecastbox.schemata.jobs as _jobs_module
+from forecastbox.schemata.jobs import Base
+from forecastbox.utility.auth import AuthContext
+
+
+@pytest_asyncio.fixture
+async def mem_session_maker(monkeypatch: pytest.MonkeyPatch) -> AsyncGenerator[async_sessionmaker[AsyncSession], None]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    monkeypatch.setattr(_jobs_module, "async_session_maker", maker)
+    monkeypatch.setattr(blueprint_db._jobs_module, "async_session_maker", maker)
+    yield maker
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_plugin_template_marks_matching_rows(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
+    """soft_delete_plugin_template marks all matching (created_by, display_name) rows as deleted."""
+    auth = AuthContext(user_id="store:plugin", is_admin=True)
+    await blueprint_db.upsert_blueprint(
+        auth_context=auth,
+        source="plugin_template",
+        created_by="store:plugin",
+        display_name="myTemplate",
+        display_description="desc",
+    )
+
+    rows_before = await blueprint_db.find_plugin_template_id(created_by="store:plugin", display_name="myTemplate")
+    assert rows_before is not None
+
+    await blueprint_db.soft_delete_plugin_template(created_by="store:plugin", display_name="myTemplate")
+
+    rows_after = await blueprint_db.find_plugin_template_id(created_by="store:plugin", display_name="myTemplate")
+    assert rows_after is None, "After soft-delete the row should not be visible"
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_plugin_template_does_not_affect_other_plugins(
+    mem_session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    """soft_delete_plugin_template only touches rows owned by the specified plugin."""
+    auth_a = AuthContext(user_id="storeA:plugin", is_admin=True)
+    auth_b = AuthContext(user_id="storeB:plugin", is_admin=True)
+    await blueprint_db.upsert_blueprint(
+        auth_context=auth_a,
+        source="plugin_template",
+        created_by="storeA:plugin",
+        display_name="shared",
+        display_description="from A",
+    )
+    await blueprint_db.upsert_blueprint(
+        auth_context=auth_b,
+        source="plugin_template",
+        created_by="storeB:plugin",
+        display_name="shared",
+        display_description="from B",
+    )
+
+    await blueprint_db.soft_delete_plugin_template(created_by="storeA:plugin", display_name="shared")
+
+    assert await blueprint_db.find_plugin_template_id(created_by="storeA:plugin", display_name="shared") is None
+    assert await blueprint_db.find_plugin_template_id(created_by="storeB:plugin", display_name="shared") is not None

--- a/backend/tests/unit/domain/blueprint/test_blueprint_service.py
+++ b/backend/tests/unit/domain/blueprint/test_blueprint_service.py
@@ -24,7 +24,7 @@ from fiab_core.fable import (
     SelfPluginId,
 )
 
-from forecastbox.domain.blueprint.service import BlueprintBuilder, remap_builder_glyphs, template_to_builder
+from forecastbox.domain.blueprint.service import BlueprintBuilder, remap_builder_glyphs, resolve_builder_with_examples, template_to_builder
 
 _REAL_PLUGIN_ID = PluginCompositeId(store=PluginStoreId("myStore"), local=PluginId("myPlugin"))
 _BLOCK_A = BlockInstanceId("blockA")
@@ -170,3 +170,60 @@ def test_remap_builder_glyphs_empty_mapping_returns_same_object() -> None:
     )
     result = remap_builder_glyphs(builder, {})
     assert result is builder
+
+
+# ---------------------------------------------------------------------------
+# resolve_builder_with_examples
+# ---------------------------------------------------------------------------
+
+
+def _make_builder(block_text: str | None = None, local_glyphs: dict[str, str] | None = None) -> BlueprintBuilder:
+    block = BlockInstance(
+        factory_id=PluginBlockFactoryId(plugin=_REAL_PLUGIN_ID, factory=BlockFactoryId("source_text")),
+        configuration_values={_OPT: block_text} if block_text is not None else {},
+        input_ids={},
+    )
+    return BlueprintBuilder(
+        blocks={_BLOCK_A: block},
+        local_glyphs=local_glyphs or {},
+    )
+
+
+def test_resolve_builder_with_examples_fills_missing_config_value() -> None:
+    """Example values fill in config options absent from the template block."""
+    builder = _make_builder(block_text=None)
+    result = resolve_builder_with_examples(builder, {_BLOCK_A: {_OPT: "from example"}}, {})
+    assert result.blocks[_BLOCK_A].configuration_values[_OPT] == "from example"
+
+
+def test_resolve_builder_with_examples_does_not_overwrite_existing_config_value() -> None:
+    """An explicit template value takes precedence over the example value."""
+    builder = _make_builder(block_text="template value")
+    result = resolve_builder_with_examples(builder, {_BLOCK_A: {_OPT: "example value"}}, {})
+    assert result.blocks[_BLOCK_A].configuration_values[_OPT] == "template value"
+
+
+def test_resolve_builder_with_examples_merges_example_glyphs() -> None:
+    """Example glyphs are merged into local_glyphs when they are absent."""
+    builder = _make_builder(local_glyphs={})
+    result = resolve_builder_with_examples(builder, {}, {"name": "world"})
+    assert result.local_glyphs["name"] == "world"
+
+
+def test_resolve_builder_with_examples_does_not_overwrite_existing_local_glyph() -> None:
+    """An explicit template local glyph takes precedence over an example glyph."""
+    builder = _make_builder(local_glyphs={"name": "template"})
+    result = resolve_builder_with_examples(builder, {}, {"name": "example"})
+    assert result.local_glyphs["name"] == "template"
+
+
+def test_resolve_builder_with_examples_does_not_mutate_original() -> None:
+    """The function is pure: the original builder is unchanged after the call."""
+    builder = _make_builder(block_text=None, local_glyphs={})
+    original_config = dict(builder.blocks[_BLOCK_A].configuration_values)
+    original_glyphs = dict(builder.local_glyphs)
+
+    resolve_builder_with_examples(builder, {_BLOCK_A: {_OPT: "example"}}, {"k": "v"})
+
+    assert builder.blocks[_BLOCK_A].configuration_values == original_config
+    assert builder.local_glyphs == original_glyphs

--- a/backend/tests/unit/domain/blueprint/test_blueprint_service.py
+++ b/backend/tests/unit/domain/blueprint/test_blueprint_service.py
@@ -196,11 +196,11 @@ def test_resolve_builder_with_examples_fills_missing_config_value() -> None:
     assert result.blocks[_BLOCK_A].configuration_values[_OPT] == "from example"
 
 
-def test_resolve_builder_with_examples_does_not_overwrite_existing_config_value() -> None:
-    """An explicit template value takes precedence over the example value."""
+def test_resolve_builder_with_examples_overrides_existing_config_value() -> None:
+    """Example values override existing template values for validation purposes."""
     builder = _make_builder(block_text="template value")
     result = resolve_builder_with_examples(builder, {_BLOCK_A: {_OPT: "example value"}}, {})
-    assert result.blocks[_BLOCK_A].configuration_values[_OPT] == "template value"
+    assert result.blocks[_BLOCK_A].configuration_values[_OPT] == "example value"
 
 
 def test_resolve_builder_with_examples_merges_example_glyphs() -> None:
@@ -210,11 +210,11 @@ def test_resolve_builder_with_examples_merges_example_glyphs() -> None:
     assert result.local_glyphs["name"] == "world"
 
 
-def test_resolve_builder_with_examples_does_not_overwrite_existing_local_glyph() -> None:
-    """An explicit template local glyph takes precedence over an example glyph."""
+def test_resolve_builder_with_examples_overrides_existing_local_glyph() -> None:
+    """Example glyphs override existing template local glyphs for validation purposes."""
     builder = _make_builder(local_glyphs={"name": "template"})
     result = resolve_builder_with_examples(builder, {}, {"name": "example"})
-    assert result.local_glyphs["name"] == "template"
+    assert result.local_glyphs["name"] == "example"
 
 
 def test_resolve_builder_with_examples_does_not_mutate_original() -> None:

--- a/backend/tests/unit/domain/blueprint/test_blueprint_service.py
+++ b/backend/tests/unit/domain/blueprint/test_blueprint_service.py
@@ -1,0 +1,131 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Unit tests for blueprint service helpers."""
+
+from fiab_core.fable import (
+    BlockFactory,
+    BlockFactoryId,
+    BlockInstance,
+    BlockInstanceId,
+    BlueprintTemplate,
+    BlueprintTemplateEnvironment,
+    ConfigurationOptionId,
+    PluginBlockFactoryId,
+    PluginCompositeId,
+    PluginId,
+    PluginStoreId,
+    SelfPluginId,
+)
+
+from forecastbox.domain.blueprint.service import template_to_builder
+
+_REAL_PLUGIN_ID = PluginCompositeId(store=PluginStoreId("myStore"), local=PluginId("myPlugin"))
+_BLOCK_A = BlockInstanceId("blockA")
+_BLOCK_B = BlockInstanceId("blockB")
+_OPT = ConfigurationOptionId("text")
+
+
+def _self_block(text: str = "hello") -> BlockInstance:
+    return BlockInstance(
+        factory_id=PluginBlockFactoryId(plugin=SelfPluginId, factory=BlockFactoryId("source_text")),
+        configuration_values={_OPT: text},
+        input_ids={},
+    )
+
+
+def _real_block(text: str = "hello") -> BlockInstance:
+    return BlockInstance(
+        factory_id=PluginBlockFactoryId(plugin=_REAL_PLUGIN_ID, factory=BlockFactoryId("source_text")),
+        configuration_values={_OPT: text},
+        input_ids={},
+    )
+
+
+def test_template_to_builder_replaces_self_plugin_id() -> None:
+    """SelfPluginId sentinels in block factory IDs are replaced with the real plugin ID."""
+    template = BlueprintTemplate(
+        display_name="t",
+        display_description="d",
+        blocks={_BLOCK_A: _self_block()},
+    )
+    builder = template_to_builder(template, _REAL_PLUGIN_ID)
+    assert builder.blocks[_BLOCK_A].factory_id.plugin == _REAL_PLUGIN_ID
+
+
+def test_template_to_builder_keeps_real_plugin_id() -> None:
+    """A block already using the real plugin ID is not modified."""
+    template = BlueprintTemplate(
+        display_name="t",
+        display_description="d",
+        blocks={_BLOCK_A: _real_block()},
+    )
+    builder = template_to_builder(template, _REAL_PLUGIN_ID)
+    assert builder.blocks[_BLOCK_A].factory_id.plugin == _REAL_PLUGIN_ID
+
+
+def test_template_to_builder_propagates_env_vars() -> None:
+    """environment_variables from the template are copied into the builder environment."""
+    template = BlueprintTemplate(
+        display_name="t",
+        display_description="d",
+        blocks={},
+        environment=BlueprintTemplateEnvironment(environment_variables={"MY_VAR": "42"}),
+    )
+    builder = template_to_builder(template, _REAL_PLUGIN_ID)
+    assert builder.environment is not None
+    assert builder.environment.environment_variables == {"MY_VAR": "42"}
+    # Other EnvironmentSpecification fields default to None / empty.
+    assert builder.environment.hosts is None
+    assert builder.environment.workers_per_host is None
+    assert builder.environment.runtime_artifacts == []
+
+
+def test_template_to_builder_no_environment() -> None:
+    """When template.environment is None, builder.environment is None."""
+    template = BlueprintTemplate(
+        display_name="t",
+        display_description="d",
+        blocks={},
+        environment=None,
+    )
+    builder = template_to_builder(template, _REAL_PLUGIN_ID)
+    assert builder.environment is None
+
+
+def test_template_to_builder_preserves_local_glyphs() -> None:
+    """local_glyphs are copied verbatim."""
+    template = BlueprintTemplate(
+        display_name="t",
+        display_description="d",
+        blocks={},
+        local_glyphs={"greeting": "hello"},
+    )
+    builder = template_to_builder(template, _REAL_PLUGIN_ID)
+    assert builder.local_glyphs == {"greeting": "hello"}
+
+
+def test_template_to_builder_example_values_not_in_configuration_values() -> None:
+    """example_values must not appear in any block's configuration_values."""
+    example_block = BlockInstanceId("example_block")
+    opt = ConfigurationOptionId("text")
+    block = BlockInstance(
+        factory_id=PluginBlockFactoryId(plugin=SelfPluginId, factory=BlockFactoryId("source_text")),
+        configuration_values={},
+        input_ids={},
+    )
+    template = BlueprintTemplate(
+        display_name="t",
+        display_description="d",
+        blocks={example_block: block},
+        example_values={example_block: {opt: "example text"}},
+        example_glyphs={"name": "world"},
+    )
+    builder = template_to_builder(template, _REAL_PLUGIN_ID)
+    assert opt not in builder.blocks[example_block].configuration_values

--- a/backend/tests/unit/domain/blueprint/test_blueprint_service.py
+++ b/backend/tests/unit/domain/blueprint/test_blueprint_service.py
@@ -24,7 +24,7 @@ from fiab_core.fable import (
     SelfPluginId,
 )
 
-from forecastbox.domain.blueprint.service import template_to_builder
+from forecastbox.domain.blueprint.service import BlueprintBuilder, remap_builder_glyphs, template_to_builder
 
 _REAL_PLUGIN_ID = PluginCompositeId(store=PluginStoreId("myStore"), local=PluginId("myPlugin"))
 _BLOCK_A = BlockInstanceId("blockA")
@@ -129,3 +129,44 @@ def test_template_to_builder_example_values_not_in_configuration_values() -> Non
     )
     builder = template_to_builder(template, _REAL_PLUGIN_ID)
     assert opt not in builder.blocks[example_block].configuration_values
+
+
+# ---------------------------------------------------------------------------
+# remap_builder_glyphs
+# ---------------------------------------------------------------------------
+
+
+def test_remap_builder_glyphs_renames_config_value_and_local_glyph() -> None:
+    """Block config values, local-glyph values, and local-glyph keys are all renamed."""
+    builder = BlueprintBuilder(
+        blocks={
+            _BLOCK_A: BlockInstance(
+                factory_id=PluginBlockFactoryId(plugin=_REAL_PLUGIN_ID, factory=BlockFactoryId("source_text")),
+                configuration_values={_OPT: "${oldGlyph}"},
+                input_ids={},
+            )
+        },
+        local_glyphs={"localOld": "${oldGlyph}"},
+    )
+    mapping = {"oldGlyph": "newGlyph", "localOld": "localNew"}
+    remapped = remap_builder_glyphs(builder, mapping)
+
+    assert remapped.blocks[_BLOCK_A].configuration_values[_OPT] == "${newGlyph}"
+    assert "localNew" in remapped.local_glyphs
+    assert remapped.local_glyphs["localNew"] == "${newGlyph}"
+    assert "localOld" not in remapped.local_glyphs
+
+
+def test_remap_builder_glyphs_empty_mapping_returns_same_object() -> None:
+    builder = BlueprintBuilder(
+        blocks={
+            _BLOCK_A: BlockInstance(
+                factory_id=PluginBlockFactoryId(plugin=_REAL_PLUGIN_ID, factory=BlockFactoryId("source_text")),
+                configuration_values={_OPT: "${oldGlyph}"},
+                input_ids={},
+            )
+        },
+        local_glyphs={"myKey": "myVal"},
+    )
+    result = remap_builder_glyphs(builder, {})
+    assert result is builder

--- a/backend/tests/unit/domain/glyphs/test_resolution.py
+++ b/backend/tests/unit/domain/glyphs/test_resolution.py
@@ -23,7 +23,13 @@ from fiab_core.fable import (
 )
 
 from forecastbox.domain.glyphs.exceptions import GlyphCircularReferenceError
-from forecastbox.domain.glyphs.resolution import ExtractedGlyphs, expand_glyph_values, extract_glyphs, resolve_configurations
+from forecastbox.domain.glyphs.resolution import (
+    ExtractedGlyphs,
+    expand_glyph_values,
+    extract_glyphs,
+    remap_glyph_names,
+    resolve_configurations,
+)
 from forecastbox.utility.time import value_dt2str
 
 
@@ -488,3 +494,75 @@ def test_resolve_mixed_literal_and_expression() -> None:
     block = _block({"key": "prefix_${submitDatetime | floor_day}_suffix"})
     resolve_configurations(block, _GLYPHS)
     assert _value(block, "key") == "prefix_2024-01-15T00:00:00_suffix"
+
+
+# ---------------------------------------------------------------------------
+# remap_glyph_names
+# ---------------------------------------------------------------------------
+
+
+def test_remap_simple_name() -> None:
+    assert remap_glyph_names("${oldName}", {"oldName": "newName"}) == "${newName}"
+
+
+def test_remap_name_not_in_mapping_unchanged() -> None:
+    assert remap_glyph_names("${otherName}", {"oldName": "newName"}) == "${otherName}"
+
+
+def test_remap_no_mapping_unchanged() -> None:
+    assert remap_glyph_names("${myGlyph}", {}) == "${myGlyph}"
+
+
+def test_remap_plain_string_unchanged() -> None:
+    assert remap_glyph_names("plain text", {"oldName": "newName"}) == "plain text"
+
+
+def test_remap_word_boundary_safety() -> None:
+    """Renaming 'root' must not affect 'rootDir'."""
+    result = remap_glyph_names("${rootDir}", {"root": "base"})
+    assert result == "${rootDir}"
+
+
+def test_remap_word_boundary_exact_match() -> None:
+    """An exact whole-word match is still renamed."""
+    result = remap_glyph_names("${root}", {"root": "base"})
+    assert result == "${base}"
+
+
+def test_remap_filter_preserved() -> None:
+    """Filter names are never touched; only the variable identifier is renamed."""
+    result = remap_glyph_names("${x | floor_day}", {"x": "myDate"})
+    assert result == "${myDate | floor_day}"
+
+
+def test_remap_filter_name_not_renamed() -> None:
+    """A filter name that happens to match a mapping key is left untouched."""
+    result = remap_glyph_names("${submitDatetime | floor_day}", {"floor_day": "whatever"})
+    assert result == "${submitDatetime | floor_day}"
+
+
+def test_remap_multiple_references_in_one_string() -> None:
+    result = remap_glyph_names("${a} and ${b}", {"a": "x", "b": "y"})
+    assert result == "${x} and ${y}"
+
+
+def test_remap_partial_mapping_leaves_other_names() -> None:
+    result = remap_glyph_names("${a}_${b}", {"a": "A"})
+    assert result == "${A}_${b}"
+
+
+def test_remap_no_double_application() -> None:
+    """When a→b and b→c, renaming ${a} must yield ${b}, not ${c}."""
+    result = remap_glyph_names("${a}", {"a": "b", "b": "c"})
+    assert result == "${b}"
+
+
+def test_remap_mixed_literal_and_expression() -> None:
+    result = remap_glyph_names("prefix_${oldName}_suffix", {"oldName": "newName"})
+    assert result == "prefix_${newName}_suffix"
+
+
+def test_remap_expression_with_arithmetic() -> None:
+    """Rename works inside expressions containing arithmetic."""
+    result = remap_glyph_names("${submitDatetime | add_days(1)}", {"submitDatetime": "baseDate"})
+    assert result == "${baseDate | add_days(1)}"

--- a/backend/tests/unit/domain/plugins/test_plugin_db.py
+++ b/backend/tests/unit/domain/plugins/test_plugin_db.py
@@ -39,13 +39,13 @@ async def mem_session_maker(monkeypatch: pytest.MonkeyPatch) -> AsyncGenerator[a
 @pytest.mark.asyncio
 async def test_upsert_creates_row_with_defaults(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
     """First upsert inserts a row with empty excluded_templates and glyph_remapping."""
-    await plugin_db.upsert_plugin_state(plugin_id="localTest:single", version="1.2.3", error=None)
+    await plugin_db.upsert_plugin_state(plugin_id="localTest:single", version="1.2.3", install_error=None)
 
     state = await plugin_db.get_plugin_state("localTest:single")
     assert state is not None
     assert state.plugin_id == "localTest:single"
-    assert state.version == "1.2.3"
-    assert state.error is None
+    assert state.plugin_version == "1.2.3"
+    assert state.install_error is None
     assert state.excluded_templates == []
     assert state.glyph_remapping == {}
     assert state.template_errors is None
@@ -54,10 +54,10 @@ async def test_upsert_creates_row_with_defaults(mem_session_maker: async_session
 
 @pytest.mark.asyncio
 async def test_upsert_updates_version_without_clobbering(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
-    """Second upsert updates version/error but does not clobber excluded_templates / glyph_remapping."""
-    await plugin_db.upsert_plugin_state(plugin_id="myStore:myPlugin", version="0.1.0", error=None)
+    """Second upsert updates plugin_version/install_error but does not clobber excluded_templates / glyph_remapping."""
+    await plugin_db.upsert_plugin_state(plugin_id="myStore:myPlugin", version="0.1.0", install_error=None)
 
-    # Simulate task-04/05 writes directly to DB
+    # Simulate writes by later subsystems directly to DB
     from sqlalchemy import update as sa_update
 
     async with _jobs_module.async_session_maker() as session:
@@ -68,13 +68,13 @@ async def test_upsert_updates_version_without_clobbering(mem_session_maker: asyn
         )
         await session.commit()
 
-    # Now re-install (update)
-    await plugin_db.upsert_plugin_state(plugin_id="myStore:myPlugin", version="0.2.0", error=None)
+    # Re-install (update)
+    await plugin_db.upsert_plugin_state(plugin_id="myStore:myPlugin", version="0.2.0", install_error=None)
 
     state = await plugin_db.get_plugin_state("myStore:myPlugin")
     assert state is not None
-    assert state.version == "0.2.0"
-    assert state.error is None
+    assert state.plugin_version == "0.2.0"
+    assert state.install_error is None
     # excluded_templates / glyph_remapping must NOT be reset
     assert state.excluded_templates == ["tplA"]
     assert state.glyph_remapping == {"old": "new"}
@@ -83,20 +83,20 @@ async def test_upsert_updates_version_without_clobbering(mem_session_maker: asyn
 @pytest.mark.asyncio
 async def test_upsert_persists_install_error(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
     """An install failure writes the error string and records the attempt."""
-    await plugin_db.upsert_plugin_state(plugin_id="bad:plugin", version=None, error="pip failed: some reason")
+    await plugin_db.upsert_plugin_state(plugin_id="bad:plugin", version="unknown", install_error="pip failed: some reason")
 
     state = await plugin_db.get_plugin_state("bad:plugin")
     assert state is not None
-    assert state.error == "pip failed: some reason"
-    assert state.version is None
+    assert state.install_error == "pip failed: some reason"
+    assert state.plugin_version == "unknown"
     assert state.updated_at is not None
 
 
 @pytest.mark.asyncio
 async def test_get_all_plugin_states(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
     """get_all_plugin_states returns all persisted rows."""
-    await plugin_db.upsert_plugin_state(plugin_id="storeA:p1", version="1.0", error=None)
-    await plugin_db.upsert_plugin_state(plugin_id="storeA:p2", version=None, error="err")
+    await plugin_db.upsert_plugin_state(plugin_id="storeA:p1", version="1.0", install_error=None)
+    await plugin_db.upsert_plugin_state(plugin_id="storeA:p2", version="unknown", install_error="err")
 
     states = await plugin_db.get_all_plugin_states()
     ids = {s.plugin_id for s in states}

--- a/backend/tests/unit/domain/plugins/test_plugin_db.py
+++ b/backend/tests/unit/domain/plugins/test_plugin_db.py
@@ -39,7 +39,7 @@ async def mem_session_maker(monkeypatch: pytest.MonkeyPatch) -> AsyncGenerator[a
 @pytest.mark.asyncio
 async def test_upsert_creates_row_with_defaults(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
     """First upsert inserts a row with empty excluded_templates and glyph_remapping."""
-    await plugin_db.upsert_plugin_state(plugin_id="localTest:single", version="1.2.3", install_error=None)
+    await plugin_db.upsert_plugin_state(plugin_id="localTest:single", version="1.2.3", enabled=True, install_error=None)
 
     state = await plugin_db.get_plugin_state("localTest:single")
     assert state is not None
@@ -50,12 +50,14 @@ async def test_upsert_creates_row_with_defaults(mem_session_maker: async_session
     assert state.glyph_remapping == {}
     assert state.template_errors is None
     assert state.updated_at is not None
+    assert state.asset_ingest_needed is True
+    assert state.enabled is True
 
 
 @pytest.mark.asyncio
 async def test_upsert_updates_version_without_clobbering(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
     """Second upsert updates plugin_version/install_error but does not clobber excluded_templates / glyph_remapping."""
-    await plugin_db.upsert_plugin_state(plugin_id="myStore:myPlugin", version="0.1.0", install_error=None)
+    await plugin_db.upsert_plugin_state(plugin_id="myStore:myPlugin", version="0.1.0", enabled=True, install_error=None)
 
     # Simulate writes by later subsystems directly to DB
     from sqlalchemy import update as sa_update
@@ -68,8 +70,8 @@ async def test_upsert_updates_version_without_clobbering(mem_session_maker: asyn
         )
         await session.commit()
 
-    # Re-install (update)
-    await plugin_db.upsert_plugin_state(plugin_id="myStore:myPlugin", version="0.2.0", install_error=None)
+    # Re-install (update) -- new version triggers asset_ingest_needed=True
+    await plugin_db.upsert_plugin_state(plugin_id="myStore:myPlugin", version="0.2.0", enabled=True, install_error=None)
 
     state = await plugin_db.get_plugin_state("myStore:myPlugin")
     assert state is not None
@@ -78,12 +80,48 @@ async def test_upsert_updates_version_without_clobbering(mem_session_maker: asyn
     # excluded_templates / glyph_remapping must NOT be reset
     assert state.excluded_templates == ["tplA"]
     assert state.glyph_remapping == {"old": "new"}
+    assert state.asset_ingest_needed is True
+
+
+@pytest.mark.asyncio
+async def test_upsert_no_version_change_does_not_set_ingest(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
+    """When version is unchanged, asset_ingest_needed is not set again once cleared."""
+    await plugin_db.upsert_plugin_state(plugin_id="s:p", version="1.0.0", enabled=True, install_error=None)
+    await plugin_db.clear_asset_ingest_needed(plugin_id="s:p")
+
+    await plugin_db.upsert_plugin_state(plugin_id="s:p", version="1.0.0", enabled=True, install_error=None)
+
+    state = await plugin_db.get_plugin_state("s:p")
+    assert state is not None
+    assert state.asset_ingest_needed is False
+
+
+@pytest.mark.asyncio
+async def test_upsert_reenable_sets_ingest(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
+    """Re-enabling a disabled plugin sets asset_ingest_needed=True."""
+    await plugin_db.upsert_plugin_state(plugin_id="s:q", version="1.0.0", enabled=True, install_error=None)
+    await plugin_db.clear_asset_ingest_needed(plugin_id="s:q")
+    await plugin_db.set_plugin_enabled_state(plugin_id="s:q", enabled=False)
+
+    await plugin_db.upsert_plugin_state(plugin_id="s:q", version=None, enabled=True, install_error=None)
+
+    state = await plugin_db.get_plugin_state("s:q")
+    assert state is not None
+    assert state.enabled is True
+    assert state.asset_ingest_needed is True
+
+
+@pytest.mark.asyncio
+async def test_upsert_none_version_on_missing_row_raises(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
+    """upsert_plugin_state with version=None and no existing row is a programming error."""
+    with pytest.raises(RuntimeError, match="no prior DB row"):
+        await plugin_db.upsert_plugin_state(plugin_id="never:seen", version=None, enabled=True, install_error=None)
 
 
 @pytest.mark.asyncio
 async def test_upsert_persists_install_error(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
     """An install failure writes the error string and records the attempt."""
-    await plugin_db.upsert_plugin_state(plugin_id="bad:plugin", version="unknown", install_error="pip failed: some reason")
+    await plugin_db.upsert_plugin_state(plugin_id="bad:plugin", version="unknown", enabled=True, install_error="pip failed: some reason")
 
     state = await plugin_db.get_plugin_state("bad:plugin")
     assert state is not None
@@ -95,8 +133,8 @@ async def test_upsert_persists_install_error(mem_session_maker: async_sessionmak
 @pytest.mark.asyncio
 async def test_get_all_plugin_states(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
     """get_all_plugin_states returns all persisted rows."""
-    await plugin_db.upsert_plugin_state(plugin_id="storeA:p1", version="1.0", install_error=None)
-    await plugin_db.upsert_plugin_state(plugin_id="storeA:p2", version="unknown", install_error="err")
+    await plugin_db.upsert_plugin_state(plugin_id="storeA:p1", version="1.0", enabled=True, install_error=None)
+    await plugin_db.upsert_plugin_state(plugin_id="storeA:p2", version="unknown", enabled=True, install_error="err")
 
     states = await plugin_db.get_all_plugin_states()
     ids = {s.plugin_id for s in states}
@@ -113,7 +151,7 @@ async def test_get_plugin_state_missing(mem_session_maker: async_sessionmaker[As
 @pytest.mark.asyncio
 async def test_update_plugin_settings_partial_excluded(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
     """update_plugin_settings overwrites excluded_templates when provided, leaves glyph_remapping unchanged."""
-    await plugin_db.upsert_plugin_state(plugin_id="s:p", version="1.0", install_error=None)
+    await plugin_db.upsert_plugin_state(plugin_id="s:p", version="1.0", enabled=True, install_error=None)
     await plugin_db.update_plugin_settings(plugin_id="s:p", excluded_templates=["tplA"], glyph_remapping=None)
 
     state = await plugin_db.get_plugin_state("s:p")
@@ -131,7 +169,7 @@ async def test_update_plugin_settings_partial_excluded(mem_session_maker: async_
 @pytest.mark.asyncio
 async def test_update_plugin_settings_empty_list_clears(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
     """Passing an empty list for excluded_templates explicitly clears the stored list."""
-    await plugin_db.upsert_plugin_state(plugin_id="s:q", version="1.0", install_error=None)
+    await plugin_db.upsert_plugin_state(plugin_id="s:q", version="1.0", enabled=True, install_error=None)
     await plugin_db.update_plugin_settings(plugin_id="s:q", excluded_templates=["x", "y"], glyph_remapping=None)
     await plugin_db.update_plugin_settings(plugin_id="s:q", excluded_templates=[], glyph_remapping=None)
 
@@ -150,11 +188,3 @@ async def test_update_plugin_settings_creates_row_if_missing(mem_session_maker: 
     assert state.excluded_templates == ["tplX"]
     assert state.glyph_remapping == {}
     assert state.plugin_version == "not installed"
-
-
-@pytest.mark.asyncio
-async def test_get_plugin_settings_defaults(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
-    """get_plugin_settings returns empty defaults for a plugin with no persisted state."""
-    excluded, remapping = await plugin_db.get_plugin_settings("unknown:plugin")
-    assert excluded == []
-    assert remapping == {}

--- a/backend/tests/unit/domain/plugins/test_plugin_db.py
+++ b/backend/tests/unit/domain/plugins/test_plugin_db.py
@@ -1,0 +1,110 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Unit tests for domain/plugin/db.py helpers.
+
+Uses an in-memory SQLite engine (monkeypatching _jobs_module.async_session_maker)
+so no filesystem state is required.
+"""
+
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+import forecastbox.domain.plugin.db as plugin_db
+import forecastbox.schemata.jobs as _jobs_module
+from forecastbox.schemata.jobs import Base
+
+
+@pytest_asyncio.fixture
+async def mem_session_maker(monkeypatch: pytest.MonkeyPatch) -> AsyncGenerator[async_sessionmaker[AsyncSession], None]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    monkeypatch.setattr(_jobs_module, "async_session_maker", maker)
+    monkeypatch.setattr(plugin_db._jobs_module, "async_session_maker", maker)
+    yield maker
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_upsert_creates_row_with_defaults(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
+    """First upsert inserts a row with empty excluded_templates and glyph_remapping."""
+    await plugin_db.upsert_plugin_state(plugin_id="localTest:single", version="1.2.3", error=None)
+
+    state = await plugin_db.get_plugin_state("localTest:single")
+    assert state is not None
+    assert state.plugin_id == "localTest:single"
+    assert state.version == "1.2.3"
+    assert state.error is None
+    assert state.excluded_templates == []
+    assert state.glyph_remapping == {}
+    assert state.template_errors is None
+    assert state.updated_at is not None
+
+
+@pytest.mark.asyncio
+async def test_upsert_updates_version_without_clobbering(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
+    """Second upsert updates version/error but does not clobber excluded_templates / glyph_remapping."""
+    await plugin_db.upsert_plugin_state(plugin_id="myStore:myPlugin", version="0.1.0", error=None)
+
+    # Simulate task-04/05 writes directly to DB
+    from sqlalchemy import update as sa_update
+
+    async with _jobs_module.async_session_maker() as session:
+        await session.execute(
+            sa_update(_jobs_module.PluginState)
+            .where(_jobs_module.PluginState.plugin_id == "myStore:myPlugin")
+            .values(excluded_templates=["tplA"], glyph_remapping={"old": "new"})
+        )
+        await session.commit()
+
+    # Now re-install (update)
+    await plugin_db.upsert_plugin_state(plugin_id="myStore:myPlugin", version="0.2.0", error=None)
+
+    state = await plugin_db.get_plugin_state("myStore:myPlugin")
+    assert state is not None
+    assert state.version == "0.2.0"
+    assert state.error is None
+    # excluded_templates / glyph_remapping must NOT be reset
+    assert state.excluded_templates == ["tplA"]
+    assert state.glyph_remapping == {"old": "new"}
+
+
+@pytest.mark.asyncio
+async def test_upsert_persists_install_error(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
+    """An install failure writes the error string and records the attempt."""
+    await plugin_db.upsert_plugin_state(plugin_id="bad:plugin", version=None, error="pip failed: some reason")
+
+    state = await plugin_db.get_plugin_state("bad:plugin")
+    assert state is not None
+    assert state.error == "pip failed: some reason"
+    assert state.version is None
+    assert state.updated_at is not None
+
+
+@pytest.mark.asyncio
+async def test_get_all_plugin_states(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
+    """get_all_plugin_states returns all persisted rows."""
+    await plugin_db.upsert_plugin_state(plugin_id="storeA:p1", version="1.0", error=None)
+    await plugin_db.upsert_plugin_state(plugin_id="storeA:p2", version=None, error="err")
+
+    states = await plugin_db.get_all_plugin_states()
+    ids = {s.plugin_id for s in states}
+    assert ids == {"storeA:p1", "storeA:p2"}
+
+
+@pytest.mark.asyncio
+async def test_get_plugin_state_missing(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
+    """get_plugin_state returns None for a plugin not yet installed."""
+    state = await plugin_db.get_plugin_state("never:installed")
+    assert state is None

--- a/backend/tests/unit/domain/plugins/test_plugin_db.py
+++ b/backend/tests/unit/domain/plugins/test_plugin_db.py
@@ -99,11 +99,11 @@ async def test_upsert_no_version_change_does_not_set_ingest(mem_session_maker: a
 @pytest.mark.asyncio
 async def test_upsert_reenable_sets_ingest(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
     """Re-enabling a disabled plugin sets asset_ingest_needed=True."""
-    await plugin_db.upsert_plugin_state(plugin_id="s:q", version="1.0.0", enabled=True, install_error=None)
+    await plugin_db.upsert_plugin_state(plugin_id="s:q", version="1.0.0", enabled=True)
     await plugin_db.clear_asset_ingest_needed(plugin_id="s:q")
-    await plugin_db.set_plugin_enabled_state(plugin_id="s:q", enabled=False)
+    await plugin_db.upsert_plugin_state(plugin_id="s:q", enabled=False)
 
-    await plugin_db.upsert_plugin_state(plugin_id="s:q", version=None, enabled=True, install_error=None)
+    await plugin_db.upsert_plugin_state(plugin_id="s:q", enabled=True)
 
     state = await plugin_db.get_plugin_state("s:q")
     assert state is not None
@@ -179,12 +179,7 @@ async def test_update_plugin_settings_empty_list_clears(mem_session_maker: async
 
 
 @pytest.mark.asyncio
-async def test_update_plugin_settings_creates_row_if_missing(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
-    """update_plugin_settings inserts a row with defaults when no PluginState exists yet."""
-    await plugin_db.update_plugin_settings(plugin_id="new:plugin", excluded_templates=["tplX"], glyph_remapping=None)
-
-    state = await plugin_db.get_plugin_state("new:plugin")
-    assert state is not None
-    assert state.excluded_templates == ["tplX"]
-    assert state.glyph_remapping == {}
-    assert state.plugin_version == "not installed"
+async def test_update_plugin_settings_raises_if_missing(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
+    """update_plugin_settings raises RuntimeError when no PluginState row exists yet."""
+    with pytest.raises(RuntimeError, match="not installed"):
+        await plugin_db.update_plugin_settings(plugin_id="new:plugin", excluded_templates=["tplX"], glyph_remapping=None)

--- a/backend/tests/unit/domain/plugins/test_plugin_db.py
+++ b/backend/tests/unit/domain/plugins/test_plugin_db.py
@@ -108,3 +108,53 @@ async def test_get_plugin_state_missing(mem_session_maker: async_sessionmaker[As
     """get_plugin_state returns None for a plugin not yet installed."""
     state = await plugin_db.get_plugin_state("never:installed")
     assert state is None
+
+
+@pytest.mark.asyncio
+async def test_update_plugin_settings_partial_excluded(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
+    """update_plugin_settings overwrites excluded_templates when provided, leaves glyph_remapping unchanged."""
+    await plugin_db.upsert_plugin_state(plugin_id="s:p", version="1.0", install_error=None)
+    await plugin_db.update_plugin_settings(plugin_id="s:p", excluded_templates=["tplA"], glyph_remapping=None)
+
+    state = await plugin_db.get_plugin_state("s:p")
+    assert state is not None
+    assert state.excluded_templates == ["tplA"]
+    assert state.glyph_remapping == {}
+
+    await plugin_db.update_plugin_settings(plugin_id="s:p", excluded_templates=None, glyph_remapping={"old": "new"})
+    state = await plugin_db.get_plugin_state("s:p")
+    assert state is not None
+    assert state.excluded_templates == ["tplA"]
+    assert state.glyph_remapping == {"old": "new"}
+
+
+@pytest.mark.asyncio
+async def test_update_plugin_settings_empty_list_clears(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
+    """Passing an empty list for excluded_templates explicitly clears the stored list."""
+    await plugin_db.upsert_plugin_state(plugin_id="s:q", version="1.0", install_error=None)
+    await plugin_db.update_plugin_settings(plugin_id="s:q", excluded_templates=["x", "y"], glyph_remapping=None)
+    await plugin_db.update_plugin_settings(plugin_id="s:q", excluded_templates=[], glyph_remapping=None)
+
+    state = await plugin_db.get_plugin_state("s:q")
+    assert state is not None
+    assert state.excluded_templates == []
+
+
+@pytest.mark.asyncio
+async def test_update_plugin_settings_creates_row_if_missing(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
+    """update_plugin_settings inserts a row with defaults when no PluginState exists yet."""
+    await plugin_db.update_plugin_settings(plugin_id="new:plugin", excluded_templates=["tplX"], glyph_remapping=None)
+
+    state = await plugin_db.get_plugin_state("new:plugin")
+    assert state is not None
+    assert state.excluded_templates == ["tplX"]
+    assert state.glyph_remapping == {}
+    assert state.plugin_version == "not installed"
+
+
+@pytest.mark.asyncio
+async def test_get_plugin_settings_defaults(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
+    """get_plugin_settings returns empty defaults for a plugin with no persisted state."""
+    excluded, remapping = await plugin_db.get_plugin_settings("unknown:plugin")
+    assert excluded == []
+    assert remapping == {}

--- a/docs/developer/changeSpecs/core-plugin_assets-01-result_summary.md
+++ b/docs/developer/changeSpecs/core-plugin_assets-01-result_summary.md
@@ -1,0 +1,84 @@
+# Task 01 -- Result Summary
+
+## What was implemented
+
+Introduced the `BlueprintTemplate` entity into `fiab-core` and wired it through
+to the test plugin. No backend code was changed.
+
+### Key files changed / added
+
+* `backend/packages/fiab-core/src/fiab_core/fable.py` -- added
+  `BlueprintTemplateEnvironment` and `BlueprintTemplate` pydantic models.
+* `backend/packages/fiab-core/src/fiab_core/plugin.py` -- added the import of
+  `BlueprintTemplate` and the `blueprint_templates` field to `Plugin`.
+* `backend/packages/fiab-core/tests/test_fable.py` -- added four focused unit
+  tests covering construction, extra-field rejection, and round-trip
+  serialisation of `BlueprintTemplate` / `BlueprintTemplateEnvironment`.
+* `backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py` -- added
+  the `testBasic` template and updated the `plugin` lambda.
+* `backend/packages/fiab-plugin-test/tests/test_base.py` -- added two unit tests
+  asserting the template is present and its `display_name` is correct.
+
+## Final field names and types
+
+### `BlueprintTemplateEnvironment` (in `fiab_core.fable`)
+
+| field | type | default |
+|---|---|---|
+| `environment_variables` | `dict[str, str]` | `{}` |
+
+### `BlueprintTemplate` (in `fiab_core.fable`)
+
+| field | type | default |
+|---|---|---|
+| `display_name` | `str` | required |
+| `display_description` | `str` | required |
+| `blocks` | `dict[BlockInstanceId, BlockInstance]` | required |
+| `environment` | `BlueprintTemplateEnvironment \| None` | `None` |
+| `local_glyphs` | `dict[str, str]` | `{}` |
+| `example_values` | `dict[BlockInstanceId, dict[ConfigurationOptionId, str]]` | `{}` |
+| `example_glyphs` | `dict[str, str]` | `{}` |
+
+### `Plugin` new field (in `fiab_core.plugin`)
+
+| field | type | default |
+|---|---|---|
+| `blueprint_templates` | `tuple[BlueprintTemplate, ...]` | `()` |
+
+## `testBasic` shape (in `fiab_plugin_test`)
+
+```python
+display_name      = "testBasic"
+display_description = "A minimal test template with a single source_text block."
+blocks = {
+    BlockInstanceId("text_source"): BlockInstance(
+        factory_id = PluginBlockFactoryId(
+            plugin  = PluginCompositeId(store="__self__", local="__self__"),
+            factory = BlockFactoryId("source_text"),
+        ),
+        configuration_values = {ConfigurationOptionId("text"): "{{ example_text }}"},
+        input_ids = {},
+    )
+}
+local_glyphs    = {"example_text": "hello world"}
+example_values  = {BlockInstanceId("text_source"): {ConfigurationOptionId("text"): "hello world"}}
+example_glyphs  = {"example_text": "hello world"}
+```
+
+The `PluginCompositeId` uses the sentinel `"__self__"` strings; task 03 (or
+later) must substitute the real composite ID when reading templates off the
+installed plugin.
+
+## Deviations from plan
+
+None.
+
+## What task 03 will build on
+
+* `Plugin.blueprint_templates: tuple[BlueprintTemplate, ...]` -- iterate this
+  to read all templates a plugin ships.
+* `BlueprintTemplate.display_name` -- the stable upsert key; must be unique
+  within a plugin.
+* The sentinel `PluginCompositeId(store="__self__", local="__self__")` in the
+  test plugin's block factory IDs -- task 03 should replace these with the real
+  composite ID at install time.

--- a/docs/developer/changeSpecs/core-plugin_assets-02-result_summary.md
+++ b/docs/developer/changeSpecs/core-plugin_assets-02-result_summary.md
@@ -13,13 +13,22 @@ endpoint, and added unit + integration tests.
   `upsert_plugin_state`, `get_plugin_state`, `get_all_plugin_states`.
 * `backend/src/forecastbox/domain/plugin/manager.py` -- added
   `PluginManager.loop`, helper `_run_async_from_thread`, wired DB persistence
-  into `load_plugins` and `update_single`; made `status_full` async; added
-  `plugin_install_errors` field to `PluginsStatus`.
+  into `load_plugins` and `update_single`; made `status_full` async; removed
+  `PluginManager.versions` and `PluginManager.updatedatetime` PMap fields
+  (versions and timestamps now come from DB exclusively); added
+  `plugin_versions` and `plugin_updatedatetime` fields to `PluginsStatus`
+  populated from DB.
 * `backend/src/forecastbox/domain/plugin/__init__.py` -- updated docstring.
 * `backend/src/forecastbox/entrypoint/app.py` -- stash running loop on
   `PluginManager.loop` before `submit_load_plugins`.
 * `backend/src/forecastbox/routes/plugins.py` -- made `get_plugins_status_full`
   and `get_plugin_details` `async def` (both call `await status_full()`).
+* `backend/src/forecastbox/utility/packages.py` -- `try_install` now returns
+  `Either[dict[str, str], str]` (dict mapping package names to installed
+  versions on success, error string on failure); added `_parse_pip_install`
+  helper to extract installed versions from `uv pip install` stdout.
+* `backend/src/forecastbox/domain/plugin/compatibility.py` --
+  `install_plugin_compatibly` now returns `Either[dict[str, str], str]`.
 * `backend/tests/unit/domain/plugins/test_plugin_db.py` -- 5 unit tests for
   `upsert_plugin_state` insert/update semantics, error persistence, and
   `get_all_plugin_states`.
@@ -32,22 +41,30 @@ endpoint, and added unit + integration tests.
 | column | type | nullable | default |
 |---|---|---|---|
 | `plugin_id` | `String(255)` | no | PK |
-| `version` | `String(255)` | yes | |
+| `plugin_version` | `String(255)` | no | |
 | `updated_at` | `UTCDateTime` | no | |
-| `error` | `String(4096)` | yes | |
+| `install_error` | `String(4096)` | yes | |
 | `excluded_templates` | `JSON` | no | `[]` |
 | `glyph_remapping` | `JSON` | no | `{}` |
 | `template_errors` | `JSON` | yes | |
 
+Note: `plugin_version` is non-nullable. On install failure the sentinel string
+`"install failed"` is stored (not `None` or `"unknown"`).
+
 ## `domain/plugin/db.py` function signatures
 
 ```python
-async def upsert_plugin_state(*, plugin_id: str, version: str | None, error: str | None) -> None
+async def upsert_plugin_state(*, plugin_id: str, version: str, install_error: str | None) -> None
 async def get_plugin_state(plugin_id: str) -> PluginState | None
 async def get_all_plugin_states() -> list[PluginState]
 ```
 
 `plugin_id` is `PluginCompositeId.to_str(pluginId)` (i.e. `"store:local"`).
+
+`upsert_plugin_state` inserts the row on first call with `excluded_templates=[]`,
+`glyph_remapping={}`, `template_errors=None`; on subsequent calls it updates
+only `plugin_version`, `updated_at`, and `install_error`, leaving the other
+columns untouched.
 
 ## How the loop is stashed
 
@@ -60,18 +77,40 @@ PluginManager.loop = asyncio.get_running_loop()
 Background threads (`load_plugins`, `update_single`) read `PluginManager.loop`
 and call `asyncio.run_coroutine_threadsafe(coro, loop).result()` via
 the private `_run_async_from_thread` helper in `manager.py`.
+`_run_async_from_thread` raises `RuntimeError` if `PluginManager.loop` is
+`None` (i.e. called before app startup completes).
+
+## Version detection
+
+`_parse_pip_install(stdout: str) -> dict[str, str]` parses lines starting with
+`+` from `uv pip install --verbose` output to extract `{package_name: version}`
+pairs.  `_version_from_install(installed: dict[str, str], module_name: str)`
+applies PEP 503 normalisation before lookup so `fiab_plugin_test` matches
+`fiab-plugin-test` in the pip output.
+
+On success the stored version comes from the pip output dict if available,
+falling back to `try_version(pip_source, module_name)` (importlib metadata).
+On failure the stored version is the sentinel `"install failed"`.
 
 ## Status synthesis
 
-`PluginsStatus` gains a new optional field (default `{}`):
+`PluginsStatus` fields populated from DB (via `status_full`):
 
 ```python
-plugin_install_errors: dict[str, str] = {}
+plugin_versions: dict[PluginCompositeId, str] = {}
+plugin_updatedatetime: dict[PluginCompositeId, str] = {}
 ```
 
-`status_full()` is now `async def`; it calls `get_all_plugin_states()` and
-populates `plugin_install_errors` from rows where `error is not None`. DB
-failures are caught and logged; the field defaults to `{}` on error.
+Install errors from DB (`install_error is not None`) are merged into the
+existing `plugin_errors` dict (keyed by `PluginCompositeId`). If both an
+import error and an install error exist for the same plugin, they are
+concatenated with `"; "`.
+
+`PluginManager.versions` and `PluginManager.updatedatetime` PMap fields have
+been removed; `status_full()` is the authoritative source for both.
+
+`status_full()` is now `async def`; DB failures are caught and logged; the
+dict fields default to `{}` on error.
 
 Both routes that call `status_full` (`GET /plugin/status` and
 `GET /plugin/details`) are now `async def`.
@@ -85,6 +124,8 @@ Both routes that call `status_full` (`GET /plugin/status` and
   unchanged.
 * The outer `PluginManager.updater_error` is still set if an unexpected
   exception escapes the per-plugin loop (e.g. a lock acquisition failure).
+* `PluginManager.versions` and `PluginManager.updatedatetime` were removed
+  entirely; both are now DB-exclusive.
 
 ## What tasks 03-06 will build on
 
@@ -96,10 +137,10 @@ Both routes that call `status_full` (`GET /plugin/status` and
 * `PluginState.template_errors` (JSON, nullable) -- task 06 writes per-template
   validation errors here.
 * `upsert_plugin_state` -- task 03 calls this after reading templates; tasks
-  04/05/06 call it to write their respective columns (use direct SQLAlchemy
-  `update` on the columns they own, not `upsert_plugin_state`, to avoid
-  clobbering the `version`/`error` fields).
+  04/05/06 should use direct SQLAlchemy `update` on only the columns they own
+  (not `upsert_plugin_state`) to avoid clobbering `plugin_version`/`install_error`.
 * `get_all_plugin_states` / `get_plugin_state` -- task 03+ use these to read
   persisted settings when (re)installing templates.
-* `PluginsStatus.plugin_install_errors` -- already exposed at `/plugin/status`;
-  tasks 04-06 may extend the status surface with additional fields.
+* `PluginsStatus.plugin_versions` and `plugin_errors` -- already exposed at
+  `/plugin/status`; tasks 04-06 may extend the status surface with additional
+  fields.

--- a/docs/developer/changeSpecs/core-plugin_assets-02-result_summary.md
+++ b/docs/developer/changeSpecs/core-plugin_assets-02-result_summary.md
@@ -1,0 +1,105 @@
+# Task 02 -- Result Summary
+
+## What was implemented
+
+Added a persistent install-state DB table for plugins (`plugin_state`), wired it
+into the install lifecycle, surfaced install errors on the `/plugin/status`
+endpoint, and added unit + integration tests.
+
+### Key files added / changed
+
+* `backend/src/forecastbox/schemata/jobs.py` -- added `PluginState` ORM class.
+* `backend/src/forecastbox/domain/plugin/db.py` -- new file; async helpers
+  `upsert_plugin_state`, `get_plugin_state`, `get_all_plugin_states`.
+* `backend/src/forecastbox/domain/plugin/manager.py` -- added
+  `PluginManager.loop`, helper `_run_async_from_thread`, wired DB persistence
+  into `load_plugins` and `update_single`; made `status_full` async; added
+  `plugin_install_errors` field to `PluginsStatus`.
+* `backend/src/forecastbox/domain/plugin/__init__.py` -- updated docstring.
+* `backend/src/forecastbox/entrypoint/app.py` -- stash running loop on
+  `PluginManager.loop` before `submit_load_plugins`.
+* `backend/src/forecastbox/routes/plugins.py` -- made `get_plugins_status_full`
+  and `get_plugin_details` `async def` (both call `await status_full()`).
+* `backend/tests/unit/domain/plugins/test_plugin_db.py` -- 5 unit tests for
+  `upsert_plugin_state` insert/update semantics, error persistence, and
+  `get_all_plugin_states`.
+* `backend/tests/integration/test_db_startup.py` -- added
+  `test_plugin_install_state_persisted` asserting `/plugin/status` reflects
+  the test plugin install with no install error after startup.
+
+## Final column names / types (`PluginState` in `schemata/jobs.py`)
+
+| column | type | nullable | default |
+|---|---|---|---|
+| `plugin_id` | `String(255)` | no | PK |
+| `version` | `String(255)` | yes | |
+| `updated_at` | `UTCDateTime` | no | |
+| `error` | `String(4096)` | yes | |
+| `excluded_templates` | `JSON` | no | `[]` |
+| `glyph_remapping` | `JSON` | no | `{}` |
+| `template_errors` | `JSON` | yes | |
+
+## `domain/plugin/db.py` function signatures
+
+```python
+async def upsert_plugin_state(*, plugin_id: str, version: str | None, error: str | None) -> None
+async def get_plugin_state(plugin_id: str) -> PluginState | None
+async def get_all_plugin_states() -> list[PluginState]
+```
+
+`plugin_id` is `PluginCompositeId.to_str(pluginId)` (i.e. `"store:local"`).
+
+## How the loop is stashed
+
+In `entrypoint/app.py` `lifespan`, just before `submit_load_plugins`:
+
+```python
+PluginManager.loop = asyncio.get_running_loop()
+```
+
+Background threads (`load_plugins`, `update_single`) read `PluginManager.loop`
+and call `asyncio.run_coroutine_threadsafe(coro, loop).result()` via
+the private `_run_async_from_thread` helper in `manager.py`.
+
+## Status synthesis
+
+`PluginsStatus` gains a new optional field (default `{}`):
+
+```python
+plugin_install_errors: dict[str, str] = {}
+```
+
+`status_full()` is now `async def`; it calls `get_all_plugin_states()` and
+populates `plugin_install_errors` from rows where `error is not None`. DB
+failures are caught and logged; the field defaults to `{}` on error.
+
+Both routes that call `status_full` (`GET /plugin/status` and
+`GET /plugin/details`) are now `async def`.
+
+## Deviations from plan
+
+* `load_plugins` now wraps each plugin's install in a per-plugin try/except,
+  persists the per-plugin install error to DB, and continues to the next
+  plugin rather than aborting the whole load on the first install failure. This
+  is a minor behavioral improvement. Import errors (`PluginManager.errors`) are
+  unchanged.
+* The outer `PluginManager.updater_error` is still set if an unexpected
+  exception escapes the per-plugin loop (e.g. a lock acquisition failure).
+
+## What tasks 03-06 will build on
+
+* `PluginState.plugin_id` (string `store:local`) -- the stable upsert key.
+* `PluginState.excluded_templates` (JSON list of `display_name` strings) --
+  task 04 writes this via a new settings-update route.
+* `PluginState.glyph_remapping` (JSON dict `{old_name: new_name}`) -- task 05
+  writes this.
+* `PluginState.template_errors` (JSON, nullable) -- task 06 writes per-template
+  validation errors here.
+* `upsert_plugin_state` -- task 03 calls this after reading templates; tasks
+  04/05/06 call it to write their respective columns (use direct SQLAlchemy
+  `update` on the columns they own, not `upsert_plugin_state`, to avoid
+  clobbering the `version`/`error` fields).
+* `get_all_plugin_states` / `get_plugin_state` -- task 03+ use these to read
+  persisted settings when (re)installing templates.
+* `PluginsStatus.plugin_install_errors` -- already exposed at `/plugin/status`;
+  tasks 04-06 may extend the status surface with additional fields.

--- a/docs/developer/changeSpecs/core-plugin_assets-03-result_summary.md
+++ b/docs/developer/changeSpecs/core-plugin_assets-03-result_summary.md
@@ -1,0 +1,107 @@
+# Task 03 -- Result Summary
+
+## What was implemented
+
+Plugin blueprint templates are now ingested into the `blueprint` table as
+`plugin_template` rows on every (re)install.  The `testBasic` template from
+`fiab-plugin-test` appears in `GET /blueprint/list` for any authenticated user
+after startup.
+
+### Key files changed / added
+
+* `backend/src/forecastbox/domain/blueprint/db.py` -- added
+  `find_plugin_template_id(*, created_by, display_name) -> BlueprintId | None`.
+* `backend/src/forecastbox/domain/blueprint/service.py` -- added
+  `template_to_builder(template, plugin_id) -> BlueprintBuilder` (pure helper);
+  also imported `BlueprintTemplate`, `PluginCompositeId`, and `SelfPluginId`
+  from `fiab_core.fable`.
+* `backend/src/forecastbox/domain/plugin/manager.py` -- added the async
+  `_ingest_plugin_templates(plugin_id, plugin)` coroutine (uses lazy imports to
+  avoid a circular dependency between the plugin and blueprint domains); wired
+  `_run_async_from_thread(_ingest_plugin_templates(...))` into both
+  `load_plugins` (per-plugin, after `upsert_plugin_state`) and `update_single`
+  (after `upsert_plugin_state`, only when the load produced a `Plugin`).
+* `backend/tests/unit/domain/blueprint/test_blueprint_service.py` -- 6 new
+  unit tests for `template_to_builder` (SelfPluginId replacement, environment
+  propagation, local_glyphs copy, example_values isolation).
+* `backend/tests/integration/test_blueprint.py` -- added
+  `test_plugin_template_in_blueprint_list`, which polls `/plugin/status` until
+  the loader is ready then asserts `GET /blueprint/list` returns exactly one
+  item with `source == "plugin_template"` and `display_name == "testBasic"`.
+
+## Mapping helper signature
+
+```python
+# backend/src/forecastbox/domain/blueprint/service.py
+def template_to_builder(
+    template: BlueprintTemplate,
+    plugin_id: PluginCompositeId,
+) -> BlueprintBuilder:
+```
+
+* Iterates `template.blocks`; replaces any `factory_id.plugin == SelfPluginId`
+  with `plugin_id`.
+* Builds `EnvironmentSpecification(environment_variables=...)` from
+  `template.environment.environment_variables` if present, else leaves
+  `builder.environment = None`.
+* Copies `template.local_glyphs` verbatim.
+* Does **not** copy `example_values` or `example_glyphs` -- these are
+  guiding-only and must not appear in `configuration_values`.
+
+## `find_plugin_template_id` signature
+
+```python
+# backend/src/forecastbox/domain/blueprint/db.py
+async def find_plugin_template_id(
+    *,
+    created_by: str,
+    display_name: str,
+) -> BlueprintId | None:
+```
+
+Queries for the latest non-deleted `plugin_template` blueprint with the given
+`created_by` (plugin composite id string) and `display_name`.  Returns `None`
+if no row exists.
+
+## Where the ingestion call sits in the lifecycle
+
+`_ingest_plugin_templates` is an `async def` coroutine declared in
+`domain/plugin/manager.py`.  It uses lazy (function-body) imports of
+`domain.blueprint.db` and `domain.blueprint.service` to avoid a circular
+dependency (`blueprint.service` imports `plugin.manager`).
+
+Both `load_plugins` and `update_single` call it via
+`_run_async_from_thread(_ingest_plugin_templates(plugin_id, plugin))` -- the
+same pattern used for `upsert_plugin_state` -- immediately after the
+`upsert_plugin_state` call, and only when the plugin loaded successfully.
+
+A per-template `try/except` logs failures without aborting ingestion of the
+remaining templates.
+
+## How example_values / example_glyphs were handled
+
+They are **ignored** in this task.  The `template_to_builder` function does not
+copy them anywhere; the stored `BlueprintBuilder` JSON contains only `blocks`,
+`environment`, and `local_glyphs`.  Tasks 04/05/06 may read them directly from
+the `BlueprintTemplate` object (available at install time) or choose a
+persistence strategy.
+
+## Deviations from plan
+
+* Lazy imports inside `_ingest_plugin_templates` were used rather than placing
+  the function in `domain/blueprint/`.  This keeps the plugin domain
+  self-contained and avoids restructuring the existing circular-import
+  relationship between `blueprint.service` and `plugin.manager`.
+
+## What tasks 04/05/06 will build on
+
+* `find_plugin_template_id(created_by, display_name) -> BlueprintId | None` --
+  task 04 (exclusion) can use this to locate the row to soft-delete.
+* `template_to_builder(template, plugin_id) -> BlueprintBuilder` -- task 05
+  (glyph remapping) should apply the remapping map to the builder returned by
+  this function before persisting.
+* `_ingest_plugin_templates` -- tasks 04/05/06 hook exclusion, remapping, and
+  validation into this same per-template loop by extending the function body.
+* `PluginState.excluded_templates`, `PluginState.glyph_remapping` (from task
+  02) -- task 03 does not read them; tasks 04/05 will read them here to filter
+  and remap templates before upsert.

--- a/docs/developer/changeSpecs/core-plugin_assets-04-result_summary.md
+++ b/docs/developer/changeSpecs/core-plugin_assets-04-result_summary.md
@@ -1,0 +1,143 @@
+# Task 04 -- Result Summary
+
+## What was implemented
+
+Added a `POST /plugin/settings` admin-guarded route that persists per-plugin
+install settings (`excluded_templates`, `glyph_remapping`) and triggers a
+re-ingest so exclusions take effect immediately.  The ingestion path (from
+task 03) now honours the `excluded_templates` list: excluded templates are
+soft-deleted from the DB and skipped; non-excluded templates are upserted as
+before.
+
+### Key files added / changed
+
+* `backend/src/forecastbox/domain/plugin/db.py` -- added
+  `update_plugin_settings` (partial update of settings columns) and
+  `get_plugin_settings` (returns `(excluded_templates, glyph_remapping)`
+  tuple with empty defaults when no state exists yet).
+* `backend/src/forecastbox/domain/blueprint/db.py` -- added
+  `soft_delete_plugin_template(*, created_by, display_name)` bulk
+  soft-delete helper.
+* `backend/src/forecastbox/domain/plugin/manager.py` -- modified
+  `_ingest_plugin_templates` to load `excluded_templates` from
+  `PluginState`, soft-delete excluded templates, and skip their upsert.
+  Glyph remapping is loaded but not applied (task 05 seam is noted inline).
+* `backend/src/forecastbox/routes/plugins.py` -- added
+  `PluginSettingsUpdateRequest` and `async def update_plugin_settings_endpoint`
+  at `POST /plugin/settings`, admin-guarded.
+* `backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py` --
+  added `_testExclusion` template and exposed it via the `plugin` lambda
+  alongside `_testBasic`.
+* `backend/tests/unit/domain/plugins/test_plugin_db.py` -- 5 new unit tests
+  for `update_plugin_settings` (partial update, explicit clear, missing row)
+  and `get_plugin_settings`.
+* `backend/tests/unit/domain/blueprint/test_blueprint_db.py` -- new file;
+  2 unit tests for `soft_delete_plugin_template` (matching rows deleted,
+  other plugins unaffected).
+* `backend/tests/integration/conftest.py` -- added `backend_admin_client`
+  session fixture (separate httpx.Client authenticated as `admin@somewhere.org`).
+* `backend/tests/integration/test_blueprint.py` -- added
+  `test_plugin_template_exclusion` integration test.
+
+## Route + request class
+
+```python
+class PluginSettingsUpdateRequest(FiabBaseModel):
+    pluginCompositeId: PluginCompositeId
+    excluded_templates: list[str] | None = None  # None => leave unchanged
+    glyph_remapping: dict[str, str] | None = None  # None => leave unchanged
+
+@router.post("/settings")
+async def update_plugin_settings_endpoint(
+    request: Request,
+    body: PluginSettingsUpdateRequest,
+    admin: UserRead | None = Depends(get_admin_user),
+) -> Response:
+```
+
+The route `await`s `update_plugin_settings`, then calls
+`submit_update_single(..., install=False, version=None)` to trigger a
+re-ingest without a pip install. Returns the 202 `get_catalogue_redirect`
+pattern.
+
+## Settings / DB helper signatures
+
+```python
+# domain/plugin/db.py
+async def update_plugin_settings(
+    *,
+    plugin_id: str,
+    excluded_templates: list[str] | None,
+    glyph_remapping: dict[str, str] | None,
+) -> None: ...
+
+async def get_plugin_settings(plugin_id: str) -> tuple[list[str], dict[str, str]]: ...
+```
+
+`update_plugin_settings` is a partial update: `None` means "leave stored value
+unchanged".  An empty list/dict explicitly clears.  If no row exists yet, a new
+row is inserted with `plugin_version="not installed"` and provided settings (or
+empty defaults for omitted fields).
+
+## Exclusion seam in `_ingest_plugin_templates`
+
+```python
+excluded_templates, _glyph_remapping = await get_plugin_settings(plugin_id_str)
+excluded_set = set(excluded_templates)
+
+for template in plugin.blueprint_templates:
+    if template.display_name in excluded_set:
+        await soft_delete_plugin_template(created_by=plugin_id_str, display_name=template.display_name)
+        continue
+    # ... upsert as before
+```
+
+`_glyph_remapping` is intentionally unused here; the underscore prefix signals
+that task 05 should replace it with an application step between
+`template_to_builder(template, plugin_id)` and the `upsert_blueprint` call.
+
+## Where task 05 applies remapping
+
+In `_ingest_plugin_templates`, immediately after:
+
+```python
+builder = template_to_builder(template, plugin_id)
+```
+
+task 05 should apply `_glyph_remapping` to rewrite glyph names in `builder`
+before calling `upsert_blueprint`.  The variable `_glyph_remapping` (currently
+a `dict[str, str]`) is already in scope at that point; task 05 only needs to
+rename it to `glyph_remapping` (remove the leading underscore) and add the
+application logic.
+
+## Re-inclusion semantics for previously-excluded templates
+
+When a template is re-included after having been excluded (soft-deleted),
+`find_plugin_template_id` returns `None` (it ignores soft-deleted rows).  The
+upsert therefore creates a fresh blueprint with a new UUID.  The old
+soft-deleted rows remain untouched (historical references via pinned
+`blueprint_id` + version remain resolvable).
+
+## Deviations from plan
+
+* `update_plugin_settings` creates rows with sentinel `plugin_version="not
+  installed"` when no state exists yet.  This matches the pattern already
+  established by `upsert_plugin_state` which uses `"install failed"` for failed
+  installs.
+* The integration test uses a new `backend_admin_client` session fixture
+  (separate httpx.Client) rather than reusing `backend_client_with_auth`.
+  This avoids cookie-state interference between the shared clients.  The
+  fixture relies on `admin@somewhere.org` being a superuser (registered first
+  by `test_admin_flows.py`), consistent with the existing known ordering
+  dependency in the test suite.
+
+## What task 05 will build on
+
+* `get_plugin_settings(plugin_id) -> (list[str], dict[str, str])` -- already
+  called in `_ingest_plugin_templates`; task 05 uses the returned
+  `glyph_remapping` dict to rewrite glyph names.
+* `_glyph_remapping` variable in `_ingest_plugin_templates` -- rename to
+  `glyph_remapping` and apply it to the builder.
+* `update_plugin_settings` -- task 05 can call it (or call
+  `domain/plugin/db.py`'s `update` directly) to write the `glyph_remapping`
+  column via the same settings route; no new DB helpers needed.

--- a/docs/developer/changeSpecs/core-plugin_assets-05-result_summary.md
+++ b/docs/developer/changeSpecs/core-plugin_assets-05-result_summary.md
@@ -1,0 +1,100 @@
+# Task 05 -- Result Summary
+
+## What was implemented
+
+Glyph-name remapping is now applied at install time: when a plugin's stored
+`glyph_remapping` is non-empty, every non-excluded template's builder has its
+glyph identifier references rewritten before the DB upsert.
+
+### Key files added / changed
+
+* `backend/src/forecastbox/domain/glyphs/resolution.py` -- added
+  `remap_glyph_names(value, mapping) -> str`.
+* `backend/src/forecastbox/domain/blueprint/service.py` -- added
+  `remap_builder_glyphs(builder, mapping) -> BlueprintBuilder`; also imported
+  `remap_glyph_names` from the glyphs domain.
+* `backend/src/forecastbox/domain/plugin/manager.py` -- wired remapping into
+  `_ingest_plugin_templates`: renamed `_glyph_remapping` to `glyph_remapping`,
+  added `remap_builder_glyphs` to the lazy import, and applied it to each
+  non-excluded builder when the remapping is non-empty.
+* `backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py` -- added
+  `_testRemapping` template and exposed it via the `plugin` lambda.
+* `backend/tests/unit/domain/glyphs/test_resolution.py` -- added 13 focused
+  unit tests for `remap_glyph_names`.
+* `backend/tests/unit/domain/blueprint/test_blueprint_service.py` -- added 2
+  unit tests for `remap_builder_glyphs`.
+* `backend/tests/integration/test_blueprint.py` -- extended
+  `test_plugin_template_exclusion` to also set `glyph_remapping` and assert the
+  renamed glyph appears in the persisted builder for `testRemapping`.
+
+## Function signatures
+
+```python
+# backend/src/forecastbox/domain/glyphs/resolution.py
+def remap_glyph_names(value: str, mapping: dict[str, str]) -> str:
+    ...
+```
+
+Rewrites glyph identifier names referenced inside `${...}` expressions of
+`value` according to `mapping`.  Only names returned by `extract_glyph_names`
+(AST-level variable identifiers, excluding filter and global names) are
+candidates; everything else is left untouched.
+
+```python
+# backend/src/forecastbox/domain/blueprint/service.py
+def remap_builder_glyphs(builder: BlueprintBuilder, mapping: dict[str, str]) -> BlueprintBuilder:
+    ...
+```
+
+Returns a new `BlueprintBuilder` with:
+* every block configuration-option value run through `remap_glyph_names`;
+* every local-glyph value run through `remap_glyph_names`;
+* every local-glyph key renamed if it is a key in `mapping`.
+
+Returns the same object unchanged when `mapping` is empty.
+
+## Substitution strategy and guarantees
+
+`remap_glyph_names` uses a two-level regex pass:
+
+1. Outer: `re.sub` over `\$\{([^}]+)\}` -- processes each `${...}` expression
+   once, left to right, without re-scanning the result.
+2. Inner: for each matched expression body, a single `re.sub` replaces all
+   identifier tokens in `to_rename` at once using a union pattern
+   `\b(name1|name2|...)\b`, where names are ordered longest-first to avoid
+   prefix-ambiguity in alternation.
+
+The non-recursive, no-double-application guarantee follows from `re.sub`
+semantics: replacement strings are not re-scanned by the engine.  Mapping
+`{"a": "b", "b": "c"}` on `${a}` yields `${b}`, not `${c}`.
+
+Filter and global names (e.g. `floor_day`, `timedelta`) are already excluded
+by `extract_glyph_names` and are therefore never touched by the inner pass.
+
+## Where in ingestion the remap runs
+
+In `_ingest_plugin_templates` (in `domain/plugin/manager.py`), for each
+non-excluded template:
+
+```python
+builder = template_to_builder(template, plugin_id)
+if glyph_remapping:
+    builder = remap_builder_glyphs(builder, glyph_remapping)
+# then upsert_blueprint(... builder ...)
+```
+
+This is after exclusion filtering and before the DB upsert.  Task 06 inserts
+its validation step immediately after the `remap_builder_glyphs` call.
+
+## Deviations from plan
+
+None.  The implementation follows the plan verbatim.
+
+## What task 06 will build on
+
+* `remap_builder_glyphs` and `remap_glyph_names` -- already applied; task 06
+  does not need to touch remapping.
+* The seam in `_ingest_plugin_templates` after the remapping call is where task
+  06 inserts its `validate_with_examples` step before `upsert_blueprint`.
+* `_testRemapping` is now in the test plugin; it references `pluginGlyphOld`
+  (renamed to `pluginGlyphNew` in the integration test settings fixture).

--- a/docs/developer/changeSpecs/core-plugin_assets-06-result_summary.md
+++ b/docs/developer/changeSpecs/core-plugin_assets-06-result_summary.md
@@ -1,0 +1,126 @@
+# Task 06 -- Result Summary
+
+## What was implemented
+
+Template ingestion is now gated behind validation.  After exclusion and glyph
+remapping, each template's builder is overlaid with the template's example
+values and example glyphs, then run through `validate_expand(validate_only=True)`
+before any DB upsert.  Templates that fail are skipped and their errors are
+collected and persisted.  The plugin status endpoint surfaces them under a new
+`plugin_template_errors` field.
+
+### Key files added / changed
+
+* `backend/src/forecastbox/domain/blueprint/service.py` -- added
+  `resolve_builder_with_examples(builder, example_values, example_glyphs) -> BlueprintBuilder`.
+* `backend/src/forecastbox/domain/plugin/db.py` -- added
+  `update_template_errors(*, plugin_id, template_errors) -> None`.
+* `backend/src/forecastbox/domain/plugin/manager.py` -- several changes:
+  - `_ingest_plugin_templates`: wired in `resolve_builder_with_examples` +
+    `validate_expand(validate_only=True)` before upsert; collects
+    `template_errors`; calls `update_template_errors` after the loop.
+  - `load_plugins`: restructured to a two-pass approach -- all plugins are
+    installed/loaded and `PluginManager.plugins` is published before template
+    ingestion starts.  This ensures `validate_expand` can resolve factory
+    references during validation.
+  - `PluginsStatus`: added `plugin_template_errors` field.
+  - `status_full`: populates `plugin_template_errors` from
+    `PluginState.template_errors`.
+* `backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py` --
+  added `_testFailValidation` template (references `nonexistent_factory`;
+  always fails validation).
+* `backend/tests/unit/domain/blueprint/test_blueprint_service.py` -- added 5
+  unit tests for `resolve_builder_with_examples`.
+* `backend/tests/integration/test_blueprint.py` -- added
+  `test_plugin_template_validation_failure` integration test.
+
+## `resolve_builder_with_examples` contract
+
+```python
+# backend/src/forecastbox/domain/blueprint/service.py
+def resolve_builder_with_examples(
+    builder: BlueprintBuilder,
+    example_values: dict[BlockInstanceId, dict[ConfigurationOptionId, str]],
+    example_glyphs: dict[str, str],
+) -> BlueprintBuilder:
+```
+
+Returns a deep copy of `builder` with:
+
+* Each block's missing `configuration_values` keys filled from
+  `example_values[block_id]`; existing template values are never overwritten.
+* `local_glyphs` extended by `example_glyphs` for any key absent from the
+  template's own `local_glyphs`; existing local glyphs take precedence.
+
+The function is pure: the caller's `builder` is never mutated.
+
+## Pass/fail criteria
+
+A template is considered failed if `validate_expand(validate_only=True)` returns
+any non-empty `global_errors` list OR any entry in `block_errors` with at least
+one error string.  The missing-glyphs soft path does not count as a hard failure
+(missing glyph references are stripped from the block and reported separately).
+On pass, any prior error recorded for that `display_name` is cleared (not
+present in the dict written to `template_errors`).
+
+An unexpected exception during per-template resolve+validate is also treated as
+a failure: the `repr()` of the exception becomes that template's error string,
+and ingestion continues with the remaining templates.
+
+## Example value overlay precedence
+
+"Example fills missing, does not clobber" -- chosen because example values are
+documented as guiding defaults that the user is expected to override.  A value
+already set in the template's `configuration_values` (e.g. a partial default the
+plugin author wants locked in) must not be silently overwritten by an example.
+
+## Load ordering change in `load_plugins`
+
+The original `load_plugins` interleaved install, state-upsert, and template
+ingestion in a single per-plugin loop, with `PluginManager.plugins` published
+only at the end.  During validation, `validate_expand` reads
+`PluginManager.plugins` to resolve factory references; since the plugin was not
+yet published, every block reported "Plugin not found".
+
+The fix restructures `load_plugins` into two passes:
+1. Install + load all plugins; call `upsert_plugin_state` per plugin.
+2. Publish `PluginManager.plugins = pmap(lookup)`.
+3. Run `_ingest_plugin_templates` for each loaded plugin.
+
+The updater thread remains alive throughout, so `status_brief()` still reports
+"running" until the full process (including ingestion) completes.  No change was
+needed for `update_single`, where the plugin is already published before
+ingestion.
+
+## How template errors are surfaced
+
+`PluginState.template_errors` (JSON column added in task 02) stores a
+`dict[str, str]` mapping `display_name` to error string, or `None` when all
+templates validated successfully.  `status_full` reads this column and populates
+`PluginsStatus.plugin_template_errors: dict[PluginCompositeId, dict[str, str]]`.
+The field is omitted from the JSON response for plugins with no errors (Pydantic
+default_factory).
+
+Note: `PluginCompositeId` dict keys in `PluginsStatus` are serialized using
+Python's `str()` of the frozen Pydantic model (e.g.
+`"store='localTest' local='single'"`), not the `store:local` colon format
+returned by `PluginCompositeId.to_str()`.  This is consistent with the existing
+`plugin_errors` / `plugin_versions` fields.  Client code should use `str(plugin_id)`
+to construct the lookup key.
+
+## Deviations from plan
+
+* `load_plugins` was restructured (two-pass) rather than using a temporary
+  `PluginManager.plugins` mutation inside `_ingest_plugin_templates`.  The
+  two-pass approach is cleaner and keeps all validation concerns inside the
+  ingestion function.
+
+## Follow-ups
+
+* `PluginsStatus` dict keys should ideally use `PluginCompositeId.to_str()` as
+  the serialized string (e.g. `"localTest:single"`).  This would require a
+  custom Pydantic serializer on `PluginsStatus` or on `PluginCompositeId`
+  itself, and affects all existing fields, so it is left as a separate cleanup.
+* The lazy-import breach (plugin domain importing blueprint domain) noted in
+  task 03 is still present; the planned refactor to an event/bus pattern remains
+  deferred.


### PR DESCRIPTION
feat(plugin): plugin-owned blueprint templates

Plugins can now ship blueprint templates -- partial, ready-to-customise graphs that are ingested into the blueprints table at install time and made available to all users as starting points.

## What was added

### fiab-core contract

- New `BlueprintTemplate` entity exposing the public subset of a blueprint builder: `display_name`, `display_description`, `blocks`, `environment` (only `environment_variables`), `local_glyphs`, `example_values`, and `example_glyphs`. Tags and infrastructure fields are intentionally excluded.
- `SelfPluginId` sentinel so plugin code can reference its own factories without knowing its composite ID at authoring time; the backend substitutes the real ID at install time. **Note**: this is a hack. I will later remove the whole PluginId business from the plugin's PoV
- `Plugin.blueprint_templates` field (defaults to empty tuple, fully backwards compatible).
- Four test templates added to `fiab-plugin-test` covering the core scenarios: fixed values, glyph substitution, exclusion, glyph remapping, and deliberate validation failure.

### Backend persistence (plugin install state)

- New `plugin_state` DB table (one row per plugin) storing installed version, timestamp, install error, per-plugin settings (`excluded_templates`, `glyph_remapping`, `enabled`), and per-template validation errors.
- Plugin version and install timestamp are no longer held in memory; they are written to the DB at install time and read back by `GET /plugins/status`. Install errors now survive app restarts.
- Plugin install is guarded by the existing `PluginManager` lock, keeping it atomic.

### Template ingestion

- On every install or re-ingest, each non-excluded template is converted to a `BlueprintBuilder`, glyph names are rewritten per the stored remapping, and the result is validated with `validate_expand(validate_only=True)` after overlaying `example_values`/`example_glyphs`. Templates that fail validation are skipped and their errors are recorded in `plugin_state.template_errors`, which surfaces in the status endpoint.
- Upsert semantics keyed on `(created_by, display_name)`: the same `blueprint_id` is reused across plugin updates so that past runs and user-derived blueprints remain valid. Excluded templates are soft-deleted.

### Settings route

- `POST /plugins/settings` (admin only) persists `excluded_templates` and/or `glyph_remapping` with partial-update semantics (`null` means "leave unchanged", empty list/dict means "clear"), then immediately triggers a re-ingest without reinstalling the pip package.
- toggling `modifyEnabled` to disabled causes all the templates to be deleted as well
- the plugin details route now additionally returns excluded templates and glyph remapping

### Glyph remapping

- `remap_glyph_names` (in `domain/glyphs/resolution`) performs a single non-recursive pass over `${...}` expressions, renaming only AST-level variable identifiers at word boundaries -- filter and global names are untouched.
- `remap_builder_glyphs` (in `domain/blueprint/service`) applies this to every configuration value and to both keys and values of `local_glyphs`.

### Config

- the `enabled` settings for plugin got removed, because it is now on the DB level. This is a **breaking** change -- configs with this field will refuse to load.

## Notes

- `status_full()` became `async`; both call sites in the plugins router updated accordingly.
- There is a known circular dependency between the `plugin` and `blueprint` domains, mitigated with lazy imports and documented in both module docstrings. It will be resolved in a future refactoring towards an event-driven model.
- Filtering the blueprint list by source/plugin is deferred to a subsequent PR.