### PR TITLE
Add GET /plugin/templateExampleValues route

### DIFF
--- a/backend/src/forecastbox/domain/glyphs/__init__.py
+++ b/backend/src/forecastbox/domain/glyphs/__init__.py
@@ -4,7 +4,5 @@ user can use the Key across all their Blueprints, and these are then replaced
 by the Value at runtime when executing a Run. This facilitates value reusal.
 
 Depends on no other domain.
-Depended on by Blueprint, Experiment, and Run (each of them needs to resolve Glyphs).
-Also depended on by the Plugin route (``routes/plugins.py``) for ``remap_glyph_names``,
-used when serving template example values via ``/plugin/templateExampleValues``.
+Depended on by Blueprint, Experiment, and Run (each of them needs to resolve Glyphs), and Plugin (for glyph remapping).
 """

--- a/backend/src/forecastbox/domain/glyphs/__init__.py
+++ b/backend/src/forecastbox/domain/glyphs/__init__.py
@@ -5,4 +5,6 @@ by the Value at runtime when executing a Run. This facilitates value reusal.
 
 Depends on no other domain.
 Depended on by Blueprint, Experiment, and Run (each of them needs to resolve Glyphs).
+Also depended on by the Plugin route (``routes/plugins.py``) for ``remap_glyph_names``,
+used when serving template example values via ``/plugin/templateExampleValues``.
 """

--- a/backend/src/forecastbox/domain/plugin/__init__.py
+++ b/backend/src/forecastbox/domain/plugin/__init__.py
@@ -5,12 +5,8 @@ building and validation, and Run execution.
 Now also owns persisted install state: each configured plugin's install outcome (version, timestamp,
 install error) is recorded in the ``plugin_state`` DB table via ``domain/plugin/db.py``.
 
-Depends on no other domain.
+Depends on Glyph domain (for glyph remapping).
 Depended on by Blueprint and Run domains -- they need to extract individual plugin validations and compilers, and to validate fiab-core version.
 
 Note: there is a dependency circularity where this domain *depends on* Blueprint, for validating imported blueprint templates and for remapping glyph names in those templates. This will be fixed later by refactoring into events.
-
-Note: the plugin route (``routes/plugins.py``) depends on the Glyph domain (``domain/glyphs``) for
-``remap_glyph_names``, used to apply glyph remapping to template example values and glyphs in the
-``/plugin/templateExampleValues`` endpoint.
 """

--- a/backend/src/forecastbox/domain/plugin/__init__.py
+++ b/backend/src/forecastbox/domain/plugin/__init__.py
@@ -9,4 +9,8 @@ Depends on no other domain.
 Depended on by Blueprint and Run domains -- they need to extract individual plugin validations and compilers, and to validate fiab-core version.
 
 Note: there is a dependency circularity where this domain *depends on* Blueprint, for validating imported blueprint templates and for remapping glyph names in those templates. This will be fixed later by refactoring into events.
+
+Note: the plugin route (``routes/plugins.py``) depends on the Glyph domain (``domain/glyphs``) for
+``remap_glyph_names``, used to apply glyph remapping to template example values and glyphs in the
+``/plugin/templateExampleValues`` endpoint.
 """

--- a/backend/src/forecastbox/routes/plugins.py
+++ b/backend/src/forecastbox/routes/plugins.py
@@ -22,9 +22,17 @@ from fiab_core.fable import PluginCompositeId
 from packaging.version import InvalidVersion, Version
 
 from forecastbox.domain.auth.users import UserRead
+from forecastbox.domain.glyphs.resolution import remap_glyph_names
 from forecastbox.domain.plugin.compatibility import get_compatible_versions
-from forecastbox.domain.plugin.db import upsert_plugin_state
-from forecastbox.domain.plugin.manager import PluginsStatus, status_full, submit_update_single, uninstall_plugin, unload_single
+from forecastbox.domain.plugin.db import get_plugin_state, upsert_plugin_state
+from forecastbox.domain.plugin.manager import (
+    PluginManager,
+    PluginsStatus,
+    status_full,
+    submit_update_single,
+    uninstall_plugin,
+    unload_single,
+)
 from forecastbox.domain.plugin.store import PluginRemoteInfo, PluginStoreEntry, get_plugins_detail, submit_install_plugin
 from forecastbox.routes.admin import get_admin_user
 from forecastbox.utility.config import PluginSettings, config
@@ -226,3 +234,55 @@ async def update_plugin_settings_endpoint(
     if result:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=result)
     return get_catalogue_redirect(request)
+
+
+class TemplateExampleValuesResponse(FiabBaseModel):
+    example_values: dict[str, dict[str, str]]
+    """Per-block example configuration values, keyed by block instance id then option id."""
+    example_glyphs: dict[str, str]
+    """Example glyph name-to-value pairs the user is expected to override."""
+
+
+@router.get("/templateExampleValues")
+async def get_template_example_values(
+    pluginCompositeId: Annotated[PluginCompositeId, Depends()],
+    displayName: str,
+) -> TemplateExampleValuesResponse:
+    """Return example_values and example_glyphs for a specific blueprint template from a loaded plugin.
+
+    Applies any stored glyph remapping to both the values and keys of the example data,
+    mirroring the remapping applied during template ingestion.
+
+    Returns 404 if the plugin is not loaded or the display name is not found.
+    Returns 403 if the template is excluded by admin settings.
+    """
+    plugin = PluginManager.plugins.get(pluginCompositeId)
+    if plugin is None:
+        raise HTTPException(status_code=404, detail=f"Plugin {PluginCompositeId.to_str(pluginCompositeId)!r} not loaded")
+
+    template = next((t for t in plugin.blueprint_templates if t.display_name == displayName), None)
+    if template is None:
+        raise HTTPException(
+            status_code=404, detail=f"Template {displayName!r} not found in plugin {PluginCompositeId.to_str(pluginCompositeId)!r}"
+        )
+
+    plugin_id_str = PluginCompositeId.to_str(pluginCompositeId)
+    plugin_state = await get_plugin_state(plugin_id_str)
+    excluded_set: set[str] = set(plugin_state.excluded_templates) if plugin_state and plugin_state.excluded_templates else set()  # type: ignore[arg-type]
+    if displayName in excluded_set:
+        raise HTTPException(status_code=403, detail=f"Template {displayName!r} is excluded")
+
+    glyph_remapping: dict[str, str] = dict(plugin_state.glyph_remapping) if plugin_state and plugin_state.glyph_remapping else {}  # type: ignore[no-matching-overload]
+
+    remapped_example_values: dict[str, dict[str, str]] = {
+        block_id: {opt_id: remap_glyph_names(val, glyph_remapping) for opt_id, val in opts.items()}
+        for block_id, opts in template.example_values.items()
+    }
+    remapped_example_glyphs: dict[str, str] = {
+        glyph_remapping.get(key, key): remap_glyph_names(val, glyph_remapping) for key, val in template.example_glyphs.items()
+    }
+
+    return TemplateExampleValuesResponse(
+        example_values=remapped_example_values,
+        example_glyphs=remapped_example_glyphs,
+    )

--- a/backend/src/forecastbox/routes/plugins.py
+++ b/backend/src/forecastbox/routes/plugins.py
@@ -18,7 +18,7 @@ from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import Response
-from fiab_core.fable import PluginCompositeId
+from fiab_core.fable import BlockInstanceId, ConfigurationOptionId, PluginCompositeId
 from packaging.version import InvalidVersion, Version
 
 from forecastbox.domain.auth.users import UserRead
@@ -237,7 +237,7 @@ async def update_plugin_settings_endpoint(
 
 
 class TemplateExampleValuesResponse(FiabBaseModel):
-    example_values: dict[str, dict[str, str]]
+    example_values: dict[BlockInstanceId, dict[ConfigurationOptionId, str]]
     """Per-block example configuration values, keyed by block instance id then option id."""
     example_glyphs: dict[str, str]
     """Example glyph name-to-value pairs the user is expected to override."""
@@ -268,11 +268,13 @@ async def get_template_example_values(
 
     plugin_id_str = PluginCompositeId.to_str(pluginCompositeId)
     plugin_state = await get_plugin_state(plugin_id_str)
-    excluded_set: set[str] = set(plugin_state.excluded_templates) if plugin_state and plugin_state.excluded_templates else set()  # type: ignore[arg-type]
+    if plugin_state is None:
+        raise HTTPException(status_code=404, detail=f"Plugin {PluginCompositeId.to_str(pluginCompositeId)!r} not installed")
+    excluded_set: set[str] = set(plugin_state.excluded_templates) if plugin_state.excluded_templates else set()  # type: ignore[arg-type]
     if displayName in excluded_set:
         raise HTTPException(status_code=403, detail=f"Template {displayName!r} is excluded")
 
-    glyph_remapping: dict[str, str] = dict(plugin_state.glyph_remapping) if plugin_state and plugin_state.glyph_remapping else {}  # type: ignore[no-matching-overload]
+    glyph_remapping: dict[str, str] = dict(plugin_state.glyph_remapping) if plugin_state.glyph_remapping else {}  # type: ignore[no-matching-overload]
 
     remapped_example_values: dict[str, dict[str, str]] = {
         block_id: {opt_id: remap_glyph_names(val, glyph_remapping) for opt_id, val in opts.items()}
@@ -283,6 +285,6 @@ async def get_template_example_values(
     }
 
     return TemplateExampleValuesResponse(
-        example_values=remapped_example_values,
+        example_values=remapped_example_values,  # ty:ignore[invalid-argument-type]
         example_glyphs=remapped_example_glyphs,
     )

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -316,6 +316,22 @@ def test_plugin_template_exclusion(backend_client_with_auth: httpx.Client, backe
     )
     assert response.status_code == 403, f"Expected 403 for excluded testExclusion, got: {response.status_code} {response.text}"
 
+    # Unknown display name in a known plugin -> 404.
+    response = backend_client_with_auth.get(
+        "/plugin/templateExampleValues",
+        params={"store": testPluginId.store, "local": testPluginId.local, "displayName": "doesNotExist"},
+        timeout=10,
+    )
+    assert response.status_code == 404, f"Expected 404 for unknown displayName, got: {response.status_code} {response.text}"
+
+    # Unknown plugin -> 404.
+    response = backend_client_with_auth.get(
+        "/plugin/templateExampleValues",
+        params={"store": "unknownStore", "local": "unknownPlugin", "displayName": "testBasic"},
+        timeout=10,
+    )
+    assert response.status_code == 404, f"Expected 404 for unknown plugin, got: {response.status_code} {response.text}"
+
     # Verify that the glyph remapping was applied to testRemapping.
     remap_item = next(b for b in blueprints if b.get("display_name") == "testRemapping")
     remap_id = remap_item["blueprint_id"]
@@ -335,27 +351,6 @@ def test_plugin_template_exclusion(backend_client_with_auth: httpx.Client, backe
     assert "localNew" in local_glyphs, f"Expected localNew in local_glyphs after remapping, got: {local_glyphs}"
     assert "localOld" not in local_glyphs, f"localOld should have been renamed, got: {local_glyphs}"
     assert "pluginGlyphNew" in local_glyphs.get("localNew", ""), f"Expected localNew value to reference pluginGlyphNew, got: {local_glyphs}"
-
-
-def test_template_example_values_not_found(backend_client_with_auth: httpx.Client) -> None:
-    """Non-existent display name and non-existent plugin return 404 from templateExampleValues."""
-    from .conftest import testPluginId
-
-    # Unknown display name in a known plugin -> 404.
-    response = backend_client_with_auth.get(
-        "/plugin/templateExampleValues",
-        params={"store": testPluginId.store, "local": testPluginId.local, "displayName": "doesNotExist"},
-        timeout=10,
-    )
-    assert response.status_code == 404, f"Expected 404 for unknown displayName, got: {response.status_code} {response.text}"
-
-    # Unknown plugin -> 404.
-    response = backend_client_with_auth.get(
-        "/plugin/templateExampleValues",
-        params={"store": "unknownStore", "local": "unknownPlugin", "displayName": "testBasic"},
-        timeout=10,
-    )
-    assert response.status_code == 404, f"Expected 404 for unknown plugin, got: {response.status_code} {response.text}"
 
 
 def test_plugin_template_validation_failure(backend_client_with_auth: httpx.Client) -> None:

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -212,6 +212,7 @@ def test_blueprint_upsert_nonexistent_id(backend_client_with_auth: httpx.Client)
 
 def test_plugin_template_in_blueprint_list(backend_client_with_auth: httpx.Client) -> None:
     """Verify that the testBasic plugin template appears in the blueprint list after startup."""
+    from .conftest import testPluginId
 
     def do_action() -> dict:
         response = backend_client_with_auth.get("/plugin/status", timeout=10)
@@ -244,6 +245,18 @@ def test_plugin_template_in_blueprint_list(backend_client_with_auth: httpx.Clien
     assert any(b.get("display_name") == "testBasic" for b in owner_filtered), (
         f"testBasic should appear when filtered by created_by=localTest:single, got: {owner_filtered}"
     )
+
+    # The templateExampleValues route returns the correct examples for testBasic.
+    response = backend_client_with_auth.get(
+        "/plugin/templateExampleValues",
+        params={"store": testPluginId.store, "local": testPluginId.local, "displayName": "testBasic"},
+        timeout=10,
+    )
+    assert response.is_success, f"Expected 200 for testBasic example values, got: {response.status_code} {response.text}"
+    data = response.json()
+    assert "example_values" in data
+    assert "example_glyphs" in data
+    assert data["example_glyphs"].get("name") == "world", f"Expected name=world in example_glyphs, got: {data['example_glyphs']}"
 
 
 def test_plugin_template_exclusion(backend_client_with_auth: httpx.Client, backend_admin_client: httpx.Client) -> None:
@@ -295,6 +308,14 @@ def test_plugin_template_exclusion(backend_client_with_auth: httpx.Client, backe
     assert "testBasic" in names, f"testBasic should still be present, but found: {names}"
     assert "testRemapping" in names, f"testRemapping should be present, but found: {names}"
 
+    # Excluded template must return 403 from templateExampleValues.
+    response = backend_client_with_auth.get(
+        "/plugin/templateExampleValues",
+        params={"store": testPluginId.store, "local": testPluginId.local, "displayName": "testExclusion"},
+        timeout=10,
+    )
+    assert response.status_code == 403, f"Expected 403 for excluded testExclusion, got: {response.status_code} {response.text}"
+
     # Verify that the glyph remapping was applied to testRemapping.
     remap_item = next(b for b in blueprints if b.get("display_name") == "testRemapping")
     remap_id = remap_item["blueprint_id"]
@@ -314,6 +335,27 @@ def test_plugin_template_exclusion(backend_client_with_auth: httpx.Client, backe
     assert "localNew" in local_glyphs, f"Expected localNew in local_glyphs after remapping, got: {local_glyphs}"
     assert "localOld" not in local_glyphs, f"localOld should have been renamed, got: {local_glyphs}"
     assert "pluginGlyphNew" in local_glyphs.get("localNew", ""), f"Expected localNew value to reference pluginGlyphNew, got: {local_glyphs}"
+
+
+def test_template_example_values_not_found(backend_client_with_auth: httpx.Client) -> None:
+    """Non-existent display name and non-existent plugin return 404 from templateExampleValues."""
+    from .conftest import testPluginId
+
+    # Unknown display name in a known plugin -> 404.
+    response = backend_client_with_auth.get(
+        "/plugin/templateExampleValues",
+        params={"store": testPluginId.store, "local": testPluginId.local, "displayName": "doesNotExist"},
+        timeout=10,
+    )
+    assert response.status_code == 404, f"Expected 404 for unknown displayName, got: {response.status_code} {response.text}"
+
+    # Unknown plugin -> 404.
+    response = backend_client_with_auth.get(
+        "/plugin/templateExampleValues",
+        params={"store": "unknownStore", "local": "unknownPlugin", "displayName": "testBasic"},
+        timeout=10,
+    )
+    assert response.status_code == 404, f"Expected 404 for unknown plugin, got: {response.status_code} {response.text}"
 
 
 def test_plugin_template_validation_failure(backend_client_with_auth: httpx.Client) -> None:

--- a/backend/tests/unit/routes/test_plugins.py
+++ b/backend/tests/unit/routes/test_plugins.py
@@ -9,16 +9,32 @@
 
 """Unit tests for plugin route helpers — version/specifier parsing logic and /versions route."""
 
-from unittest.mock import patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.exceptions import HTTPException
-from fiab_core.fable import PluginCompositeId, PluginId, PluginStoreId
+from fiab_core.fable import (
+    BlockFactory,
+    BlockFactoryCatalogue,
+    BlockFactoryId,
+    BlockInstance,
+    BlockInstanceId,
+    BlueprintTemplate,
+    ConfigurationOptionId,
+    PluginBlockFactoryId,
+    PluginCompositeId,
+    PluginId,
+    PluginStoreId,
+    SelfPluginId,
+)
+from fiab_core.plugin import Plugin
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
+from pyrsistent import pmap
 
 from forecastbox.domain.plugin.store import PluginRemoteInfo, PluginStoreEntry
-from forecastbox.routes.plugins import get_plugin_versions
+from forecastbox.routes.plugins import get_plugin_versions, get_template_example_values
 from forecastbox.utility.config import PluginSettings
 
 # ---------------------------------------------------------------------------
@@ -168,3 +184,111 @@ def test_versions_pip_source_passed_to_get_package_versions() -> None:
         with patch("forecastbox.routes.plugins.get_package_versions", return_value=iter([])) as mock_gpv:
             get_plugin_versions(_COMPOSITE_ID)
     mock_gpv.assert_called_once_with("fiab-plugin-ecmwf")
+
+
+# ---------------------------------------------------------------------------
+# /templateExampleValues route
+# ---------------------------------------------------------------------------
+
+_PLUGIN_ID = PluginCompositeId(store=PluginStoreId("test"), local=PluginId("plugin"))
+_TEXT = ConfigurationOptionId("text")
+_BLOCK_A = BlockInstanceId("block_a")
+
+_TEMPLATE_WITH_EXAMPLES = BlueprintTemplate(
+    display_name="myTemplate",
+    display_description="desc",
+    blocks={
+        _BLOCK_A: BlockInstance(
+            factory_id=PluginBlockFactoryId(plugin=SelfPluginId, factory=BlockFactoryId("source_text")),
+            configuration_values={_TEXT: "fixed"},
+            input_ids={},
+        ),
+    },
+    example_values={_BLOCK_A: {_TEXT: "${exampleGlyph}"}},
+    example_glyphs={"exampleGlyph": "hello world"},
+)
+
+_TEMPLATE_NO_EXAMPLES = BlueprintTemplate(
+    display_name="noExamples",
+    display_description="desc",
+    blocks={},
+)
+
+
+def _make_plugin(*templates: BlueprintTemplate) -> Plugin:
+    return Plugin(
+        catalogue=BlockFactoryCatalogue(factories={}),
+        validator=lambda inst, inputs: (_ for _ in ()).throw(NotImplementedError),  # type: ignore[return-value]
+        expander=lambda output: [],
+        compiler=lambda lookup, inst: (_ for _ in ()).throw(NotImplementedError),  # type: ignore[return-value]
+        blueprint_templates=templates,
+    )
+
+
+def _make_plugin_state(excluded: list[str] | None = None, remapping: dict[str, str] | None = None) -> MagicMock:
+    state = MagicMock()
+    state.excluded_templates = excluded or []
+    state.glyph_remapping = remapping or {}
+    return state
+
+
+def _run(coro: object) -> object:  # type: ignore[type-arg]
+    return asyncio.run(coro)  # type: ignore[arg-type]
+
+
+def test_template_example_values_returns_examples() -> None:
+    plugin = _make_plugin(_TEMPLATE_WITH_EXAMPLES)
+    state = _make_plugin_state()
+    with (
+        patch("forecastbox.routes.plugins.PluginManager") as mock_pm,
+        patch("forecastbox.routes.plugins.get_plugin_state", new=AsyncMock(return_value=state)),
+    ):
+        mock_pm.plugins = pmap({_PLUGIN_ID: plugin})
+        result = _run(get_template_example_values(_PLUGIN_ID, "myTemplate"))
+    assert result.example_values == {_BLOCK_A: {_TEXT: "${exampleGlyph}"}}
+    assert result.example_glyphs == {"exampleGlyph": "hello world"}
+
+
+def test_template_example_values_applies_remapping() -> None:
+    plugin = _make_plugin(_TEMPLATE_WITH_EXAMPLES)
+    state = _make_plugin_state(remapping={"exampleGlyph": "renamedGlyph"})
+    with (
+        patch("forecastbox.routes.plugins.PluginManager") as mock_pm,
+        patch("forecastbox.routes.plugins.get_plugin_state", new=AsyncMock(return_value=state)),
+    ):
+        mock_pm.plugins = pmap({_PLUGIN_ID: plugin})
+        result = _run(get_template_example_values(_PLUGIN_ID, "myTemplate"))
+    # Key renamed, value's glyph reference renamed
+    assert result.example_glyphs == {"renamedGlyph": "hello world"}
+    # The example_value string referencing ${exampleGlyph} must be rewritten
+    assert result.example_values[_BLOCK_A][_TEXT] == "${renamedGlyph}"
+
+
+def test_template_example_values_404_unknown_plugin() -> None:
+    with patch("forecastbox.routes.plugins.PluginManager") as mock_pm:
+        mock_pm.plugins = pmap()
+        with pytest.raises(HTTPException) as exc_info:
+            _run(get_template_example_values(_PLUGIN_ID, "myTemplate"))
+    assert exc_info.value.status_code == 404
+
+
+def test_template_example_values_404_unknown_display_name() -> None:
+    plugin = _make_plugin(_TEMPLATE_WITH_EXAMPLES)
+    with patch("forecastbox.routes.plugins.PluginManager") as mock_pm:
+        mock_pm.plugins = pmap({_PLUGIN_ID: plugin})
+        with pytest.raises(HTTPException) as exc_info:
+            _run(get_template_example_values(_PLUGIN_ID, "nonExistent"))
+    assert exc_info.value.status_code == 404
+
+
+def test_template_example_values_403_excluded() -> None:
+    plugin = _make_plugin(_TEMPLATE_WITH_EXAMPLES)
+    state = _make_plugin_state(excluded=["myTemplate"])
+    with (
+        patch("forecastbox.routes.plugins.PluginManager") as mock_pm,
+        patch("forecastbox.routes.plugins.get_plugin_state", new=AsyncMock(return_value=state)),
+    ):
+        mock_pm.plugins = pmap({_PLUGIN_ID: plugin})
+        with pytest.raises(HTTPException) as exc_info:
+            _run(get_template_example_values(_PLUGIN_ID, "myTemplate"))
+    assert exc_info.value.status_code == 403


### PR DESCRIPTION
Returns example_values and example_glyphs for a blueprint template from a loaded plugin, with glyph remapping applied (matching the remapping done at template ingest time).

- 404 when plugin is not loaded or display_name not found in the plugin
- 403 when the template is excluded by admin settings
- remapping applied to example_values (values via remap_glyph_names) and example_glyphs (keys renamed via mapping, values via remap_glyph_names)

Uses remap_glyph_names from domain/glyphs; notes the new domain dependency in both domain/__init__.py files.

Unit tests cover happy path, remapping, and all error cases. Integration tests verify real examples, the 403 on excluded template, and 404 for unknown display name and unknown plugin.

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
