### PR TITLE
refactor(plugin): structured PluginError list replaces string error c…

### DIFF
--- a/backend/src/forecastbox/domain/plugin/db.py
+++ b/backend/src/forecastbox/domain/plugin/db.py
@@ -28,6 +28,7 @@ import logging
 from sqlalchemy import select, update
 
 import forecastbox.schemata.jobs as _jobs_module
+from forecastbox.domain.plugin.errors import PluginErrors
 from forecastbox.schemata.jobs import PluginState
 from forecastbox.utility.db import dbRetry, querySingle
 from forecastbox.utility.time import current_time
@@ -40,7 +41,7 @@ async def upsert_plugin_state(
     plugin_id: str,
     version: str | None = None,
     enabled: bool | None = None,
-    install_error: str | None = None,
+    plugin_errors: PluginErrors | None = None,
     excluded_templates: list[str] | None = None,
     glyph_remapping: dict[str, str] | None = None,
 ) -> None:
@@ -53,8 +54,8 @@ async def upsert_plugin_state(
 
     On subsequent calls: only the explicitly provided (non-``None``) arguments are
     written; ``None`` means "leave the stored value unchanged".  The exception is
-    ``install_error``: pass ``""`` to explicitly clear a previous error; ``None``
-    leaves it untouched.
+    ``plugin_errors``: pass an empty list to explicitly clear previous errors; ``None``
+    leaves them untouched.
 
     ``asset_ingest_needed`` is set to ``True`` when any of the following is true on
     an existing row: the flag was already set, the version changed, the plugin is
@@ -64,6 +65,7 @@ async def upsert_plugin_state(
     as that indicates a programming error (updating a plugin that was never installed).
     """
     ref_time = current_time("dbref")
+    plugin_errors_raw = [e.model_dump() for e in plugin_errors] if plugin_errors is not None else None
 
     async def function(i: int) -> None:
         async with _jobs_module.async_session_maker() as session:
@@ -80,7 +82,7 @@ async def upsert_plugin_state(
                         plugin_id=plugin_id,
                         plugin_version=version,
                         updated_at=ref_time,
-                        install_error=install_error if install_error is not None else "",
+                        plugin_errors=plugin_errors_raw if plugin_errors_raw is not None else [],
                         excluded_templates=excluded_templates if excluded_templates is not None else [],
                         glyph_remapping=glyph_remapping if glyph_remapping is not None else {},
                         template_errors={},
@@ -104,8 +106,8 @@ async def upsert_plugin_state(
                     values["plugin_version"] = version
                 if enabled is not None:
                     values["enabled"] = enabled
-                if install_error is not None:
-                    values["install_error"] = install_error
+                if plugin_errors_raw is not None:
+                    values["plugin_errors"] = plugin_errors_raw
                 if excluded_templates is not None:
                     values["excluded_templates"] = excluded_templates
                 if glyph_remapping is not None:

--- a/backend/src/forecastbox/domain/plugin/db.py
+++ b/backend/src/forecastbox/domain/plugin/db.py
@@ -53,9 +53,8 @@ async def upsert_plugin_state(
     new rows.
 
     On subsequent calls: only the explicitly provided (non-``None``) arguments are
-    written; ``None`` means "leave the stored value unchanged".  The exception is
-    ``plugin_errors``: pass an empty list to explicitly clear previous errors; ``None``
-    leaves them untouched.
+    written; ``None`` means "leave the stored value unchanged".  Pass an empty list
+    to explicitly clear previously stored errors.
 
     ``asset_ingest_needed`` is set to ``True`` when any of the following is true on
     an existing row: the flag was already set, the version changed, the plugin is

--- a/backend/src/forecastbox/domain/plugin/errors.py
+++ b/backend/src/forecastbox/domain/plugin/errors.py
@@ -1,0 +1,46 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Structured error types for plugin lifecycle events.
+
+A ``PluginError`` captures one diagnostic item produced during the plugin
+lifecycle. A plugin may accumulate multiple errors and/or warnings across
+different lifecycle phases.
+
+Lifecycle sources:
+- ``install`` -- pip install phase; failure here means the package could not be
+  installed at all.
+- ``load`` -- importlib / Plugin() instantiation phase; failure here means the
+  package is installed but the plugin object cannot be constructed.
+- ``template_ingest`` -- blueprint template validation and DB upsert phase;
+  errors here are per-template and do not prevent the plugin from being used for
+  other templates.
+
+Severities:
+- ``warning`` -- the plugin still loads and operates; e.g. version mismatch
+  between DB record and installed package, or a single template failing
+  validation.
+- ``error`` -- the plugin cannot be used; e.g. install failure or import
+  failure.
+- ``critical`` -- reserved for conditions that would cause the whole backend to
+  shut down; none exist at the time of writing.
+"""
+
+from typing import Literal
+
+from forecastbox.utility.pydantic import FiabBaseModel
+
+
+class PluginError(FiabBaseModel):
+    source: Literal["install", "load", "template_ingest"]
+    detail: str
+    severity: Literal["warning", "error", "critical"]
+
+
+PluginErrors = list[PluginError]

--- a/backend/src/forecastbox/domain/plugin/errors.py
+++ b/backend/src/forecastbox/domain/plugin/errors.py
@@ -32,7 +32,7 @@ Severities:
   shut down; none exist at the time of writing.
 """
 
-from typing import Literal
+from typing import Literal, NewType
 
 from forecastbox.utility.pydantic import FiabBaseModel
 
@@ -43,4 +43,4 @@ class PluginError(FiabBaseModel):
     severity: Literal["warning", "error", "critical"]
 
 
-PluginErrors = list[PluginError]
+PluginErrors = NewType("PluginErrors", list[PluginError])

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -33,7 +33,7 @@ import re
 import threading
 import time
 from concurrent.futures import Future
-from typing import Literal, cast
+from typing import Literal
 
 from cascade.low.func import Either, assert_never
 from fiab_core.fable import BlockFactoryCatalogue, PluginCompositeId
@@ -50,6 +50,7 @@ from forecastbox.domain.plugin.db import (
     update_template_errors,
     upsert_plugin_state,
 )
+from forecastbox.domain.plugin.errors import PluginError, PluginErrors
 from forecastbox.utility.concurrent import delayed_thread, timed_acquire
 from forecastbox.utility.config import PluginSettings, PluginsSettings, config, config_edit_lock
 from forecastbox.utility.packages import try_import, try_version
@@ -62,7 +63,7 @@ logger = logging.getLogger(__name__)
 class PluginManager:
     lock: threading.Lock = threading.Lock()
     plugins: PMap[PluginCompositeId, Plugin] = pmap()
-    errors: PMap[PluginCompositeId, str] = pmap()
+    errors: PMap[PluginCompositeId, PluginErrors] = pmap()
     updater: threading.Thread | None = None
     updater_error: str | None = None
     loop: asyncio.AbstractEventLoop | None = None
@@ -200,8 +201,8 @@ async def _ingest_plugin_templates(plugin_id: PluginCompositeId, plugin: Plugin)
 def load_plugins(plugins: PluginsSettings) -> None:
     logger.info("starting initial plugin load")
     try:
-        lookup = {}
-        errors = {}
+        lookup: dict[PluginCompositeId, Plugin] = {}
+        errors: dict[PluginCompositeId, PluginErrors] = {}
         for pluginKey, pluginSettings in plugins.items():
             plugin_id_str = PluginCompositeId.to_str(pluginKey)
             db_state = _run_async_from_thread(get_plugin_state(plugin_id_str))
@@ -230,19 +231,30 @@ def load_plugins(plugins: PluginsSettings) -> None:
             if install_error is not None:
                 logger.error(f"install failed for {pluginKey}: {install_error}")
                 _run_async_from_thread(
-                    upsert_plugin_state(plugin_id=plugin_id_str, version="install failed", enabled=True, install_error=install_error)
+                    upsert_plugin_state(
+                        plugin_id=plugin_id_str,
+                        version="install failed",
+                        enabled=True,
+                        plugin_errors=[PluginError(source="install", severity="error", detail=install_error)],
+                    )
                 )
                 continue
             if installed_versions:
                 version_str = _version_from_install(installed_versions, pluginSettings.module_name)
                 if version_str is not None:
-                    _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_str, install_error=""))
+                    _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_str, plugin_errors=[]))
                 else:
                     # pip does not report the version if it isn't changed -> this branch is not necessarily a bug
                     logger.warning(f"pip install of plugin {plugin_id_str} did not produce a version, assuming no change")
 
             if pluginKey in lookup:
-                errors[pluginKey] = f"plugin {pluginKey} is provided by more than just {pluginSettings.pip_source}"
+                errors[pluginKey] = [
+                    PluginError(
+                        source="load",
+                        severity="error",
+                        detail=f"plugin {pluginKey} is provided by more than just {pluginSettings.pip_source}",
+                    )
+                ]
                 continue
             else:
                 plugin_result = load_single(pluginSettings)
@@ -256,19 +268,19 @@ def load_plugins(plugins: PluginsSettings) -> None:
                         # but dont prevent template ingest
                         err_msg = f"plugin {pluginKey} state not found -- install originally failed?"
                         logger.error(err_msg)
-                        errors[pluginKey] = err_msg
+                        errors[pluginKey] = [PluginError(source="load", severity="error", detail=err_msg)]
                         _run_async_from_thread(
-                            upsert_plugin_state(plugin_id=plugin_id_str, version=version_imported, enabled=True, install_error="")
+                            upsert_plugin_state(plugin_id=plugin_id_str, version=version_imported, enabled=True, plugin_errors=[])
                         )
                     else:
                         db_ver: str = fresh_state.plugin_version  # type: ignore[assignment]
                         if db_ver != version_imported:
                             mismatch_msg = f"version mismatch: DB has {db_ver!r} but {version_imported!r} is imported"
                             logger.warning(f"plugin {pluginKey}: {mismatch_msg}")
-                            errors[pluginKey] = mismatch_msg
+                            errors[pluginKey] = [PluginError(source="load", severity="warning", detail=mismatch_msg)]
                 else:
                     logger.debug(f"plugin {pluginKey} loaded with success: False")
-                    errors[pluginKey] = plugin_result.e
+                    errors[pluginKey] = [PluginError(source="load", severity="error", detail=plugin_result.e)]  # type: ignore[arg-type]
 
         # Publish all loaded plugins before running template ingestion so that
         # validate_expand can resolve factory references during validation.
@@ -301,7 +313,11 @@ def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, i
             install_result = install_plugin_compatibly(pluginSettings.pip_source, version)
             if install_result.e:
                 _run_async_from_thread(
-                    upsert_plugin_state(plugin_id=plugin_id_str, version="install failed", install_error=install_result.e)
+                    upsert_plugin_state(
+                        plugin_id=plugin_id_str,
+                        version="install failed",
+                        plugin_errors=[PluginError(source="install", severity="error", detail=install_result.e)],
+                    )
                 )
                 raise RuntimeError(f"install failed for {pluginId}: {install_result.e}")
             installed_versions = install_result.t or {}
@@ -311,26 +327,30 @@ def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, i
         logger.debug(f"plugin {pluginId} loaded with success: {result.t is not None}")
         version_install = _version_from_install(installed_versions, pluginSettings.module_name)
         version_imported = try_version(pluginSettings.pip_source, pluginSettings.module_name)
-        version_mismatch: str | None = None
+        version_mismatch_err: PluginError | None = None
         if version_install is not None and version_install != version_imported:
-            version_mismatch = f"version mismatch: pip installed {version_install!r} but {version_imported!r} is imported"
-            logger.warning(f"plugin {pluginId}: {version_mismatch}")
+            mismatch_msg = f"version mismatch: pip installed {version_install!r} but {version_imported!r} is imported"
+            logger.warning(f"plugin {pluginId}: {mismatch_msg}")
+            version_mismatch_err = PluginError(source="load", severity="warning", detail=mismatch_msg)
         with timed_acquire(PluginManager.lock, 60) as acquire_result:
             if not acquire_result:
                 raise ValueError("failed to acquire the shared lock")
             if result.t is not None:
                 PluginManager.plugins = PluginManager.plugins.set(pluginId, result.t)
+                new_errs: PluginErrors = [version_mismatch_err] if version_mismatch_err is not None else []
             else:
-                PluginManager.errors = PluginManager.errors.set(pluginId, cast(str, result.e))
-            if version_mismatch is not None:
-                existing_err = PluginManager.errors.get(pluginId)
-                PluginManager.errors = PluginManager.errors.set(
-                    pluginId, f"{existing_err}; {version_mismatch}" if existing_err else version_mismatch
-                )
+                load_err = PluginError(source="load", severity="error", detail=result.e)  # type: ignore[arg-type]
+                new_errs = [load_err]
+                if version_mismatch_err is not None:
+                    new_errs.append(version_mismatch_err)
+            if new_errs:
+                PluginManager.errors = PluginManager.errors.set(pluginId, new_errs)
+            elif pluginId in PluginManager.errors:
+                PluginManager.errors = PluginManager.errors.remove(pluginId)
         if version_install is not None:
-            _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_install, install_error=""))
+            _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_install, plugin_errors=[]))
         else:
-            _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, install_error=""))
+            _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, plugin_errors=[]))
         if result.t is not None:
             _run_async_from_thread(_ingest_plugin_templates(pluginId, result.t))
         logger.debug(f"single plugin loading finished: {pluginId}")
@@ -376,7 +396,7 @@ class PluginsStatus(FiabBaseModel):
     # TODO Change these fields to use pyrsistent types (PMap) instead of dict once we solve pydantic serialization.
     # However, no immediate hotfix is needed as this class is constructed with a lock, ie, consistently
     updater_status: Literal["ok", "running", "retrieving"] | str
-    plugin_errors: dict[PluginCompositeId, str]
+    plugin_errors: dict[PluginCompositeId, PluginErrors]
     plugin_versions: dict[PluginCompositeId, str]
     plugin_updatedatetime: dict[PluginCompositeId, str]
     plugin_enabled: dict[PluginCompositeId, bool]
@@ -402,7 +422,7 @@ async def status_full() -> PluginsStatus:
     with timed_acquire(PluginManager.lock, 0.2) as result:
         if not result:
             status = "retrieving"
-            plugin_errors: dict[PluginCompositeId, str] = {}
+            plugin_errors: dict[PluginCompositeId, PluginErrors] = {}
         else:
             status = status_brief()
             plugin_errors = dict(PluginManager.errors)
@@ -419,25 +439,25 @@ async def status_full() -> PluginsStatus:
             except Exception:
                 logger.warning(f"could not parse plugin_id {state.plugin_id!r} from DB; skipping")
                 continue
-            if state.install_error:  # type: ignore[misc]
-                existing = plugin_errors.get(plugin_id)
-                plugin_errors[plugin_id] = (
-                    f"{existing}; {state.install_error}" if existing else state.install_error  # type: ignore[misc]
-                )
+            db_plugin_errors: PluginErrors = [
+                PluginError(**e)
+                for e in (state.plugin_errors or [])  # type: ignore[union-attr]
+            ]
+            if db_plugin_errors:
+                existing = plugin_errors.get(plugin_id, [])
+                plugin_errors[plugin_id] = existing + db_plugin_errors
             plugin_versions[plugin_id] = state.plugin_version  # type: ignore[assignment]
             plugin_updatedatetime[plugin_id] = value_dt2str(state.updated_at)  # type: ignore[arg-type]
             plugin_enabled[plugin_id] = bool(state.enabled)
             plugin_excluded_templates[plugin_id] = list(state.excluded_templates) if state.excluded_templates else []  # type: ignore[arg-type]
             plugin_glyph_remapping[plugin_id] = dict(state.glyph_remapping) if state.glyph_remapping else {}  # type: ignore[arg-type]
             if state.template_errors:  # type: ignore[truthy-bool]
-                # Format per-template errors as a single string and merge into plugin_errors,
-                # consistent with the existing install_error merge above.
-                template_err_str = "; ".join(
-                    f"template {name!r}: {msg}"
+                template_errs: PluginErrors = [
+                    PluginError(source="template_ingest", severity="warning", detail=f"template {name!r}: {msg}")
                     for name, msg in state.template_errors.items()  # type: ignore[union-attr]
-                )
-                existing = plugin_errors.get(plugin_id)
-                plugin_errors[plugin_id] = f"{existing}; {template_err_str}" if existing else template_err_str
+                ]
+                existing = plugin_errors.get(plugin_id, [])
+                plugin_errors[plugin_id] = existing + template_errs
     except Exception:
         logger.warning("failed to load plugin states from DB; status may be incomplete", exc_info=True)
     return PluginsStatus(

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -235,26 +235,30 @@ def load_plugins(plugins: PluginsSettings) -> None:
                         plugin_id=plugin_id_str,
                         version="install failed",
                         enabled=True,
-                        plugin_errors=[PluginError(source="install", severity="error", detail=install_error)],
+                        plugin_errors=PluginErrors([PluginError(source="install", severity="error", detail=install_error)]),
                     )
                 )
                 continue
             if installed_versions:
                 version_str = _version_from_install(installed_versions, pluginSettings.module_name)
                 if version_str is not None:
-                    _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_str, plugin_errors=[]))
+                    _run_async_from_thread(
+                        upsert_plugin_state(plugin_id=plugin_id_str, version=version_str, plugin_errors=PluginErrors([]))
+                    )
                 else:
                     # pip does not report the version if it isn't changed -> this branch is not necessarily a bug
                     logger.warning(f"pip install of plugin {plugin_id_str} did not produce a version, assuming no change")
 
             if pluginKey in lookup:
-                errors[pluginKey] = [
-                    PluginError(
-                        source="load",
-                        severity="error",
-                        detail=f"plugin {pluginKey} is provided by more than just {pluginSettings.pip_source}",
-                    )
-                ]
+                errors[pluginKey] = PluginErrors(
+                    [
+                        PluginError(
+                            source="load",
+                            severity="error",
+                            detail=f"plugin {pluginKey} is provided by more than just {pluginSettings.pip_source}",
+                        )
+                    ]
+                )
                 continue
             else:
                 plugin_result = load_single(pluginSettings)
@@ -268,19 +272,21 @@ def load_plugins(plugins: PluginsSettings) -> None:
                         # but dont prevent template ingest
                         err_msg = f"plugin {pluginKey} state not found -- install originally failed?"
                         logger.error(err_msg)
-                        errors[pluginKey] = [PluginError(source="load", severity="error", detail=err_msg)]
+                        errors[pluginKey] = PluginErrors([PluginError(source="load", severity="error", detail=err_msg)])
                         _run_async_from_thread(
-                            upsert_plugin_state(plugin_id=plugin_id_str, version=version_imported, enabled=True, plugin_errors=[])
+                            upsert_plugin_state(
+                                plugin_id=plugin_id_str, version=version_imported, enabled=True, plugin_errors=PluginErrors([])
+                            )
                         )
                     else:
                         db_ver: str = fresh_state.plugin_version  # type: ignore[assignment]
                         if db_ver != version_imported:
                             mismatch_msg = f"version mismatch: DB has {db_ver!r} but {version_imported!r} is imported"
                             logger.warning(f"plugin {pluginKey}: {mismatch_msg}")
-                            errors[pluginKey] = [PluginError(source="load", severity="warning", detail=mismatch_msg)]
+                            errors[pluginKey] = PluginErrors([PluginError(source="load", severity="warning", detail=mismatch_msg)])
                 else:
                     logger.debug(f"plugin {pluginKey} loaded with success: False")
-                    errors[pluginKey] = [PluginError(source="load", severity="error", detail=plugin_result.e)]  # type: ignore[arg-type]
+                    errors[pluginKey] = PluginErrors([PluginError(source="load", severity="error", detail=plugin_result.e)])  # type: ignore[arg-type]
 
         # Publish all loaded plugins before running template ingestion so that
         # validate_expand can resolve factory references during validation.
@@ -316,7 +322,7 @@ def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, i
                     upsert_plugin_state(
                         plugin_id=plugin_id_str,
                         version="install failed",
-                        plugin_errors=[PluginError(source="install", severity="error", detail=install_result.e)],
+                        plugin_errors=PluginErrors([PluginError(source="install", severity="error", detail=install_result.e)]),
                     )
                 )
                 raise RuntimeError(f"install failed for {pluginId}: {install_result.e}")
@@ -337,20 +343,18 @@ def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, i
                 raise ValueError("failed to acquire the shared lock")
             if result.t is not None:
                 PluginManager.plugins = PluginManager.plugins.set(pluginId, result.t)
-                new_errs: PluginErrors = [version_mismatch_err] if version_mismatch_err is not None else []
+                new_errs: PluginErrors = PluginErrors([version_mismatch_err]) if version_mismatch_err is not None else PluginErrors([])
             else:
                 load_err = PluginError(source="load", severity="error", detail=result.e)  # type: ignore[arg-type]
-                new_errs = [load_err]
-                if version_mismatch_err is not None:
-                    new_errs.append(version_mismatch_err)
+                new_errs = PluginErrors([load_err, version_mismatch_err] if version_mismatch_err is not None else [load_err])
             if new_errs:
                 PluginManager.errors = PluginManager.errors.set(pluginId, new_errs)
             elif pluginId in PluginManager.errors:
                 PluginManager.errors = PluginManager.errors.remove(pluginId)
         if version_install is not None:
-            _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_install, plugin_errors=[]))
+            _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, version=version_install, plugin_errors=PluginErrors([])))
         else:
-            _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, plugin_errors=[]))
+            _run_async_from_thread(upsert_plugin_state(plugin_id=plugin_id_str, plugin_errors=PluginErrors([])))
         if result.t is not None:
             _run_async_from_thread(_ingest_plugin_templates(pluginId, result.t))
         logger.debug(f"single plugin loading finished: {pluginId}")
@@ -439,25 +443,29 @@ async def status_full() -> PluginsStatus:
             except Exception:
                 logger.warning(f"could not parse plugin_id {state.plugin_id!r} from DB; skipping")
                 continue
-            db_plugin_errors: PluginErrors = [
-                PluginError(**e)
-                for e in (state.plugin_errors or [])  # type: ignore[union-attr]
-            ]
+            db_plugin_errors: PluginErrors = PluginErrors(
+                [
+                    PluginError(**e)  # type: ignore[arg-type]
+                    for e in (state.plugin_errors or [])  # type: ignore[union-attr]
+                ]
+            )
             if db_plugin_errors:
                 existing = plugin_errors.get(plugin_id, [])
-                plugin_errors[plugin_id] = existing + db_plugin_errors
+                plugin_errors[plugin_id] = PluginErrors(existing + db_plugin_errors)
             plugin_versions[plugin_id] = state.plugin_version  # type: ignore[assignment]
             plugin_updatedatetime[plugin_id] = value_dt2str(state.updated_at)  # type: ignore[arg-type]
             plugin_enabled[plugin_id] = bool(state.enabled)
             plugin_excluded_templates[plugin_id] = list(state.excluded_templates) if state.excluded_templates else []  # type: ignore[arg-type]
             plugin_glyph_remapping[plugin_id] = dict(state.glyph_remapping) if state.glyph_remapping else {}  # type: ignore[arg-type]
             if state.template_errors:  # type: ignore[truthy-bool]
-                template_errs: PluginErrors = [
-                    PluginError(source="template_ingest", severity="warning", detail=f"template {name!r}: {msg}")
-                    for name, msg in state.template_errors.items()  # type: ignore[union-attr]
-                ]
+                template_errs: PluginErrors = PluginErrors(
+                    [
+                        PluginError(source="template_ingest", severity="warning", detail=f"template {name!r}: {msg}")
+                        for name, msg in state.template_errors.items()  # type: ignore[union-attr]
+                    ]
+                )
                 existing = plugin_errors.get(plugin_id, [])
-                plugin_errors[plugin_id] = existing + template_errs
+                plugin_errors[plugin_id] = PluginErrors(existing + template_errs)
     except Exception:
         logger.warning("failed to load plugin states from DB; status may be incomplete", exc_info=True)
     return PluginsStatus(

--- a/backend/src/forecastbox/routes/plugins.py
+++ b/backend/src/forecastbox/routes/plugins.py
@@ -25,6 +25,7 @@ from forecastbox.domain.auth.users import UserRead
 from forecastbox.domain.glyphs.resolution import remap_glyph_names
 from forecastbox.domain.plugin.compatibility import get_compatible_versions
 from forecastbox.domain.plugin.db import get_plugin_state, upsert_plugin_state
+from forecastbox.domain.plugin.errors import PluginErrors
 from forecastbox.domain.plugin.manager import (
     PluginManager,
     PluginsStatus,
@@ -54,8 +55,8 @@ class PluginDetail(FiabBaseModel):
     """Info about the plugin from the respective store. None if the plugin was installed locally"""
     remote_info: PluginRemoteInfo | None = None
     """Dynamic remote information such as the most recent published version. None if the plugin was installed locally"""
-    errored_detail: str | None = None
-    """In case the plugin is errored, (eg installed but failed to load), this displays detail"""
+    errored_detail: PluginErrors | None = None
+    """In case the plugin is errored or has warnings, this displays structured diagnostics"""
     loaded_version: str | None = None
     """In case the plugin is loaded, this shows the version"""
     update_datetime: str | None = None

--- a/backend/src/forecastbox/schemata/jobs.py
+++ b/backend/src/forecastbox/schemata/jobs.py
@@ -211,7 +211,7 @@ class PluginState(Base):
     plugin_id = Column(String(255), primary_key=True, nullable=False)
     plugin_version = Column(String(255), nullable=False)
     updated_at = Column(UTCDateTime, nullable=False)
-    install_error = Column(String(4096), nullable=False, default="")
+    plugin_errors = Column(JSON, nullable=False, default=list)
     excluded_templates = Column(JSON, nullable=False, default=list)
     glyph_remapping = Column(JSON, nullable=False, default=dict)
     template_errors = Column(JSON, nullable=False, default=dict)

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -380,9 +380,10 @@ def test_plugin_template_validation_failure(backend_client_with_auth: httpx.Clie
     # PluginsStatus dict keys for PluginCompositeId are serialized via str(plugin_id).
     plugin_id_key = str(testPluginId)
     plugin_errors = status.get("plugin_errors", {})
-    plugin_error_str = plugin_errors.get(plugin_id_key, "")
-    assert "testFailValidation" in plugin_error_str, (
-        f"Expected 'testFailValidation' in plugin_errors[{plugin_id_key!r}], got: {plugin_error_str!r}"
+    plugin_error_entries = plugin_errors.get(plugin_id_key, [])
+    details = " ".join(e.get("detail", "") for e in plugin_error_entries)
+    assert "testFailValidation" in details, (
+        f"Expected 'testFailValidation' in plugin_errors[{plugin_id_key!r}], got: {plugin_error_entries!r}"
     )
 
 

--- a/backend/tests/unit/domain/plugins/test_plugin_db.py
+++ b/backend/tests/unit/domain/plugins/test_plugin_db.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 import forecastbox.domain.plugin.db as plugin_db
 import forecastbox.schemata.jobs as _jobs_module
+from forecastbox.domain.plugin.errors import PluginError
 from forecastbox.schemata.jobs import Base
 
 
@@ -45,7 +46,7 @@ async def test_upsert_creates_row_with_defaults(mem_session_maker: async_session
     assert state is not None
     assert state.plugin_id == "localTest:single"
     assert state.plugin_version == "1.2.3"
-    assert state.install_error == ""
+    assert state.plugin_errors == []
     assert state.excluded_templates == []
     assert state.glyph_remapping == {}
     assert state.template_errors == {}
@@ -56,7 +57,7 @@ async def test_upsert_creates_row_with_defaults(mem_session_maker: async_session
 
 @pytest.mark.asyncio
 async def test_upsert_updates_version_without_clobbering(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
-    """Second upsert updates plugin_version/install_error but does not clobber excluded_templates / glyph_remapping."""
+    """Second upsert updates plugin_version/plugin_errors but does not clobber excluded_templates / glyph_remapping."""
     await plugin_db.upsert_plugin_state(plugin_id="myStore:myPlugin", version="0.1.0", enabled=True)
 
     # Simulate writes by later subsystems directly to DB
@@ -71,12 +72,12 @@ async def test_upsert_updates_version_without_clobbering(mem_session_maker: asyn
         await session.commit()
 
     # Re-install (update) -- new version triggers asset_ingest_needed=True
-    await plugin_db.upsert_plugin_state(plugin_id="myStore:myPlugin", version="0.2.0", install_error="")
+    await plugin_db.upsert_plugin_state(plugin_id="myStore:myPlugin", version="0.2.0", plugin_errors=[])
 
     state = await plugin_db.get_plugin_state("myStore:myPlugin")
     assert state is not None
     assert state.plugin_version == "0.2.0"
-    assert state.install_error == ""
+    assert state.plugin_errors == []
     # excluded_templates / glyph_remapping must NOT be reset
     assert state.excluded_templates == ["tplA"]
     assert state.glyph_remapping == {"old": "new"}
@@ -119,38 +120,45 @@ async def test_upsert_none_version_on_missing_row_raises(mem_session_maker: asyn
 
 
 @pytest.mark.asyncio
-async def test_upsert_persists_install_error(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
-    """An install failure writes the error string and records the attempt."""
-    await plugin_db.upsert_plugin_state(plugin_id="bad:plugin", version="unknown", enabled=True, install_error="pip failed: some reason")
+async def test_upsert_persists_plugin_errors(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
+    """An install failure writes structured errors and records the attempt."""
+    install_err = PluginError(source="install", severity="error", detail="pip failed: some reason")
+    await plugin_db.upsert_plugin_state(plugin_id="bad:plugin", version="unknown", enabled=True, plugin_errors=[install_err])
 
     state = await plugin_db.get_plugin_state("bad:plugin")
     assert state is not None
-    assert state.install_error == "pip failed: some reason"
+    assert state.plugin_errors == [install_err.model_dump()]
     assert state.plugin_version == "unknown"
     assert state.updated_at is not None
 
 
 @pytest.mark.asyncio
-async def test_upsert_clears_install_error_with_empty_string(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
-    """Passing install_error='' clears a previously stored error; passing None leaves it untouched."""
-    await plugin_db.upsert_plugin_state(plugin_id="bad:plugin", version="0.1.0", install_error="old error")
-    # None should not touch the error
+async def test_upsert_clears_plugin_errors_with_empty_list(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
+    """Passing plugin_errors=[] clears previously stored errors; passing None leaves them untouched."""
+    old_err = PluginError(source="install", severity="error", detail="old error")
+    await plugin_db.upsert_plugin_state(plugin_id="bad:plugin", version="0.1.0", plugin_errors=[old_err])
+    # None should not touch the errors
     await plugin_db.upsert_plugin_state(plugin_id="bad:plugin")
     state = await plugin_db.get_plugin_state("bad:plugin")
     assert state is not None
-    assert state.install_error == "old error"
-    # "" should clear it
-    await plugin_db.upsert_plugin_state(plugin_id="bad:plugin", install_error="")
+    assert state.plugin_errors == [old_err.model_dump()]
+    # [] should clear them
+    await plugin_db.upsert_plugin_state(plugin_id="bad:plugin", plugin_errors=[])
     state = await plugin_db.get_plugin_state("bad:plugin")
     assert state is not None
-    assert state.install_error == ""
+    assert state.plugin_errors == []
 
 
 @pytest.mark.asyncio
 async def test_get_all_plugin_states(mem_session_maker: async_sessionmaker[AsyncSession]) -> None:
     """get_all_plugin_states returns all persisted rows."""
     await plugin_db.upsert_plugin_state(plugin_id="storeA:p1", version="1.0", enabled=True)
-    await plugin_db.upsert_plugin_state(plugin_id="storeA:p2", version="unknown", enabled=True, install_error="err")
+    await plugin_db.upsert_plugin_state(
+        plugin_id="storeA:p2",
+        version="unknown",
+        enabled=True,
+        plugin_errors=[PluginError(source="install", severity="error", detail="err")],
+    )
 
     states = await plugin_db.get_all_plugin_states()
     ids = {s.plugin_id for s in states}

--- a/frontend/src/api/types/plugins.types.ts
+++ b/frontend/src/api/types/plugins.types.ts
@@ -127,6 +127,12 @@ export const PluginRemoteInfoSchema = z.object({
 
 export type PluginRemoteInfo = z.infer<typeof PluginRemoteInfoSchema>
 
+const PluginErrorSchema = z.object({
+  source: z.string(),
+  detail: z.string(),
+  severity: z.string(),
+})
+
 /**
  * Plugin detail - full plugin information from backend
  */
@@ -134,7 +140,10 @@ export const PluginDetailSchema = z.object({
   status: z.enum(pluginStatusValues),
   store_info: PluginStoreEntrySchema.nullable(),
   remote_info: PluginRemoteInfoSchema.nullable(),
-  errored_detail: z.string().nullable(),
+  errored_detail: z
+    .array(PluginErrorSchema)
+    .transform((errors) => errors.map((e) => e.detail).join('\n') || null)
+    .nullable(),
   loaded_version: z.string().nullable(),
   update_datetime: z.string().nullable(), // UTC ISO with offset, e.g. "...+00:00"
 })
@@ -155,7 +164,12 @@ export type PluginListing = z.infer<typeof PluginListingSchema>
  */
 export const PluginsStatusSchema = z.object({
   updater_status: z.string(),
-  plugin_errors: z.record(z.string(), z.string()),
+  plugin_errors: z.record(
+    z.string(),
+    z
+      .array(PluginErrorSchema)
+      .transform((errors) => errors.map((e) => e.detail).join('\n')),
+  ),
   plugin_versions: z.record(z.string(), z.string()),
   plugin_updatedatetime: z.record(z.string(), z.string()),
 })

--- a/frontend/tests/unit/api/endpoints/plugins.test.ts
+++ b/frontend/tests/unit/api/endpoints/plugins.test.ts
@@ -14,7 +14,6 @@ import { worker } from '@tests/../mocks/browser'
 import type {
   PluginCompositeId,
   PluginListing,
-  PluginsStatus,
 } from '@/api/types/plugins.types'
 import {
   getPluginDetails,
@@ -51,11 +50,16 @@ describe('getPluginStatus', () => {
   })
 
   it('fetches plugin status successfully', async () => {
-    const mockResponse: PluginsStatus = {
+    const mockResponse = {
       updater_status: 'idle',
       plugin_errors: {
-        [createPluginKey('ecmwf', 'legacy-viz')]:
-          'Failed to load: incompatible version',
+        [createPluginKey('ecmwf', 'legacy-viz')]: [
+          {
+            source: 'load',
+            detail: 'Failed to load: incompatible version',
+            severity: 'error',
+          },
+        ],
       },
       plugin_versions: {
         [createPluginKey('ecmwf', 'anemoi-inference')]: '1.0.0',

--- a/frontend/tests/unit/api/types/plugins.types.test.ts
+++ b/frontend/tests/unit/api/types/plugins.types.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, expect, it } from 'vitest'
 import type { PluginCompositeId, PluginDetail } from '@/api/types/plugins.types'
-import { toPluginInfo } from '@/api/types/plugins.types'
+import { PluginDetailSchema, toPluginInfo } from '@/api/types/plugins.types'
 
 const ID: PluginCompositeId = { store: 'ecmwf', local: 'anemoi-inference' }
 
@@ -58,5 +58,49 @@ describe('toPluginInfo — updatedAt timezone normalization', () => {
 
   it('is null for an unparseable datetime', () => {
     expect(toPluginInfo(ID, detailWith('not-a-date')).updatedAt).toBeNull()
+  })
+})
+
+const baseRaw = {
+  status: 'loaded' as const,
+  store_info: null,
+  remote_info: null,
+  loaded_version: '1.0.0',
+  update_datetime: null,
+}
+
+describe('PluginDetailSchema — errored_detail parsing', () => {
+  it('accepts null and outputs null', () => {
+    const result = PluginDetailSchema.parse({
+      ...baseRaw,
+      errored_detail: null,
+    })
+    expect(result.errored_detail).toBeNull()
+  })
+
+  it('concatenates multiple error details with newline', () => {
+    const result = PluginDetailSchema.parse({
+      ...baseRaw,
+      errored_detail: [
+        { source: 'install', detail: 'pip failed', severity: 'error' },
+        { source: 'load', detail: 'import error', severity: 'error' },
+      ],
+    })
+    expect(result.errored_detail).toBe('pip failed\nimport error')
+  })
+
+  it('returns a single detail string for one error', () => {
+    const result = PluginDetailSchema.parse({
+      ...baseRaw,
+      errored_detail: [
+        { source: 'load', detail: 'module not found', severity: 'error' },
+      ],
+    })
+    expect(result.errored_detail).toBe('module not found')
+  })
+
+  it('returns null for an empty error list', () => {
+    const result = PluginDetailSchema.parse({ ...baseRaw, errored_detail: [] })
+    expect(result.errored_detail).toBeNull()
   })
 })


### PR DESCRIPTION
…oncatenation

Replace the flat error string (install_error column / PluginManager.errors PMap) with a structured PluginErrors = list[PluginError] type.

PluginError has three fields:
- source: Literal["install", "load", "template_ingest"]
- detail: str
- severity: Literal["warning", "error", "critical"]

DB schema change (backwards-incompatible):
- PluginState.install_error String(4096) removed
- PluginState.plugin_errors JSON column added (default [])

The template_errors column (dict[str, str]) is unchanged in DB; at read time each entry is converted to a PluginError(source="template_ingest", severity="warning") and merged into the returned PluginErrors list.

Severities assigned:
- install failure          -> source="install", severity="error"
- load/import failure      -> source="load",    severity="error"
- version mismatch warning -> source="load",    severity="warning"
- template validation fail -> source="template_ingest", severity="warning"

API surface changes:
- PluginsStatus.plugin_errors: dict[PluginCompositeId, str] -> dict[PluginCompositeId, PluginErrors]
- PluginDetail.errored_detail: str | None -> PluginErrors | None

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
