### PR TITLE
[frontend]  Plugin-assets API alignment + severity-aware diagnostics

### DIFF
--- a/frontend/mocks/handlers/plugins.handlers.ts
+++ b/frontend/mocks/handlers/plugins.handlers.ts
@@ -26,6 +26,7 @@ import type {
   PluginCompositeId,
   PluginDetail,
   PluginListing,
+  PluginSettingsUpdate,
   PluginsStatus,
 } from '@/api/types/plugins.types'
 import { API_ENDPOINTS } from '@/api/endpoints'
@@ -95,6 +96,9 @@ export const pluginsHandlers = [
       plugin_errors: {},
       plugin_versions: {},
       plugin_updatedatetime: {},
+      plugin_enabled: {},
+      plugin_excluded_templates: {},
+      plugin_glyph_remapping: {},
     }
 
     for (const [key, detail] of Object.entries(pluginsState.plugins)) {
@@ -106,6 +110,11 @@ export const pluginsHandlers = [
       }
       if (detail.update_datetime) {
         status.plugin_updatedatetime[key] = detail.update_datetime
+      }
+      if (detail.status !== 'available') {
+        status.plugin_enabled[key] = detail.status !== 'disabled'
+        status.plugin_excluded_templates[key] = []
+        status.plugin_glyph_remapping[key] = {}
       }
     }
 
@@ -257,8 +266,7 @@ export const pluginsHandlers = [
     await delay(300)
     const body = (await request.json()) as {
       pluginCompositeId: PluginCompositeId
-      isEnabled?: boolean
-    }
+    } & PluginSettingsUpdate
     const { pluginCompositeId, isEnabled } = body
 
     const key = createPluginKey(

--- a/frontend/src/api/endpoints/plugins.ts
+++ b/frontend/src/api/endpoints/plugins.ts
@@ -18,6 +18,7 @@
 import type {
   PluginCompositeId,
   PluginListing,
+  PluginSettingsUpdate,
   PluginsStatus,
 } from '@/api/types/plugins.types'
 import { apiClient } from '@/api/client'
@@ -80,36 +81,36 @@ export async function updatePlugin(
 }
 
 /**
- * Modify plugin enabled state (enable or disable)
+ * Update plugin settings (enabled flag, template exclusions, glyph remapping)
  * @param compositeId - The plugin composite ID { store, local }
- * @param isEnabled - Whether to enable (true) or disable (false) the plugin
+ * @param settings - Fields to change; omitted fields stay unchanged
  */
-export async function modifyPluginEnabled(
+export async function updatePluginSettings(
   compositeId: PluginCompositeId,
-  isEnabled: boolean,
+  settings: PluginSettingsUpdate,
 ): Promise<void> {
   await apiClient.post(API_ENDPOINTS.plugin.settings, {
     pluginCompositeId: compositeId,
-    isEnabled,
+    ...settings,
   })
 }
 
 /**
- * Enable a plugin (convenience wrapper for modifyPluginEnabled)
+ * Enable a plugin (convenience wrapper for updatePluginSettings)
  * @param compositeId - The plugin composite ID { store, local }
  */
 export async function enablePlugin(
   compositeId: PluginCompositeId,
 ): Promise<void> {
-  await modifyPluginEnabled(compositeId, true)
+  await updatePluginSettings(compositeId, { isEnabled: true })
 }
 
 /**
- * Disable a plugin (convenience wrapper for modifyPluginEnabled)
+ * Disable a plugin (convenience wrapper for updatePluginSettings)
  * @param compositeId - The plugin composite ID { store, local }
  */
 export async function disablePlugin(
   compositeId: PluginCompositeId,
 ): Promise<void> {
-  await modifyPluginEnabled(compositeId, false)
+  await updatePluginSettings(compositeId, { isEnabled: false })
 }

--- a/frontend/src/api/hooks/usePlugins.ts
+++ b/frontend/src/api/hooks/usePlugins.ts
@@ -22,6 +22,7 @@ import type {
   PluginCompositeId,
   PluginInfo,
   PluginListing,
+  PluginSettingsUpdate,
   PluginsStatus,
 } from '@/api/types/plugins.types'
 import {
@@ -30,9 +31,9 @@ import {
   getPluginDetails,
   getPluginStatus,
   installPlugin,
-  modifyPluginEnabled,
   uninstallPlugin,
   updatePlugin,
+  updatePluginSettings,
 } from '@/api/endpoints/plugins'
 import { getCatalogue } from '@/api/endpoints/fable'
 import { toPluginInfoList } from '@/api/types/plugins.types'
@@ -200,15 +201,15 @@ export function useUpdatePlugin() {
   return usePluginMutation(updatePlugin)
 }
 
-export function useModifyPluginEnabled() {
+export function useUpdatePluginSettings() {
   return usePluginMutation(
     ({
       compositeId,
-      isEnabled,
+      settings,
     }: {
       compositeId: PluginCompositeId
-      isEnabled: boolean
-    }) => modifyPluginEnabled(compositeId, isEnabled),
+      settings: PluginSettingsUpdate
+    }) => updatePluginSettings(compositeId, settings),
   )
 }
 

--- a/frontend/src/api/types/plugins.types.ts
+++ b/frontend/src/api/types/plugins.types.ts
@@ -127,11 +127,25 @@ export const PluginRemoteInfoSchema = z.object({
 
 export type PluginRemoteInfo = z.infer<typeof PluginRemoteInfoSchema>
 
-const PluginErrorSchema = z.object({
+/**
+ * Structured plugin diagnostic (backend PluginError).
+ * source: install | load | template_ingest; severity: warning | error | critical.
+ * Plain strings so new backend values don't fail parsing.
+ */
+export const PluginErrorSchema = z.object({
   source: z.string(),
   detail: z.string(),
   severity: z.string(),
 })
+
+export type PluginError = z.infer<typeof PluginErrorSchema>
+
+/**
+ * Flatten structured plugin errors to a display string, one detail per line
+ */
+export function pluginErrorsToText(errors: Array<PluginError>): string {
+  return errors.map((e) => e.detail).join('\n')
+}
 
 /**
  * Plugin detail - full plugin information from backend
@@ -140,10 +154,7 @@ export const PluginDetailSchema = z.object({
   status: z.enum(pluginStatusValues),
   store_info: PluginStoreEntrySchema.nullable(),
   remote_info: PluginRemoteInfoSchema.nullable(),
-  errored_detail: z
-    .array(PluginErrorSchema)
-    .transform((errors) => errors.map((e) => e.detail).join('\n') || null)
-    .nullable(),
+  errored_detail: z.array(PluginErrorSchema).nullable(),
   loaded_version: z.string().nullable(),
   update_datetime: z.string().nullable(), // UTC ISO with offset, e.g. "...+00:00"
 })
@@ -164,17 +175,31 @@ export type PluginListing = z.infer<typeof PluginListingSchema>
  */
 export const PluginsStatusSchema = z.object({
   updater_status: z.string(),
-  plugin_errors: z.record(
-    z.string(),
-    z
-      .array(PluginErrorSchema)
-      .transform((errors) => errors.map((e) => e.detail).join('\n')),
-  ),
+  plugin_errors: z.record(z.string(), z.array(PluginErrorSchema)),
   plugin_versions: z.record(z.string(), z.string()),
   plugin_updatedatetime: z.record(z.string(), z.string()),
+  plugin_enabled: z.record(z.string(), z.boolean()),
+  plugin_excluded_templates: z.record(z.string(), z.array(z.string())),
+  plugin_glyph_remapping: z.record(
+    z.string(),
+    z.record(z.string(), z.string()),
+  ),
 })
 
 export type PluginsStatus = z.infer<typeof PluginsStatusSchema>
+
+/**
+ * Payload fields for POST /plugin/settings (backend PluginSettingsUpdateRequest).
+ * Omitted fields leave the stored value unchanged; an empty list/dict clears it.
+ */
+export interface PluginSettingsUpdate {
+  /** Enable or disable the plugin */
+  isEnabled?: boolean
+  /** Blueprint-template display names to exclude from ingestion */
+  excluded_templates?: Array<string>
+  /** Glyph rename map applied at template ingestion */
+  glyph_remapping?: Record<string, string>
+}
 
 /**
  * UI-friendly plugin info (transformed from PluginDetail)
@@ -211,8 +236,8 @@ export interface PluginInfo {
   hasUpdate: boolean
   /** Last-updated UTC ISO, tz-aware (from update_datetime) */
   updatedAt: string | null
-  /** Error details if status is errored */
-  errorDetail: string | null
+  /** Structured diagnostics when the plugin has errors or warnings */
+  errorDetail: Array<PluginError> | null
   /** Store comment */
   comment: string | null
   /** Pip source for installation */
@@ -234,6 +259,29 @@ export interface PluginsStats {
 }
 
 /**
+ * True when `remote` is a strictly newer release than `loaded`.
+ * Compares numeric release segments only — pre-release suffixes are ignored,
+ * and unparseable versions (e.g. the backend's "unknown" sentinel) are never newer.
+ */
+export function isNewerVersion(remote: string, loaded: string): boolean {
+  const remoteSegments = parseReleaseSegments(remote)
+  const loadedSegments = parseReleaseSegments(loaded)
+  if (!remoteSegments || !loadedSegments) return false
+  const length = Math.max(remoteSegments.length, loadedSegments.length)
+  for (let i = 0; i < length; i++) {
+    const r = remoteSegments[i] ?? 0
+    const l = loadedSegments[i] ?? 0
+    if (r !== l) return r > l
+  }
+  return false
+}
+
+function parseReleaseSegments(version: string): Array<number> | null {
+  const release = version.trim().match(/^v?(\d+(?:\.\d+)*)/)?.[1]
+  return release ? release.split('.').map(Number) : null
+}
+
+/**
  * Transform a PluginDetail to UI-friendly PluginInfo
  */
 export function toPluginInfo(
@@ -246,7 +294,7 @@ export function toPluginInfo(
     isInstalled &&
     detail.loaded_version !== null &&
     detail.remote_info !== null &&
-    detail.loaded_version !== detail.remote_info.version
+    isNewerVersion(detail.remote_info.version, detail.loaded_version)
 
   return {
     id,
@@ -264,7 +312,7 @@ export function toPluginInfo(
     updatedAt: detail.update_datetime
       ? toUtcIsoOrNull(detail.update_datetime)
       : null,
-    errorDetail: detail.errored_detail,
+    errorDetail: detail.errored_detail?.length ? detail.errored_detail : null,
     comment: detail.store_info?.comment ?? null,
     pipSource: detail.store_info?.pip_source ?? null,
     moduleName: detail.store_info?.module_name ?? null,

--- a/frontend/src/api/types/plugins.types.ts
+++ b/frontend/src/api/types/plugins.types.ts
@@ -140,11 +140,33 @@ export const PluginErrorSchema = z.object({
 
 export type PluginError = z.infer<typeof PluginErrorSchema>
 
-/**
- * Flatten structured plugin errors to a display string, one detail per line
- */
-export function pluginErrorsToText(errors: Array<PluginError>): string {
-  return errors.map((e) => e.detail).join('\n')
+export type PluginErrorSeverity = 'warning' | 'error' | 'critical'
+
+const SEVERITY_RANK: Record<PluginErrorSeverity, number> = {
+  warning: 1,
+  error: 2,
+  critical: 3,
+}
+
+/** Unknown severity strings count as 'error' */
+export function normalizePluginErrorSeverity(
+  severity: string,
+): PluginErrorSeverity {
+  return severity in SEVERITY_RANK ? (severity as PluginErrorSeverity) : 'error'
+}
+
+/** Highest severity present, null for an empty list */
+export function pluginErrorsMaxSeverity(
+  errors: Array<PluginError>,
+): PluginErrorSeverity | null {
+  let max: PluginErrorSeverity | null = null
+  for (const error of errors) {
+    const severity = normalizePluginErrorSeverity(error.severity)
+    if (!max || SEVERITY_RANK[severity] > SEVERITY_RANK[max]) {
+      max = severity
+    }
+  }
+  return max
 }
 
 /**
@@ -238,6 +260,8 @@ export interface PluginInfo {
   updatedAt: string | null
   /** Structured diagnostics when the plugin has errors or warnings */
   errorDetail: Array<PluginError> | null
+  /** Highest severity among errorDetail entries */
+  errorSeverity: PluginErrorSeverity | null
   /** Store comment */
   comment: string | null
   /** Pip source for installation */
@@ -295,6 +319,9 @@ export function toPluginInfo(
     detail.loaded_version !== null &&
     detail.remote_info !== null &&
     isNewerVersion(detail.remote_info.version, detail.loaded_version)
+  const errorDetail = detail.errored_detail?.length
+    ? detail.errored_detail
+    : null
 
   return {
     id,
@@ -312,7 +339,8 @@ export function toPluginInfo(
     updatedAt: detail.update_datetime
       ? toUtcIsoOrNull(detail.update_datetime)
       : null,
-    errorDetail: detail.errored_detail?.length ? detail.errored_detail : null,
+    errorDetail,
+    errorSeverity: errorDetail ? pluginErrorsMaxSeverity(errorDetail) : null,
     comment: detail.store_info?.comment ?? null,
     pipSource: detail.store_info?.pip_source ?? null,
     moduleName: detail.store_info?.module_name ?? null,

--- a/frontend/src/api/types/plugins.types.ts
+++ b/frontend/src/api/types/plugins.types.ts
@@ -305,6 +305,12 @@ function parseReleaseSegments(version: string): Array<number> | null {
   return release ? release.split('.').map(Number) : null
 }
 
+/** All-zero versions come from unstamped dev installs — nothing to compare against */
+export function isUnstampedVersion(version: string): boolean {
+  const segments = parseReleaseSegments(version)
+  return segments !== null && segments.every((segment) => segment === 0)
+}
+
 /**
  * Transform a PluginDetail to UI-friendly PluginInfo
  */
@@ -317,6 +323,7 @@ export function toPluginInfo(
   const hasUpdate =
     isInstalled &&
     detail.loaded_version !== null &&
+    !isUnstampedVersion(detail.loaded_version) &&
     detail.remote_info !== null &&
     isNewerVersion(detail.remote_info.version, detail.loaded_version)
   const errorDetail = detail.errored_detail?.length

--- a/frontend/src/features/plugins/components/PluginCard.tsx
+++ b/frontend/src/features/plugins/components/PluginCard.tsx
@@ -15,23 +15,16 @@
  */
 
 import { formatDistanceToNow } from 'date-fns'
-import {
-  AlertCircle,
-  Download,
-  ExternalLink,
-  MoreVertical,
-  Trash2,
-} from 'lucide-react'
+import { Download, ExternalLink, MoreVertical, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { getPyPIUrl } from '../utils/plugin-url'
 import { CapabilityBadges } from './CapabilityBadges'
+import { PluginDiagnostics } from './PluginDiagnostics'
 import { PluginIcon } from './PluginIcon'
 import { PluginStatusBadge } from './PluginStatusBadge'
 import type { PluginCompositeId, PluginInfo } from '@/api/types/plugins.types'
 import type { DashboardVariant, PanelShadow } from '@/stores/uiStore'
-import { pluginErrorsToText } from '@/api/types/plugins.types'
-import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import {
@@ -94,7 +87,10 @@ export function PluginCard({
         !plugin.isEnabled &&
           plugin.isInstalled &&
           'opacity-80 hover:opacity-100',
-        hasError && 'border-red-200 dark:border-red-800',
+        hasError &&
+          (plugin.errorSeverity === 'warning'
+            ? 'border-amber-200 dark:border-amber-800'
+            : 'border-red-200 dark:border-red-800'),
       )}
       variant={variant}
       shadow={shadow}
@@ -125,6 +121,7 @@ export function PluginCard({
         <PluginStatusBadge
           status={plugin.status}
           hasUpdate={plugin.hasUpdate}
+          severity={plugin.errorSeverity}
           className="shrink-0"
         />
       </div>
@@ -154,14 +151,9 @@ export function PluginCard({
         </P>
       )}
 
-      {/* Error Alert */}
-      {hasError && plugin.errorDetail && (
-        <Alert variant="destructive" className="mb-3 py-2">
-          <AlertCircle className="h-4 w-4" />
-          <AlertDescription className="text-xs whitespace-pre-line">
-            {pluginErrorsToText(plugin.errorDetail)}
-          </AlertDescription>
-        </Alert>
+      {/* Diagnostics — also shown for loaded plugins carrying warnings */}
+      {plugin.errorDetail && (
+        <PluginDiagnostics errors={plugin.errorDetail} className="mb-3 py-2" />
       )}
 
       {/* Capabilities - only show for installed plugins with capabilities */}

--- a/frontend/src/features/plugins/components/PluginCard.tsx
+++ b/frontend/src/features/plugins/components/PluginCard.tsx
@@ -30,6 +30,7 @@ import { PluginIcon } from './PluginIcon'
 import { PluginStatusBadge } from './PluginStatusBadge'
 import type { PluginCompositeId, PluginInfo } from '@/api/types/plugins.types'
 import type { DashboardVariant, PanelShadow } from '@/stores/uiStore'
+import { pluginErrorsToText } from '@/api/types/plugins.types'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
@@ -157,8 +158,8 @@ export function PluginCard({
       {hasError && plugin.errorDetail && (
         <Alert variant="destructive" className="mb-3 py-2">
           <AlertCircle className="h-4 w-4" />
-          <AlertDescription className="text-xs">
-            {plugin.errorDetail}
+          <AlertDescription className="text-xs whitespace-pre-line">
+            {pluginErrorsToText(plugin.errorDetail)}
           </AlertDescription>
         </Alert>
       )}

--- a/frontend/src/features/plugins/components/PluginDetailPage.tsx
+++ b/frontend/src/features/plugins/components/PluginDetailPage.tsx
@@ -21,6 +21,7 @@ import { useTranslation } from 'react-i18next'
 import { createSingleBlockFable } from '../utils/pipeline-generator'
 import { BlockFactoryCard } from './BlockFactoryCard'
 import { CapabilityBadges } from './CapabilityBadges'
+import { PluginDiagnostics } from './PluginDiagnostics'
 import { PluginIcon } from './PluginIcon'
 import { PluginStatusBadge } from './PluginStatusBadge'
 import type {
@@ -146,6 +147,7 @@ export function PluginDetailPage({ plugin, catalogue }: PluginDetailPageProps) {
             <PluginStatusBadge
               status={plugin.status}
               hasUpdate={plugin.hasUpdate}
+              severity={plugin.errorSeverity}
             />
           </div>
         </div>
@@ -155,6 +157,9 @@ export function PluginDetailPage({ plugin, catalogue }: PluginDetailPageProps) {
       {plugin.description && (
         <P className="text-muted-foreground">{plugin.description}</P>
       )}
+
+      {/* Diagnostics */}
+      {plugin.errorDetail && <PluginDiagnostics errors={plugin.errorDetail} />}
 
       {/* Capabilities */}
       {plugin.capabilities.length > 0 && (

--- a/frontend/src/features/plugins/components/PluginDiagnostics.tsx
+++ b/frontend/src/features/plugins/components/PluginDiagnostics.tsx
@@ -1,0 +1,109 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * PluginDiagnostics Component
+ *
+ * Severity-coloured list of structured plugin errors, either bare (`plain`,
+ * e.g. inside a tooltip) or wrapped in an alert styled by the max severity.
+ */
+
+import { AlertCircle, OctagonAlert, TriangleAlert } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import type { LucideIcon } from 'lucide-react'
+import type {
+  PluginError,
+  PluginErrorSeverity,
+} from '@/api/types/plugins.types'
+import {
+  normalizePluginErrorSeverity,
+  pluginErrorsMaxSeverity,
+} from '@/api/types/plugins.types'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { cn } from '@/lib/utils'
+
+const SEVERITY_ICONS: Record<
+  PluginErrorSeverity,
+  { Icon: LucideIcon; className: string }
+> = {
+  warning: { Icon: TriangleAlert, className: 'text-amber-500' },
+  error: { Icon: AlertCircle, className: 'text-red-500' },
+  critical: { Icon: OctagonAlert, className: 'text-red-700 dark:text-red-400' },
+}
+
+interface PluginDiagnosticsProps {
+  errors: Array<PluginError>
+  /** Render the bare list without the alert wrapper (e.g. inside a tooltip) */
+  plain?: boolean
+  className?: string
+}
+
+export function PluginDiagnostics({
+  errors,
+  plain = false,
+  className,
+}: PluginDiagnosticsProps) {
+  const { t } = useTranslation('plugins')
+
+  const sourceLabels: Record<string, string> = {
+    install: t('diagnostics.source.install'),
+    load: t('diagnostics.source.load'),
+    template_ingest: t('diagnostics.source.template_ingest'),
+  }
+
+  const list = (
+    <ul className={cn('flex flex-col gap-1.5', plain && className)}>
+      {errors.map((error, index) => {
+        const severity = normalizePluginErrorSeverity(error.severity)
+        const { Icon, className: iconClass } = SEVERITY_ICONS[severity]
+        return (
+          <li key={index} className="flex items-start gap-1.5 text-xs">
+            <Icon
+              className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', iconClass)}
+              aria-label={t(
+                severity === 'warning'
+                  ? 'diagnostics.severity.warning'
+                  : severity === 'critical'
+                    ? 'diagnostics.severity.critical'
+                    : 'diagnostics.severity.error',
+              )}
+            />
+            <span>
+              <span className="font-medium">
+                {sourceLabels[error.source] ?? error.source}
+              </span>
+              {' — '}
+              {error.detail}
+            </span>
+          </li>
+        )
+      })}
+    </ul>
+  )
+
+  if (plain) {
+    return list
+  }
+
+  const isWarningOnly = pluginErrorsMaxSeverity(errors) === 'warning'
+
+  return (
+    <Alert
+      variant={isWarningOnly ? 'default' : 'destructive'}
+      className={cn(
+        isWarningOnly &&
+          'border-amber-300 bg-amber-50/50 dark:border-amber-900/50 dark:bg-amber-900/10',
+        className,
+      )}
+    >
+      <AlertDescription className="text-xs">{list}</AlertDescription>
+    </Alert>
+  )
+}

--- a/frontend/src/features/plugins/components/PluginRow.tsx
+++ b/frontend/src/features/plugins/components/PluginRow.tsx
@@ -15,13 +15,19 @@
  */
 
 import { formatDistanceToNow } from 'date-fns'
-import { AlertCircle, Eye, MoreVertical, Trash2 } from 'lucide-react'
+import {
+  AlertCircle,
+  Eye,
+  MoreVertical,
+  Trash2,
+  TriangleAlert,
+} from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { getPyPIUrl } from '../utils/plugin-url'
 import { CapabilityBadges } from './CapabilityBadges'
+import { PluginDiagnostics } from './PluginDiagnostics'
 import { PluginIcon } from './PluginIcon'
 import type { PluginCompositeId, PluginInfo } from '@/api/types/plugins.types'
-import { pluginErrorsToText } from '@/api/types/plugins.types'
 import { PluginStatusBadge } from '@/features/plugins/components/PluginStatusBadge'
 import { Button } from '@/components/ui/button'
 import {
@@ -61,6 +67,7 @@ export function PluginRow({
     : null
 
   const hasError = plugin.status === 'errored'
+  const isWarningOnly = plugin.errorSeverity === 'warning'
   const pypiUrl = getPyPIUrl(plugin.pipSource)
 
   return (
@@ -68,7 +75,10 @@ export function PluginRow({
       className={cn(
         'group grid grid-cols-1 items-center gap-4 px-6 py-5 transition-colors hover:bg-muted/50 sm:grid-cols-12',
         !plugin.isEnabled && 'opacity-75 hover:opacity-100',
-        hasError && 'bg-red-50/50 dark:bg-red-950/20',
+        hasError &&
+          (isWarningOnly
+            ? 'bg-amber-50/50 dark:bg-amber-950/20'
+            : 'bg-red-50/50 dark:bg-red-950/20'),
       )}
     >
       {/* Plugin Details */}
@@ -77,17 +87,28 @@ export function PluginRow({
         <div>
           <div className="flex items-center gap-2">
             <H4 className="text-sm font-semibold">{plugin.name}</H4>
-            {hasError && (
+            {/* Diagnostics icon — also shown for loaded plugins carrying warnings */}
+            {(hasError || plugin.errorDetail) && (
               <Tooltip>
                 <TooltipTrigger>
-                  <AlertCircle className="h-4 w-4 text-red-500" />
+                  {isWarningOnly ? (
+                    <TriangleAlert className="h-4 w-4 text-amber-500" />
+                  ) : (
+                    <AlertCircle className="h-4 w-4 text-red-500" />
+                  )}
                 </TooltipTrigger>
                 <TooltipContent>
-                  <P className="max-w-xs text-xs whitespace-pre-line text-inherit">
-                    {plugin.errorDetail
-                      ? pluginErrorsToText(plugin.errorDetail)
-                      : t('status.errored')}
-                  </P>
+                  {plugin.errorDetail ? (
+                    <PluginDiagnostics
+                      errors={plugin.errorDetail}
+                      plain
+                      className="max-w-xs"
+                    />
+                  ) : (
+                    <P className="max-w-xs text-xs text-inherit">
+                      {t('status.errored')}
+                    </P>
+                  )}
                 </TooltipContent>
               </Tooltip>
             )}
@@ -121,6 +142,7 @@ export function PluginRow({
         <PluginStatusBadge
           status={plugin.status}
           hasUpdate={plugin.hasUpdate}
+          severity={plugin.errorSeverity}
         />
       </div>
 

--- a/frontend/src/features/plugins/components/PluginRow.tsx
+++ b/frontend/src/features/plugins/components/PluginRow.tsx
@@ -70,6 +70,10 @@ export function PluginRow({
   const isWarningOnly = plugin.errorSeverity === 'warning'
   const pypiUrl = getPyPIUrl(plugin.pipSource)
 
+  // Roughly when line-clamp-6 will cut the tooltip text (~45 chars/line)
+  const diagnosticsClamped =
+    (plugin.errorDetail?.reduce((n, e) => n + e.detail.length, 0) ?? 0) > 240
+
   return (
     <div
       className={cn(
@@ -99,11 +103,16 @@ export function PluginRow({
                 </TooltipTrigger>
                 <TooltipContent>
                   {plugin.errorDetail ? (
-                    <PluginDiagnostics
-                      errors={plugin.errorDetail}
-                      plain
-                      className="max-w-xs"
-                    />
+                    <div className="max-w-xs">
+                      <div className="line-clamp-6">
+                        <PluginDiagnostics errors={plugin.errorDetail} plain />
+                      </div>
+                      {diagnosticsClamped && (
+                        <P className="mt-1 text-xs text-inherit opacity-70">
+                          {t('diagnostics.seeDetails')}
+                        </P>
+                      )}
+                    </div>
                   ) : (
                     <P className="max-w-xs text-xs text-inherit">
                       {t('status.errored')}

--- a/frontend/src/features/plugins/components/PluginRow.tsx
+++ b/frontend/src/features/plugins/components/PluginRow.tsx
@@ -21,6 +21,7 @@ import { getPyPIUrl } from '../utils/plugin-url'
 import { CapabilityBadges } from './CapabilityBadges'
 import { PluginIcon } from './PluginIcon'
 import type { PluginCompositeId, PluginInfo } from '@/api/types/plugins.types'
+import { pluginErrorsToText } from '@/api/types/plugins.types'
 import { PluginStatusBadge } from '@/features/plugins/components/PluginStatusBadge'
 import { Button } from '@/components/ui/button'
 import {
@@ -82,8 +83,10 @@ export function PluginRow({
                   <AlertCircle className="h-4 w-4 text-red-500" />
                 </TooltipTrigger>
                 <TooltipContent>
-                  <P className="max-w-xs text-xs text-inherit">
-                    {plugin.errorDetail || t('status.errored')}
+                  <P className="max-w-xs text-xs whitespace-pre-line text-inherit">
+                    {plugin.errorDetail
+                      ? pluginErrorsToText(plugin.errorDetail)
+                      : t('status.errored')}
                   </P>
                 </TooltipContent>
               </Tooltip>

--- a/frontend/src/features/plugins/components/PluginStatusBadge.tsx
+++ b/frontend/src/features/plugins/components/PluginStatusBadge.tsx
@@ -21,7 +21,10 @@
  */
 
 import { useTranslation } from 'react-i18next'
-import type { PluginStatus } from '@/api/types/plugins.types'
+import type {
+  PluginErrorSeverity,
+  PluginStatus,
+} from '@/api/types/plugins.types'
 import type { StatusBadgeVariant } from '@/components/common/StatusBadge'
 import {
   STATUS_BADGE_VARIANTS,
@@ -32,12 +35,15 @@ interface PluginStatusBadgeProps {
   status: PluginStatus
   /** Whether an update is available (shown as visual indicator) */
   hasUpdate?: boolean
+  /** Max diagnostic severity — softens 'errored' to a Warning badge when warning-only */
+  severity?: PluginErrorSeverity | null
   className?: string
 }
 
 export function PluginStatusBadge({
   status,
   hasUpdate,
+  severity,
   className,
 }: PluginStatusBadgeProps) {
   const { t } = useTranslation('plugins')
@@ -58,7 +64,9 @@ export function PluginStatusBadge({
   const variant: StatusBadgeVariant =
     hasUpdate && status === 'loaded'
       ? { label: t('status.updateAvailable'), ...STATUS_BADGE_VARIANTS.warning }
-      : statusConfig[status]
+      : status === 'errored' && severity === 'warning'
+        ? { label: t('status.warning'), ...STATUS_BADGE_VARIANTS.warning }
+        : statusConfig[status]
 
   return <StatusBadge variant={variant} className={className} />
 }

--- a/frontend/src/features/plugins/components/UpdatesAvailableSection.tsx
+++ b/frontend/src/features/plugins/components/UpdatesAvailableSection.tsx
@@ -17,6 +17,7 @@
 import { Download } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { PluginIcon } from './PluginIcon'
+import { PluginStatusBadge } from './PluginStatusBadge'
 import type { PluginCompositeId, PluginInfo } from '@/api/types/plugins.types'
 import { H3, H4, P } from '@/components/base/typography'
 import { Button } from '@/components/ui/button'
@@ -61,6 +62,10 @@ export function UpdatesAvailableSection({
                 <div className="flex flex-col gap-1">
                   <div className="flex items-center gap-2">
                     <H4 className="font-semibold">{plugin.name}</H4>
+                    {/* Non-healthy state belongs next to the update decision */}
+                    {plugin.status !== 'loaded' && (
+                      <PluginStatusBadge status={plugin.status} />
+                    )}
                     <span className="rounded-full border border-amber-200 bg-amber-100 px-2 py-0.5 text-sm font-bold text-amber-800 dark:border-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
                       {t('updateBadge', { version: plugin.latestVersion })}
                     </span>

--- a/frontend/src/features/plugins/components/UpdatesAvailableSection.tsx
+++ b/frontend/src/features/plugins/components/UpdatesAvailableSection.tsx
@@ -64,7 +64,10 @@ export function UpdatesAvailableSection({
                     <H4 className="font-semibold">{plugin.name}</H4>
                     {/* Non-healthy state belongs next to the update decision */}
                     {plugin.status !== 'loaded' && (
-                      <PluginStatusBadge status={plugin.status} />
+                      <PluginStatusBadge
+                        status={plugin.status}
+                        severity={plugin.errorSeverity}
+                      />
                     )}
                     <span className="rounded-full border border-amber-200 bg-amber-100 px-2 py-0.5 text-sm font-bold text-amber-800 dark:border-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
                       {t('updateBadge', { version: plugin.latestVersion })}

--- a/frontend/src/locales/en/plugins.json
+++ b/frontend/src/locales/en/plugins.json
@@ -67,6 +67,7 @@
     "error": "Plugin System Error"
   },
   "diagnostics": {
+    "seeDetails": "See the details page for the full text",
     "source": {
       "install": "Installation",
       "load": "Plugin load",

--- a/frontend/src/locales/en/plugins.json
+++ b/frontend/src/locales/en/plugins.json
@@ -61,9 +61,22 @@
     "uninstalled": "Uninstalled",
     "available": "Available",
     "errored": "Errored",
+    "warning": "Warning",
     "updateAvailable": "Update Available",
     "incompatible": "Incompatible",
     "error": "Plugin System Error"
+  },
+  "diagnostics": {
+    "source": {
+      "install": "Installation",
+      "load": "Plugin load",
+      "template_ingest": "Template ingestion"
+    },
+    "severity": {
+      "warning": "Warning",
+      "error": "Error",
+      "critical": "Critical"
+    }
   },
   "updatesSection": {
     "title": "Updates Available",

--- a/frontend/src/routes/_authenticated/admin/plugins.index.tsx
+++ b/frontend/src/routes/_authenticated/admin/plugins.index.tsx
@@ -140,12 +140,16 @@ function PluginsPage() {
       .filter(matchesCapability)
       .filter(matchesSearch)
 
-    // Separate updates
+    // Updatable plugins get the call-to-action section but stay in the installed
+    // list — excluding them there hides status, diagnostics, and controls.
     const withUpdates = filteredPlugins.filter((p) => p.hasUpdate)
-    const installed = filteredPlugins.filter((p) => !p.hasUpdate)
+    const installed = filteredPlugins
 
-    // Sort: loaded first, then by name
+    // Sort: updatable first, then enabled, then by name
     installed.sort((a, b) => {
+      if (a.hasUpdate !== b.hasUpdate) {
+        return a.hasUpdate ? -1 : 1
+      }
       if (a.isEnabled !== b.isEnabled) {
         return a.isEnabled ? -1 : 1
       }

--- a/frontend/tests/integration/features/plugins/plugin-detail.test.tsx
+++ b/frontend/tests/integration/features/plugins/plugin-detail.test.tsx
@@ -48,6 +48,7 @@ const mockPlugin: PluginInfo = {
   hasUpdate: false,
   updatedAt: null,
   errorDetail: null,
+  errorSeverity: null,
   comment: null,
   pipSource: null,
   moduleName: null,

--- a/frontend/tests/integration/features/plugins/plugin-updates.test.tsx
+++ b/frontend/tests/integration/features/plugins/plugin-updates.test.tsx
@@ -26,8 +26,10 @@
 import { useMemo, useState } from 'react'
 import { RefreshCw } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { HttpResponse, http } from 'msw'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderWithRouter } from '@tests/utils/render'
+import { worker } from '@tests/../mocks/browser'
 import type { PluginCompositeId, PluginInfo } from '@/api/types/plugins.types'
 import type {
   CapabilityFilter,
@@ -42,6 +44,7 @@ import {
   useUninstallPlugin,
   useUpdatePlugin,
 } from '@/api/hooks/usePlugins'
+import { API_ENDPOINTS } from '@/api/endpoints'
 import { Button } from '@/components/ui/button'
 import { LoadingSpinner } from '@/components/common/LoadingSpinner'
 import { PageHeader } from '@/components/common/PageHeader'
@@ -142,10 +145,14 @@ function TestPluginsPage() {
       )
     }
 
+    // Mirrors plugins.index.tsx: updatable plugins stay in the installed list too
     const withUpdates = filteredPlugins.filter((p) => p.hasUpdate)
-    const installed = filteredPlugins.filter((p) => !p.hasUpdate)
+    const installed = filteredPlugins
 
     installed.sort((a, b) => {
+      if (a.hasUpdate !== b.hasUpdate) {
+        return a.hasUpdate ? -1 : 1
+      }
       if (a.isEnabled !== b.isEnabled) {
         return a.isEnabled ? -1 : 1
       }
@@ -293,8 +300,11 @@ describe('Plugin Updates Integration', () => {
         .element(screen.getByRole('heading', { name: 'Plugin Store' }))
         .toBeVisible()
 
-      // ECMWF Ensemble has loaded_version '2.1.0' but remote_info version '2.4.0'
-      await expect.element(screen.getByText('ECMWF Ensemble')).toBeVisible()
+      // ECMWF Ensemble has loaded_version '2.1.0' but remote_info version '2.4.0';
+      // it renders in the updates section AND the installed list
+      await expect
+        .element(screen.getByText('ECMWF Ensemble').first())
+        .toBeVisible()
     })
 
     it('shows the update count in the section header', async () => {
@@ -366,6 +376,67 @@ describe('Plugin Updates Integration', () => {
     })
   })
 
+  describe('Errored Plugin With Update (dual visibility)', () => {
+    afterEach(() => {
+      worker.resetHandlers()
+    })
+
+    it('shows an errored updatable plugin in both sections with its diagnostics', async () => {
+      worker.use(
+        http.get(API_ENDPOINTS.plugin.details, () =>
+          HttpResponse.json({
+            plugins: {
+              "store='ecmwf' local='broken-ensemble'": {
+                status: 'errored',
+                store_info: {
+                  pip_source: 'fiab-plugin-broken',
+                  module_name: 'fiab_plugin_broken',
+                  display_title: 'Broken Ensemble',
+                  display_description: 'Errored plugin that has an update',
+                  display_author: 'ECMWF',
+                  comment: '',
+                },
+                remote_info: { version: '2.4.0' },
+                errored_detail: [
+                  {
+                    source: 'load',
+                    detail: 'import failed: incompatible core',
+                    severity: 'error',
+                  },
+                ],
+                loaded_version: '2.1.0',
+                update_datetime: '2026-02-03T00:00:00+00:00',
+              },
+            },
+          }),
+        ),
+      )
+
+      const screen = await renderWithRouter(<TestPluginsPage />)
+
+      await expect
+        .element(screen.getByRole('heading', { name: 'Plugin Store' }))
+        .toBeVisible()
+
+      // In the updates call-to-action section...
+      await expect.element(screen.getByText('Updates Available')).toBeVisible()
+
+      // ...AND counted in the installed list
+      await expect.element(screen.getByText('Total: 1')).toBeVisible()
+      await expect
+        .element(screen.getByText('Broken Ensemble').nth(1))
+        .toBeVisible()
+
+      // Errored status badge in both places (updates row + installed card)
+      await expect.element(screen.getByText('Errored').nth(1)).toBeVisible()
+
+      // Structured diagnostics visible on the installed card
+      await expect
+        .element(screen.getByText('import failed: incompatible core'))
+        .toBeVisible()
+    })
+  })
+
   describe('Filtering Updates', () => {
     it('shows only plugins with updates when hasUpdate filter is selected', async () => {
       const screen = await renderWithRouter(<TestPluginsPage />)
@@ -386,10 +457,12 @@ describe('Plugin Updates Integration', () => {
       await updatesOption.click()
 
       // After filtering, ECMWF Ensemble should still be visible (it has an update)
-      await expect.element(screen.getByText('ECMWF Ensemble')).toBeVisible()
+      await expect
+        .element(screen.getByText('ECMWF Ensemble').first())
+        .toBeVisible()
 
-      // Installed count should show 0 (all plugins with updates are in the updates section, not installed)
-      await expect.element(screen.getByText('Total: 0')).toBeVisible()
+      // Updatable plugins stay in the installed list, so the count includes them
+      await expect.element(screen.getByText('Total: 1')).toBeVisible()
     })
 
     it('filters updates section by search query', async () => {
@@ -405,7 +478,9 @@ describe('Plugin Updates Integration', () => {
       await searchInput.fill('Ensemble')
 
       // ECMWF Ensemble should still be visible
-      await expect.element(screen.getByText('ECMWF Ensemble')).toBeVisible()
+      await expect
+        .element(screen.getByText('ECMWF Ensemble').first())
+        .toBeVisible()
 
       // The updates section should still show
       await expect.element(screen.getByText('Updates Available')).toBeVisible()
@@ -509,7 +584,9 @@ describe('Plugin Updates Integration', () => {
 
       // Verify updates section is visible initially
       await expect.element(screen.getByText('Updates Available')).toBeVisible()
-      await expect.element(screen.getByText('ECMWF Ensemble')).toBeVisible()
+      await expect
+        .element(screen.getByText('ECMWF Ensemble').first())
+        .toBeVisible()
       await expect.element(screen.getByText('Current: v2.1.0')).toBeVisible()
 
       // Click Update Now on the ECMWF Ensemble plugin

--- a/frontend/tests/integration/features/plugins/plugins-management.test.tsx
+++ b/frontend/tests/integration/features/plugins/plugins-management.test.tsx
@@ -452,6 +452,114 @@ describe('Plugins Management Integration', () => {
     })
   })
 
+  describe('Severity-Aware Diagnostics', () => {
+    function detailsResponse(plugin: object) {
+      return HttpResponse.json({
+        plugins: { "store='ecmwf' local='diag-test'": plugin },
+      })
+    }
+
+    const baseDetail = {
+      store_info: {
+        pip_source: 'fiab-plugin-diag',
+        module_name: 'fiab_plugin_diag',
+        display_title: 'Diag Test',
+        display_description: 'Plugin for diagnostics rendering',
+        display_author: 'ECMWF',
+        comment: '',
+      },
+      remote_info: null,
+      loaded_version: '1.0.0',
+      update_datetime: null,
+    }
+
+    it('softens a warning-only errored plugin to an amber Warning badge', async () => {
+      worker.use(
+        http.get(API_ENDPOINTS.plugin.details, () =>
+          detailsResponse({
+            ...baseDetail,
+            status: 'errored',
+            errored_detail: [
+              {
+                source: 'template_ingest',
+                detail: "template 'x' failed validation",
+                severity: 'warning',
+              },
+            ],
+          }),
+        ),
+      )
+
+      const screen = await renderWithRouter(<TestPluginsPage />)
+      await expect
+        .element(screen.getByRole('heading', { name: 'Plugin Store' }))
+        .toBeVisible()
+
+      await expect
+        .element(screen.getByText('Warning', { exact: true }))
+        .toBeVisible()
+      await expect.element(screen.getByText('Errored')).not.toBeInTheDocument()
+      await expect
+        .element(screen.getByText(/template 'x' failed validation/))
+        .toBeVisible()
+    })
+
+    it('keeps the red Errored badge when any diagnostic is an error', async () => {
+      worker.use(
+        http.get(API_ENDPOINTS.plugin.details, () =>
+          detailsResponse({
+            ...baseDetail,
+            status: 'errored',
+            errored_detail: [
+              { source: 'install', detail: 'pip failed', severity: 'error' },
+              {
+                source: 'template_ingest',
+                detail: 'bad template',
+                severity: 'warning',
+              },
+            ],
+          }),
+        ),
+      )
+
+      const screen = await renderWithRouter(<TestPluginsPage />)
+      await expect
+        .element(screen.getByRole('heading', { name: 'Plugin Store' }))
+        .toBeVisible()
+
+      await expect.element(screen.getByText('Errored')).toBeVisible()
+      // Both diagnostics listed with their source labels
+      await expect.element(screen.getByText('Installation')).toBeVisible()
+      await expect.element(screen.getByText('Template ingestion')).toBeVisible()
+    })
+
+    it('shows warnings on a loaded plugin', async () => {
+      worker.use(
+        http.get(API_ENDPOINTS.plugin.details, () =>
+          detailsResponse({
+            ...baseDetail,
+            status: 'loaded',
+            errored_detail: [
+              {
+                source: 'load',
+                detail: 'version mismatch: DB has 0.9',
+                severity: 'warning',
+              },
+            ],
+          }),
+        ),
+      )
+
+      const screen = await renderWithRouter(<TestPluginsPage />)
+      await expect
+        .element(screen.getByRole('heading', { name: 'Plugin Store' }))
+        .toBeVisible()
+
+      await expect.element(screen.getByText('Loaded')).toBeVisible()
+      await expect.element(screen.getByText(/version mismatch/)).toBeVisible()
+    })
+  })
+
   describe('Error Handling', () => {
     it('handles plugin details API returning 500', async () => {
       worker.use(

--- a/frontend/tests/integration/features/plugins/plugins-management.test.tsx
+++ b/frontend/tests/integration/features/plugins/plugins-management.test.tsx
@@ -126,10 +126,14 @@ function TestPluginsPage() {
       .filter(matchesCapability)
       .filter(matchesSearch)
 
+    // Mirrors plugins.index.tsx: updatable plugins stay in the installed list too
     const withUpdates = filteredPlugins.filter((p) => p.hasUpdate)
-    const installed = filteredPlugins.filter((p) => !p.hasUpdate)
+    const installed = filteredPlugins
 
     installed.sort((a, b) => {
+      if (a.hasUpdate !== b.hasUpdate) {
+        return a.hasUpdate ? -1 : 1
+      }
       if (a.isEnabled !== b.isEnabled) {
         return a.isEnabled ? -1 : 1
       }
@@ -290,8 +294,11 @@ describe('Plugins Management Integration', () => {
 
       // Updates section should show plugins with hasUpdate: true
       // From mock data: "ECMWF Ensemble" has an update available
+      // (it renders in the updates section AND the installed list)
       await expect.element(screen.getByText('Updates Available')).toBeVisible()
-      await expect.element(screen.getByText('ECMWF Ensemble')).toBeVisible()
+      await expect
+        .element(screen.getByText('ECMWF Ensemble').first())
+        .toBeVisible()
     })
 
     it('displays available plugins section', async () => {

--- a/frontend/tests/unit/api/endpoints/plugins.test.ts
+++ b/frontend/tests/unit/api/endpoints/plugins.test.ts
@@ -14,14 +14,15 @@ import { worker } from '@tests/../mocks/browser'
 import type {
   PluginCompositeId,
   PluginListing,
+  PluginSettingsUpdate,
 } from '@/api/types/plugins.types'
 import {
   getPluginDetails,
   getPluginStatus,
   installPlugin,
-  modifyPluginEnabled,
   uninstallPlugin,
   updatePlugin,
+  updatePluginSettings,
 } from '@/api/endpoints/plugins'
 import { API_ENDPOINTS } from '@/api/endpoints'
 
@@ -66,6 +67,18 @@ describe('getPluginStatus', () => {
       },
       plugin_updatedatetime: {
         [createPluginKey('ecmwf', 'anemoi-inference')]: '2025-01-15T00:00:00',
+      },
+      plugin_enabled: {
+        [createPluginKey('ecmwf', 'anemoi-inference')]: true,
+        [createPluginKey('ecmwf', 'legacy-viz')]: true,
+      },
+      plugin_excluded_templates: {
+        [createPluginKey('ecmwf', 'anemoi-inference')]: ['Excluded Template'],
+      },
+      plugin_glyph_remapping: {
+        [createPluginKey('ecmwf', 'anemoi-inference')]: {
+          old_name: 'new_name',
+        },
       },
     }
 
@@ -194,10 +207,14 @@ describe('uninstallPlugin', () => {
   })
 })
 
-describe('modifyPluginEnabled', () => {
+describe('updatePluginSettings', () => {
   afterEach(() => {
     worker.resetHandlers()
   })
+
+  type SettingsBody = {
+    pluginCompositeId: PluginCompositeId
+  } & PluginSettingsUpdate
 
   it('enables plugin successfully', async () => {
     const testPluginId = pluginId('ecmwf', 'anemoi-inference')
@@ -205,10 +222,7 @@ describe('modifyPluginEnabled', () => {
 
     worker.use(
       http.post(API_ENDPOINTS.plugin.settings, async ({ request }) => {
-        const body = (await request.json()) as {
-          pluginCompositeId: PluginCompositeId
-          isEnabled?: boolean
-        }
+        const body = (await request.json()) as SettingsBody
         expect(body.pluginCompositeId.store).toBe('ecmwf')
         expect(body.pluginCompositeId.local).toBe('anemoi-inference')
         receivedIsEnabled = body.isEnabled
@@ -216,7 +230,7 @@ describe('modifyPluginEnabled', () => {
       }),
     )
 
-    await modifyPluginEnabled(testPluginId, true)
+    await updatePluginSettings(testPluginId, { isEnabled: true })
     expect(receivedIsEnabled).toBe(true)
   })
 
@@ -226,17 +240,36 @@ describe('modifyPluginEnabled', () => {
 
     worker.use(
       http.post(API_ENDPOINTS.plugin.settings, async ({ request }) => {
-        const body = (await request.json()) as {
-          pluginCompositeId: PluginCompositeId
-          isEnabled?: boolean
-        }
+        const body = (await request.json()) as SettingsBody
         receivedIsEnabled = body.isEnabled
         return HttpResponse.json({ success: true })
       }),
     )
 
-    await modifyPluginEnabled(testPluginId, false)
+    await updatePluginSettings(testPluginId, { isEnabled: false })
     expect(receivedIsEnabled).toBe(false)
+  })
+
+  it('sends template exclusions and glyph remapping, omitting unset fields', async () => {
+    const testPluginId = pluginId('ecmwf', 'anemoi-inference')
+    let receivedBody: SettingsBody | undefined = undefined
+
+    worker.use(
+      http.post(API_ENDPOINTS.plugin.settings, async ({ request }) => {
+        receivedBody = (await request.json()) as SettingsBody
+        return HttpResponse.json({ success: true })
+      }),
+    )
+
+    await updatePluginSettings(testPluginId, {
+      excluded_templates: ['Broken Template'],
+      glyph_remapping: { old_name: 'new_name' },
+    })
+    expect(receivedBody).toEqual({
+      pluginCompositeId: testPluginId,
+      excluded_templates: ['Broken Template'],
+      glyph_remapping: { old_name: 'new_name' },
+    })
   })
 })
 

--- a/frontend/tests/unit/api/types/plugins.types.test.ts
+++ b/frontend/tests/unit/api/types/plugins.types.test.ts
@@ -13,6 +13,7 @@ import type { PluginCompositeId, PluginDetail } from '@/api/types/plugins.types'
 import {
   PluginDetailSchema,
   isNewerVersion,
+  isUnstampedVersion,
   pluginErrorsMaxSeverity,
   toPluginInfo,
 } from '@/api/types/plugins.types'
@@ -208,5 +209,24 @@ describe('toPluginInfo — hasUpdate', () => {
     expect(toPluginInfo(ID, installedWith('2.4.0', '2.1.0')).hasUpdate).toBe(
       false,
     )
+  })
+
+  it('does not flag against an unstamped (all-zero) dev install', () => {
+    expect(toPluginInfo(ID, installedWith('0.0.0', '1.0.0')).hasUpdate).toBe(
+      false,
+    )
+  })
+})
+
+describe('isUnstampedVersion', () => {
+  it('detects all-zero versions', () => {
+    expect(isUnstampedVersion('0.0.0')).toBe(true)
+    expect(isUnstampedVersion('0.0')).toBe(true)
+  })
+
+  it('is false for stamped or unparseable versions', () => {
+    expect(isUnstampedVersion('1.0.0')).toBe(false)
+    expect(isUnstampedVersion('0.0.1')).toBe(false)
+    expect(isUnstampedVersion('unknown')).toBe(false)
   })
 })

--- a/frontend/tests/unit/api/types/plugins.types.test.ts
+++ b/frontend/tests/unit/api/types/plugins.types.test.ts
@@ -13,6 +13,7 @@ import type { PluginCompositeId, PluginDetail } from '@/api/types/plugins.types'
 import {
   PluginDetailSchema,
   isNewerVersion,
+  pluginErrorsMaxSeverity,
   toPluginInfo,
 } from '@/api/types/plugins.types'
 
@@ -103,15 +104,51 @@ describe('toPluginInfo — errorDetail normalization', () => {
   it('normalizes an empty error list to null', () => {
     const info = toPluginInfo(ID, { ...detailWith(null), errored_detail: [] })
     expect(info.errorDetail).toBeNull()
+    expect(info.errorSeverity).toBeNull()
   })
 
-  it('passes structured errors through', () => {
+  it('passes structured errors through and derives the max severity', () => {
     const errors = [{ source: 'load', detail: 'boom', severity: 'error' }]
     const info = toPluginInfo(ID, {
       ...detailWith(null),
       errored_detail: errors,
     })
     expect(info.errorDetail).toEqual(errors)
+    expect(info.errorSeverity).toBe('error')
+  })
+})
+
+describe('pluginErrorsMaxSeverity', () => {
+  it('returns null for an empty list', () => {
+    expect(pluginErrorsMaxSeverity([])).toBeNull()
+  })
+
+  it('ranks critical > error > warning', () => {
+    expect(
+      pluginErrorsMaxSeverity([
+        { source: 'load', detail: 'a', severity: 'warning' },
+        { source: 'install', detail: 'b', severity: 'critical' },
+        { source: 'load', detail: 'c', severity: 'error' },
+      ]),
+    ).toBe('critical')
+  })
+
+  it('is warning for a warning-only list', () => {
+    expect(
+      pluginErrorsMaxSeverity([
+        { source: 'template_ingest', detail: 'a', severity: 'warning' },
+        { source: 'template_ingest', detail: 'b', severity: 'warning' },
+      ]),
+    ).toBe('warning')
+  })
+
+  it('treats unknown severities as error', () => {
+    expect(
+      pluginErrorsMaxSeverity([
+        { source: 'load', detail: 'a', severity: 'warning' },
+        { source: 'load', detail: 'b', severity: 'fatal' },
+      ]),
+    ).toBe('error')
   })
 })
 

--- a/frontend/tests/unit/api/types/plugins.types.test.ts
+++ b/frontend/tests/unit/api/types/plugins.types.test.ts
@@ -10,7 +10,11 @@
 
 import { describe, expect, it } from 'vitest'
 import type { PluginCompositeId, PluginDetail } from '@/api/types/plugins.types'
-import { PluginDetailSchema, toPluginInfo } from '@/api/types/plugins.types'
+import {
+  PluginDetailSchema,
+  isNewerVersion,
+  toPluginInfo,
+} from '@/api/types/plugins.types'
 
 const ID: PluginCompositeId = { store: 'ecmwf', local: 'anemoi-inference' }
 
@@ -78,29 +82,94 @@ describe('PluginDetailSchema — errored_detail parsing', () => {
     expect(result.errored_detail).toBeNull()
   })
 
-  it('concatenates multiple error details with newline', () => {
+  it('preserves structured errors', () => {
+    const errors = [
+      { source: 'install', detail: 'pip failed', severity: 'error' },
+      {
+        source: 'template_ingest',
+        detail: 'bad template',
+        severity: 'warning',
+      },
+    ]
     const result = PluginDetailSchema.parse({
       ...baseRaw,
-      errored_detail: [
-        { source: 'install', detail: 'pip failed', severity: 'error' },
-        { source: 'load', detail: 'import error', severity: 'error' },
-      ],
+      errored_detail: errors,
     })
-    expect(result.errored_detail).toBe('pip failed\nimport error')
+    expect(result.errored_detail).toEqual(errors)
+  })
+})
+
+describe('toPluginInfo — errorDetail normalization', () => {
+  it('normalizes an empty error list to null', () => {
+    const info = toPluginInfo(ID, { ...detailWith(null), errored_detail: [] })
+    expect(info.errorDetail).toBeNull()
   })
 
-  it('returns a single detail string for one error', () => {
-    const result = PluginDetailSchema.parse({
-      ...baseRaw,
-      errored_detail: [
-        { source: 'load', detail: 'module not found', severity: 'error' },
-      ],
+  it('passes structured errors through', () => {
+    const errors = [{ source: 'load', detail: 'boom', severity: 'error' }]
+    const info = toPluginInfo(ID, {
+      ...detailWith(null),
+      errored_detail: errors,
     })
-    expect(result.errored_detail).toBe('module not found')
+    expect(info.errorDetail).toEqual(errors)
+  })
+})
+
+describe('isNewerVersion', () => {
+  it('detects a newer remote release', () => {
+    expect(isNewerVersion('2.4.0', '2.1.0')).toBe(true)
   })
 
-  it('returns null for an empty error list', () => {
-    const result = PluginDetailSchema.parse({ ...baseRaw, errored_detail: [] })
-    expect(result.errored_detail).toBeNull()
+  it('compares segments numerically, not lexicographically', () => {
+    expect(isNewerVersion('1.10.0', '1.9.0')).toBe(true)
+    expect(isNewerVersion('1.9.0', '1.10.0')).toBe(false)
+  })
+
+  it('is false for equal versions, also with differing segment counts', () => {
+    expect(isNewerVersion('1.2.0', '1.2.0')).toBe(false)
+    expect(isNewerVersion('1.2', '1.2.0')).toBe(false)
+    expect(isNewerVersion('1.2.0', '1.2')).toBe(false)
+  })
+
+  it('is false when the loaded version is newer (dev installs)', () => {
+    expect(isNewerVersion('2.1.0', '2.4.0')).toBe(false)
+  })
+
+  it('is false for the backend "unknown" sentinel (failed PyPI lookup)', () => {
+    expect(isNewerVersion('unknown', '1.0.0')).toBe(false)
+    expect(isNewerVersion('1.0.0', 'unknown')).toBe(false)
+  })
+
+  it('ignores pre-release suffixes (final does not out-rank its own rc)', () => {
+    expect(isNewerVersion('1.2.3', '1.2.3rc1')).toBe(false)
+    expect(isNewerVersion('1.2.4', '1.2.3rc1')).toBe(true)
+  })
+})
+
+describe('toPluginInfo — hasUpdate', () => {
+  function installedWith(loaded: string, remote: string): PluginDetail {
+    return {
+      ...detailWith(null),
+      loaded_version: loaded,
+      remote_info: { version: remote },
+    }
+  }
+
+  it('flags an update when the remote release is newer', () => {
+    expect(toPluginInfo(ID, installedWith('2.1.0', '2.4.0')).hasUpdate).toBe(
+      true,
+    )
+  })
+
+  it('does not flag when the remote version is "unknown"', () => {
+    expect(toPluginInfo(ID, installedWith('2.1.0', 'unknown')).hasUpdate).toBe(
+      false,
+    )
+  })
+
+  it('does not flag when the loaded version is ahead of the remote', () => {
+    expect(toPluginInfo(ID, installedWith('2.4.0', '2.1.0')).hasUpdate).toBe(
+      false,
+    )
   })
 })


### PR DESCRIPTION
## Summary

Aligns the frontend with the plugin-assets backend work (#528–#530) and fixes how plugin problems are detected and displayed. Verified against a live backend serving plugin-shipped blueprint templates and structured diagnostics.

### API alignment (backend #528/#530)

- Keep `PluginError[]` structured instead of flattening it to a joined string; `PluginsStatusSchema` now parses the new `plugin_enabled`, `plugin_excluded_templates`, and `plugin_glyph_remapping` fields.
- Rename `modifyPluginEnabled` to `updatePluginSettings`, matching the merged `POST /plugin/settings` route and supporting its full request body (enable flag, template exclusions, glyph remapping); MSW mocks follow the new shapes.

### Update detection

- `hasUpdate` compared version strings with `!==` against the latest published release, so a failed PyPI lookup (the backend's literal `"unknown"` sentinel) or a locally newer dev install produced phantom update badges; it now uses a numeric release comparison (`isNewerVersion`) that ignores pre-release suffixes and never flags unparseable versions.
- All-zero versions (unstamped dev/workspace installs reporting `0.0.0`) are treated as having no update, so dev checkouts stop advertising "updates" that would pip-install over the editable workspace package.

### Plugin error visibility

- Updatable plugins were shown only in the updates call-to-action section, which renders no status, diagnostics, or enable/uninstall controls — an errored plugin with a pending update looked perfectly healthy; they now also stay in the installed list (sorted first), and the updates section shows a status badge for non-loaded plugins.
- New `PluginDiagnostics` component renders each structured error with a severity icon and a source label (Installation / Plugin load / Template ingestion) — in cards, list-row tooltips, and the plugin detail page, which previously showed no diagnostics at all.
- Warning-only plugins soften from red "Errored" to an amber "Warning" badge, border, and row tint, and warnings on loaded plugins (version mismatch, template ingest failures) are now visible instead of silently dropped.
- Row tooltips clamp long diagnostics (e.g. full pip resolution logs) to six lines and point to the detail page, which renders the full text.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
