### PR TITLE
refactor: strip factory_id from BlockInstance; add LocalBlock and Rou…

### DIFF
--- a/.github/lsp.json
+++ b/.github/lsp.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "it would make more sense to put this file to repo root lsp.json, instead of .github -- but copilot cli currently fails to utilize that correctly, hence we need to have it here. Even a symlink glitches. Additionally, we *dont* use the project's venv, because in container+mount agent setup, the venv is non-standard, and again copilot clean child spawning does not cooperate nicely with that",
+  "lspServers": {
+    "python": {
+      "command": "uvx",
+      "args": ["--directory", "backend", "ty", "server"],
+      "fileExtensions": {
+        ".py": "python"
+      }
+    }
+  }
+}

--- a/.github/skills/frontend-impact/SKILL.md
+++ b/.github/skills/frontend-impact/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: frontend-impact
+description: Analyzes the changes made in the current branch to the codebase in `backend/`, determines how those changes impact the `frontend/` codebase, and writes minimalistic fixes to resolve compatibility issues.
+---
+
+# Submodule Impact Analyzer and Fixer
+
+You are a software engineer designed to propagation-fix changes across tightly coupled codebases.
+You have full power to run git commands, view files, make direct code edits, run unit tests and lint commands.
+
+## Step-by-Step Execution Plan
+
+1. **Inspect Backend Changes:**
+   - Use `git` to inspect all changes in the current branch against the `main` branch that are located in the `backend/` subdirectory.
+   - Keep the backend/development.md guide in mind -- it should be that only changes that affect any `*/routes/*` path affect `frontend`, nothing else. But there are a few exception -- some classes in `*/domain/*` are exposed, as well as some classes in `*/fiab-core/*`.
+   - Do not focus on *new features* introduces -- focus on breaking changes of *existing features*.
+   
+2. **Trace Impact on Frontend:**
+   - Search the `frontend/` codebase for whether they use affected routes and Request/Response classes, and note all affected files.
+   - Note that you need to cover *both* the production code as well as the mock tests which simulate the backend.
+   - You may notice at this stage that despite the change on the backend is formally breaking, the frontend was actually not using that -- you can then ignore those.
+
+3. **Formulate and Execute Fixes:**
+   - Ideate the changes. You should be minimalistic! Do not introduce new UI elements, do not change inner workings of the frontend. If possible, coerce via some sort of adapter the new contract into the original one, so that the blast radius is minimized. The goal is not to improve the frontend, it is only to *maintain existing functionality*.
+   - Modify the code in the `frontend/` codebase and tests and mocks to accommodate the changes. Make sure you respect the frontend style guide and local conventions.
+   - Do *not* modify the `backend/` codebase! If you believe you have identified a bug in the backend codebase, stop making any further edits, output description of the bug, and wait for user input.
+
+4. **Verification:**
+    - Run all the tests and linting as specified in the `frontend/AGENTS.md`. Once all of that passes, commit, don't push.

--- a/backend/packages/fiab-core/src/fiab_core/fable.py
+++ b/backend/packages/fiab-core/src/fiab_core/fable.py
@@ -132,7 +132,7 @@ class BlockInstance(FiabCoreBaseModel):
 
     configuration_values: dict[ConfigurationOptionId, Any]
     """Keys come from factory's `configuration_options`, values are either str-serialized (frontend2backend) or deserialized (backend2plugin)"""
-    input_ids: dict[str, BlockInstanceId]
+    input_ids: dict[str, BlockInstanceId] = Field(default_factory=dict)
     """Keys come from factory's `inputs`, values are other blocks in the (partial) fable"""
 
 

--- a/backend/packages/fiab-core/src/fiab_core/fable.py
+++ b/backend/packages/fiab-core/src/fiab_core/fable.py
@@ -22,6 +22,9 @@ from typing_extensions import Self
 from fiab_core.pydantic_utils import FiabCoreBaseModel
 from fiab_core.types import FableType, NotFableType
 
+Error = str
+"""Compiler/validator error message type alias."""
+
 
 class BlockConfigurationOption(FiabCoreBaseModel):
     title: str

--- a/backend/packages/fiab-core/src/fiab_core/fable.py
+++ b/backend/packages/fiab-core/src/fiab_core/fable.py
@@ -149,14 +149,19 @@ class PluginBlockExpansion(FiabCoreBaseModel):
 
 
 class BlockInstance(FiabCoreBaseModel):
-    """As produced by BlockFactory *by the client* -- basically the configuration/inputs values"""
+    """Pure block content: configuration values and input wiring. No routing concern."""
 
-    factory_id: PluginBlockFactoryId
-    # TODO separe into two classes with BlockInstanceRequest containing str, to improve the backend codebase typing etc
     configuration_values: dict[ConfigurationOptionId, Any]
-    """Keys come frome factory's `configuration_options`, values are either str-serialized (frontend2backend) or deserialized (backend2plugin)"""
+    """Keys come from factory's `configuration_options`, values are either str-serialized (frontend2backend) or deserialized (backend2plugin)"""
     input_ids: dict[str, BlockInstanceId]
     """Keys come from factory's `inputs`, values are other blocks in the (partial) fable"""
+
+
+class LocalBlock(FiabCoreBaseModel):
+    """A block as declared inside a plugin (for BlueprintTemplates): carries only a local factory id."""
+
+    factory_id: BlockFactoryId
+    instance: BlockInstance
 
 
 class QubedOutput(FiabCoreBaseModel):
@@ -199,16 +204,8 @@ class BlueprintTemplate(FiabCoreBaseModel):
 
     display_name: str
     display_description: str
-    blocks: dict[BlockInstanceId, BlockInstance]
+    blocks: dict[BlockInstanceId, LocalBlock]
     environment: BlueprintTemplateEnvironment | None = None
     local_glyphs: dict[str, str] = Field(default_factory=dict)
     example_values: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = Field(default_factory=dict)
     example_glyphs: dict[str, str] = Field(default_factory=dict)
-
-
-SelfPluginId = PluginCompositeId(store=PluginStoreId("__self__"), local=PluginId("__self__"))
-"""Use this when building the blueprint templates shipped by a plugin.
-
-The backend substitutes the real plugin composite ID at install time.
-"""
-# TODO this class shows some awkwardness -- ideally, we'll make the existence of PluginCompositeId completely unknown to the insides of the plugins, at the expense of the backend mutating the classes at the routing time

--- a/backend/packages/fiab-core/src/fiab_core/fable.py
+++ b/backend/packages/fiab-core/src/fiab_core/fable.py
@@ -124,19 +124,6 @@ class BlockExpansion(FiabCoreBaseModel):
     """Restrictions on configuration options for this expansion"""
 
 
-class PluginBlockExpansion(FiabCoreBaseModel):
-    """Expansion result as returned to clients, combining plugin identity with restrictions.
-
-    This is the service-level representation sent to API consumers, containing
-    the full plugin composite id, factory id, and serialized restriction types.
-    """
-
-    plugin: PluginCompositeId
-    factory: BlockFactoryId
-    restrictions: dict[ConfigurationOptionId, str] = Field(default_factory=dict)
-    """Serialized FableType restrictions (e.g., 'int', 'enumClosed[a,b]')"""
-
-
 class BlockInstance(FiabCoreBaseModel):
     """Configuration values and input wiring, as specified by a client when building a Fable."""
 

--- a/backend/packages/fiab-core/src/fiab_core/fable.py
+++ b/backend/packages/fiab-core/src/fiab_core/fable.py
@@ -132,6 +132,7 @@ class BlockInstance(FiabCoreBaseModel):
 
     configuration_values: dict[ConfigurationOptionId, Any]
     """Keys come from factory's `configuration_options`, values are either str-serialized (frontend2backend) or deserialized (backend2plugin)"""
+    # TODO separate the backend class to have a str type there
     input_ids: dict[str, BlockInstanceId] = Field(default_factory=dict)
     """Keys come from factory's `inputs`, values are other blocks in the (partial) fable"""
 

--- a/backend/packages/fiab-core/src/fiab_core/fable.py
+++ b/backend/packages/fiab-core/src/fiab_core/fable.py
@@ -100,17 +100,6 @@ class PluginCompositeId(FiabCoreBaseModel):
         return f"{k.store}:{k.local}"
 
 
-class PluginBlockFactoryId(FiabCoreBaseModel):
-    """Note to plugin authors: This is a routing class. When you implement your BlockFactories for the catalogue,
-    you dont use this, you only need to declare a BlockFactoryId unique inside your plugin. Similarly, when you
-    return which BlockFactories are possible in the expand method, you only return your BlockFactoryIds. This
-    appears only when you receive BlockInstances in the compile/validate -- and again, you just need to use the
-    BlockFactoryId part of this class, as the PluginCompositeId is guaranteed to correspond to your plugin"""
-
-    plugin: PluginCompositeId
-    factory: BlockFactoryId
-
-
 class BlockFactoryCatalogue(FiabCoreBaseModel):
     factories: dict[BlockFactoryId, BlockFactory]
 
@@ -139,7 +128,7 @@ class PluginBlockExpansion(FiabCoreBaseModel):
     """Expansion result as returned to clients, combining plugin identity with restrictions.
 
     This is the service-level representation sent to API consumers, containing
-    the full PluginBlockFactoryId and serialized restriction types.
+    the full plugin composite id, factory id, and serialized restriction types.
     """
 
     plugin: PluginCompositeId
@@ -149,19 +138,12 @@ class PluginBlockExpansion(FiabCoreBaseModel):
 
 
 class BlockInstance(FiabCoreBaseModel):
-    """Pure block content: configuration values and input wiring. No routing concern."""
+    """Configuration values and input wiring, as specified by a client when building a Fable."""
 
     configuration_values: dict[ConfigurationOptionId, Any]
     """Keys come from factory's `configuration_options`, values are either str-serialized (frontend2backend) or deserialized (backend2plugin)"""
     input_ids: dict[str, BlockInstanceId]
     """Keys come from factory's `inputs`, values are other blocks in the (partial) fable"""
-
-
-class LocalBlock(FiabCoreBaseModel):
-    """A block as declared inside a plugin (for BlueprintTemplates): carries only a local factory id."""
-
-    factory_id: BlockFactoryId
-    instance: BlockInstance
 
 
 class QubedOutput(FiabCoreBaseModel):
@@ -193,6 +175,13 @@ class BlueprintTemplateEnvironment(FiabCoreBaseModel):
     environment_variables: dict[str, str] = Field(default_factory=dict)
 
 
+class BlueprintTemplateBlock(FiabCoreBaseModel):
+    """A routing-equipped wrapper around a BlockInstance"""
+
+    factory_id: BlockFactoryId
+    instance: BlockInstance
+
+
 class BlueprintTemplate(FiabCoreBaseModel):
     """A partial, ready-to-customise blueprint shipped by a plugin.
 
@@ -204,7 +193,7 @@ class BlueprintTemplate(FiabCoreBaseModel):
 
     display_name: str
     display_description: str
-    blocks: dict[BlockInstanceId, LocalBlock]
+    blocks: dict[BlockInstanceId, BlueprintTemplateBlock]
     environment: BlueprintTemplateEnvironment | None = None
     local_glyphs: dict[str, str] = Field(default_factory=dict)
     example_values: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = Field(default_factory=dict)

--- a/backend/packages/fiab-core/src/fiab_core/plugin.py
+++ b/backend/packages/fiab-core/src/fiab_core/plugin.py
@@ -59,7 +59,7 @@ Expander = Callable[[BlockInstanceOutput], list[BlockExpansion]]
 """Given a block instance output (including from other plugin), provide which block factories from this plugin can expand it"""
 
 Compiler = Callable[[ActionLookup, BlockFactoryId, BlockInstance], Either[Action, Error]]  # ty:ignore[invalid-type-arguments] # semigroup
-"""Given a cascade builder, represented as lookup of fluent actions, the local factory id, and a block instance corresponding to this plugin's Factory, either return the fluent action resulting from this block or an error"""
+"""Given a cascade builder, represented as lookup of fluent actions, a factory id from this Plugin, and a block instance corresponding to it, either return the fluent action resulting from this block or an error"""
 
 
 @dataclass(frozen=True, eq=True, slots=True)

--- a/backend/packages/fiab-core/src/fiab_core/plugin.py
+++ b/backend/packages/fiab-core/src/fiab_core/plugin.py
@@ -21,6 +21,7 @@ from fiab_core.fable import (
     ActionLookup,
     BlockExpansion,
     BlockFactoryCatalogue,
+    BlockFactoryId,
     BlockInstance,
     BlockInstanceOutput,
     BlueprintTemplate,
@@ -51,14 +52,14 @@ class BlockValidation:
     restrictions: ConfigurationOptionRestriction = field(default_factory=dict)
 
 
-Validator = Callable[[BlockInstance, dict[str, BlockInstanceOutput]], BlockValidation]
-"""Given a block instance and its inputs, return either error or output and configuration restrictions"""
+Validator = Callable[[BlockFactoryId, BlockInstance, dict[str, BlockInstanceOutput]], BlockValidation]
+"""Given a factory id, a block instance, and its inputs, return either error or output and configuration restrictions"""
 
 Expander = Callable[[BlockInstanceOutput], list[BlockExpansion]]
 """Given a block instance output (including from other plugin), provide which block factories from this plugin can expand it"""
 
-Compiler = Callable[[ActionLookup, BlockInstance], Either[Action, Error]]  # ty:ignore[invalid-type-arguments] # semigroup
-"""Given a cascade builder, represented as lookup of fluent actions, and a block instance corresponding to this plugin's Factory, either return the fluent action resulting from this block or an error"""
+Compiler = Callable[[ActionLookup, BlockFactoryId, BlockInstance], Either[Action, Error]]  # ty:ignore[invalid-type-arguments] # semigroup
+"""Given a cascade builder, represented as lookup of fluent actions, the local factory id, and a block instance corresponding to this plugin's Factory, either return the fluent action resulting from this block or an error"""
 
 
 @dataclass(frozen=True, eq=True, slots=True)

--- a/backend/packages/fiab-core/src/fiab_core/plugin.py
+++ b/backend/packages/fiab-core/src/fiab_core/plugin.py
@@ -26,9 +26,8 @@ from fiab_core.fable import (
     BlockInstanceOutput,
     BlueprintTemplate,
     ConfigurationOptionRestriction,
+    Error,
 )
-
-Error = str
 
 
 @dataclass(frozen=True, eq=True, slots=True)

--- a/backend/packages/fiab-core/src/fiab_core/plugin.py
+++ b/backend/packages/fiab-core/src/fiab_core/plugin.py
@@ -52,7 +52,7 @@ class BlockValidation:
 
 
 Validator = Callable[[BlockFactoryId, BlockInstance, dict[str, BlockInstanceOutput]], BlockValidation]
-"""Given a factory id, a block instance, and its inputs, return either error or output and configuration restrictions"""
+"""Given a factory id from this PLugin, a block instance corresponding to it, and its inputs, return either error or output and configuration restrictions"""
 
 Expander = Callable[[BlockInstanceOutput], list[BlockExpansion]]
 """Given a block instance output (including from other plugin), provide which block factories from this plugin can expand it"""

--- a/backend/packages/fiab-core/src/fiab_core/tools/blocks.py
+++ b/backend/packages/fiab-core/src/fiab_core/tools/blocks.py
@@ -20,6 +20,7 @@ from fiab_core.fable import (
     ActionLookup,
     BlockConfigurationOption,
     BlockFactory,
+    BlockFactoryId,
     BlockInstance,
     BlockInstanceOutput,
     BlockKind,
@@ -40,15 +41,18 @@ T = TypeVar("T")
 
 class BlockInstanceRich(BlockInstance):
     _configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = PrivateAttr(default_factory=dict)
+    _factory_id: BlockFactoryId = PrivateAttr(default=BlockFactoryId(""))
 
     @classmethod
     def from_block(
         cls,
+        factory_id: BlockFactoryId,
         block: BlockInstance,
         configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption],
     ) -> Self:
         rich = cls.model_validate(block.model_dump(mode="python"))
         rich._configuration_options = configuration_options
+        rich._factory_id = factory_id
         return rich
 
     def _get_configuration_option(self, key: str | ConfigurationOptionId) -> tuple[ConfigurationOptionId, BlockConfigurationOption]:
@@ -56,16 +60,14 @@ class BlockInstanceRich(BlockInstance):
         option = self._configuration_options.get(option_id)
         if option is None:
             raise BlockInstanceConfigurationError(
-                f"Configuration option {option_id!r} is not declared for block factory {self.factory_id.factory!r}"
+                f"Configuration option {option_id!r} is not declared for block factory {self._factory_id!r}"
             )
         return option_id, option
 
     def _get_raw_value(self, option_id: ConfigurationOptionId) -> object:
         if option_id in self.configuration_values:
             return self.configuration_values[option_id]
-        raise BlockInstanceConfigurationError(
-            f"Configuration option {option_id!r} is missing for block factory {self.factory_id.factory!r}"
-        )
+        raise BlockInstanceConfigurationError(f"Configuration option {option_id!r} is missing for block factory {self._factory_id!r}")
 
     def config_as_str(self, key: str | ConfigurationOptionId, *, validator: Callable[[str, str], None] | None = None) -> str:
         option_id, option = self._get_configuration_option(key)

--- a/backend/packages/fiab-core/src/fiab_core/tools/blocks.py
+++ b/backend/packages/fiab-core/src/fiab_core/tools/blocks.py
@@ -26,9 +26,9 @@ from fiab_core.fable import (
     BlockKind,
     ConfigurationOptionId,
     ConfigurationOptionRestriction,
+    Error,
     QubedOutput,
 )
-from fiab_core.plugin import Error
 from fiab_core.types import ClosedEnumType, DatetimeType, DateType, FloatType, IntType, ListType, OpenEnumType, StringType
 
 

--- a/backend/packages/fiab-core/src/fiab_core/tools/blocks.py
+++ b/backend/packages/fiab-core/src/fiab_core/tools/blocks.py
@@ -8,13 +8,12 @@
 # nor does it submit to any jurisdiction.
 
 import abc
+from dataclasses import dataclass, field, replace
 from datetime import date, datetime
 from typing import Any, Callable, Literal, TypeVar, cast
 
 from cascade.low.func import Either
 from earthkit.workflows.fluent import Action
-from pydantic import PrivateAttr
-from typing_extensions import Self
 
 from fiab_core.fable import (
     ActionLookup,
@@ -22,6 +21,7 @@ from fiab_core.fable import (
     BlockFactory,
     BlockFactoryId,
     BlockInstance,
+    BlockInstanceId,
     BlockInstanceOutput,
     BlockKind,
     ConfigurationOptionId,
@@ -39,9 +39,17 @@ class BlockInstanceConfigurationError(ValueError):
 T = TypeVar("T")
 
 
-class BlockInstanceRich(BlockInstance):
-    _configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = PrivateAttr(default_factory=dict)
-    _factory_id: BlockFactoryId = PrivateAttr(default=BlockFactoryId(""))
+@dataclass(frozen=True)
+class BlockInstanceRich:
+    """Wraps a BlockInstance with typed configuration accessors and the factory context needed for error messages.
+
+    Plugin authors receive this in validate/compile callbacks instead of the raw BlockInstance.
+    All field reads go through typed methods (config_as_str, config_as_int, ...) or the input_ids property.
+    """
+
+    factory_id: BlockFactoryId
+    block: BlockInstance
+    configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = field(default_factory=dict)
 
     @classmethod
     def from_block(
@@ -49,25 +57,31 @@ class BlockInstanceRich(BlockInstance):
         factory_id: BlockFactoryId,
         block: BlockInstance,
         configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption],
-    ) -> Self:
-        rich = cls.model_validate(block.model_dump(mode="python"))
-        rich._configuration_options = configuration_options
-        rich._factory_id = factory_id
-        return rich
+    ) -> "BlockInstanceRich":
+        return cls(factory_id=factory_id, block=block, configuration_options=configuration_options)
+
+    @property
+    def input_ids(self) -> dict[str, BlockInstanceId]:
+        """The input slot names mapped to the upstream block instance ids."""
+        return self.block.input_ids
+
+    def with_configuration_values(self, values: dict[ConfigurationOptionId, object]) -> "BlockInstanceRich":
+        """Return a copy with the given configuration_values replacing the block's current ones."""
+        return replace(self, block=self.block.model_copy(update={"configuration_values": values}))
 
     def _get_configuration_option(self, key: str | ConfigurationOptionId) -> tuple[ConfigurationOptionId, BlockConfigurationOption]:
         option_id = ConfigurationOptionId(key)
-        option = self._configuration_options.get(option_id)
+        option = self.configuration_options.get(option_id)
         if option is None:
             raise BlockInstanceConfigurationError(
-                f"Configuration option {option_id!r} is not declared for block factory {self._factory_id!r}"
+                f"Configuration option {option_id!r} is not declared for block factory {self.factory_id!r}"
             )
         return option_id, option
 
     def _get_raw_value(self, option_id: ConfigurationOptionId) -> object:
-        if option_id in self.configuration_values:
-            return self.configuration_values[option_id]
-        raise BlockInstanceConfigurationError(f"Configuration option {option_id!r} is missing for block factory {self._factory_id!r}")
+        if option_id in self.block.configuration_values:
+            return self.block.configuration_values[option_id]
+        raise BlockInstanceConfigurationError(f"Configuration option {option_id!r} is missing for block factory {self.factory_id!r}")
 
     def config_as_str(self, key: str | ConfigurationOptionId, *, validator: Callable[[str, str], None] | None = None) -> str:
         option_id, option = self._get_configuration_option(key)
@@ -183,7 +197,7 @@ class QubedBlockBuilder(abc.ABC):
     def compile(
         self,
         inputs: ActionLookup,
-        block: BlockInstance,
+        block: "BlockInstanceRich",
     ) -> Either[Action, Error]:  # ty:ignore[invalid-type-arguments] # semigroup
         raise NotImplementedError
 

--- a/backend/packages/fiab-core/src/fiab_core/tools/plugins.py
+++ b/backend/packages/fiab-core/src/fiab_core/tools/plugins.py
@@ -53,7 +53,7 @@ class QubedPluginBuilder:
         self.base_environment = [_detect_editable_install(e) for e in base_environment]
 
     def validate(self, factory_id: BlockFactoryId, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
-        """Given a factory id, a block instance and its inputs, return either error or output and configuration restrictions."""
+        """Given a factory id from this Plugin, a block instance corresponding to it, and its inputs, return either error or output and configuration restrictions."""
         factory = self.block_builders[factory_id]
         rich_block = BlockInstanceRich.from_block(factory_id, block, factory.configuration_options)
         restrictions: ConfigurationOptionRestriction = {}
@@ -77,7 +77,7 @@ class QubedPluginBuilder:
         factory_id: BlockFactoryId,
         block: BlockInstance,
     ) -> Either[Action, Error]:  # ty:ignore[invalid-type-arguments] # semigroup
-        """Given a cascade builder and a block instance corresponding to this plugin's Factory, either update the builder with corresponding tasks or provide error"""
+        """Given a cascade builder of ActionLookup, a factory id from this Plugin, and a block instance corresponding to it, either update the builder with corresponding tasks or provide error"""
         with PayloadBuildingContext(environment=self.base_environment):
             factory = self.block_builders[factory_id]
             rich_block = BlockInstanceRich.from_block(factory_id, block, factory.configuration_options)

--- a/backend/packages/fiab-core/src/fiab_core/tools/plugins.py
+++ b/backend/packages/fiab-core/src/fiab_core/tools/plugins.py
@@ -52,10 +52,10 @@ class QubedPluginBuilder:
         self.block_builders = block_builders
         self.base_environment = [_detect_editable_install(e) for e in base_environment]
 
-    def validate(self, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
-        """Given a block instance and its inputs, return either error or output and configuration restrictions."""
-        factory = self.block_builders[block.factory_id.factory]
-        rich_block = BlockInstanceRich.from_block(block, factory.configuration_options)
+    def validate(self, factory_id: BlockFactoryId, block: BlockInstance, inputs: dict[str, QubedOutput]) -> BlockValidation:
+        """Given a factory id, a block instance and its inputs, return either error or output and configuration restrictions."""
+        factory = self.block_builders[factory_id]
+        rich_block = BlockInstanceRich.from_block(factory_id, block, factory.configuration_options)
         restrictions: ConfigurationOptionRestriction = {}
         try:
             result = factory.validate(rich_block, inputs, restrictions)
@@ -74,12 +74,13 @@ class QubedPluginBuilder:
     def compile(
         self,
         inputs: ActionLookup,
+        factory_id: BlockFactoryId,
         block: BlockInstance,
     ) -> Either[Action, Error]:  # ty:ignore[invalid-type-arguments] # semigroup
         """Given a cascade builder and a block instance corresponding to this plugin's Factory, either update the builder with corresponding tasks or provide error"""
         with PayloadBuildingContext(environment=self.base_environment):
-            factory = self.block_builders[block.factory_id.factory]
-            rich_block = BlockInstanceRich.from_block(block, factory.configuration_options)
+            factory = self.block_builders[factory_id]
+            rich_block = BlockInstanceRich.from_block(factory_id, block, factory.configuration_options)
             try:
                 return factory.compile(inputs, rich_block)
             except BlockInstanceConfigurationError as exc:
@@ -92,7 +93,7 @@ class QubedPluginBuilder:
             else:
                 return []
 
-        def _generic_validate(block: BlockInstance, inputs: dict[str, BlockInstanceOutput]) -> BlockValidation:
+        def _generic_validate(factory_id: BlockFactoryId, block: BlockInstance, inputs: dict[str, BlockInstanceOutput]) -> BlockValidation:
             invalid = [f"{key}->{value.__class__.__name__}" for key, value in inputs.items() if not isinstance(value, QubedOutput)]
             if any(invalid):
                 return BlockValidation(
@@ -102,7 +103,7 @@ class QubedPluginBuilder:
                 )
             else:
                 inputs_validated = cast(dict[str, QubedOutput], inputs)
-                return self.validate(block, inputs_validated)
+                return self.validate(factory_id, block, inputs_validated)
 
         return lambda: Plugin(
             catalogue=BlockFactoryCatalogue(

--- a/backend/packages/fiab-core/tests/test_fable.py
+++ b/backend/packages/fiab-core/tests/test_fable.py
@@ -18,7 +18,7 @@ from fiab_core.fable import (
     BlueprintTemplate,
     BlueprintTemplateEnvironment,
     ConfigurationOptionId,
-    PluginBlockFactoryId,
+    LocalBlock,
     PluginCompositeId,
     PluginId,
     PluginStoreId,
@@ -58,11 +58,10 @@ _BLOCK_ID = BlockInstanceId("b1")
 _TEXT = ConfigurationOptionId("text")
 
 
-def _make_block() -> BlockInstance:
-    return BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=_PLUGIN_ID, factory=BlockFactoryId("source_text")),
-        configuration_values={_TEXT: "hello"},
-        input_ids={},
+def _make_block() -> LocalBlock:
+    return LocalBlock(
+        factory_id=BlockFactoryId("source_text"),
+        instance=BlockInstance(configuration_values={_TEXT: "hello"}, input_ids={}),
     )
 
 

--- a/backend/packages/fiab-core/tests/test_fable.py
+++ b/backend/packages/fiab-core/tests/test_fable.py
@@ -16,9 +16,9 @@ from fiab_core.fable import (
     BlockInstance,
     BlockInstanceId,
     BlueprintTemplate,
+    BlueprintTemplateBlock,
     BlueprintTemplateEnvironment,
     ConfigurationOptionId,
-    LocalBlock,
     PluginCompositeId,
     PluginId,
     PluginStoreId,
@@ -58,8 +58,8 @@ _BLOCK_ID = BlockInstanceId("b1")
 _TEXT = ConfigurationOptionId("text")
 
 
-def _make_block() -> LocalBlock:
-    return LocalBlock(
+def _make_block() -> BlueprintTemplateBlock:
+    return BlueprintTemplateBlock(
         factory_id=BlockFactoryId("source_text"),
         instance=BlockInstance(configuration_values={_TEXT: "hello"}, input_ids={}),
     )

--- a/backend/packages/fiab-core/tests/test_fable.py
+++ b/backend/packages/fiab-core/tests/test_fable.py
@@ -53,7 +53,6 @@ def test_block_configuration_option_rejects_invalid_value_type() -> None:
 # BlueprintTemplate
 # ---------------------------------------------------------------------------
 
-_PLUGIN_ID = PluginCompositeId(store=PluginStoreId("s"), local=PluginId("p"))
 _BLOCK_ID = BlockInstanceId("b1")
 _TEXT = ConfigurationOptionId("text")
 

--- a/backend/packages/fiab-mcp-server/src/fiab_mcp_server/server.py
+++ b/backend/packages/fiab-mcp-server/src/fiab_mcp_server/server.py
@@ -84,46 +84,39 @@ class FiabMcpServer:
                 ),
                 Tool(
                     name="fable_add_block",
-                    description="Add a block to the builder and get validation/expansion results. The builder should be a FableBuilder with a 'blocks' dict mapping block IDs to BlockInstance objects. Returns the updated builder and validation results including possible next blocks.",
+                    description="Add a block to the builder and get validation/expansion results. The builder should be a FableBuilder with a 'blocks' list of RoutableBlock objects. Returns the updated builder and validation results including possible next blocks.",
                     inputSchema={
                         "type": "object",
                         "properties": {
                             "builder": {
                                 "type": "object",
-                                "description": "Current FableBuilder state with 'blocks' dict",
+                                "description": "Current FableBuilder state with 'blocks' list",
                                 "properties": {
                                     "blocks": {
-                                        "type": "object",
-                                        "description": "Dictionary mapping block_id to BlockInstance objects",
+                                        "type": "array",
+                                        "description": "List of RoutableBlock objects",
                                     }
                                 },
                                 "required": ["blocks"],
                             },
-                            "block_id": {
-                                "type": "string",
-                                "description": "Unique identifier for this block instance (e.g., 'source1', 'product1')",
-                            },
                             "block": {
                                 "type": "object",
-                                "description": "RoutedBlock with factory_id and instance fields",
+                                "description": "RoutableBlock: flat routing + content for a single block",
                                 "properties": {
-                                    "factory_id": {
-                                        "type": "object",
-                                        "description": "PluginBlockFactoryId with plugin and factory fields",
-                                        "properties": {
-                                            "plugin": {
-                                                "type": "object",
-                                                "description": "PluginCompositeId with store and local fields",
-                                                "properties": {
-                                                    "store": {"type": "string", "description": "e.g., 'ecmwf'"},
-                                                    "local": {"type": "string", "description": "e.g., 'toy2'"},
-                                                },
-                                                "required": ["store", "local"],
-                                            },
-                                            "factory": {"type": "string", "description": "Factory name, e.g., 'exampleSource'"},
-                                        },
-                                        "required": ["plugin", "factory"],
+                                    "instance_id": {
+                                        "type": "string",
+                                        "description": "Unique identifier for this block instance (e.g., 'source1', 'product1')",
                                     },
+                                    "plugin": {
+                                        "type": "object",
+                                        "description": "PluginCompositeId with store and local fields",
+                                        "properties": {
+                                            "store": {"type": "string", "description": "e.g., 'ecmwf'"},
+                                            "local": {"type": "string", "description": "e.g., 'toy2'"},
+                                        },
+                                        "required": ["store", "local"],
+                                    },
+                                    "factory": {"type": "string", "description": "Factory name, e.g., 'exampleSource'"},
                                     "instance": {
                                         "type": "object",
                                         "description": "BlockInstance with configuration_values and input_ids",
@@ -142,10 +135,10 @@ class FiabMcpServer:
                                         "required": ["configuration_values", "input_ids"],
                                     },
                                 },
-                                "required": ["factory_id", "instance"],
+                                "required": ["instance_id", "plugin", "factory", "instance"],
                             },
                         },
-                        "required": ["builder", "block_id", "block"],
+                        "required": ["builder", "block"],
                     },
                 ),
                 Tool(
@@ -198,15 +191,14 @@ class FiabMcpServer:
         async def call_tool(name: str, arguments: Any) -> list[TextContent]:
             try:
                 if name == "fable_start_building":
-                    result = {"blocks": {}}
+                    result = {"blocks": []}
                     return [TextContent(type="text", text=str(result))]
 
                 elif name == "fable_add_block":
                     builder = arguments["builder"]
-                    block_id = arguments["block_id"]
                     block = arguments["block"]
 
-                    builder["blocks"][block_id] = block
+                    builder["blocks"].append(block)
 
                     route = "api/v1/fable/expand"
                     logger.debug(f"PUT {route}, params=None, body={builder}")
@@ -283,13 +275,13 @@ class FiabMcpServer:
 1. First, check the catalogue resource (fable://catalogue) to see available blocks
 2. Start a new builder with fable_start_building
 3. Add an 'exampleSource' as the data source (usually from fiab_plugin_toy)
-   - Use fable_add_block with proper RoutedBlock structure: factory_id (with plugin and factory) and instance (with configuration_values and input_ids)
+   - Use fable_add_block with a RoutableBlock: instance_id, plugin (store+local), factory, and instance (configuration_values + input_ids)
 4. Add a 'meanProduct' to calculate the mean of the 2t variable
    - Connect it to the source using instance.input_ids
 5. Each add_block call returns validation results showing if the workflow is valid and what blocks can be added next
 6. Save it with fable_save and appropriate tags
 
-Remember: Use the exact server schema - factory_id (with plugin and factory), and instance (with configuration_values and input_ids).""",
+Remember: Use the exact server schema - instance_id, plugin (with store and local), factory, and instance (with configuration_values and input_ids).""",
                             },
                         }
                     ]

--- a/backend/packages/fiab-mcp-server/src/fiab_mcp_server/server.py
+++ b/backend/packages/fiab-mcp-server/src/fiab_mcp_server/server.py
@@ -105,7 +105,7 @@ class FiabMcpServer:
                             },
                             "block": {
                                 "type": "object",
-                                "description": "BlockInstance with factory_id, configuration_values, and input_ids",
+                                "description": "RoutedBlock with factory_id and instance fields",
                                 "properties": {
                                     "factory_id": {
                                         "type": "object",
@@ -124,18 +124,25 @@ class FiabMcpServer:
                                         },
                                         "required": ["plugin", "factory"],
                                     },
-                                    "configuration_values": {
+                                    "instance": {
                                         "type": "object",
-                                        "description": "Configuration values for the block",
-                                        "additionalProperties": True,
-                                    },
-                                    "input_ids": {
-                                        "type": "object",
-                                        "description": "Input connections mapping input names to block IDs",
-                                        "additionalProperties": {"type": "string"},
+                                        "description": "BlockInstance with configuration_values and input_ids",
+                                        "properties": {
+                                            "configuration_values": {
+                                                "type": "object",
+                                                "description": "Configuration values for the block",
+                                                "additionalProperties": True,
+                                            },
+                                            "input_ids": {
+                                                "type": "object",
+                                                "description": "Input connections mapping input names to block IDs",
+                                                "additionalProperties": {"type": "string"},
+                                            },
+                                        },
+                                        "required": ["configuration_values", "input_ids"],
                                     },
                                 },
-                                "required": ["factory_id", "configuration_values", "input_ids"],
+                                "required": ["factory_id", "instance"],
                             },
                         },
                         "required": ["builder", "block_id", "block"],
@@ -276,13 +283,13 @@ class FiabMcpServer:
 1. First, check the catalogue resource (fable://catalogue) to see available blocks
 2. Start a new builder with fable_start_building
 3. Add an 'exampleSource' as the data source (usually from fiab_plugin_toy)
-   - Use fable_add_block with proper BlockInstance structure (factory_id, configuration_values, input_ids)
+   - Use fable_add_block with proper RoutedBlock structure: factory_id (with plugin and factory) and instance (with configuration_values and input_ids)
 4. Add a 'meanProduct' to calculate the mean of the 2t variable
-   - Connect it to the source using input_ids
+   - Connect it to the source using instance.input_ids
 5. Each add_block call returns validation results showing if the workflow is valid and what blocks can be added next
 6. Save it with fable_save and appropriate tags
 
-Remember: Use the exact server schema - factory_id (with plugin and factory), configuration_values, and input_ids.""",
+Remember: Use the exact server schema - factory_id (with plugin and factory), and instance (with configuration_values and input_ids).""",
                             },
                         }
                     ]

--- a/backend/packages/fiab-plugin-demo/src/fiab_plugin_demo/blocks.py
+++ b/backend/packages/fiab-plugin-demo/src/fiab_plugin_demo/blocks.py
@@ -12,7 +12,6 @@ from earthkit.workflows.fluent import Action
 from fiab_core.fable import (
     ActionLookup,
     BlockConfigurationOption,
-    BlockInstance,
     BlockInstanceOutput,
     ConfigurationOptionId,
     ConfigurationOptionRestriction,
@@ -20,7 +19,7 @@ from fiab_core.fable import (
     QubedOutput,
 )
 from fiab_core.plugin import Error
-from fiab_core.tools.blocks import Product, Sink, Transform
+from fiab_core.tools.blocks import BlockInstanceRich, Product, Sink, Transform
 
 DIR = ConfigurationOptionId("dir")
 PARAM = ConfigurationOptionId("param")
@@ -31,7 +30,7 @@ class _DemoTransform(Transform):
     inputs: list[str] = ["dataset"]
 
     def validate(
-        self, block: BlockInstance, inputs: dict[str, QubedOutput], restrictions: ConfigurationOptionRestriction
+        self, block: BlockInstanceRich, inputs: dict[str, QubedOutput], restrictions: ConfigurationOptionRestriction
     ) -> BlockInstanceOutput:
         dataset = inputs.get("dataset")
         if dataset is None:
@@ -41,7 +40,7 @@ class _DemoTransform(Transform):
     def compile(
         self,
         inputs: ActionLookup,
-        block: BlockInstance,
+        block: BlockInstanceRich,
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         return Either.ok(inputs[block.input_ids["dataset"]])
 
@@ -54,7 +53,7 @@ class _DemoProduct(Product):
     inputs: list[str] = ["dataset"]
 
     def validate(
-        self, block: BlockInstance, inputs: dict[str, QubedOutput], restrictions: ConfigurationOptionRestriction
+        self, block: BlockInstanceRich, inputs: dict[str, QubedOutput], restrictions: ConfigurationOptionRestriction
     ) -> BlockInstanceOutput:
         dataset = inputs.get("dataset")
         if dataset is None:
@@ -64,7 +63,7 @@ class _DemoProduct(Product):
     def compile(
         self,
         inputs: ActionLookup,
-        block: BlockInstance,
+        block: BlockInstanceRich,
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         return Either.ok(inputs[block.input_ids["dataset"]])
 
@@ -77,7 +76,7 @@ class _DemoSink(Sink):
     inputs: list[str] = ["dataset"]
 
     def validate(
-        self, block: BlockInstance, inputs: dict[str, QubedOutput], restrictions: ConfigurationOptionRestriction
+        self, block: BlockInstanceRich, inputs: dict[str, QubedOutput], restrictions: ConfigurationOptionRestriction
     ) -> BlockInstanceOutput:
         if "dataset" not in inputs:
             raise ValueError("Missing input 'dataset'")
@@ -86,7 +85,7 @@ class _DemoSink(Sink):
     def compile(
         self,
         inputs: ActionLookup,
-        block: BlockInstance,
+        block: BlockInstanceRich,
     ) -> Either[Action, Error]:  # type:ignore[invalid-argument] # semigroup
         return Either.ok(inputs[block.input_ids["dataset"]])
 

--- a/backend/packages/fiab-plugin-demo/tests/test_blocks.py
+++ b/backend/packages/fiab-plugin-demo/tests/test_blocks.py
@@ -8,7 +8,7 @@
 # nor does it submit to any jurisdiction.
 
 import pytest
-from fiab_core.fable import BlockFactoryId, BlockInstance, BlockInstanceId, NoOutput, PluginBlockFactoryId, PluginCompositeId, QubedOutput
+from fiab_core.fable import BlockFactoryId, BlockInstance, BlockInstanceId, NoOutput, QubedOutput
 from fiab_core.tools.blocks import BlockInstanceRich, QubedBlockBuilder
 
 from fiab_plugin_demo import plugin
@@ -39,14 +39,13 @@ EXPECTED_FACTORY_IDS = {
 
 def _block(factory_id: BlockFactoryId) -> BlockInstance:
     return BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("demo:demo"), factory=factory_id),
         input_ids={"dataset": BlockInstanceId("source_output")},
         configuration_values={},
     )
 
 
 def _rich_block(factory_id: BlockFactoryId, builder: QubedBlockBuilder) -> BlockInstanceRich:
-    return BlockInstanceRich.from_block(_block(factory_id), builder.configuration_options)
+    return BlockInstanceRich.from_block(factory_id, _block(factory_id), builder.configuration_options)
 
 
 @pytest.fixture

--- a/backend/packages/fiab-plugin-ecmwf/tests/runtime/test_anemoi_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/runtime/test_anemoi_blocks.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from unittest.mock import MagicMock
 
 import pytest
-from fiab_core.fable import BlockFactoryId, ConfigurationOptionId, PluginBlockFactoryId, PluginCompositeId, QubedOutput
+from fiab_core.fable import BlockFactoryId, ConfigurationOptionId, PluginCompositeId, QubedOutput
 from fiab_core.fable import BlockInstance as BlockInstanceBase
 from fiab_core.tools.blocks import BlockInstanceConfigurationError
 from fiab_core.tools.blocks import BlockInstanceRich as BlockInstance
@@ -39,14 +39,10 @@ def _make_block(
     """Build a *typed* BlockInstanceRich whose configuration values have already
     been converted to the correct Python types (int, datetime, …)."""
     base = BlockInstanceBase(
-        factory_id=PluginBlockFactoryId(
-            plugin=PluginCompositeId.from_str("ecmwf:ecmwf"),
-            factory=factory_cls.__name__,  # type: ignore[arg-type]
-        ),
         input_ids=input_ids or {},
         configuration_values=_config(config),
     )
-    return BlockInstance.from_block(base, factory_cls.configuration_options)
+    return BlockInstance.from_block(BlockFactoryId(factory_cls.__name__), base, factory_cls.configuration_options)  # type: ignore[arg-type]
 
 
 def _make_raw_block(
@@ -57,14 +53,10 @@ def _make_raw_block(
     """Build a BlockInstanceRich whose configuration values are *raw strings*
     (as they would arrive from the frontend before deserialisation)."""
     base = BlockInstanceBase(
-        factory_id=PluginBlockFactoryId(
-            plugin=PluginCompositeId.from_str("ecmwf:ecmwf"),
-            factory=factory_cls.__name__,  # type: ignore[arg-type]
-        ),
         input_ids=input_ids or {},
         configuration_values=_config(config),
     )
-    return BlockInstance.from_block(base, factory_cls.configuration_options)
+    return BlockInstance.from_block(BlockFactoryId(factory_cls.__name__), base, factory_cls.configuration_options)  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -595,7 +595,9 @@ class TestSelect:
     def test_validator_adds_dimension_restrictions(
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
     ) -> None:
-        restrictions = plugin().validator(select_configuration, {"dataset": operational_forecast_source_output}).restrictions
+        restrictions = (
+            plugin().validator(BlockFactoryId("select"), select_configuration, {"dataset": operational_forecast_source_output}).restrictions
+        )
         restriction = restrictions[DIMENSION].serialize()
         assert restriction.startswith("enumClosed[")
         assert "param" in restriction
@@ -606,14 +608,14 @@ class TestSelect:
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
     ) -> None:
         config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "step", "values": ["0"]})})
-        restrictions = plugin().validator(config, {"dataset": operational_forecast_source_output}).restrictions
+        restrictions = plugin().validator(BlockFactoryId("select"), config, {"dataset": operational_forecast_source_output}).restrictions
         assert restrictions[VALUES].serialize() == "list[enumClosed[0,6,12]]"
 
     def test_validator_keeps_restrictions_when_configuration_is_missing(
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
     ) -> None:
         config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "step"})})
-        validation = plugin().validator(config, {"dataset": operational_forecast_source_output})
+        validation = plugin().validator(BlockFactoryId("select"), config, {"dataset": operational_forecast_source_output})
         assert validation.result.e is not None
         assert DIMENSION in validation.restrictions
         assert VALUES in validation.restrictions
@@ -809,7 +811,11 @@ class TestMapPlotSink:
     def test_validator_adds_parameters_restrictions(
         self, map_plot_sink_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
     ) -> None:
-        restrictions = plugin().validator(map_plot_sink_configuration, {"dataset": operational_forecast_source_output}).restrictions
+        restrictions = (
+            plugin()
+            .validator(BlockFactoryId("mapPlotSink"), map_plot_sink_configuration, {"dataset": operational_forecast_source_output})
+            .restrictions
+        )
         assert restrictions[PARAM].serialize() == "list[enumClosed[2t,msl,u]]"
 
     def test_expander_has_no_parameters_restrictions(self, operational_forecast_source_output: QubedOutput) -> None:

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -20,8 +20,6 @@ from fiab_core.fable import (
     BlockInstanceId,
     ConfigurationOptionId,
     ConfigurationOptionRestriction,
-    PluginBlockFactoryId,
-    PluginCompositeId,
     QubedOutput,
     RawOutput,
 )
@@ -71,7 +69,6 @@ def _block_instance(
     factory_id: str, values: dict[str, object], *, input_ids: dict[str, BlockInstanceId] | None = None
 ) -> BlockInstanceBase:
     return BlockInstanceBase(
-        factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId(factory_id)),
         input_ids=input_ids or {},
         configuration_values=_config(values),
     )
@@ -99,6 +96,7 @@ class _TinyForecastPreset:
 @pytest.fixture
 def dummy_blockinstance() -> BlockInstance:
     return BlockInstance.from_block(
+        BlockFactoryId("dummy"),
         _block_instance(
             "dummy",
             {
@@ -119,6 +117,7 @@ def dummy_blockinstance_output() -> QubedOutput:
 @pytest.fixture
 def operational_forecast_source_configuration() -> BlockInstance:
     return BlockInstance.from_block(
+        BlockFactoryId("operationalForecastSource"),
         _block_instance(
             "operationalForecastSource",
             {
@@ -155,8 +154,8 @@ def operational_forecast_source_action(operational_forecast_source_output: Qubed
 @pytest.fixture
 def ensemble_statistics_configuration() -> BlockInstance:
     return BlockInstance.from_block(
+        BlockFactoryId("ensembleStatistics"),
         BlockInstanceBase(
-            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="EnsembleStatistics"),  # type: ignore
             input_ids={"dataset": BlockInstanceId("source_output")},
             configuration_values=_config(
                 {
@@ -172,8 +171,8 @@ def ensemble_statistics_configuration() -> BlockInstance:
 @pytest.fixture
 def temporal_statistics_configuration() -> BlockInstance:
     return BlockInstance.from_block(
+        BlockFactoryId("temporalStatistics"),
         BlockInstanceBase(
-            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="TemporalStatistics"),  # type: ignore
             input_ids={"dataset": BlockInstanceId("source_output")},
             configuration_values=_config(
                 {
@@ -189,6 +188,7 @@ def temporal_statistics_configuration() -> BlockInstance:
 @pytest.fixture
 def select_configuration() -> BlockInstance:
     return BlockInstance.from_block(
+        BlockFactoryId("select"),
         _block_instance(
             "select",
             {
@@ -204,8 +204,8 @@ def select_configuration() -> BlockInstance:
 @pytest.fixture
 def zarr_sink_configuration() -> BlockInstance:
     return BlockInstance.from_block(
+        BlockFactoryId("zarrSink"),
         BlockInstanceBase(
-            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="ZarrSink"),  # type: ignore
             input_ids={"dataset": BlockInstanceId("source_output")},
             configuration_values=_config(
                 {
@@ -220,8 +220,8 @@ def zarr_sink_configuration() -> BlockInstance:
 @pytest.fixture
 def grib_sink_configuration() -> BlockInstance:
     return BlockInstance.from_block(
+        BlockFactoryId("gribSink"),
         BlockInstanceBase(
-            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="GribSink"),  # type: ignore
             input_ids={"dataset": BlockInstanceId("source_output")},
             configuration_values=_config(
                 {
@@ -236,8 +236,8 @@ def grib_sink_configuration() -> BlockInstance:
 @pytest.fixture
 def map_plot_sink_configuration() -> BlockInstance:
     return BlockInstance.from_block(
+        BlockFactoryId("mapPlotSink"),
         BlockInstanceBase(
-            factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("mapPlotSink")),
             input_ids={"dataset": BlockInstanceId("source_output")},
             configuration_values=_config(
                 {
@@ -260,8 +260,8 @@ class TestOperationalForecastSource:
 
         assert not block.intersect(other=dummy_blockinstance_output)  # type: ignore[arg-type]
         block_instance = BlockInstance.from_block(
+            BlockFactoryId("operationalForecastSource"),
             BlockInstanceBase(
-                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="OperationalForecastSource"),  # type: ignore
                 input_ids={},
                 configuration_values=_config(
                     dict(
@@ -286,6 +286,7 @@ class TestOperationalForecastSource:
         monkeypatch.setitem(FORECAST_DATASETS, "aifs-ens", _TinyForecastPreset())
         block = OperationalForecastSource()
         block_instance = BlockInstance.from_block(
+            BlockFactoryId("operationalForecastSource"),
             _block_instance(
                 "operationalForecastSource",
                 {
@@ -311,8 +312,8 @@ class TestOperationalForecastSource:
     def test_validate(self, config: dict, error: str) -> None:
         block = OperationalForecastSource()
         block_instance = BlockInstance.from_block(
+            BlockFactoryId("operationalForecastSource"),
             BlockInstanceBase(
-                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="OperationalForecastSource"),  # type: ignore
                 input_ids={},
                 configuration_values=_config(
                     dict(
@@ -718,8 +719,8 @@ class TestGribSink:
     def test_validate_template_values(self, operational_forecast_source_output: QubedOutput, filepath: str) -> None:
         block = GribSink()
         config = BlockInstance.from_block(
+            BlockFactoryId("operationalForecastSource"),
             BlockInstanceBase(
-                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="GribSink"),  # type: ignore
                 input_ids={"dataset": BlockInstanceId("source_output")},
                 configuration_values=_config(
                     {
@@ -739,8 +740,8 @@ class TestGribSink:
     def test_invalid_path(self, operational_forecast_source_output: QubedOutput) -> None:
         block = GribSink()
         config = BlockInstance.from_block(
+            BlockFactoryId("operationalForecastSource"),
             BlockInstanceBase(
-                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="GribSink"),  # type: ignore
                 input_ids={"dataset": BlockInstanceId("source_output")},
                 configuration_values=_config(
                     {
@@ -775,8 +776,8 @@ class TestGribSink:
     ) -> None:
         block = GribSink()
         config = BlockInstance.from_block(
+            BlockFactoryId("operationalForecastSource"),
             BlockInstanceBase(
-                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory="GribSink"),  # type: ignore
                 input_ids={"dataset": BlockInstanceId("source_output")},
                 configuration_values=_config(
                     {
@@ -846,8 +847,8 @@ class TestMapPlotSink:
     def test_validate_sets_mime_from_format(self, fmt: str, expected_mime: str, operational_forecast_source_output: QubedOutput) -> None:
         block = MapPlotSink()
         config = BlockInstance.from_block(
+            BlockFactoryId("operationalForecastSource"),
             BlockInstanceBase(
-                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("MapPlotSink")),  # type: ignore
                 input_ids={"dataset": BlockInstanceId("source_output")},
                 configuration_values=_config(
                     {
@@ -869,8 +870,8 @@ class TestMapPlotSink:
     def test_validate_multi_param(self, operational_forecast_source_output: QubedOutput) -> None:
         block = MapPlotSink()
         config = BlockInstance.from_block(
+            BlockFactoryId("operationalForecastSource"),
             BlockInstanceBase(
-                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("MapPlotSink")),  # type: ignore
                 input_ids={"dataset": BlockInstanceId("source_output")},
                 configuration_values=_config(
                     {
@@ -890,8 +891,8 @@ class TestMapPlotSink:
     def test_validate_rejects_unknown_param(self, operational_forecast_source_output: QubedOutput) -> None:
         block = MapPlotSink()
         config = BlockInstance.from_block(
+            BlockFactoryId("operationalForecastSource"),
             BlockInstanceBase(
-                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("MapPlotSink")),  # type: ignore
                 input_ids={"dataset": BlockInstanceId("source_output")},
                 configuration_values=_config(
                     {
@@ -913,8 +914,8 @@ class TestMapPlotSink:
     def test_validate_rejects_partial_unknown_params(self, operational_forecast_source_output: QubedOutput) -> None:
         block = MapPlotSink()
         config = BlockInstance.from_block(
+            BlockFactoryId("operationalForecastSource"),
             BlockInstanceBase(
-                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("MapPlotSink")),  # type: ignore
                 input_ids={"dataset": BlockInstanceId("source_output")},
                 configuration_values=_config(
                     {
@@ -956,8 +957,8 @@ class TestMapPlotSink:
     ) -> None:
         block = MapPlotSink()
         config = BlockInstance.from_block(
+            BlockFactoryId("operationalForecastSource"),
             BlockInstanceBase(
-                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("MapPlotSink")),  # type: ignore
                 input_ids={"dataset": BlockInstanceId("source_output")},
                 configuration_values=_config(
                     {
@@ -978,8 +979,8 @@ class TestMapPlotSink:
     def test_validate_splitby(self, operational_forecast_source_output: QubedOutput) -> None:
         block = MapPlotSink()
         config = BlockInstance.from_block(
+            BlockFactoryId("operationalForecastSource"),
             BlockInstanceBase(
-                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("MapPlotSink")),  # type: ignore
                 input_ids={"dataset": BlockInstanceId("source_output")},
                 configuration_values=_config(
                     {
@@ -1008,8 +1009,8 @@ class TestMapPlotSink:
     ) -> None:
         block = MapPlotSink()
         config = BlockInstance.from_block(
+            BlockFactoryId("operationalForecastSource"),
             BlockInstanceBase(
-                factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("ecmwf:ecmwf"), factory=BlockFactoryId("MapPlotSink")),  # type: ignore
                 input_ids={"dataset": BlockInstanceId("source_output")},
                 configuration_values=_config(
                     {

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -547,7 +547,7 @@ class TestSelect:
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
     ) -> None:
         block = _select()
-        config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "param", "values": ["2t", "msl"]})})
+        config = select_configuration.with_configuration_values(_config({"dimension": "param", "values": ["2t", "msl"]}))
         output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}, restrictions={})  # type: ignore[dict-item]
         assert isinstance(output, QubedOutput)
         assert axes(output)[PARAM] == {"2t", "msl"}
@@ -556,7 +556,7 @@ class TestSelect:
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
     ) -> None:
         block = _select()
-        config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "step", "values": ["0", "6"]})})
+        config = select_configuration.with_configuration_values(_config({"dimension": "step", "values": ["0", "6"]}))
         output = block.validate(block=config, inputs={"dataset": operational_forecast_source_output}, restrictions={})  # type: ignore[dict-item]
         assert isinstance(output, QubedOutput)
         assert axes(output)[STEP] == {0, 6}
@@ -565,7 +565,7 @@ class TestSelect:
         block = _select()
         broken_qube = Qube.make_root([Qube.make_node("step", [6, 12], Qube.from_datacube({"param": ["2t"]}).children)])
         input_dataset = QubedOutput(dataqube=broken_qube)
-        config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "step", "values": ["6"]})})
+        config = select_configuration.with_configuration_values(_config({"dimension": "step", "values": ["6"]}))
 
         with pytest.raises(Exception, match="produced an empty dataset"):
             block.validate(block=config, inputs={"dataset": input_dataset}, restrictions={})
@@ -574,7 +574,7 @@ class TestSelect:
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
     ) -> None:
         block = _select()
-        config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "missing", "values": ["2t"]})})
+        config = select_configuration.with_configuration_values(_config({"dimension": "missing", "values": ["2t"]}))
         restrictions: ConfigurationOptionRestriction = {}
         with pytest.raises(Exception, match="dimension missing is not in the input dimensions"):
             block.validate(block=config, inputs={"dataset": operational_forecast_source_output}, restrictions=restrictions)  # type: ignore[dict-item]
@@ -585,7 +585,7 @@ class TestSelect:
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
     ) -> None:
         block = _select()
-        config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "param", "values": ["missing"]})})
+        config = select_configuration.with_configuration_values(_config({"dimension": "param", "values": ["missing"]}))
         restrictions: ConfigurationOptionRestriction = {}
         with pytest.raises(Exception, match="values.*are not in dimension param"):
             block.validate(block=config, inputs={"dataset": operational_forecast_source_output}, restrictions=restrictions)  # type: ignore[dict-item]
@@ -607,14 +607,14 @@ class TestSelect:
     def test_validator_adds_values_for_selected_dimension(
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
     ) -> None:
-        config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "step", "values": ["0"]})})
+        config = select_configuration.with_configuration_values(_config({"dimension": "step", "values": ["0"]}))
         restrictions = plugin().validator(BlockFactoryId("select"), config, {"dataset": operational_forecast_source_output}).restrictions
         assert restrictions[VALUES].serialize() == "list[enumClosed[0,6,12]]"
 
     def test_validator_keeps_restrictions_when_configuration_is_missing(
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
     ) -> None:
-        config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "step"})})
+        config = select_configuration.with_configuration_values(_config({"dimension": "step"}))
         validation = plugin().validator(BlockFactoryId("select"), config, {"dataset": operational_forecast_source_output})
         assert validation.result.e is not None
         assert DIMENSION in validation.restrictions
@@ -635,7 +635,7 @@ class TestSelect:
         input_action = MagicMock()
         selected_action = MagicMock()
         input_action.select.return_value = selected_action
-        config = select_configuration.model_copy(update={"configuration_values": _config({"dimension": "step", "values": ["0", "6"]})})
+        config = select_configuration.with_configuration_values(_config({"dimension": "step", "values": ["0", "6"]}))
 
         result = block.compile(inputs={BlockInstanceId("source_output"): input_action}, block=config)  # type: ignore[dict-item]
         assert result.t is selected_action

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -596,7 +596,9 @@ class TestSelect:
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
     ) -> None:
         restrictions = (
-            plugin().validator(BlockFactoryId("select"), select_configuration, {"dataset": operational_forecast_source_output}).restrictions
+            plugin()
+            .validator(BlockFactoryId("select"), select_configuration.block, {"dataset": operational_forecast_source_output})
+            .restrictions
         )
         restriction = restrictions[DIMENSION].serialize()
         assert restriction.startswith("enumClosed[")
@@ -608,14 +610,16 @@ class TestSelect:
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
     ) -> None:
         config = select_configuration.with_configuration_values(_config({"dimension": "step", "values": ["0"]}))
-        restrictions = plugin().validator(BlockFactoryId("select"), config, {"dataset": operational_forecast_source_output}).restrictions
+        restrictions = (
+            plugin().validator(BlockFactoryId("select"), config.block, {"dataset": operational_forecast_source_output}).restrictions
+        )
         assert restrictions[VALUES].serialize() == "list[enumClosed[0,6,12]]"
 
     def test_validator_keeps_restrictions_when_configuration_is_missing(
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
     ) -> None:
         config = select_configuration.with_configuration_values(_config({"dimension": "step"}))
-        validation = plugin().validator(BlockFactoryId("select"), config, {"dataset": operational_forecast_source_output})
+        validation = plugin().validator(BlockFactoryId("select"), config.block, {"dataset": operational_forecast_source_output})
         assert validation.result.e is not None
         assert DIMENSION in validation.restrictions
         assert VALUES in validation.restrictions
@@ -813,7 +817,7 @@ class TestMapPlotSink:
     ) -> None:
         restrictions = (
             plugin()
-            .validator(BlockFactoryId("mapPlotSink"), map_plot_sink_configuration, {"dataset": operational_forecast_source_output})
+            .validator(BlockFactoryId("mapPlotSink"), map_plot_sink_configuration.block, {"dataset": operational_forecast_source_output})
             .restrictions
         )
         assert restrictions[PARAM].serialize() == "list[enumClosed[2t,msl,u]]"

--- a/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
+++ b/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
@@ -14,9 +14,9 @@ from fiab_core.fable import (
     BlockInstanceId,
     BlockInstanceOutput,
     BlueprintTemplate,
+    BlueprintTemplateBlock,
     ConfigurationOptionId,
     ConfigurationOptionRestriction,
-    LocalBlock,
     NoOutput,
     RawOutput,
 )
@@ -195,8 +195,8 @@ def compiler(lookup: ActionLookup, factory_id: BlockFactoryId, instance: BlockIn
 plugin = lambda: Plugin(catalogue=catalogue(), validator=validator, expander=expander, compiler=compiler)
 
 
-def _make_source_text_block(text: str) -> LocalBlock:
-    return LocalBlock(
+def _make_source_text_block(text: str) -> BlueprintTemplateBlock:
+    return BlueprintTemplateBlock(
         factory_id=BlockFactoryId("source_text"),
         instance=BlockInstance(
             configuration_values={TEXT: text} if text else {},
@@ -254,7 +254,7 @@ _testFailValidation = BlueprintTemplate(
     display_name="testFailValidation",
     display_description="A template that references a non-existent factory and always fails validation.",
     blocks={
-        _BLOCK_FAIL_VAL: LocalBlock(
+        _BLOCK_FAIL_VAL: BlueprintTemplateBlock(
             factory_id=BlockFactoryId("nonexistent_factory"),
             instance=BlockInstance(configuration_values={}, input_ids={}),
         ),

--- a/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
+++ b/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
@@ -16,10 +16,9 @@ from fiab_core.fable import (
     BlueprintTemplate,
     ConfigurationOptionId,
     ConfigurationOptionRestriction,
+    LocalBlock,
     NoOutput,
-    PluginBlockFactoryId,
     RawOutput,
-    SelfPluginId,
 )
 from fiab_core.plugin import BlockValidation, Error, Plugin
 from fiab_core.types import FableType
@@ -108,20 +107,20 @@ catalogue = lambda: BlockFactoryCatalogue(
 )
 
 
-def validator(instance: BlockInstance, inputs: dict[str, BlockInstanceOutput]) -> BlockValidation:
+def validator(factory_id: BlockFactoryId, instance: BlockInstance, inputs: dict[str, BlockInstanceOutput]) -> BlockValidation:
     restrictions: ConfigurationOptionRestriction = {}
-    if instance.factory_id.factory == BlockFactoryId("transform_increment"):
+    if factory_id == BlockFactoryId("transform_increment"):
         restrictions = {AMOUNT: FableType.parse("enumClosed[1,2,3]")[0]}
-    if instance.factory_id.factory in ("sink_file",):
+    if factory_id in ("sink_file",):
         return BlockValidation(Either.ok(RawOutput(type_fqn="bytes", mime_type="text/plain")), restrictions)
-    elif instance.factory_id.factory in ("sink_image",):
+    elif factory_id in ("sink_image",):
         return BlockValidation(Either.ok(RawOutput(type_fqn="bytes", mime_type="image/png")), restrictions)
-    elif instance.factory_id.factory in ("source_sleep", "source_text", "source_filesize"):
+    elif factory_id in ("source_sleep", "source_text", "source_filesize"):
         return BlockValidation(Either.ok(RawOutput(type_fqn="str", mime_type="text/plain")), restrictions)
-    elif instance.factory_id.factory in ("source_42", "transform_increment", "product_join"):
+    elif factory_id in ("source_42", "transform_increment", "product_join"):
         return BlockValidation(Either.ok(RawOutput(type_fqn="int")), restrictions)
     else:
-        raise TypeError(f"unexpected factory {instance.factory_id.factory}")
+        raise TypeError(f"unexpected factory {factory_id}")
 
 
 def expander(output: BlockInstanceOutput) -> list[BlockExpansion]:
@@ -141,17 +140,17 @@ def expander(output: BlockInstanceOutput) -> list[BlockExpansion]:
     return []
 
 
-def compiler(lookup: ActionLookup, instance: BlockInstance) -> Either[Action, Error]:  # ty:ignore[invalid-type-arguments] # semigroup
+def compiler(lookup: ActionLookup, factory_id: BlockFactoryId, instance: BlockInstance) -> Either[Action, Error]:  # ty:ignore[invalid-type-arguments] # semigroup
     with PayloadBuildingContext(environment=[f"-e {pathlib.Path(__file__).parent.parent.parent}"]):
         # with PayloadBuildingContext(environment=["-e /home/dev/src/fiab-plugin-test"]): # TODO handle the ssh:// scenario intelligently
-        if instance.factory_id.factory == "source_42":
+        if factory_id == "source_42":
             action = from_source(Payload("fiab_plugin_test.runtime.source_42"))
-        elif instance.factory_id.factory == "source_text":
+        elif factory_id == "source_text":
             text = instance.configuration_values[TEXT]
             if not isinstance(text, str):
                 return Either.error(f"Invalid type for {TEXT!r}: expected str, got {type(text).__name__}")
             action = from_source(Payload("fiab_plugin_test.runtime.source_text", kwargs={"text": text}))
-        elif instance.factory_id.factory == "source_sleep":
+        elif factory_id == "source_sleep":
             text = instance.configuration_values[TEXT]
             duration = instance.configuration_values[DURATION]
             if not isinstance(text, str):
@@ -159,7 +158,7 @@ def compiler(lookup: ActionLookup, instance: BlockInstance) -> Either[Action, Er
             if not isinstance(duration, float):
                 return Either.error(f"Invalid type for {DURATION!r}: expected float, got {type(duration).__name__}")
             action = from_source(Payload("fiab_plugin_test.runtime.source_sleep", kwargs={"text": text, "duration": duration}))
-        elif instance.factory_id.factory == "source_filesize":
+        elif factory_id == "source_filesize":
             checkpoint_str = instance.configuration_values[CHECKPOINT]
             if not isinstance(checkpoint_str, str):
                 return Either.error(f"Invalid type for {CHECKPOINT!r}: expected str, got {type(checkpoint_str).__name__}")
@@ -169,38 +168,40 @@ def compiler(lookup: ActionLookup, instance: BlockInstance) -> Either[Action, Er
                 "fiab_plugin_test.runtime.source_filesize", kwargs={"path": str(local_path)}, metadata={"artifacts": [artifact_id]}
             )
             action = from_source(payload)
-        elif instance.factory_id.factory == "transform_increment":
+        elif factory_id == "transform_increment":
             a = lookup[instance.input_ids["a"]]
             amount = instance.configuration_values[AMOUNT]
             if not isinstance(amount, int):
                 return Either.error(f"Invalid type for {AMOUNT!r}: expected int, got {type(amount).__name__}")
             action = a.map(Payload("fiab_plugin_test.runtime.transform_increment", kwargs={"amount": amount}))
-        elif instance.factory_id.factory == "product_join":
+        elif factory_id == "product_join":
             a = lookup[instance.input_ids["a"]]
             b = lookup[instance.input_ids["b"]]
             action = a.join(b, dim="inputs").reduce(Payload("fiab_plugin_test.runtime.product_join"))
-        elif instance.factory_id.factory == "sink_file":
+        elif factory_id == "sink_file":
             data = lookup[instance.input_ids["data"]]
             fname = instance.configuration_values[FNAME]
             if not isinstance(fname, str):
                 return Either.error(f"Invalid type for {FNAME!r}: expected str, got {type(fname).__name__}")
             action = data.map(Payload("fiab_plugin_test.runtime.sink_file", kwargs={"fname": fname}))
-        elif instance.factory_id.factory == "sink_image":
+        elif factory_id == "sink_image":
             data = lookup[instance.input_ids["data"]]
             action = data.map(Payload("fiab_plugin_test.runtime.sink_image"))
         else:
-            raise TypeError(instance.factory_id.factory)
+            raise TypeError(factory_id)
         return Either.ok(action)
 
 
 plugin = lambda: Plugin(catalogue=catalogue(), validator=validator, expander=expander, compiler=compiler)
 
 
-def _make_source_text_block(text: str) -> BlockInstance:
-    return BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=SelfPluginId, factory=BlockFactoryId("source_text")),
-        configuration_values={TEXT: text} if text else {},
-        input_ids={},
+def _make_source_text_block(text: str) -> LocalBlock:
+    return LocalBlock(
+        factory_id=BlockFactoryId("source_text"),
+        instance=BlockInstance(
+            configuration_values={TEXT: text} if text else {},
+            input_ids={},
+        ),
     )
 
 
@@ -253,10 +254,9 @@ _testFailValidation = BlueprintTemplate(
     display_name="testFailValidation",
     display_description="A template that references a non-existent factory and always fails validation.",
     blocks={
-        _BLOCK_FAIL_VAL: BlockInstance(
-            factory_id=PluginBlockFactoryId(plugin=SelfPluginId, factory=BlockFactoryId("nonexistent_factory")),
-            configuration_values={},
-            input_ids={},
+        _BLOCK_FAIL_VAL: LocalBlock(
+            factory_id=BlockFactoryId("nonexistent_factory"),
+            instance=BlockInstance(configuration_values={}, input_ids={}),
         ),
     },
 )

--- a/backend/packages/fiab-plugin-test/tests/test_base.py
+++ b/backend/packages/fiab-plugin-test/tests/test_base.py
@@ -17,10 +17,6 @@ from fiab_core.fable import (
     BlockFactoryId,
     BlockInstance,
     ConfigurationOptionId,
-    PluginBlockFactoryId,
-    PluginCompositeId,
-    PluginId,
-    PluginStoreId,
     RawOutput,
 )
 
@@ -84,20 +80,20 @@ def test_source_filesize_factory_uses_closed_enum_checkpoint_type() -> None:
 # validator
 # ---------------------------------------------------------------------------
 
-_FAKE_PLUGIN_ID = PluginCompositeId(store=PluginStoreId("s"), local=PluginId("l"))
 
-
-def _make_instance(factory: str, config: dict) -> BlockInstance:
-    return BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=_FAKE_PLUGIN_ID, factory=BlockFactoryId(factory)),
-        configuration_values={ConfigurationOptionId(key): value for key, value in config.items()},
-        input_ids={},
+def _make_instance(factory: str, config: dict) -> tuple[BlockFactoryId, BlockInstance]:
+    return (
+        BlockFactoryId(factory),
+        BlockInstance(
+            configuration_values={ConfigurationOptionId(key): value for key, value in config.items()},
+            input_ids={},
+        ),
     )
 
 
 def test_validator_source_filesize_returns_str_raw_output() -> None:
-    instance = _make_instance("source_filesize", {"checkpoint": "mystore:mycheckpoint"})
-    validation = validator(instance, {})
+    factory_id, instance = _make_instance("source_filesize", {"checkpoint": "mystore:mycheckpoint"})
+    validation = validator(factory_id, instance, {})
     result = validation.result
     assert validation.restrictions == {}
     assert result.t is not None
@@ -115,8 +111,8 @@ def test_compiler_source_filesize_embeds_path_and_artifact_in_payload(tmp_path: 
     fake_id = CompositeArtifactId.from_str("mystore:mycheckpoint")
 
     with patch.object(ArtifactsProvider, "get_artifact_local_path", return_value=artifact_path):
-        instance = _make_instance("source_filesize", {"checkpoint": "mystore:mycheckpoint"})
-        result = compiler({}, instance)
+        factory_id, instance = _make_instance("source_filesize", {"checkpoint": "mystore:mycheckpoint"})
+        result = compiler({}, factory_id, instance)
 
     assert result.t is not None, f"compiler returned error: {result.e}"
 

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -33,14 +33,14 @@ from fiab_core.fable import (
     BlockKind,
     BlueprintTemplate,
     ConfigurationOptionId,
+    LocalBlock,
     NoOutput,
     PluginBlockExpansion,
     PluginBlockFactoryId,
     PluginCompositeId,
     QubedOutput,
-    SelfPluginId,
 )
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from forecastbox.domain.blueprint import db
 from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
@@ -71,9 +71,30 @@ class Tag(FiabBaseModel):
     value: str | None = None
 
 
+class RoutedBlock(FiabBaseModel):
+    """A block as stored and transmitted via the API: carries the full plugin routing factory id."""
+
+    factory_id: PluginBlockFactoryId
+    instance: BlockInstance
+
+    @model_validator(mode="before")
+    @classmethod
+    def _compat_flat_format(cls, data: Any) -> Any:
+        """Accept the legacy flat format where configuration_values and input_ids were top-level."""
+        if isinstance(data, dict) and "instance" not in data and "factory_id" in data:
+            return {
+                "factory_id": data["factory_id"],
+                "instance": {
+                    "configuration_values": data.get("configuration_values", {}),
+                    "input_ids": data.get("input_ids", {}),
+                },
+            }
+        return data
+
+
 class BlueprintBuilder(FiabBaseModel):
     # NOTE warning -- this class is used by the web api. Be careful about changes here
-    blocks: dict[BlockInstanceId, BlockInstance]
+    blocks: dict[BlockInstanceId, RoutedBlock]
     environment: EnvironmentSpecification | None = None
     local_glyphs: dict[str, str] = Field(default_factory=dict)
 
@@ -196,23 +217,23 @@ async def validate_expand(
     invalidable: set[BlockInstanceId] = set()
     visited: set[BlockInstanceId] = set()
 
-    for blockId in topological_order(blueprint.blocks.items(), lambda block: block.input_ids.values()):
+    for blockId in topological_order(blueprint.blocks.items(), lambda block: block.instance.input_ids.values()):
         visited.add(blockId)
-        blockInstance = blueprint.blocks[blockId]
-        plugin = plugins.get(blockInstance.factory_id.plugin, None)
+        routed = blueprint.blocks[blockId]
+        plugin = plugins.get(routed.factory_id.plugin, None)
         if not plugin:
             block_errors[blockId] += ["Plugin not found"]
             invalidable.add(blockId)
             continue
-        blockFactory = plugin.catalogue.factories.get(blockInstance.factory_id.factory, None)
+        blockFactory = plugin.catalogue.factories.get(routed.factory_id.factory, None)
         if not blockFactory:
             block_errors[blockId] += ["BlockFactory not found in the catalogue"]
             invalidable.add(blockId)
             continue
-        extraConfig = blockInstance.configuration_values.keys() - blockFactory.configuration_options.keys()
+        extraConfig = routed.instance.configuration_values.keys() - blockFactory.configuration_options.keys()
         if extraConfig:
             block_errors[blockId] += [f"Block contains extra config: {extraConfig}"]
-        extract_result = resolution.extract_glyphs(blockInstance)
+        extract_result = resolution.extract_glyphs(routed.instance)
         if extract_result.e is not None:
             block_errors[blockId] += extract_result.e
             invalidable.add(blockId)
@@ -222,21 +243,21 @@ async def validate_expand(
         if unknown_glyphs:
             # Soft path: omit options referencing unknown glyphs and record them,
             # rather than failing the whole block.
-            option_glyph_map = resolution.extract_glyphs_per_option(blockInstance)
+            option_glyph_map = resolution.extract_glyphs_per_option(routed.instance)
             for opt_id, opt_glyphs in option_glyph_map.items():
                 opt_unknown = opt_glyphs & unknown_glyphs
                 if opt_unknown:
                     missing_glyphs_result.setdefault(blockId, {})[opt_id] = sorted(opt_unknown)
-                    del blockInstance.configuration_values[opt_id]
+                    del routed.instance.configuration_values[opt_id]
             # Re-extract after removing affected options to get an accurate extracted state.
-            extract_result = resolution.extract_glyphs(blockInstance)
+            extract_result = resolution.extract_glyphs(routed.instance)
             if extract_result.e is not None:
                 block_errors[blockId] += extract_result.e
                 invalidable.add(blockId)
                 continue
             extracted = cast(ExtractedGlyphs, extract_result.t)
         try:
-            resolution.resolve_configurations(blockInstance, all_glyphs)
+            resolution.resolve_configurations(routed.instance, all_glyphs)
         except Exception as exc:
             block_errors[blockId] += [f"Jinja expression error: {exc}"]
             invalidable.add(blockId)
@@ -244,36 +265,36 @@ async def validate_expand(
         # A glyph value may itself reference an unknown glyph (e.g. myPath="${root}/${missing}").
         # After substitution those unresolved ${...} patterns survive in the config values;
         # a second extract_glyphs pass surfaces them.
-        extract_after = resolution.extract_glyphs(blockInstance)
+        extract_after = resolution.extract_glyphs(routed.instance)
         nested_unknowns = cast(ExtractedGlyphs, extract_after.t).glyphs
         if nested_unknowns:
             # Soft path: omit options with unresolved nested glyph references.
-            option_glyph_map_after = resolution.extract_glyphs_per_option(blockInstance)
+            option_glyph_map_after = resolution.extract_glyphs_per_option(routed.instance)
             for opt_id, opt_glyphs in option_glyph_map_after.items():
                 opt_nested = opt_glyphs & nested_unknowns
                 if opt_nested:
                     block_opts = missing_glyphs_result.setdefault(blockId, {})
                     existing = set(block_opts.get(opt_id, []))
                     block_opts[opt_id] = sorted(existing | opt_nested)
-                    del blockInstance.configuration_values[opt_id]
+                    del routed.instance.configuration_values[opt_id]
         # We dont want to return resolutions of nested glyphs, just the top levels. For this reason
         # we need to run the extraction twice, not just once after the substitution
         resolved_configuration_options[blockId] = {
-            k: blockInstance.configuration_values[k] for k in extracted.glyphed_options if k in blockInstance.configuration_values
+            k: routed.instance.configuration_values[k] for k in extracted.glyphed_options if k in routed.instance.configuration_values
         }
-        converted_values = convert_known_configuration_values(blockInstance, blockFactory)
+        converted_values = convert_known_configuration_values(routed.instance, blockFactory)
         if converted_values.t is None:
             block_errors[blockId] += converted_values.e
             invalidable.add(blockId)
             continue
-        blockInstance.configuration_values = converted_values.t
+        routed.instance.configuration_values = converted_values.t
 
-        if any(source_id in invalidable for source_id in blockInstance.input_ids.values()):
+        if any(source_id in invalidable for source_id in routed.instance.input_ids.values()):
             invalidable.add(blockId)
             continue
 
-        inputs = {input_id: outputs[source_id] for input_id, source_id in blockInstance.input_ids.items()}
-        validation = plugin.validator(blockInstance, inputs)
+        inputs = {input_id: outputs[source_id] for input_id, source_id in routed.instance.input_ids.items()}
+        validation = plugin.validator(routed.factory_id.factory, routed.instance, inputs)
         output_or_error = validation.result
         restrictions = validation.restrictions
         if not validate_only and restrictions:
@@ -308,9 +329,9 @@ async def validate_expand(
             )
 
     # the topological search *omits* nodes in cycles or with missing ancestors -- thus we need to report and detect them
-    for blockId, blockInstance in blueprint.blocks.items():
+    for blockId, routed in blueprint.blocks.items():
         if blockId not in visited:
-            missing = [source_id for source_id in blockInstance.input_ids.values() if source_id not in blueprint.blocks]
+            missing = [source_id for source_id in routed.instance.input_ids.values() if source_id not in blueprint.blocks]
             if missing:
                 block_errors[blockId] += [f"References non-existent block(s): {missing}"]
                 invalidable.add(blockId)
@@ -330,20 +351,19 @@ async def validate_expand(
 def template_to_builder(template: BlueprintTemplate, plugin_id: PluginCompositeId) -> BlueprintBuilder:
     """Convert a ``BlueprintTemplate`` to a ``BlueprintBuilder`` suitable for persistence.
 
-    ``SelfPluginId`` sentinels in block factory IDs are replaced with the real
-    plugin composite ID.  ``example_values`` and ``example_glyphs`` are
+    The local factory ids in template blocks are combined with the real plugin composite
+    ID to produce routed blocks.  ``example_values`` and ``example_glyphs`` are
     intentionally not copied -- they are guiding-only data and must not appear
     in ``configuration_values``.
     """
-    blocks: dict[BlockInstanceId, BlockInstance] = {}
-    for block_id, block in template.blocks.items():
-        factory = block.factory_id
-        if factory.plugin == SelfPluginId:
-            factory = PluginBlockFactoryId(plugin=plugin_id, factory=factory.factory)
-        blocks[block_id] = BlockInstance(
-            factory_id=factory,
-            configuration_values=dict(block.configuration_values),
-            input_ids=dict(block.input_ids),
+    blocks: dict[BlockInstanceId, RoutedBlock] = {}
+    for block_id, local_block in template.blocks.items():
+        blocks[block_id] = RoutedBlock(
+            factory_id=PluginBlockFactoryId(plugin=plugin_id, factory=local_block.factory_id),
+            instance=BlockInstance(
+                configuration_values=dict(local_block.instance.configuration_values),
+                input_ids=dict(local_block.instance.input_ids),
+            ),
         )
     environment: EnvironmentSpecification | None = None
     if template.environment is not None:
@@ -379,14 +399,16 @@ def resolve_builder_with_examples(
     """
     copy = builder.model_copy(deep=True)
 
-    new_blocks: dict[BlockInstanceId, BlockInstance] = {}
-    for block_id, block in copy.blocks.items():
+    new_blocks: dict[BlockInstanceId, RoutedBlock] = {}
+    for block_id, routed in copy.blocks.items():
         if block_id in example_values:
             # Merge: example values override existing template configuration values.
-            merged_config = {**block.configuration_values, **example_values[block_id]}
-            new_blocks[block_id] = block.model_copy(update={"configuration_values": merged_config})
+            merged_config = {**routed.instance.configuration_values, **example_values[block_id]}
+            new_blocks[block_id] = routed.model_copy(
+                update={"instance": routed.instance.model_copy(update={"configuration_values": merged_config})}
+            )
         else:
-            new_blocks[block_id] = block
+            new_blocks[block_id] = routed
 
     # Merge example_glyphs into local_glyphs; example glyphs take precedence.
     merged_local_glyphs: dict[str, str] = {**copy.local_glyphs, **example_glyphs}
@@ -410,10 +432,12 @@ def remap_builder_glyphs(builder: BlueprintBuilder, mapping: dict[str, str]) -> 
     if not mapping:
         return builder
 
-    new_blocks: dict[BlockInstanceId, BlockInstance] = {}
-    for block_id, block in builder.blocks.items():
-        new_config = {opt_id: remap_glyph_names(val, mapping) for opt_id, val in block.configuration_values.items()}
-        new_blocks[block_id] = block.model_copy(update={"configuration_values": new_config})
+    new_blocks: dict[BlockInstanceId, RoutedBlock] = {}
+    for block_id, routed in builder.blocks.items():
+        new_config = {opt_id: remap_glyph_names(val, mapping) for opt_id, val in routed.instance.configuration_values.items()}
+        new_blocks[block_id] = routed.model_copy(
+            update={"instance": routed.instance.model_copy(update={"configuration_values": new_config})}
+        )
 
     new_local_glyphs: dict[str, str] = {}
     for key, val in builder.local_glyphs.items():

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -34,7 +34,6 @@ from fiab_core.fable import (
     BlueprintTemplate,
     ConfigurationOptionId,
     NoOutput,
-    PluginBlockExpansion,
     PluginCompositeId,
     QubedOutput,
 )
@@ -79,6 +78,19 @@ class PluginBlockFactoryId(FiabBaseModel):
 
     plugin: PluginCompositeId
     factory: BlockFactoryId
+
+
+class SerializedBlockExpansion(FiabBaseModel):
+    """Expansion result as returned to clients, combining plugin identity with restrictions.
+
+    This is the service-level representation sent to API consumers, containing
+    the full plugin composite id, factory id, and serialized restriction types.
+    """
+
+    plugin: PluginCompositeId
+    factory: BlockFactoryId
+    restrictions: dict[ConfigurationOptionId, str] = Field(default_factory=dict)
+    """Serialized FableType restrictions (e.g., 'int', 'enumClosed[a,b]')"""
 
 
 class RoutableBlock(FiabBaseModel):
@@ -127,7 +139,7 @@ class BlueprintValidationExpansion(FiabBaseModel):
     global_errors: list[str]
     block_errors: dict[BlockInstanceId, list[str]]
     possible_sources: list[PluginBlockFactoryId]
-    possible_expansions: dict[BlockInstanceId, list[PluginBlockExpansion]]
+    possible_expansions: dict[BlockInstanceId, list[SerializedBlockExpansion]]
     configuration_restrictions: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = Field(default_factory=dict)
     resolved_configuration_options: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = Field(default_factory=dict)
     missing_glyphs: dict[BlockInstanceId, dict[ConfigurationOptionId, list[str]]] = Field(default_factory=dict)
@@ -182,7 +194,7 @@ async def validate_expand(
             if block_factory.kind == "source" and not block_factory.inputs
         ]
     )
-    possible_expansions: dict[BlockInstanceId, list[PluginBlockExpansion]] = {}
+    possible_expansions: dict[BlockInstanceId, list[SerializedBlockExpansion]] = {}
     configuration_restrictions: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = {}
     resolved_configuration_options: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = {}
     block_errors: dict[BlockInstanceId, list[str]] = defaultdict(list)
@@ -326,7 +338,7 @@ async def validate_expand(
         if not validate_only:
             possible_expansions[blockId] = (
                 [
-                    PluginBlockExpansion(
+                    SerializedBlockExpansion(
                         plugin=any_plugin_id,
                         factory=expansion.factory,
                         restrictions={k: v.serialize() for k, v in expansion.restrictions.items()},

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -33,14 +33,12 @@ from fiab_core.fable import (
     BlockKind,
     BlueprintTemplate,
     ConfigurationOptionId,
-    LocalBlock,
     NoOutput,
     PluginBlockExpansion,
-    PluginBlockFactoryId,
     PluginCompositeId,
     QubedOutput,
 )
-from pydantic import Field, model_validator
+from pydantic import Field
 
 from forecastbox.domain.blueprint import db
 from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
@@ -71,30 +69,34 @@ class Tag(FiabBaseModel):
     value: str | None = None
 
 
-class RoutedBlock(FiabBaseModel):
-    """A block as stored and transmitted via the API: carries the full plugin routing factory id."""
+class PluginBlockFactoryId(FiabBaseModel):
+    """Routing key combining plugin identity with a local factory id.
 
-    factory_id: PluginBlockFactoryId
+    Used in API responses (possible_sources) and expansion results to give
+    clients the full address of a block factory across all installed plugins.
+    Plugin authors never construct or consume this class directly.
+    """
+
+    plugin: PluginCompositeId
+    factory: BlockFactoryId
+
+
+class RoutableBlock(FiabBaseModel):
+    """A block as stored and transmitted via the API.
+
+    Flat structure: carries the block's own identity (instance_id), its full
+    routing address (plugin + factory), and its content (instance).
+    """
+
+    instance_id: BlockInstanceId
+    plugin: PluginCompositeId
+    factory: BlockFactoryId
     instance: BlockInstance
-
-    @model_validator(mode="before")
-    @classmethod
-    def _compat_flat_format(cls, data: Any) -> Any:
-        """Accept the legacy flat format where configuration_values and input_ids were top-level."""
-        if isinstance(data, dict) and "instance" not in data and "factory_id" in data:
-            return {
-                "factory_id": data["factory_id"],
-                "instance": {
-                    "configuration_values": data.get("configuration_values", {}),
-                    "input_ids": data.get("input_ids", {}),
-                },
-            }
-        return data
 
 
 class BlueprintBuilder(FiabBaseModel):
     # NOTE warning -- this class is used by the web api. Be careful about changes here
-    blocks: dict[BlockInstanceId, RoutedBlock]
+    blocks: list[RoutableBlock] = Field(default_factory=list)
     environment: EnvironmentSpecification | None = None
     local_glyphs: dict[str, str] = Field(default_factory=dict)
 
@@ -208,6 +210,14 @@ async def validate_expand(
     for key in sorted(colliding_keys):
         global_errors.append(f"Local glyph key {key!r} is reserved as an intrinsic glyph and cannot be overridden.")
 
+    # Build lookup and detect duplicate instance ids.
+    block_lookup: dict[BlockInstanceId, RoutableBlock] = {}
+    for routable in blueprint.blocks:
+        if routable.instance_id in block_lookup:
+            global_errors.append(f"Duplicate block instance id: {routable.instance_id!r}")
+        else:
+            block_lookup[routable.instance_id] = routable
+
     try:
         all_glyphs = expand_glyph_values(all_glyphs_raw)
     except GlyphCircularReferenceError as e:
@@ -217,23 +227,23 @@ async def validate_expand(
     invalidable: set[BlockInstanceId] = set()
     visited: set[BlockInstanceId] = set()
 
-    for blockId in topological_order(blueprint.blocks.items(), lambda block: block.instance.input_ids.values()):
+    for blockId in topological_order(block_lookup.items(), lambda block: block.instance.input_ids.values()):
         visited.add(blockId)
-        routed = blueprint.blocks[blockId]
-        plugin = plugins.get(routed.factory_id.plugin, None)
+        routable = block_lookup[blockId]
+        plugin = plugins.get(routable.plugin, None)
         if not plugin:
             block_errors[blockId] += ["Plugin not found"]
             invalidable.add(blockId)
             continue
-        blockFactory = plugin.catalogue.factories.get(routed.factory_id.factory, None)
+        blockFactory = plugin.catalogue.factories.get(routable.factory, None)
         if not blockFactory:
             block_errors[blockId] += ["BlockFactory not found in the catalogue"]
             invalidable.add(blockId)
             continue
-        extraConfig = routed.instance.configuration_values.keys() - blockFactory.configuration_options.keys()
+        extraConfig = routable.instance.configuration_values.keys() - blockFactory.configuration_options.keys()
         if extraConfig:
             block_errors[blockId] += [f"Block contains extra config: {extraConfig}"]
-        extract_result = resolution.extract_glyphs(routed.instance)
+        extract_result = resolution.extract_glyphs(routable.instance)
         if extract_result.e is not None:
             block_errors[blockId] += extract_result.e
             invalidable.add(blockId)
@@ -243,21 +253,21 @@ async def validate_expand(
         if unknown_glyphs:
             # Soft path: omit options referencing unknown glyphs and record them,
             # rather than failing the whole block.
-            option_glyph_map = resolution.extract_glyphs_per_option(routed.instance)
+            option_glyph_map = resolution.extract_glyphs_per_option(routable.instance)
             for opt_id, opt_glyphs in option_glyph_map.items():
                 opt_unknown = opt_glyphs & unknown_glyphs
                 if opt_unknown:
                     missing_glyphs_result.setdefault(blockId, {})[opt_id] = sorted(opt_unknown)
-                    del routed.instance.configuration_values[opt_id]
+                    del routable.instance.configuration_values[opt_id]
             # Re-extract after removing affected options to get an accurate extracted state.
-            extract_result = resolution.extract_glyphs(routed.instance)
+            extract_result = resolution.extract_glyphs(routable.instance)
             if extract_result.e is not None:
                 block_errors[blockId] += extract_result.e
                 invalidable.add(blockId)
                 continue
             extracted = cast(ExtractedGlyphs, extract_result.t)
         try:
-            resolution.resolve_configurations(routed.instance, all_glyphs)
+            resolution.resolve_configurations(routable.instance, all_glyphs)
         except Exception as exc:
             block_errors[blockId] += [f"Jinja expression error: {exc}"]
             invalidable.add(blockId)
@@ -265,36 +275,36 @@ async def validate_expand(
         # A glyph value may itself reference an unknown glyph (e.g. myPath="${root}/${missing}").
         # After substitution those unresolved ${...} patterns survive in the config values;
         # a second extract_glyphs pass surfaces them.
-        extract_after = resolution.extract_glyphs(routed.instance)
+        extract_after = resolution.extract_glyphs(routable.instance)
         nested_unknowns = cast(ExtractedGlyphs, extract_after.t).glyphs
         if nested_unknowns:
             # Soft path: omit options with unresolved nested glyph references.
-            option_glyph_map_after = resolution.extract_glyphs_per_option(routed.instance)
+            option_glyph_map_after = resolution.extract_glyphs_per_option(routable.instance)
             for opt_id, opt_glyphs in option_glyph_map_after.items():
                 opt_nested = opt_glyphs & nested_unknowns
                 if opt_nested:
                     block_opts = missing_glyphs_result.setdefault(blockId, {})
                     existing = set(block_opts.get(opt_id, []))
                     block_opts[opt_id] = sorted(existing | opt_nested)
-                    del routed.instance.configuration_values[opt_id]
+                    del routable.instance.configuration_values[opt_id]
         # We dont want to return resolutions of nested glyphs, just the top levels. For this reason
         # we need to run the extraction twice, not just once after the substitution
         resolved_configuration_options[blockId] = {
-            k: routed.instance.configuration_values[k] for k in extracted.glyphed_options if k in routed.instance.configuration_values
+            k: routable.instance.configuration_values[k] for k in extracted.glyphed_options if k in routable.instance.configuration_values
         }
-        converted_values = convert_known_configuration_values(routed.instance, blockFactory)
+        converted_values = convert_known_configuration_values(routable.instance, blockFactory)
         if converted_values.t is None:
             block_errors[blockId] += converted_values.e
             invalidable.add(blockId)
             continue
-        routed.instance.configuration_values = converted_values.t
+        routable.instance.configuration_values = converted_values.t
 
-        if any(source_id in invalidable for source_id in routed.instance.input_ids.values()):
+        if any(source_id in invalidable for source_id in routable.instance.input_ids.values()):
             invalidable.add(blockId)
             continue
 
-        inputs = {input_id: outputs[source_id] for input_id, source_id in routed.instance.input_ids.items()}
-        validation = plugin.validator(routed.factory_id.factory, routed.instance, inputs)
+        inputs = {input_id: outputs[source_id] for input_id, source_id in routable.instance.input_ids.items()}
+        validation = plugin.validator(routable.factory, routable.instance, inputs)
         output_or_error = validation.result
         restrictions = validation.restrictions
         if not validate_only and restrictions:
@@ -329,9 +339,9 @@ async def validate_expand(
             )
 
     # the topological search *omits* nodes in cycles or with missing ancestors -- thus we need to report and detect them
-    for blockId, routed in blueprint.blocks.items():
+    for blockId, routable in block_lookup.items():
         if blockId not in visited:
-            missing = [source_id for source_id in routed.instance.input_ids.values() if source_id not in blueprint.blocks]
+            missing = [source_id for source_id in routable.instance.input_ids.values() if source_id not in block_lookup]
             if missing:
                 block_errors[blockId] += [f"References non-existent block(s): {missing}"]
                 invalidable.add(blockId)
@@ -356,14 +366,18 @@ def template_to_builder(template: BlueprintTemplate, plugin_id: PluginCompositeI
     intentionally not copied -- they are guiding-only data and must not appear
     in ``configuration_values``.
     """
-    blocks: dict[BlockInstanceId, RoutedBlock] = {}
-    for block_id, local_block in template.blocks.items():
-        blocks[block_id] = RoutedBlock(
-            factory_id=PluginBlockFactoryId(plugin=plugin_id, factory=local_block.factory_id),
-            instance=BlockInstance(
-                configuration_values=dict(local_block.instance.configuration_values),
-                input_ids=dict(local_block.instance.input_ids),
-            ),
+    blocks: list[RoutableBlock] = []
+    for block_id, template_block in template.blocks.items():
+        blocks.append(
+            RoutableBlock(
+                instance_id=block_id,
+                plugin=plugin_id,
+                factory=template_block.factory_id,
+                instance=BlockInstance(
+                    configuration_values=dict(template_block.instance.configuration_values),
+                    input_ids=dict(template_block.instance.input_ids),
+                ),
+            )
         )
     environment: EnvironmentSpecification | None = None
     if template.environment is not None:
@@ -399,16 +413,16 @@ def resolve_builder_with_examples(
     """
     copy = builder.model_copy(deep=True)
 
-    new_blocks: dict[BlockInstanceId, RoutedBlock] = {}
-    for block_id, routed in copy.blocks.items():
-        if block_id in example_values:
+    new_blocks: list[RoutableBlock] = []
+    for routable in copy.blocks:
+        if routable.instance_id in example_values:
             # Merge: example values override existing template configuration values.
-            merged_config = {**routed.instance.configuration_values, **example_values[block_id]}
-            new_blocks[block_id] = routed.model_copy(
-                update={"instance": routed.instance.model_copy(update={"configuration_values": merged_config})}
+            merged_config = {**routable.instance.configuration_values, **example_values[routable.instance_id]}
+            new_blocks.append(
+                routable.model_copy(update={"instance": routable.instance.model_copy(update={"configuration_values": merged_config})})
             )
         else:
-            new_blocks[block_id] = routed
+            new_blocks.append(routable)
 
     # Merge example_glyphs into local_glyphs; example glyphs take precedence.
     merged_local_glyphs: dict[str, str] = {**copy.local_glyphs, **example_glyphs}
@@ -432,11 +446,11 @@ def remap_builder_glyphs(builder: BlueprintBuilder, mapping: dict[str, str]) -> 
     if not mapping:
         return builder
 
-    new_blocks: dict[BlockInstanceId, RoutedBlock] = {}
-    for block_id, routed in builder.blocks.items():
-        new_config = {opt_id: remap_glyph_names(val, mapping) for opt_id, val in routed.instance.configuration_values.items()}
-        new_blocks[block_id] = routed.model_copy(
-            update={"instance": routed.instance.model_copy(update={"configuration_values": new_config})}
+    new_blocks: list[RoutableBlock] = []
+    for routable in builder.blocks:
+        new_config = {opt_id: remap_glyph_names(val, mapping) for opt_id, val in routable.instance.configuration_values.items()}
+        new_blocks.append(
+            routable.model_copy(update={"instance": routable.instance.model_copy(update={"configuration_values": new_config})})
         )
 
     new_local_glyphs: dict[str, str] = {}

--- a/backend/src/forecastbox/domain/run/background.py
+++ b/backend/src/forecastbox/domain/run/background.py
@@ -91,7 +91,7 @@ def execute_background(
         # re-expand correctly on restart even if the intermediate dependency (e.g. "root") is no
         # longer in the global DB.
         referenced_glyph_names = {
-            name for block in builder.blocks.values() for name in cast(ExtractedGlyphs, extract_glyphs(block).t).glyphs
+            name for block in builder.blocks.values() for name in cast(ExtractedGlyphs, extract_glyphs(block.instance).t).glyphs
         }
         all_glyphs_raw = merge_glyph_values(
             intrinsic_values,

--- a/backend/src/forecastbox/domain/run/background.py
+++ b/backend/src/forecastbox/domain/run/background.py
@@ -91,7 +91,7 @@ def execute_background(
         # re-expand correctly on restart even if the intermediate dependency (e.g. "root") is no
         # longer in the global DB.
         referenced_glyph_names = {
-            name for block in builder.blocks.values() for name in cast(ExtractedGlyphs, extract_glyphs(block.instance).t).glyphs
+            name for block in builder.blocks for name in cast(ExtractedGlyphs, extract_glyphs(block.instance).t).glyphs
         }
         all_glyphs_raw = merge_glyph_values(
             intrinsic_values,

--- a/backend/src/forecastbox/domain/run/compile.py
+++ b/backend/src/forecastbox/domain/run/compile.py
@@ -95,22 +95,22 @@ def compile_builder(
     block_to_mime: dict[BlockInstanceId, str] = {}
     sink_tasks: set[TaskId] = set()
 
-    for blockId in topological_order(blueprint.blocks.items(), lambda block: block.input_ids.values()):
-        blockInstance = blueprint.blocks[blockId]
-        plugin = plugins.get(blockInstance.factory_id.plugin, None)
+    for blockId in topological_order(blueprint.blocks.items(), lambda block: block.instance.input_ids.values()):
+        routed = blueprint.blocks[blockId]
+        plugin = plugins.get(routed.factory_id.plugin, None)
         if not plugin:
-            raise ValueError(f"plugin for {blockId=} not found: {blockInstance.factory_id.plugin}")
-        block_factory = plugin.catalogue.factories[blockInstance.factory_id.factory]
-        missing_config = sorted(block_factory.configuration_options.keys() - blockInstance.configuration_values.keys())
+            raise ValueError(f"plugin for {blockId=} not found: {routed.factory_id.plugin}")
+        block_factory = plugin.catalogue.factories[routed.factory_id.factory]
+        missing_config = sorted(block_factory.configuration_options.keys() - routed.instance.configuration_values.keys())
         if missing_config:
             raise ValueError(f"compile failed at {blockId=} with missing configuration options: {missing_config}")
-        resolve_configurations(blockInstance, glyph_values)
-        converted_values = convert_known_configuration_values(blockInstance, block_factory)
+        resolve_configurations(routed.instance, glyph_values)
+        converted_values = convert_known_configuration_values(routed.instance, block_factory)
         if converted_values.t is None:
             raise ValueError(f"compile failed at {blockId=} with {converted_values.e}")
-        blockInstance.configuration_values = converted_values.t
+        routed.instance.configuration_values = converted_values.t
         with PayloadBuildingContext(blockId=blockId):
-            result = plugin.compiler(action_lookup, blockInstance)
+            result = plugin.compiler(action_lookup, routed.factory_id.factory, routed.instance)
         if result.t is None:
             raise ValueError(f"compile failed at {blockId=} with {result.e}")
         action_lookup[blockId] = result.t
@@ -119,10 +119,12 @@ def compile_builder(
         # This wasteful and redundant, ideally we'd return block output in the compile.
         # At this stage the validation should pass, but we still approach it defensively
         validator_inputs = {
-            input_name: block_outputs[source_id] for input_name, source_id in blockInstance.input_ids.items() if source_id in block_outputs
+            input_name: block_outputs[source_id]
+            for input_name, source_id in routed.instance.input_ids.items()
+            if source_id in block_outputs
         }
         try:
-            validated = plugin.validator(blockInstance, validator_inputs).result
+            validated = plugin.validator(routed.factory_id.factory, routed.instance, validator_inputs).result
             if validated.t is None:
                 raise ValueError(f"compile failed at {blockId=} with {validated.e}")
             block_outputs[blockId] = validated.t

--- a/backend/src/forecastbox/domain/run/compile.py
+++ b/backend/src/forecastbox/domain/run/compile.py
@@ -95,22 +95,24 @@ def compile_builder(
     block_to_mime: dict[BlockInstanceId, str] = {}
     sink_tasks: set[TaskId] = set()
 
-    for blockId in topological_order(blueprint.blocks.items(), lambda block: block.instance.input_ids.values()):
-        routed = blueprint.blocks[blockId]
-        plugin = plugins.get(routed.factory_id.plugin, None)
+    block_lookup = {b.instance_id: b for b in blueprint.blocks}
+
+    for blockId in topological_order(block_lookup.items(), lambda block: block.instance.input_ids.values()):
+        routable = block_lookup[blockId]
+        plugin = plugins.get(routable.plugin, None)
         if not plugin:
-            raise ValueError(f"plugin for {blockId=} not found: {routed.factory_id.plugin}")
-        block_factory = plugin.catalogue.factories[routed.factory_id.factory]
-        missing_config = sorted(block_factory.configuration_options.keys() - routed.instance.configuration_values.keys())
+            raise ValueError(f"plugin for {blockId=} not found: {routable.plugin}")
+        block_factory = plugin.catalogue.factories[routable.factory]
+        missing_config = sorted(block_factory.configuration_options.keys() - routable.instance.configuration_values.keys())
         if missing_config:
             raise ValueError(f"compile failed at {blockId=} with missing configuration options: {missing_config}")
-        resolve_configurations(routed.instance, glyph_values)
-        converted_values = convert_known_configuration_values(routed.instance, block_factory)
+        resolve_configurations(routable.instance, glyph_values)
+        converted_values = convert_known_configuration_values(routable.instance, block_factory)
         if converted_values.t is None:
             raise ValueError(f"compile failed at {blockId=} with {converted_values.e}")
-        routed.instance.configuration_values = converted_values.t
+        routable.instance.configuration_values = converted_values.t
         with PayloadBuildingContext(blockId=blockId):
-            result = plugin.compiler(action_lookup, routed.factory_id.factory, routed.instance)
+            result = plugin.compiler(action_lookup, routable.factory, routable.instance)
         if result.t is None:
             raise ValueError(f"compile failed at {blockId=} with {result.e}")
         action_lookup[blockId] = result.t
@@ -120,11 +122,11 @@ def compile_builder(
         # At this stage the validation should pass, but we still approach it defensively
         validator_inputs = {
             input_name: block_outputs[source_id]
-            for input_name, source_id in routed.instance.input_ids.items()
+            for input_name, source_id in routable.instance.input_ids.items()
             if source_id in block_outputs
         }
         try:
-            validated = plugin.validator(routed.factory_id.factory, routed.instance, validator_inputs).result
+            validated = plugin.validator(routable.factory, routable.instance, validator_inputs).result
             if validated.t is None:
                 raise ValueError(f"compile failed at {blockId=} with {validated.e}")
             block_outputs[blockId] = validated.t

--- a/backend/src/forecastbox/routes/blueprint.py
+++ b/backend/src/forecastbox/routes/blueprint.py
@@ -35,7 +35,6 @@ from fiab_core.fable import (
     BlockFactoryCatalogue,
     BlockInstanceId,
     ConfigurationOptionId,
-    PluginBlockExpansion,
     PluginCompositeId,
 )
 
@@ -51,6 +50,7 @@ from forecastbox.domain.blueprint.service import (
     BlueprintSaveCommand,
     BlueprintValidationExpansion,
     PluginBlockFactoryId,
+    SerializedBlockExpansion,
     Tag,
 )
 from forecastbox.domain.blueprint.types import BlueprintId
@@ -180,7 +180,7 @@ class BlueprintValidationExpansionResponse(FiabBaseModel):
     global_errors: list[str]
     block_errors: dict[BlockInstanceId, list[str]]
     possible_sources: list[PluginBlockFactoryId]
-    possible_expansions: dict[BlockInstanceId, list[PluginBlockExpansion]]
+    possible_expansions: dict[BlockInstanceId, list[SerializedBlockExpansion]]
     configuration_restrictions: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = {}
     resolved_configuration_options: dict[BlockInstanceId, dict[ConfigurationOptionId, str]]
     missing_glyphs: dict[BlockInstanceId, dict[ConfigurationOptionId, list[str]]] = {}

--- a/backend/src/forecastbox/routes/blueprint.py
+++ b/backend/src/forecastbox/routes/blueprint.py
@@ -36,7 +36,6 @@ from fiab_core.fable import (
     BlockInstanceId,
     ConfigurationOptionId,
     PluginBlockExpansion,
-    PluginBlockFactoryId,
     PluginCompositeId,
 )
 
@@ -47,7 +46,13 @@ from forecastbox.domain.blueprint.exceptions import (
     BlueprintNotFound,
     BlueprintVersionConflict,
 )
-from forecastbox.domain.blueprint.service import BlueprintBuilder, BlueprintSaveCommand, BlueprintValidationExpansion, Tag
+from forecastbox.domain.blueprint.service import (
+    BlueprintBuilder,
+    BlueprintSaveCommand,
+    BlueprintValidationExpansion,
+    PluginBlockFactoryId,
+    Tag,
+)
 from forecastbox.domain.blueprint.types import BlueprintId
 from forecastbox.domain.glyphs import global_db
 from forecastbox.domain.glyphs.intrinsic import AvailableIntrinsicGlyphs, get_values_and_examples

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -5,11 +5,12 @@ import socketserver
 import tempfile
 import time
 from http.server import SimpleHTTPRequestHandler
-from multiprocessing import Event, Process
+from multiprocessing import Event, Process, get_context
 from typing import Any, Generator
 
 import httpx
 import pytest
+from cascade.executor.platform import get_mp_ctx
 from fiab_core.artifacts import ArtifactStoreId
 from fiab_core.fable import PluginCompositeId, PluginId, PluginStoreId
 from pydantic import SecretStr
@@ -185,7 +186,8 @@ def backend_client() -> Generator[httpx.Client, None, None]:
 
         # Start fake artifact registry before launching the app
         shutdown_event_artifacts = Event()
-        p_artifacts = Process(target=run_artifact_registry, args=(shutdown_event_artifacts,))
+        # NOTE we basically need a `fork/spawn` here, as forkserver makes us lose the envvars
+        p_artifacts = get_mp_ctx("other").Process(target=run_artifact_registry, args=(shutdown_event_artifacts,))
         p_artifacts.start()
 
         validate_runtime(config)

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -127,7 +127,6 @@ def _make_builder_full(tmpdir: str) -> BlueprintBuilder:
                 {"text": "${submitDatetime};${startDatetime};${basicExecuteGlobalGlyph};${blueprintExecuteLocalGlyph}"}
             ),
         ),
-        input_ids={},
     )
     sink_time = RoutableBlock(
         instance_id=BlockInstanceId("sink_time"),
@@ -176,7 +175,8 @@ def test_blueprint_save_and_retrieve(backend_client_with_auth: httpx.Client) -> 
     assert retrieved["version"] == 1
     assert retrieved["display_name"] == "Test Blueprint"
     assert retrieved["tags"] == [{"key": "test", "value": None}, {"key": "integration", "value": None}]
-    assert retrieved["builder"]["blocks"]["source_42"]["factory_id"]["factory"] == "source_42"
+    source_42_block = next(b for b in retrieved["builder"]["blocks"] if b["instance_id"] == "source_42")
+    assert source_42_block["factory"] == "source_42"
     assert retrieved["builder"]["environment"]["hosts"] == 2
     assert retrieved["builder"]["environment"]["workers_per_host"] == 4
 
@@ -371,7 +371,7 @@ def test_plugin_template_exclusion(backend_client_with_auth: httpx.Client, backe
     assert response.is_success, response.text
     builder_data = response.json()["builder"]
     # The block config value must reference the renamed glyph.
-    config_values = list(builder_data["blocks"].values())[0]["configuration_values"]
+    config_values = builder_data["blocks"][0]["instance"]["configuration_values"]
     assert any("pluginGlyphNew" in v for v in config_values.values()), (
         f"Expected pluginGlyphNew in config values after remapping, got: {config_values}"
     )
@@ -491,8 +491,8 @@ def test_blueprint_expand(tmpdir: Any, backend_client_with_auth: httpx.Client) -
         ),
     )
     # Using an unknown glyph should not fail validation — it should be reported in missing_glyphs
-    sink_file_bad = RoutableBlock(
-        instance_id=BlockInstanceId("sink_file_bad"),
+    sink_file = RoutableBlock(
+        instance_id=BlockInstanceId("sink_file"),
         plugin=testPluginId,
         factory=BlockFactoryId("sink_file"),
         instance=BlockInstance(
@@ -501,7 +501,7 @@ def test_blueprint_expand(tmpdir: Any, backend_client_with_auth: httpx.Client) -
         ),
     )
     blocks.append(product_join)
-    blocks.append(sink_file_bad)
+    blocks.append(sink_file)
 
     builder = BlueprintBuilder(blocks=blocks)
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())
@@ -523,15 +523,16 @@ def test_blueprint_expand(tmpdir: Any, backend_client_with_auth: httpx.Client) -
 
     # A builder with an intrinsic name used as a local glyph key should fail validation
     builder_invalid_local = BlueprintBuilder(
-        blocks=dict(blocks),
+        blocks=list(blocks),
         local_glyphs={"runId": "should-not-be-allowed"},
     )
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder_invalid_local.model_dump())
     assert len(response.json()["global_errors"]) > 0
 
-    # A block using a local glyph defined on the builder should pass validation
+    # A block using a local glyph defined on the builder should pass validation.
+    # Replace the sink_file block in the list with a variant that references the local glyph.
     sink_file_local = RoutableBlock(
-        instance_id=BlockInstanceId("sink_file_local"),
+        instance_id=BlockInstanceId("sink_file"),
         plugin=testPluginId,
         factory=BlockFactoryId("sink_file"),
         instance=BlockInstance(
@@ -539,9 +540,9 @@ def test_blueprint_expand(tmpdir: Any, backend_client_with_auth: httpx.Client) -
             input_ids={"data": BlockInstanceId("product_join")},
         ),
     )
-    blocks.append(sink_file_local)
+    blocks = [sink_file_local if b.instance_id == BlockInstanceId("sink_file") else b for b in blocks]
     builder_with_local = BlueprintBuilder(
-        blocks=dict(blocks),
+        blocks=blocks,
         local_glyphs={"blueprintExpandLocalGlyph": "expand_local_value"},
     )
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder_with_local.model_dump())
@@ -549,9 +550,10 @@ def test_blueprint_expand(tmpdir: Any, backend_client_with_auth: httpx.Client) -
     assert len(response.json()["global_errors"]) == 0
     assert response.json()["resolved_configuration_options"]["sink_file"]["fname"] == f"{tmpdir}/outputexpand_local_value.main.txt"
 
-    # A known intrinsic glyph (${runId}) should also pass validation
+    # A known intrinsic glyph (${runId}) should also pass validation.
+    # Replace the sink_file block again with the intrinsic-glyph variant.
     sink_file_intrinsic = RoutableBlock(
-        instance_id=BlockInstanceId("sink_file_intrinsic"),
+        instance_id=BlockInstanceId("sink_file"),
         plugin=testPluginId,
         factory=BlockFactoryId("sink_file"),
         instance=BlockInstance(
@@ -559,7 +561,7 @@ def test_blueprint_expand(tmpdir: Any, backend_client_with_auth: httpx.Client) -
             input_ids={"data": BlockInstanceId("product_join")},
         ),
     )
-    blocks.append(sink_file_intrinsic)
+    blocks = [sink_file_intrinsic if b.instance_id == BlockInstanceId("sink_file") else b for b in blocks]
 
     builder = BlueprintBuilder(blocks=blocks)
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -34,10 +34,10 @@ from typing import Any, get_args
 import cloudpickle
 import httpx
 import pytest
-from fiab_core.fable import BlockFactoryId, BlockInstance, BlockInstanceId, ConfigurationOptionId, PluginBlockFactoryId, PluginCompositeId
+from fiab_core.fable import BlockFactoryId, BlockInstance, BlockInstanceId, ConfigurationOptionId, PluginCompositeId
 
 from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
-from forecastbox.domain.blueprint.service import BlueprintBuilder, BlueprintSaveCommand, Tag
+from forecastbox.domain.blueprint.service import BlueprintBuilder, BlueprintSaveCommand, RoutableBlock, Tag
 from forecastbox.domain.glyphs.intrinsic import AvailableIntrinsicGlyphs
 from forecastbox.routes.run import CompilationDetailResponse, RunCreateResponse
 
@@ -65,56 +65,88 @@ def ensure_completed_v2(backend_client: httpx.Client, job_id: str, sleep: float 
 
 
 def _make_builder_source_only() -> BlueprintBuilder:
-    source_42 = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_42")),
-        configuration_values={},
-        input_ids={},
+    source_42 = RoutableBlock(
+        instance_id=BlockInstanceId("source_42"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("source_42"),
+        instance=BlockInstance(
+            configuration_values={},
+            input_ids={},
+        ),
     )
-    return BlueprintBuilder(blocks={BlockInstanceId("source_42"): source_42})
+    return BlueprintBuilder(
+        blocks=[
+            source_42,
+        ]
+    )
 
 
 def _make_builder_full(tmpdir: str) -> BlueprintBuilder:
-    source_42 = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_42")),
-        configuration_values={},
-        input_ids={},
+    source_42 = RoutableBlock(
+        instance_id=BlockInstanceId("source_42"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("source_42"),
+        instance=BlockInstance(
+            configuration_values={},
+            input_ids={},
+        ),
     )
-    transform_increment = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("transform_increment")),
-        configuration_values=_config({"amount": "1"}),
-        input_ids={"a": BlockInstanceId("source_42")},
+    transform_increment = RoutableBlock(
+        instance_id=BlockInstanceId("transform_increment"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("transform_increment"),
+        instance=BlockInstance(
+            configuration_values=_config({"amount": "1"}),
+            input_ids={"a": BlockInstanceId("source_42")},
+        ),
     )
-    product_join = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("product_join")),
-        configuration_values={},
-        input_ids={"a": BlockInstanceId("transform_increment"), "b": BlockInstanceId("source_42")},
+    product_join = RoutableBlock(
+        instance_id=BlockInstanceId("product_join"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("product_join"),
+        instance=BlockInstance(
+            configuration_values={},
+            input_ids={"a": BlockInstanceId("transform_increment"), "b": BlockInstanceId("source_42")},
+        ),
     )
-    sink_main = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("sink_file")),
-        configuration_values=_config({"fname": f"{tmpdir}/output${{runId}}.main.txt"}),
-        input_ids={"data": BlockInstanceId("product_join")},
+    sink_main = RoutableBlock(
+        instance_id=BlockInstanceId("sink_main"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("sink_file"),
+        instance=BlockInstance(
+            configuration_values=_config({"fname": f"{tmpdir}/output${{runId}}.main.txt"}),
+            input_ids={"data": BlockInstanceId("product_join")},
+        ),
     )
-    source_time = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_text")),
-        configuration_values=_config(
-            {"text": "${submitDatetime};${startDatetime};${basicExecuteGlobalGlyph};${blueprintExecuteLocalGlyph}"}
+    source_time = RoutableBlock(
+        instance_id=BlockInstanceId("source_time"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("source_text"),
+        instance=BlockInstance(
+            configuration_values=_config(
+                {"text": "${submitDatetime};${startDatetime};${basicExecuteGlobalGlyph};${blueprintExecuteLocalGlyph}"}
+            ),
         ),
         input_ids={},
     )
-    sink_time = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("sink_file")),
-        configuration_values=_config({"fname": f"{tmpdir}/output${{runId}}.time.txt"}),
-        input_ids={"data": BlockInstanceId("source_time")},
+    sink_time = RoutableBlock(
+        instance_id=BlockInstanceId("sink_time"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("sink_file"),
+        instance=BlockInstance(
+            configuration_values=_config({"fname": f"{tmpdir}/output${{runId}}.time.txt"}),
+            input_ids={"data": BlockInstanceId("source_time")},
+        ),
     )
     return BlueprintBuilder(
-        blocks={
-            BlockInstanceId("source_42"): source_42,
-            BlockInstanceId("transform_increment"): transform_increment,
-            BlockInstanceId("product_join"): product_join,
-            BlockInstanceId("sink_main"): sink_main,
-            BlockInstanceId("source_time"): source_time,
-            BlockInstanceId("sink_time"): sink_time,
-        },
+        blocks=[
+            source_42,
+            transform_increment,
+            product_join,
+            sink_main,
+            source_time,
+            sink_time,
+        ],
         local_glyphs={"blueprintExecuteLocalGlyph": "local_glyph_value"},
     )
 
@@ -391,7 +423,7 @@ def test_blueprint_expand(tmpdir: Any, backend_client_with_auth: httpx.Client) -
     response = backend_client_with_auth.get("/blueprint/catalogue").raise_for_status()
     assert len(response.json()) > 0
 
-    builder = BlueprintBuilder(blocks={})
+    builder = BlueprintBuilder(blocks=[])
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())
     assert response.json()["possible_sources"] == [
         {"plugin": {"store": "localTest", "local": "single"}, "factory": "source_42"},
@@ -401,12 +433,16 @@ def test_blueprint_expand(tmpdir: Any, backend_client_with_auth: httpx.Client) -
     ]
     assert response.json()["possible_expansions"] == {}
 
-    source_42 = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_42")),
-        configuration_values={},
-        input_ids={},
+    source_42 = RoutableBlock(
+        instance_id=BlockInstanceId("source_42"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("source_42"),
+        instance=BlockInstance(
+            configuration_values={},
+            input_ids={},
+        ),
     )
-    blocks = {BlockInstanceId("source_42"): source_42}
+    blocks = [source_42]
     builder = BlueprintBuilder(blocks=blocks)
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())
     assert response.json()["possible_expansions"] == {
@@ -422,12 +458,16 @@ def test_blueprint_expand(tmpdir: Any, backend_client_with_auth: httpx.Client) -
         ]
     }
 
-    transform_increment = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("transform_increment")),
-        configuration_values=_config({"amount": "2"}),
-        input_ids={"a": BlockInstanceId("source_42")},
+    transform_increment = RoutableBlock(
+        instance_id=BlockInstanceId("transform_increment"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("transform_increment"),
+        instance=BlockInstance(
+            configuration_values=_config({"amount": "2"}),
+            input_ids={"a": BlockInstanceId("source_42")},
+        ),
     )
-    blocks[BlockInstanceId("transform_increment")] = transform_increment
+    blocks.append(transform_increment)
     builder = BlueprintBuilder(blocks=blocks)
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())
     assert response.json()["possible_expansions"]["transform_increment"] == [
@@ -441,19 +481,27 @@ def test_blueprint_expand(tmpdir: Any, backend_client_with_auth: httpx.Client) -
         {"plugin": {"store": "localTest", "local": "single"}, "factory": "sink_image", "restrictions": {}},
     ]
 
-    product_join = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("product_join")),
-        configuration_values={},
-        input_ids={"a": BlockInstanceId("transform_increment"), "b": BlockInstanceId("source_42")},
+    product_join = RoutableBlock(
+        instance_id=BlockInstanceId("product_join"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("product_join"),
+        instance=BlockInstance(
+            configuration_values={},
+            input_ids={"a": BlockInstanceId("transform_increment"), "b": BlockInstanceId("source_42")},
+        ),
     )
     # Using an unknown glyph should not fail validation — it should be reported in missing_glyphs
-    sink_file_bad = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("sink_file")),
-        configuration_values=_config({"fname": f"{tmpdir}/output${{blueprintExpandGlobalGlyph}}.main.txt"}),
-        input_ids={"data": BlockInstanceId("product_join")},
+    sink_file_bad = RoutableBlock(
+        instance_id=BlockInstanceId("sink_file_bad"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("sink_file"),
+        instance=BlockInstance(
+            configuration_values=_config({"fname": f"{tmpdir}/output${{blueprintExpandGlobalGlyph}}.main.txt"}),
+            input_ids={"data": BlockInstanceId("product_join")},
+        ),
     )
-    blocks[BlockInstanceId("product_join")] = product_join
-    blocks[BlockInstanceId("sink_file")] = sink_file_bad
+    blocks.append(product_join)
+    blocks.append(sink_file_bad)
 
     builder = BlueprintBuilder(blocks=blocks)
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())
@@ -482,12 +530,16 @@ def test_blueprint_expand(tmpdir: Any, backend_client_with_auth: httpx.Client) -
     assert len(response.json()["global_errors"]) > 0
 
     # A block using a local glyph defined on the builder should pass validation
-    sink_file_local = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("sink_file")),
-        configuration_values=_config({"fname": f"{tmpdir}/output${{blueprintExpandLocalGlyph}}.main.txt"}),
-        input_ids={"data": BlockInstanceId("product_join")},
+    sink_file_local = RoutableBlock(
+        instance_id=BlockInstanceId("sink_file_local"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("sink_file"),
+        instance=BlockInstance(
+            configuration_values=_config({"fname": f"{tmpdir}/output${{blueprintExpandLocalGlyph}}.main.txt"}),
+            input_ids={"data": BlockInstanceId("product_join")},
+        ),
     )
-    blocks[BlockInstanceId("sink_file")] = sink_file_local
+    blocks.append(sink_file_local)
     builder_with_local = BlueprintBuilder(
         blocks=dict(blocks),
         local_glyphs={"blueprintExpandLocalGlyph": "expand_local_value"},
@@ -498,12 +550,16 @@ def test_blueprint_expand(tmpdir: Any, backend_client_with_auth: httpx.Client) -
     assert response.json()["resolved_configuration_options"]["sink_file"]["fname"] == f"{tmpdir}/outputexpand_local_value.main.txt"
 
     # A known intrinsic glyph (${runId}) should also pass validation
-    sink_file_intrinsic = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("sink_file")),
-        configuration_values=_config({"fname": f"{tmpdir}/output${{runId}}.main.txt"}),
-        input_ids={"data": BlockInstanceId("product_join")},
+    sink_file_intrinsic = RoutableBlock(
+        instance_id=BlockInstanceId("sink_file_intrinsic"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("sink_file"),
+        instance=BlockInstance(
+            configuration_values=_config({"fname": f"{tmpdir}/output${{runId}}.main.txt"}),
+            input_ids={"data": BlockInstanceId("product_join")},
+        ),
     )
-    blocks[BlockInstanceId("sink_file")] = sink_file_intrinsic
+    blocks.append(sink_file_intrinsic)
 
     builder = BlueprintBuilder(blocks=blocks)
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())
@@ -533,12 +589,20 @@ def test_blueprint_expand_restrictions(backend_client_with_auth: httpx.Client) -
     It also returns the same restriction for transform_increment's own configuration.
     This test verifies both restrictions survive the full route round-trip.
     """
-    source_42 = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_42")),
-        configuration_values={},
-        input_ids={},
+    source_42 = RoutableBlock(
+        instance_id=BlockInstanceId("source_42"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("source_42"),
+        instance=BlockInstance(
+            configuration_values={},
+            input_ids={},
+        ),
     )
-    builder = BlueprintBuilder(blocks={BlockInstanceId("source_42"): source_42})
+    builder = BlueprintBuilder(
+        blocks=[
+            source_42,
+        ]
+    )
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())
     assert response.is_success, response.text
 
@@ -548,16 +612,20 @@ def test_blueprint_expand_restrictions(backend_client_with_auth: httpx.Client) -
         "transform_increment expansion must carry an enumClosed[1,2,3] restriction on 'amount'"
     )
 
-    transform_increment = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("transform_increment")),
-        configuration_values=_config({"amount": "2"}),
-        input_ids={"a": BlockInstanceId("source_42")},
+    transform_increment = RoutableBlock(
+        instance_id=BlockInstanceId("transform_increment"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("transform_increment"),
+        instance=BlockInstance(
+            configuration_values=_config({"amount": "2"}),
+            input_ids={"a": BlockInstanceId("source_42")},
+        ),
     )
     builder = BlueprintBuilder(
-        blocks={
-            BlockInstanceId("source_42"): source_42,
-            BlockInstanceId("transform_increment"): transform_increment,
-        }
+        blocks=[
+            source_42,
+            transform_increment,
+        ]
     )
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())
     assert response.is_success, response.text
@@ -575,18 +643,31 @@ def test_blueprint_expand_missing_glyph_warnings(tmpdir: Any, backend_client_wit
       is still validated normally.
     - Malformed glyph expressions (syntax errors) remain hard block_errors.
     """
-    source_42 = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_42")),
-        configuration_values={},
-        input_ids={},
+    source_42 = RoutableBlock(
+        instance_id=BlockInstanceId("source_42"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("source_42"),
+        instance=BlockInstance(
+            configuration_values={},
+            input_ids={},
+        ),
     )
     # sink_file with fname referencing a missing glyph
-    sink_file = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("sink_file")),
-        configuration_values=_config({"fname": f"{tmpdir}/output_${{missingRoot}}.txt"}),
-        input_ids={"data": BlockInstanceId("source_42")},
+    sink_file = RoutableBlock(
+        instance_id=BlockInstanceId("sink_file"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("sink_file"),
+        instance=BlockInstance(
+            configuration_values=_config({"fname": f"{tmpdir}/output_${{missingRoot}}.txt"}),
+            input_ids={"data": BlockInstanceId("source_42")},
+        ),
     )
-    builder = BlueprintBuilder(blocks={BlockInstanceId("source_42"): source_42, BlockInstanceId("sink_file"): sink_file})
+    builder = BlueprintBuilder(
+        blocks=[
+            source_42,
+            sink_file,
+        ]
+    )
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())
     assert response.is_success, response.text
     data = response.json()
@@ -619,13 +700,20 @@ def test_blueprint_expand_missing_glyph_warnings(tmpdir: Any, backend_client_wit
     assert del_resp.is_success, del_resp.text
 
     # Malformed expression remains a hard block_error
-    sink_file_malformed = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("sink_file")),
-        configuration_values=_config({"fname": "${x |}"}),
-        input_ids={"data": BlockInstanceId("source_42")},
+    sink_file_malformed = RoutableBlock(
+        instance_id=BlockInstanceId("sink_file_malformed"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("sink_file"),
+        instance=BlockInstance(
+            configuration_values=_config({"fname": "${x |}"}),
+            input_ids={"data": BlockInstanceId("source_42")},
+        ),
     )
     builder_malformed = BlueprintBuilder(
-        blocks={BlockInstanceId("source_42"): source_42, BlockInstanceId("sink_file"): sink_file_malformed}
+        blocks=[
+            source_42,
+            sink_file_malformed.model_copy(update={"instance_id": BlockInstanceId("sink_file")}),
+        ]
     )
     response_malformed = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder_malformed.model_dump())
     assert response_malformed.is_success, response_malformed.text
@@ -867,17 +955,30 @@ def test_list_glyph_functions(backend_client_with_auth: httpx.Client) -> None:
 
 def test_blueprint_expand_failure_01(backend_client_with_auth: httpx.Client) -> None:
     """Source has an invalid factory; transform referencing it must not generate its own error."""
-    bad_source = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("nonexistent_factory")),
-        configuration_values={},
-        input_ids={},
+    bad_source = RoutableBlock(
+        instance_id=BlockInstanceId("bad_source"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("nonexistent_factory"),
+        instance=BlockInstance(
+            configuration_values={},
+            input_ids={},
+        ),
     )
-    good_transform = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("transform_increment")),
-        configuration_values=_config({"amount": "1"}),
-        input_ids={"a": BlockInstanceId("bad_source")},
+    good_transform = RoutableBlock(
+        instance_id=BlockInstanceId("good_transform"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("transform_increment"),
+        instance=BlockInstance(
+            configuration_values=_config({"amount": "1"}),
+            input_ids={"a": BlockInstanceId("bad_source")},
+        ),
     )
-    builder = BlueprintBuilder(blocks={BlockInstanceId("bad_source"): bad_source, BlockInstanceId("good_transform"): good_transform})
+    builder = BlueprintBuilder(
+        blocks=[
+            bad_source,
+            good_transform,
+        ]
+    )
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())
     assert response.is_success, response.text
     block_errors = response.json()["block_errors"]
@@ -887,17 +988,30 @@ def test_blueprint_expand_failure_01(backend_client_with_auth: httpx.Client) -> 
 
 def test_blueprint_expand_failure_02(backend_client_with_auth: httpx.Client) -> None:
     """Transform declares an input id that does not exist in the blueprint; only the transform errors."""
-    source_42 = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_42")),
-        configuration_values={},
-        input_ids={},
+    source_42 = RoutableBlock(
+        instance_id=BlockInstanceId("source_42"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("source_42"),
+        instance=BlockInstance(
+            configuration_values={},
+            input_ids={},
+        ),
     )
-    bad_transform = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("transform_increment")),
-        configuration_values=_config({"amount": "1"}),
-        input_ids={"a": BlockInstanceId("nonexistent_block")},
+    bad_transform = RoutableBlock(
+        instance_id=BlockInstanceId("bad_transform"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("transform_increment"),
+        instance=BlockInstance(
+            configuration_values=_config({"amount": "1"}),
+            input_ids={"a": BlockInstanceId("nonexistent_block")},
+        ),
     )
-    builder = BlueprintBuilder(blocks={BlockInstanceId("source_42"): source_42, BlockInstanceId("bad_transform"): bad_transform})
+    builder = BlueprintBuilder(
+        blocks=[
+            source_42,
+            bad_transform,
+        ]
+    )
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())
     assert response.is_success, response.text
     block_errors = response.json()["block_errors"]
@@ -907,17 +1021,30 @@ def test_blueprint_expand_failure_02(backend_client_with_auth: httpx.Client) -> 
 
 def test_blueprint_expand_failure_03(backend_client_with_auth: httpx.Client) -> None:
     """Bad source and transform with a non-existent input id both report independent errors."""
-    bad_source = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("nonexistent_factory")),
-        configuration_values={},
-        input_ids={},
+    bad_source = RoutableBlock(
+        instance_id=BlockInstanceId("bad_source"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("nonexistent_factory"),
+        instance=BlockInstance(
+            configuration_values={},
+            input_ids={},
+        ),
     )
-    bad_transform = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("transform_increment")),
-        configuration_values=_config({"amount": "1"}),
-        input_ids={"a": BlockInstanceId("nonexistent_block")},
+    bad_transform = RoutableBlock(
+        instance_id=BlockInstanceId("bad_transform"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("transform_increment"),
+        instance=BlockInstance(
+            configuration_values=_config({"amount": "1"}),
+            input_ids={"a": BlockInstanceId("nonexistent_block")},
+        ),
     )
-    builder = BlueprintBuilder(blocks={BlockInstanceId("bad_source"): bad_source, BlockInstanceId("bad_transform"): bad_transform})
+    builder = BlueprintBuilder(
+        blocks=[
+            bad_source,
+            bad_transform,
+        ]
+    )
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())
     assert response.is_success, response.text
     block_errors = response.json()["block_errors"]
@@ -925,12 +1052,21 @@ def test_blueprint_expand_failure_03(backend_client_with_auth: httpx.Client) -> 
     assert "bad_transform" in block_errors
 
     # we now verify that the missing-glyph warning for transform is reported, despite parent being invalid
-    bad_transform2 = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("transform_increment")),
-        configuration_values=_config({"amount": "${nonExistentGlyph}"}),
-        input_ids={"a": BlockInstanceId("bad_source")},
+    bad_transform2 = RoutableBlock(
+        instance_id=BlockInstanceId("bad_transform2"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("transform_increment"),
+        instance=BlockInstance(
+            configuration_values=_config({"amount": "${nonExistentGlyph}"}),
+            input_ids={"a": BlockInstanceId("bad_source")},
+        ),
     )
-    builder = BlueprintBuilder(blocks={BlockInstanceId("bad_source"): bad_source, BlockInstanceId("bad_transform"): bad_transform2})
+    builder = BlueprintBuilder(
+        blocks=[
+            bad_source,
+            bad_transform2.model_copy(update={"instance_id": BlockInstanceId("bad_transform")}),
+        ]
+    )
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())
     assert response.is_success, response.text
     block_errors = response.json()["block_errors"]
@@ -942,17 +1078,30 @@ def test_blueprint_expand_failure_03(backend_client_with_auth: httpx.Client) -> 
 
 def test_blueprint_expand_failure_04_invalid_configuration_type(backend_client_with_auth: httpx.Client) -> None:
     """Type conversion errors are reported by backend validation before plugin validation."""
-    source_42 = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_42")),
-        configuration_values={},
-        input_ids={},
+    source_42 = RoutableBlock(
+        instance_id=BlockInstanceId("source_42"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("source_42"),
+        instance=BlockInstance(
+            configuration_values={},
+            input_ids={},
+        ),
     )
-    bad_transform = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("transform_increment")),
-        configuration_values=_config({"amount": "not_an_int"}),
-        input_ids={"a": BlockInstanceId("source_42")},
+    bad_transform = RoutableBlock(
+        instance_id=BlockInstanceId("bad_transform"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("transform_increment"),
+        instance=BlockInstance(
+            configuration_values=_config({"amount": "not_an_int"}),
+            input_ids={"a": BlockInstanceId("source_42")},
+        ),
     )
-    builder = BlueprintBuilder(blocks={BlockInstanceId("source_42"): source_42, BlockInstanceId("bad_transform"): bad_transform})
+    builder = BlueprintBuilder(
+        blocks=[
+            source_42,
+            bad_transform,
+        ]
+    )
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())
     assert response.is_success, response.text
     block_errors = response.json()["block_errors"]
@@ -962,21 +1111,29 @@ def test_blueprint_expand_failure_04_invalid_configuration_type(backend_client_w
 
 def test_blueprint_expand_missing_configuration_is_not_error(backend_client_with_auth: httpx.Client) -> None:
     """Missing values are omitted during validation instead of producing hard errors."""
-    source_42 = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_42")),
-        configuration_values={},
-        input_ids={},
+    source_42 = RoutableBlock(
+        instance_id=BlockInstanceId("source_42"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("source_42"),
+        instance=BlockInstance(
+            configuration_values={},
+            input_ids={},
+        ),
     )
-    transform_missing_amount = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("transform_increment")),
-        configuration_values={},
-        input_ids={"a": BlockInstanceId("source_42")},
+    transform_missing_amount = RoutableBlock(
+        instance_id=BlockInstanceId("transform_missing_amount"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("transform_increment"),
+        instance=BlockInstance(
+            configuration_values={},
+            input_ids={"a": BlockInstanceId("source_42")},
+        ),
     )
     builder = BlueprintBuilder(
-        blocks={
-            BlockInstanceId("source_42"): source_42,
-            BlockInstanceId("transform_missing_amount"): transform_missing_amount,
-        }
+        blocks=[
+            source_42,
+            transform_missing_amount,
+        ]
     )
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())
     assert response.is_success, response.text
@@ -986,21 +1143,29 @@ def test_blueprint_expand_missing_configuration_is_not_error(backend_client_with
 
 def test_blueprint_create_and_update_allow_missing_configuration_values(backend_client_with_auth: httpx.Client) -> None:
     """Draft blueprints with missing config can be saved, but compilation stays strict."""
-    source_42 = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_42")),
-        configuration_values={},
-        input_ids={},
+    source_42 = RoutableBlock(
+        instance_id=BlockInstanceId("source_42"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("source_42"),
+        instance=BlockInstance(
+            configuration_values={},
+            input_ids={},
+        ),
     )
-    transform_missing_amount = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("transform_increment")),
-        configuration_values={},
-        input_ids={"a": BlockInstanceId("source_42")},
+    transform_missing_amount = RoutableBlock(
+        instance_id=BlockInstanceId("transform_missing_amount"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("transform_increment"),
+        instance=BlockInstance(
+            configuration_values={},
+            input_ids={"a": BlockInstanceId("source_42")},
+        ),
     )
     builder = BlueprintBuilder(
-        blocks={
-            BlockInstanceId("source_42"): source_42,
-            BlockInstanceId("transform_missing_amount"): transform_missing_amount,
-        }
+        blocks=[
+            source_42,
+            transform_missing_amount,
+        ]
     )
 
     create_response = backend_client_with_auth.post("/blueprint/create", json=BlueprintSaveCommand(builder=builder).model_dump())
@@ -1032,18 +1197,29 @@ def test_blueprint_composite_glyph_expand(tmpdir: Any, backend_client_with_auth:
     assert post_resp.is_success, post_resp.text
 
     # Build a blueprint whose local glyph composes the global part and a known intrinsic
-    source_text = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_text")),
-        configuration_values=_config({"text": "${compositeLocalGlyph}"}),
-        input_ids={},
+    source_text = RoutableBlock(
+        instance_id=BlockInstanceId("source_text"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("source_text"),
+        instance=BlockInstance(
+            configuration_values=_config({"text": "${compositeLocalGlyph}"}),
+            input_ids={},
+        ),
     )
-    sink_file = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("sink_file")),
-        configuration_values=_config({"fname": f"{tmpdir}/composite_expand_output.txt"}),
-        input_ids={"data": BlockInstanceId("source_text")},
+    sink_file = RoutableBlock(
+        instance_id=BlockInstanceId("sink_file"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("sink_file"),
+        instance=BlockInstance(
+            configuration_values=_config({"fname": f"{tmpdir}/composite_expand_output.txt"}),
+            input_ids={"data": BlockInstanceId("source_text")},
+        ),
     )
     builder = BlueprintBuilder(
-        blocks={BlockInstanceId("source_text"): source_text, BlockInstanceId("sink_file"): sink_file},
+        blocks=[
+            source_text,
+            sink_file,
+        ],
         local_glyphs={"compositeLocalGlyph": "${compositeExpandGlobalPart}/${runId}"},
     )
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder.model_dump())
@@ -1060,13 +1236,20 @@ def test_blueprint_composite_glyph_expand(tmpdir: Any, backend_client_with_auth:
 
     # A local glyph that references an unknown glyph surfaces as a missing_glyph warning,
     # even though the composite glyph key itself is known.
-    sink_file_missing = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("sink_file")),
-        configuration_values=_config({"fname": f"{tmpdir}/output.txt"}),
-        input_ids={"data": BlockInstanceId("source_text")},
+    sink_file_missing = RoutableBlock(
+        instance_id=BlockInstanceId("sink_file_missing"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("sink_file"),
+        instance=BlockInstance(
+            configuration_values=_config({"fname": f"{tmpdir}/output.txt"}),
+            input_ids={"data": BlockInstanceId("source_text")},
+        ),
     )
     builder_nested_unknown = BlueprintBuilder(
-        blocks={BlockInstanceId("source_text"): source_text, BlockInstanceId("sink_file"): sink_file_missing},
+        blocks=[
+            source_text,
+            sink_file_missing.model_copy(update={"instance_id": BlockInstanceId("sink_file")}),
+        ],
         local_glyphs={"compositeLocalGlyph": "${compositeExpandGlobalPart}/${notDefinedAnywhere}"},
     )
     response_nested = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder_nested_unknown.model_dump())
@@ -1078,7 +1261,10 @@ def test_blueprint_composite_glyph_expand(tmpdir: Any, backend_client_with_auth:
 
     # A builder with a circular glyph reference must report a global_error
     builder_cyclic = BlueprintBuilder(
-        blocks={BlockInstanceId("source_text"): source_text, BlockInstanceId("sink_file"): sink_file},
+        blocks=[
+            source_text,
+            sink_file,
+        ],
         local_glyphs={"compositeLocalGlyph": "${compositeLocalGlyph}/suffix"},
     )
     response_cyclic = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder_cyclic.model_dump())
@@ -1095,13 +1281,19 @@ def test_blueprint_composite_glyph_expand(tmpdir: Any, backend_client_with_auth:
     submit_example = next(g["valueExample"] for g in glyphs_resp2.json()["glyphs"] if g["name"] == "submitDatetime")
     # floor_day of the example value: strip time component
     expected_floored = submit_example[:10] + "T00:00:00+00:00"
-    source_jinja = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_text")),
-        configuration_values=_config({"text": "${jinjaFilterGlyph}"}),
-        input_ids={},
+    source_jinja = RoutableBlock(
+        instance_id=BlockInstanceId("source_jinja"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("source_text"),
+        instance=BlockInstance(
+            configuration_values=_config({"text": "${jinjaFilterGlyph}"}),
+            input_ids={},
+        ),
     )
     builder_jinja = BlueprintBuilder(
-        blocks={BlockInstanceId("source_jinja"): source_jinja},
+        blocks=[
+            source_jinja,
+        ],
         local_glyphs={"jinjaFilterGlyph": "${submitDatetime | floor_day}"},
     )
     response_jinja = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder_jinja.model_dump())
@@ -1134,12 +1326,20 @@ def test_blueprint_jinja_interpolation_expand(backend_client_with_auth: httpx.Cl
     """
     # Malformed: hyphens make `this-is-no-filter` parsed as subtraction; the resulting "glyph"
     # names (is, no, filter) are unknown, so the block gets a missing_glyph entry.
-    source_malformed = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_text")),
-        configuration_values=_config({"text": "${startDatetime | this-is-no-filter}"}),
-        input_ids={},
+    source_malformed = RoutableBlock(
+        instance_id=BlockInstanceId("source_malformed"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("source_text"),
+        instance=BlockInstance(
+            configuration_values=_config({"text": "${startDatetime | this-is-no-filter}"}),
+            input_ids={},
+        ),
     )
-    builder_malformed = BlueprintBuilder(blocks={BlockInstanceId("source_text"): source_malformed})
+    builder_malformed = BlueprintBuilder(
+        blocks=[
+            source_malformed.model_copy(update={"instance_id": BlockInstanceId("source_text")}),
+        ]
+    )
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder_malformed.model_dump())
     assert response.is_success, response.text
     data = response.json()
@@ -1149,12 +1349,20 @@ def test_blueprint_jinja_interpolation_expand(backend_client_with_auth: httpx.Cl
     # Well-formed: pure jinja arithmetic using registered globals (datetime, timedelta) and filter (floor_day).
     # Parentheses are required because Jinja2's | (filter) has higher precedence than +.
     # (datetime(2024, 1, 15) + timedelta(days=1)) | floor_day = 2024-01-16T00:00:00
-    source_wellformed = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_text")),
-        configuration_values=_config({"text": "${(datetime(2024, 1, 15) + timedelta(days=1)) | floor_day}"}),
-        input_ids={},
+    source_wellformed = RoutableBlock(
+        instance_id=BlockInstanceId("source_wellformed"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("source_text"),
+        instance=BlockInstance(
+            configuration_values=_config({"text": "${(datetime(2024, 1, 15) + timedelta(days=1)) | floor_day}"}),
+            input_ids={},
+        ),
     )
-    builder_wellformed = BlueprintBuilder(blocks={BlockInstanceId("source_text"): source_wellformed})
+    builder_wellformed = BlueprintBuilder(
+        blocks=[
+            source_wellformed.model_copy(update={"instance_id": BlockInstanceId("source_text")}),
+        ]
+    )
     response = backend_client_with_auth.request(url="/blueprint/expand", method="put", json=builder_wellformed.model_dump())
     assert response.is_success, response.text
     data = response.json()
@@ -1176,27 +1384,39 @@ def test_blueprint_composite_glyph_execute(tmpdir: Any, backend_client_with_auth
     )
     assert post_resp.is_success, post_resp.text
 
-    source_text = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_text")),
-        configuration_values=_config({"text": "${compositeLocalGlyphExec}"}),
-        input_ids={},
+    source_text = RoutableBlock(
+        instance_id=BlockInstanceId("source_text"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("source_text"),
+        instance=BlockInstance(
+            configuration_values=_config({"text": "${compositeLocalGlyphExec}"}),
+            input_ids={},
+        ),
     )
-    sink_file = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("sink_file")),
-        configuration_values=_config({"fname": f"{tmpdir}/composite_exec_output.txt"}),
-        input_ids={"data": BlockInstanceId("source_text")},
+    sink_file = RoutableBlock(
+        instance_id=BlockInstanceId("sink_file"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("sink_file"),
+        instance=BlockInstance(
+            configuration_values=_config({"fname": f"{tmpdir}/composite_exec_output.txt"}),
+            input_ids={"data": BlockInstanceId("source_text")},
+        ),
     )
-    sink_file_2 = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("sink_file")),
-        configuration_values=_config({"fname": f"{tmpdir}/composite_exec_output_2.txt"}),
-        input_ids={"data": BlockInstanceId("source_text")},
+    sink_file_2 = RoutableBlock(
+        instance_id=BlockInstanceId("sink_file_2"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("sink_file"),
+        instance=BlockInstance(
+            configuration_values=_config({"fname": f"{tmpdir}/composite_exec_output_2.txt"}),
+            input_ids={"data": BlockInstanceId("source_text")},
+        ),
     )
     builder = BlueprintBuilder(
-        blocks={
-            BlockInstanceId("source_text"): source_text,
-            BlockInstanceId("sink_file"): sink_file,
-            BlockInstanceId("sink_file_2"): sink_file_2,
-        },
+        blocks=[
+            source_text,
+            sink_file,
+            sink_file_2,
+        ],
         local_glyphs={"compositeLocalGlyphExec": "${compositeExecGlobalPart}/${runId}"},
     )
     save_resp = backend_client_with_auth.post("/blueprint/create", json=BlueprintSaveCommand(builder=builder).model_dump())
@@ -1250,42 +1470,67 @@ def _make_builder_source_and_sink(tmpdir: str) -> BlueprintBuilder:
     Produces exactly one non-sink task (source_42) whose output is the integer 42,
     and one sink task (sink_file).
     """
-    source_42 = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_42")),
-        configuration_values={},
-        input_ids={},
+    source_42 = RoutableBlock(
+        instance_id=BlockInstanceId("source_42"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("source_42"),
+        instance=BlockInstance(
+            configuration_values={},
+            input_ids={},
+        ),
     )
-    sink = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("sink_file")),
-        configuration_values=_config({"fname": f"{tmpdir}/output_${{runId}}.txt"}),
-        input_ids={"data": BlockInstanceId("source_42")},
+    sink = RoutableBlock(
+        instance_id=BlockInstanceId("sink"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("sink_file"),
+        instance=BlockInstance(
+            configuration_values=_config({"fname": f"{tmpdir}/output_${{runId}}.txt"}),
+            input_ids={"data": BlockInstanceId("source_42")},
+        ),
     )
-    return BlueprintBuilder(blocks={BlockInstanceId("source_42"): source_42, BlockInstanceId("my_sink"): sink})
+    return BlueprintBuilder(
+        blocks=[
+            source_42,
+            sink.model_copy(update={"instance_id": BlockInstanceId("my_sink")}),
+        ]
+    )
 
 
 def _make_builder_source_and_two_sinks(tmpdir: str) -> BlueprintBuilder:
     """Blueprint with source_42 → sink_file and source_42 → sink_image."""
-    source_42 = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_42")),
-        configuration_values={},
-        input_ids={},
+    source_42 = RoutableBlock(
+        instance_id=BlockInstanceId("source_42"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("source_42"),
+        instance=BlockInstance(
+            configuration_values={},
+            input_ids={},
+        ),
     )
-    sink_file = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("sink_file")),
-        configuration_values=_config({"fname": f"{tmpdir}/output_${{runId}}.txt"}),
-        input_ids={"data": BlockInstanceId("source_42")},
+    sink_file = RoutableBlock(
+        instance_id=BlockInstanceId("sink_file"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("sink_file"),
+        instance=BlockInstance(
+            configuration_values=_config({"fname": f"{tmpdir}/output_${{runId}}.txt"}),
+            input_ids={"data": BlockInstanceId("source_42")},
+        ),
     )
-    sink_image = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("sink_image")),
-        configuration_values={},
-        input_ids={"data": BlockInstanceId("source_42")},
+    sink_image = RoutableBlock(
+        instance_id=BlockInstanceId("sink_image"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("sink_image"),
+        instance=BlockInstance(
+            configuration_values={},
+            input_ids={"data": BlockInstanceId("source_42")},
+        ),
     )
     return BlueprintBuilder(
-        blocks={
-            BlockInstanceId("source_42"): source_42,
-            BlockInstanceId("my_sink"): sink_file,
-            BlockInstanceId("my_image_sink"): sink_image,
-        }
+        blocks=[
+            source_42,
+            sink_file.model_copy(update={"instance_id": BlockInstanceId("my_sink")}),
+            sink_image.model_copy(update={"instance_id": BlockInstanceId("my_image_sink")}),
+        ]
     )
 
 
@@ -1440,17 +1685,30 @@ def _wait_until_running(client: httpx.Client, run_id: str, sleep: float = 1.0, a
 @pytest.mark.skip("leaves hanging process behind")
 def test_gateway_restart_with_in_progress_job(backend_client_with_auth: httpx.Client) -> None:
     """Kill the gateway while a job is active; verify the expected status transitions."""
-    sleeper = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_sleep")),
-        configuration_values=_config({"text": "hello", "duration": "30"}),
-        input_ids={},
+    sleeper = RoutableBlock(
+        instance_id=BlockInstanceId("sleeper"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("source_sleep"),
+        instance=BlockInstance(
+            configuration_values=_config({"text": "hello", "duration": "30"}),
+            input_ids={},
+        ),
     )
-    sink = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("sink_file")),
-        configuration_values=_config({"fname": "/dev/null"}),
-        input_ids={"data": BlockInstanceId("sleeper")},
+    sink = RoutableBlock(
+        instance_id=BlockInstanceId("sink"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("sink_file"),
+        instance=BlockInstance(
+            configuration_values=_config({"fname": "/dev/null"}),
+            input_ids={"data": BlockInstanceId("sleeper")},
+        ),
     )
-    builder = BlueprintBuilder(blocks={BlockInstanceId("sleeper"): sleeper, BlockInstanceId("sleeper_sink"): sink})
+    builder = BlueprintBuilder(
+        blocks=[
+            sleeper,
+            sink.model_copy(update={"instance_id": BlockInstanceId("sleeper_sink")}),
+        ]
+    )
     save_resp = backend_client_with_auth.post("/blueprint/create", json=BlueprintSaveCommand(builder=builder).model_dump())
     assert save_resp.is_success, save_resp.text
     blueprint_id = save_resp.json()["blueprint_id"]
@@ -1509,21 +1767,29 @@ def test_blueprint_artifact_execute(tmpdir: Any, backend_client_with_auth: httpx
 
     checkpoint_composite_id = f"{fake_artifact_store_id}:{test_blueprint_artifact_id}"
 
-    source_filesize = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_filesize")),
-        configuration_values=_config({"checkpoint": checkpoint_composite_id}),
-        input_ids={},
+    source_filesize = RoutableBlock(
+        instance_id=BlockInstanceId("source_filesize"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("source_filesize"),
+        instance=BlockInstance(
+            configuration_values=_config({"checkpoint": checkpoint_composite_id}),
+            input_ids={},
+        ),
     )
-    sink = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("sink_file")),
-        configuration_values=_config({"fname": f"{tmpdir}/filesize_${{runId}}.txt"}),
-        input_ids={"data": BlockInstanceId("source_filesize")},
+    sink = RoutableBlock(
+        instance_id=BlockInstanceId("sink"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("sink_file"),
+        instance=BlockInstance(
+            configuration_values=_config({"fname": f"{tmpdir}/filesize_${{runId}}.txt"}),
+            input_ids={"data": BlockInstanceId("source_filesize")},
+        ),
     )
     builder = BlueprintBuilder(
-        blocks={
-            BlockInstanceId("source_filesize"): source_filesize,
-            BlockInstanceId("sink_file"): sink,
-        }
+        blocks=[
+            source_filesize,
+            sink.model_copy(update={"instance_id": BlockInstanceId("sink_file")}),
+        ]
     )
 
     # Validate blueprint via expand

--- a/backend/tests/integration/test_schedule.py
+++ b/backend/tests/integration/test_schedule.py
@@ -17,9 +17,9 @@ import time
 from typing import Any
 
 import httpx
-from fiab_core.fable import BlockFactoryId, BlockInstance, BlockInstanceId, ConfigurationOptionId, PluginBlockFactoryId
+from fiab_core.fable import BlockFactoryId, BlockInstance, BlockInstanceId, ConfigurationOptionId
 
-from forecastbox.domain.blueprint.service import BlueprintBuilder
+from forecastbox.domain.blueprint.service import BlueprintBuilder, RoutableBlock
 from forecastbox.domain.blueprint.service import BlueprintSaveCommand as BlueprintSaveRequest
 from forecastbox.domain.blueprint.types import BlueprintId
 from forecastbox.domain.experiment.types import ExperimentDefinitionId
@@ -59,12 +59,20 @@ def ensure_completed_v2(backend_client: httpx.Client, job_id: str, sleep: float 
 
 def _save_blueprint(client: httpx.Client) -> tuple[BlueprintId, int]:
     """Save a minimal BlueprintBuilder and return (blueprint_id, version)."""
-    source = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_42")),
-        configuration_values={},
-        input_ids={},
+    source = RoutableBlock(
+        instance_id=BlockInstanceId("source"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("source_42"),
+        instance=BlockInstance(
+            configuration_values={},
+            input_ids={},
+        ),
     )
-    builder = BlueprintBuilder(blocks={BlockInstanceId("source1"): source})
+    builder = BlueprintBuilder(
+        blocks=[
+            source.model_copy(update={"instance_id": BlockInstanceId("source1")}),
+        ]
+    )
     resp = client.post("/blueprint/create", json=BlueprintSaveRequest(builder=builder, display_name="sched-v2 test").model_dump())
     assert resp.is_success, resp.text
     data = resp.json()
@@ -73,45 +81,69 @@ def _save_blueprint(client: httpx.Client) -> tuple[BlueprintId, int]:
 
 def _save_full_blueprint(client: httpx.Client, output_path: str, time_output_path: str) -> tuple[BlueprintId, int]:
     """Save a full BlueprintBuilder (with sink) and return (blueprint_id, version)."""
-    source_42 = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_42")),
-        configuration_values={},
-        input_ids={},
+    source_42 = RoutableBlock(
+        instance_id=BlockInstanceId("source_42"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("source_42"),
+        instance=BlockInstance(
+            configuration_values={},
+            input_ids={},
+        ),
     )
-    transform_increment = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("transform_increment")),
-        configuration_values=_config({"amount": "1"}),
-        input_ids={"a": BlockInstanceId("source_42")},
+    transform_increment = RoutableBlock(
+        instance_id=BlockInstanceId("transform_increment"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("transform_increment"),
+        instance=BlockInstance(
+            configuration_values=_config({"amount": "1"}),
+            input_ids={"a": BlockInstanceId("source_42")},
+        ),
     )
-    product_join = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("product_join")),
-        configuration_values={},
-        input_ids={"a": BlockInstanceId("transform_increment"), "b": BlockInstanceId("source_42")},
+    product_join = RoutableBlock(
+        instance_id=BlockInstanceId("product_join"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("product_join"),
+        instance=BlockInstance(
+            configuration_values={},
+            input_ids={"a": BlockInstanceId("transform_increment"), "b": BlockInstanceId("source_42")},
+        ),
     )
-    sink_file = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("sink_file")),
-        configuration_values=_config({"fname": output_path}),
-        input_ids={"data": BlockInstanceId("product_join")},
+    sink_file = RoutableBlock(
+        instance_id=BlockInstanceId("sink_file"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("sink_file"),
+        instance=BlockInstance(
+            configuration_values=_config({"fname": output_path}),
+            input_ids={"data": BlockInstanceId("product_join")},
+        ),
     )
-    source_time = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("source_text")),
-        configuration_values=_config({"text": "${submitDatetime};${startDatetime}"}),
-        input_ids={},
+    source_time = RoutableBlock(
+        instance_id=BlockInstanceId("source_time"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("source_text"),
+        instance=BlockInstance(
+            configuration_values=_config({"text": "${submitDatetime};${startDatetime}"}),
+            input_ids={},
+        ),
     )
-    sink_time = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=testPluginId, factory=BlockFactoryId("sink_file")),
-        configuration_values=_config({"fname": time_output_path}),
-        input_ids={"data": BlockInstanceId("source_time")},
+    sink_time = RoutableBlock(
+        instance_id=BlockInstanceId("sink_time"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("sink_file"),
+        instance=BlockInstance(
+            configuration_values=_config({"fname": time_output_path}),
+            input_ids={"data": BlockInstanceId("source_time")},
+        ),
     )
     builder = BlueprintBuilder(
-        blocks={
-            BlockInstanceId("source_42"): source_42,
-            BlockInstanceId("transform_increment"): transform_increment,
-            BlockInstanceId("product_join"): product_join,
-            BlockInstanceId("sink_file"): sink_file,
-            BlockInstanceId("source_time"): source_time,
-            BlockInstanceId("sink_time"): sink_time,
-        }
+        blocks=[
+            source_42,
+            transform_increment,
+            product_join,
+            sink_file,
+            source_time,
+            sink_time,
+        ]
     )
     resp = client.post("/blueprint/create", json=BlueprintSaveRequest(builder=builder).model_dump())
     assert resp.is_success, resp.text

--- a/backend/tests/largeE2E/blueprint.py
+++ b/backend/tests/largeE2E/blueprint.py
@@ -9,14 +9,13 @@ from fiab_core.fable import (
     BlockInstance,
     BlockInstanceId,
     ConfigurationOptionId,
-    PluginBlockFactoryId,
     PluginCompositeId,
     PluginId,
     PluginStoreId,
 )
 
 from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
-from forecastbox.domain.blueprint.service import BlueprintBuilder, RoutedBlock
+from forecastbox.domain.blueprint.service import BlueprintBuilder, RoutableBlock
 from forecastbox.domain.run.cascade import ExecutionSpecification, RawCascadeJob
 from forecastbox.entrypoint.main import launch_all
 from forecastbox.utility.config import FIABConfig, UnmanagedGateway
@@ -69,9 +68,11 @@ if __name__ == "__main__":
             assert len(response.json()) > 0
 
             pluginId = PluginCompositeId(store=PluginStoreId("ecmwf"), local=PluginId("ecmwf-base"))
-            blocks: dict[BlockInstanceId, RoutedBlock] = {
-                BlockInstanceId("source1"): RoutedBlock(
-                    factory_id=PluginBlockFactoryId(plugin=pluginId, factory=BlockFactoryId("ekdSource")),
+            blocks: list[RoutableBlock] = [
+                RoutableBlock(
+                    instance_id=BlockInstanceId("source1"),
+                    plugin=pluginId,
+                    factory=BlockFactoryId("ekdSource"),
                     instance=BlockInstance(
                         configuration_values=_config(
                             {
@@ -83,31 +84,39 @@ if __name__ == "__main__":
                         input_ids={},
                     ),
                 ),
-                BlockInstanceId("temporalMean"): RoutedBlock(
-                    factory_id=PluginBlockFactoryId(plugin=pluginId, factory=BlockFactoryId("temporalStatistics")),
+                RoutableBlock(
+                    instance_id=BlockInstanceId("temporalMean"),
+                    plugin=pluginId,
+                    factory=BlockFactoryId("temporalStatistics"),
                     instance=BlockInstance(
                         configuration_values=_config({"param": "2t", "statistic": "mean"}),
                         input_ids={"dataset": BlockInstanceId("source1")},
                     ),
                 ),
-            }
+            ]
             for statistic in ["mean", "std"]:
-                block = RoutedBlock(
-                    factory_id=PluginBlockFactoryId(plugin=pluginId, factory=BlockFactoryId("ensembleStatistics")),
-                    instance=BlockInstance(
-                        configuration_values=_config({"param": "2t", "statistic": statistic}),
-                        input_ids={"dataset": BlockInstanceId("temporalMean")},
-                    ),
+                blocks.append(
+                    RoutableBlock(
+                        instance_id=BlockInstanceId(f"ensemble{statistic.capitalize()}"),
+                        plugin=pluginId,
+                        factory=BlockFactoryId("ensembleStatistics"),
+                        instance=BlockInstance(
+                            configuration_values=_config({"param": "2t", "statistic": statistic}),
+                            input_ids={"dataset": BlockInstanceId("temporalMean")},
+                        ),
+                    )
                 )
-                sink = RoutedBlock(
-                    factory_id=PluginBlockFactoryId(plugin=pluginId, factory=BlockFactoryId("zarrSink")),
-                    instance=BlockInstance(
-                        configuration_values=_config({"path": f"{tmpdir}/output{statistic.capitalize()}.zarr"}),
-                        input_ids={"dataset": BlockInstanceId(f"ensemble{statistic.capitalize()}")},
-                    ),
+                blocks.append(
+                    RoutableBlock(
+                        instance_id=BlockInstanceId(f"sink{statistic.capitalize()}"),
+                        plugin=pluginId,
+                        factory=BlockFactoryId("zarrSink"),
+                        instance=BlockInstance(
+                            configuration_values=_config({"path": f"{tmpdir}/output{statistic.capitalize()}.zarr"}),
+                            input_ids={"dataset": BlockInstanceId(f"ensemble{statistic.capitalize()}")},
+                        ),
+                    )
                 )
-                blocks[BlockInstanceId(f"ensemble{statistic.capitalize()}")] = block
-                blocks[BlockInstanceId(f"sink{statistic.capitalize()}")] = sink
 
             builder = BlueprintBuilder(blocks=blocks)
             response = client.request(url="/blueprint/compile", method="put", json=builder.model_dump()).json()

--- a/backend/tests/largeE2E/blueprint.py
+++ b/backend/tests/largeE2E/blueprint.py
@@ -16,7 +16,7 @@ from fiab_core.fable import (
 )
 
 from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
-from forecastbox.domain.blueprint.service import BlueprintBuilder
+from forecastbox.domain.blueprint.service import BlueprintBuilder, RoutedBlock
 from forecastbox.domain.run.cascade import ExecutionSpecification, RawCascadeJob
 from forecastbox.entrypoint.main import launch_all
 from forecastbox.utility.config import FIABConfig, UnmanagedGateway
@@ -69,34 +69,42 @@ if __name__ == "__main__":
             assert len(response.json()) > 0
 
             pluginId = PluginCompositeId(store=PluginStoreId("ecmwf"), local=PluginId("ecmwf-base"))
-            blocks: dict[BlockInstanceId, BlockInstance] = {
-                BlockInstanceId("source1"): BlockInstance(
+            blocks: dict[BlockInstanceId, RoutedBlock] = {
+                BlockInstanceId("source1"): RoutedBlock(
                     factory_id=PluginBlockFactoryId(plugin=pluginId, factory=BlockFactoryId("ekdSource")),
-                    configuration_values=_config(
-                        {
-                            "source": "ecmwf-open-data",
-                            "date": (current_time("scheduling") - timedelta(days=1)).strftime("%Y-%m-%d"),
-                            "expver": "0001",
-                        }
+                    instance=BlockInstance(
+                        configuration_values=_config(
+                            {
+                                "source": "ecmwf-open-data",
+                                "date": (current_time("scheduling") - timedelta(days=1)).strftime("%Y-%m-%d"),
+                                "expver": "0001",
+                            }
+                        ),
+                        input_ids={},
                     ),
-                    input_ids={},
                 ),
-                BlockInstanceId("temporalMean"): BlockInstance(
+                BlockInstanceId("temporalMean"): RoutedBlock(
                     factory_id=PluginBlockFactoryId(plugin=pluginId, factory=BlockFactoryId("temporalStatistics")),
-                    configuration_values=_config({"param": "2t", "statistic": "mean"}),
-                    input_ids={"dataset": BlockInstanceId("source1")},
+                    instance=BlockInstance(
+                        configuration_values=_config({"param": "2t", "statistic": "mean"}),
+                        input_ids={"dataset": BlockInstanceId("source1")},
+                    ),
                 ),
             }
             for statistic in ["mean", "std"]:
-                block = BlockInstance(
+                block = RoutedBlock(
                     factory_id=PluginBlockFactoryId(plugin=pluginId, factory=BlockFactoryId("ensembleStatistics")),
-                    configuration_values=_config({"param": "2t", "statistic": statistic}),
-                    input_ids={"dataset": BlockInstanceId("temporalMean")},
+                    instance=BlockInstance(
+                        configuration_values=_config({"param": "2t", "statistic": statistic}),
+                        input_ids={"dataset": BlockInstanceId("temporalMean")},
+                    ),
                 )
-                sink = BlockInstance(
+                sink = RoutedBlock(
                     factory_id=PluginBlockFactoryId(plugin=pluginId, factory=BlockFactoryId("zarrSink")),
-                    configuration_values=_config({"path": f"{tmpdir}/output{statistic.capitalize()}.zarr"}),
-                    input_ids={"dataset": BlockInstanceId(f"ensemble{statistic.capitalize()}")},
+                    instance=BlockInstance(
+                        configuration_values=_config({"path": f"{tmpdir}/output{statistic.capitalize()}.zarr"}),
+                        input_ids={"dataset": BlockInstanceId(f"ensemble{statistic.capitalize()}")},
+                    ),
                 )
                 blocks[BlockInstanceId(f"ensemble{statistic.capitalize()}")] = block
                 blocks[BlockInstanceId(f"sink{statistic.capitalize()}")] = sink

--- a/backend/tests/unit/domain/blueprint/test_blueprint_service.py
+++ b/backend/tests/unit/domain/blueprint/test_blueprint_service.py
@@ -17,14 +17,20 @@ from fiab_core.fable import (
     BlueprintTemplate,
     BlueprintTemplateEnvironment,
     ConfigurationOptionId,
+    LocalBlock,
     PluginBlockFactoryId,
     PluginCompositeId,
     PluginId,
     PluginStoreId,
-    SelfPluginId,
 )
 
-from forecastbox.domain.blueprint.service import BlueprintBuilder, remap_builder_glyphs, resolve_builder_with_examples, template_to_builder
+from forecastbox.domain.blueprint.service import (
+    BlueprintBuilder,
+    RoutedBlock,
+    remap_builder_glyphs,
+    resolve_builder_with_examples,
+    template_to_builder,
+)
 
 _REAL_PLUGIN_ID = PluginCompositeId(store=PluginStoreId("myStore"), local=PluginId("myPlugin"))
 _BLOCK_A = BlockInstanceId("blockA")
@@ -32,39 +38,26 @@ _BLOCK_B = BlockInstanceId("blockB")
 _OPT = ConfigurationOptionId("text")
 
 
-def _self_block(text: str = "hello") -> BlockInstance:
-    return BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=SelfPluginId, factory=BlockFactoryId("source_text")),
-        configuration_values={_OPT: text},
-        input_ids={},
+def _local_block(text: str = "hello") -> LocalBlock:
+    return LocalBlock(
+        factory_id=BlockFactoryId("source_text"),
+        instance=BlockInstance(configuration_values={_OPT: text}, input_ids={}),
     )
 
 
-def _real_block(text: str = "hello") -> BlockInstance:
-    return BlockInstance(
+def _routed_block(text: str = "hello") -> RoutedBlock:
+    return RoutedBlock(
         factory_id=PluginBlockFactoryId(plugin=_REAL_PLUGIN_ID, factory=BlockFactoryId("source_text")),
-        configuration_values={_OPT: text},
-        input_ids={},
+        instance=BlockInstance(configuration_values={_OPT: text}, input_ids={}),
     )
 
 
-def test_template_to_builder_replaces_self_plugin_id() -> None:
-    """SelfPluginId sentinels in block factory IDs are replaced with the real plugin ID."""
+def test_template_to_builder_assigns_plugin_id() -> None:
+    """Template local factory ids are combined with the given plugin id."""
     template = BlueprintTemplate(
         display_name="t",
         display_description="d",
-        blocks={_BLOCK_A: _self_block()},
-    )
-    builder = template_to_builder(template, _REAL_PLUGIN_ID)
-    assert builder.blocks[_BLOCK_A].factory_id.plugin == _REAL_PLUGIN_ID
-
-
-def test_template_to_builder_keeps_real_plugin_id() -> None:
-    """A block already using the real plugin ID is not modified."""
-    template = BlueprintTemplate(
-        display_name="t",
-        display_description="d",
-        blocks={_BLOCK_A: _real_block()},
+        blocks={_BLOCK_A: _local_block()},
     )
     builder = template_to_builder(template, _REAL_PLUGIN_ID)
     assert builder.blocks[_BLOCK_A].factory_id.plugin == _REAL_PLUGIN_ID
@@ -115,10 +108,9 @@ def test_template_to_builder_example_values_not_in_configuration_values() -> Non
     """example_values must not appear in any block's configuration_values."""
     example_block = BlockInstanceId("example_block")
     opt = ConfigurationOptionId("text")
-    block = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=SelfPluginId, factory=BlockFactoryId("source_text")),
-        configuration_values={},
-        input_ids={},
+    block = LocalBlock(
+        factory_id=BlockFactoryId("source_text"),
+        instance=BlockInstance(configuration_values={}, input_ids={}),
     )
     template = BlueprintTemplate(
         display_name="t",
@@ -128,7 +120,7 @@ def test_template_to_builder_example_values_not_in_configuration_values() -> Non
         example_glyphs={"name": "world"},
     )
     builder = template_to_builder(template, _REAL_PLUGIN_ID)
-    assert opt not in builder.blocks[example_block].configuration_values
+    assert opt not in builder.blocks[example_block].instance.configuration_values
 
 
 # ---------------------------------------------------------------------------
@@ -140,10 +132,9 @@ def test_remap_builder_glyphs_renames_config_value_and_local_glyph() -> None:
     """Block config values, local-glyph values, and local-glyph keys are all renamed."""
     builder = BlueprintBuilder(
         blocks={
-            _BLOCK_A: BlockInstance(
+            _BLOCK_A: RoutedBlock(
                 factory_id=PluginBlockFactoryId(plugin=_REAL_PLUGIN_ID, factory=BlockFactoryId("source_text")),
-                configuration_values={_OPT: "${oldGlyph}"},
-                input_ids={},
+                instance=BlockInstance(configuration_values={_OPT: "${oldGlyph}"}, input_ids={}),
             )
         },
         local_glyphs={"localOld": "${oldGlyph}"},
@@ -151,7 +142,7 @@ def test_remap_builder_glyphs_renames_config_value_and_local_glyph() -> None:
     mapping = {"oldGlyph": "newGlyph", "localOld": "localNew"}
     remapped = remap_builder_glyphs(builder, mapping)
 
-    assert remapped.blocks[_BLOCK_A].configuration_values[_OPT] == "${newGlyph}"
+    assert remapped.blocks[_BLOCK_A].instance.configuration_values[_OPT] == "${newGlyph}"
     assert "localNew" in remapped.local_glyphs
     assert remapped.local_glyphs["localNew"] == "${newGlyph}"
     assert "localOld" not in remapped.local_glyphs
@@ -160,10 +151,9 @@ def test_remap_builder_glyphs_renames_config_value_and_local_glyph() -> None:
 def test_remap_builder_glyphs_empty_mapping_returns_same_object() -> None:
     builder = BlueprintBuilder(
         blocks={
-            _BLOCK_A: BlockInstance(
+            _BLOCK_A: RoutedBlock(
                 factory_id=PluginBlockFactoryId(plugin=_REAL_PLUGIN_ID, factory=BlockFactoryId("source_text")),
-                configuration_values={_OPT: "${oldGlyph}"},
-                input_ids={},
+                instance=BlockInstance(configuration_values={_OPT: "${oldGlyph}"}, input_ids={}),
             )
         },
         local_glyphs={"myKey": "myVal"},
@@ -178,13 +168,16 @@ def test_remap_builder_glyphs_empty_mapping_returns_same_object() -> None:
 
 
 def _make_builder(block_text: str | None = None, local_glyphs: dict[str, str] | None = None) -> BlueprintBuilder:
-    block = BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=_REAL_PLUGIN_ID, factory=BlockFactoryId("source_text")),
-        configuration_values={_OPT: block_text} if block_text is not None else {},
-        input_ids={},
-    )
     return BlueprintBuilder(
-        blocks={_BLOCK_A: block},
+        blocks={
+            _BLOCK_A: RoutedBlock(
+                factory_id=PluginBlockFactoryId(plugin=_REAL_PLUGIN_ID, factory=BlockFactoryId("source_text")),
+                instance=BlockInstance(
+                    configuration_values={_OPT: block_text} if block_text is not None else {},
+                    input_ids={},
+                ),
+            )
+        },
         local_glyphs=local_glyphs or {},
     )
 
@@ -193,14 +186,14 @@ def test_resolve_builder_with_examples_fills_missing_config_value() -> None:
     """Example values fill in config options absent from the template block."""
     builder = _make_builder(block_text=None)
     result = resolve_builder_with_examples(builder, {_BLOCK_A: {_OPT: "from example"}}, {})
-    assert result.blocks[_BLOCK_A].configuration_values[_OPT] == "from example"
+    assert result.blocks[_BLOCK_A].instance.configuration_values[_OPT] == "from example"
 
 
 def test_resolve_builder_with_examples_overrides_existing_config_value() -> None:
     """Example values override existing template values for validation purposes."""
     builder = _make_builder(block_text="template value")
     result = resolve_builder_with_examples(builder, {_BLOCK_A: {_OPT: "example value"}}, {})
-    assert result.blocks[_BLOCK_A].configuration_values[_OPT] == "example value"
+    assert result.blocks[_BLOCK_A].instance.configuration_values[_OPT] == "example value"
 
 
 def test_resolve_builder_with_examples_merges_example_glyphs() -> None:
@@ -220,10 +213,10 @@ def test_resolve_builder_with_examples_overrides_existing_local_glyph() -> None:
 def test_resolve_builder_with_examples_does_not_mutate_original() -> None:
     """The function is pure: the original builder is unchanged after the call."""
     builder = _make_builder(block_text=None, local_glyphs={})
-    original_config = dict(builder.blocks[_BLOCK_A].configuration_values)
+    original_config = dict(builder.blocks[_BLOCK_A].instance.configuration_values)
     original_glyphs = dict(builder.local_glyphs)
 
     resolve_builder_with_examples(builder, {_BLOCK_A: {_OPT: "example"}}, {"k": "v"})
 
-    assert builder.blocks[_BLOCK_A].configuration_values == original_config
+    assert builder.blocks[_BLOCK_A].instance.configuration_values == original_config
     assert builder.local_glyphs == original_glyphs

--- a/backend/tests/unit/domain/blueprint/test_blueprint_service.py
+++ b/backend/tests/unit/domain/blueprint/test_blueprint_service.py
@@ -15,10 +15,9 @@ from fiab_core.fable import (
     BlockInstance,
     BlockInstanceId,
     BlueprintTemplate,
+    BlueprintTemplateBlock,
     BlueprintTemplateEnvironment,
     ConfigurationOptionId,
-    LocalBlock,
-    PluginBlockFactoryId,
     PluginCompositeId,
     PluginId,
     PluginStoreId,
@@ -26,7 +25,7 @@ from fiab_core.fable import (
 
 from forecastbox.domain.blueprint.service import (
     BlueprintBuilder,
-    RoutedBlock,
+    RoutableBlock,
     remap_builder_glyphs,
     resolve_builder_with_examples,
     template_to_builder,
@@ -38,16 +37,18 @@ _BLOCK_B = BlockInstanceId("blockB")
 _OPT = ConfigurationOptionId("text")
 
 
-def _local_block(text: str = "hello") -> LocalBlock:
-    return LocalBlock(
+def _template_block(text: str = "hello") -> BlueprintTemplateBlock:
+    return BlueprintTemplateBlock(
         factory_id=BlockFactoryId("source_text"),
         instance=BlockInstance(configuration_values={_OPT: text}, input_ids={}),
     )
 
 
-def _routed_block(text: str = "hello") -> RoutedBlock:
-    return RoutedBlock(
-        factory_id=PluginBlockFactoryId(plugin=_REAL_PLUGIN_ID, factory=BlockFactoryId("source_text")),
+def _routable_block(block_id: BlockInstanceId = _BLOCK_A, text: str = "hello") -> RoutableBlock:
+    return RoutableBlock(
+        instance_id=block_id,
+        plugin=_REAL_PLUGIN_ID,
+        factory=BlockFactoryId("source_text"),
         instance=BlockInstance(configuration_values={_OPT: text}, input_ids={}),
     )
 
@@ -57,10 +58,12 @@ def test_template_to_builder_assigns_plugin_id() -> None:
     template = BlueprintTemplate(
         display_name="t",
         display_description="d",
-        blocks={_BLOCK_A: _local_block()},
+        blocks={_BLOCK_A: _template_block()},
     )
     builder = template_to_builder(template, _REAL_PLUGIN_ID)
-    assert builder.blocks[_BLOCK_A].factory_id.plugin == _REAL_PLUGIN_ID
+    block = next(b for b in builder.blocks if b.instance_id == _BLOCK_A)
+    assert block.plugin == _REAL_PLUGIN_ID
+    assert block.factory == BlockFactoryId("source_text")
 
 
 def test_template_to_builder_propagates_env_vars() -> None:
@@ -108,7 +111,7 @@ def test_template_to_builder_example_values_not_in_configuration_values() -> Non
     """example_values must not appear in any block's configuration_values."""
     example_block = BlockInstanceId("example_block")
     opt = ConfigurationOptionId("text")
-    block = LocalBlock(
+    block = BlueprintTemplateBlock(
         factory_id=BlockFactoryId("source_text"),
         instance=BlockInstance(configuration_values={}, input_ids={}),
     )
@@ -120,7 +123,8 @@ def test_template_to_builder_example_values_not_in_configuration_values() -> Non
         example_glyphs={"name": "world"},
     )
     builder = template_to_builder(template, _REAL_PLUGIN_ID)
-    assert opt not in builder.blocks[example_block].instance.configuration_values
+    result = next(b for b in builder.blocks if b.instance_id == example_block)
+    assert opt not in result.instance.configuration_values
 
 
 # ---------------------------------------------------------------------------
@@ -131,18 +135,13 @@ def test_template_to_builder_example_values_not_in_configuration_values() -> Non
 def test_remap_builder_glyphs_renames_config_value_and_local_glyph() -> None:
     """Block config values, local-glyph values, and local-glyph keys are all renamed."""
     builder = BlueprintBuilder(
-        blocks={
-            _BLOCK_A: RoutedBlock(
-                factory_id=PluginBlockFactoryId(plugin=_REAL_PLUGIN_ID, factory=BlockFactoryId("source_text")),
-                instance=BlockInstance(configuration_values={_OPT: "${oldGlyph}"}, input_ids={}),
-            )
-        },
+        blocks=[_routable_block(text="${oldGlyph}")],
         local_glyphs={"localOld": "${oldGlyph}"},
     )
     mapping = {"oldGlyph": "newGlyph", "localOld": "localNew"}
     remapped = remap_builder_glyphs(builder, mapping)
 
-    assert remapped.blocks[_BLOCK_A].instance.configuration_values[_OPT] == "${newGlyph}"
+    assert remapped.blocks[0].instance.configuration_values[_OPT] == "${newGlyph}"
     assert "localNew" in remapped.local_glyphs
     assert remapped.local_glyphs["localNew"] == "${newGlyph}"
     assert "localOld" not in remapped.local_glyphs
@@ -150,12 +149,7 @@ def test_remap_builder_glyphs_renames_config_value_and_local_glyph() -> None:
 
 def test_remap_builder_glyphs_empty_mapping_returns_same_object() -> None:
     builder = BlueprintBuilder(
-        blocks={
-            _BLOCK_A: RoutedBlock(
-                factory_id=PluginBlockFactoryId(plugin=_REAL_PLUGIN_ID, factory=BlockFactoryId("source_text")),
-                instance=BlockInstance(configuration_values={_OPT: "${oldGlyph}"}, input_ids={}),
-            )
-        },
+        blocks=[_routable_block(text="${oldGlyph}")],
         local_glyphs={"myKey": "myVal"},
     )
     result = remap_builder_glyphs(builder, {})
@@ -169,54 +163,42 @@ def test_remap_builder_glyphs_empty_mapping_returns_same_object() -> None:
 
 def _make_builder(block_text: str | None = None, local_glyphs: dict[str, str] | None = None) -> BlueprintBuilder:
     return BlueprintBuilder(
-        blocks={
-            _BLOCK_A: RoutedBlock(
-                factory_id=PluginBlockFactoryId(plugin=_REAL_PLUGIN_ID, factory=BlockFactoryId("source_text")),
+        blocks=[
+            RoutableBlock(
+                instance_id=_BLOCK_A,
+                plugin=_REAL_PLUGIN_ID,
+                factory=BlockFactoryId("source_text"),
                 instance=BlockInstance(
                     configuration_values={_OPT: block_text} if block_text is not None else {},
                     input_ids={},
                 ),
             )
-        },
+        ],
         local_glyphs=local_glyphs or {},
     )
+
+
+def _get_block(builder: BlueprintBuilder, block_id: BlockInstanceId) -> RoutableBlock:
+    return next(b for b in builder.blocks if b.instance_id == block_id)
 
 
 def test_resolve_builder_with_examples_fills_missing_config_value() -> None:
     """Example values fill in config options absent from the template block."""
     builder = _make_builder(block_text=None)
     result = resolve_builder_with_examples(builder, {_BLOCK_A: {_OPT: "from example"}}, {})
-    assert result.blocks[_BLOCK_A].instance.configuration_values[_OPT] == "from example"
+    assert _get_block(result, _BLOCK_A).instance.configuration_values[_OPT] == "from example"
 
 
 def test_resolve_builder_with_examples_overrides_existing_config_value() -> None:
     """Example values override existing template values for validation purposes."""
     builder = _make_builder(block_text="template value")
     result = resolve_builder_with_examples(builder, {_BLOCK_A: {_OPT: "example value"}}, {})
-    assert result.blocks[_BLOCK_A].instance.configuration_values[_OPT] == "example value"
-
-
-def test_resolve_builder_with_examples_merges_example_glyphs() -> None:
-    """Example glyphs are merged into local_glyphs when they are absent."""
-    builder = _make_builder(local_glyphs={})
-    result = resolve_builder_with_examples(builder, {}, {"name": "world"})
-    assert result.local_glyphs["name"] == "world"
-
-
-def test_resolve_builder_with_examples_overrides_existing_local_glyph() -> None:
-    """Example glyphs override existing template local glyphs for validation purposes."""
-    builder = _make_builder(local_glyphs={"name": "template"})
-    result = resolve_builder_with_examples(builder, {}, {"name": "example"})
-    assert result.local_glyphs["name"] == "example"
+    assert _get_block(result, _BLOCK_A).instance.configuration_values[_OPT] == "example value"
 
 
 def test_resolve_builder_with_examples_does_not_mutate_original() -> None:
-    """The function is pure: the original builder is unchanged after the call."""
-    builder = _make_builder(block_text=None, local_glyphs={})
-    original_config = dict(builder.blocks[_BLOCK_A].instance.configuration_values)
-    original_glyphs = dict(builder.local_glyphs)
-
-    resolve_builder_with_examples(builder, {_BLOCK_A: {_OPT: "example"}}, {"k": "v"})
-
-    assert builder.blocks[_BLOCK_A].instance.configuration_values == original_config
-    assert builder.local_glyphs == original_glyphs
+    """resolve_builder_with_examples must not mutate the caller's builder."""
+    builder = _make_builder(block_text="original")
+    original_config = dict(_get_block(builder, _BLOCK_A).instance.configuration_values)
+    resolve_builder_with_examples(builder, {_BLOCK_A: {_OPT: "override"}}, {})
+    assert _get_block(builder, _BLOCK_A).instance.configuration_values == original_config

--- a/backend/tests/unit/domain/blueprint/test_configuration_values.py
+++ b/backend/tests/unit/domain/blueprint/test_configuration_values.py
@@ -6,8 +6,6 @@ from fiab_core.fable import (
     BlockFactoryId,
     BlockInstance,
     ConfigurationOptionId,
-    PluginBlockFactoryId,
-    PluginCompositeId,
 )
 
 from forecastbox.domain.blueprint.configuration_values import convert_known_configuration_values
@@ -18,7 +16,6 @@ TEXT = ConfigurationOptionId("text")
 
 def _make_block(config: dict[ConfigurationOptionId, Any]) -> BlockInstance:
     return BlockInstance(
-        factory_id=PluginBlockFactoryId(plugin=PluginCompositeId.from_str("local:test"), factory=BlockFactoryId("transform_increment")),
         configuration_values=config,
         input_ids={},
     )

--- a/backend/tests/unit/domain/glyphs/test_resolution.py
+++ b/backend/tests/unit/domain/glyphs/test_resolution.py
@@ -13,13 +13,8 @@ import datetime as dt
 
 import pytest
 from fiab_core.fable import (
-    BlockFactoryId,
     BlockInstance,
     ConfigurationOptionId,
-    PluginBlockFactoryId,
-    PluginCompositeId,
-    PluginId,
-    PluginStoreId,
 )
 
 from forecastbox.domain.glyphs.exceptions import GlyphCircularReferenceError
@@ -35,10 +30,6 @@ from forecastbox.utility.time import value_dt2str
 
 def _block(config: dict[str, str]) -> BlockInstance:
     return BlockInstance(
-        factory_id=PluginBlockFactoryId(
-            plugin=PluginCompositeId(store=PluginStoreId("test"), local=PluginId("test")),
-            factory=BlockFactoryId("test_factory"),
-        ),
         configuration_values={ConfigurationOptionId(key): value for key, value in config.items()},
         input_ids={},
     )

--- a/backend/tests/unit/domain/run/test_compile.py
+++ b/backend/tests/unit/domain/run/test_compile.py
@@ -19,7 +19,7 @@ from fiab_core.fable import (
 from fiab_core.plugin import BlockValidation, Plugin
 from pyrsistent import pmap
 
-from forecastbox.domain.blueprint.service import BlueprintBuilder
+from forecastbox.domain.blueprint.service import BlueprintBuilder, RoutedBlock
 from forecastbox.domain.glyphs.resolution import merge_glyph_values
 from forecastbox.domain.plugin.manager import PluginManager
 from forecastbox.domain.run.compile import compile_builder
@@ -137,14 +137,14 @@ def test_compile_builder_fails_missing_config_before_plugin_compile(monkeypatch:
     option_id = ConfigurationOptionId("amount")
     compiler_called = False
 
-    def _compiler(lookup: ActionLookup, instance: BlockInstance) -> Either[Action, str]:  # type:ignore[invalid-type-arguments] # semigroup
+    def _compiler(lookup: ActionLookup, factory_id: BlockFactoryId, instance: BlockInstance) -> Either[Action, str]:  # type:ignore[invalid-type-arguments] # semigroup
         nonlocal compiler_called
-        del lookup, instance
+        del lookup, factory_id, instance
         compiler_called = True
         return Either.error("should not be called")
 
-    def _validator(instance: BlockInstance, inputs: dict[str, BlockInstanceOutput]) -> BlockValidation:
-        del instance, inputs
+    def _validator(factory_id: BlockFactoryId, instance: BlockInstance, inputs: dict[str, BlockInstanceOutput]) -> BlockValidation:
+        del factory_id, instance, inputs
         return BlockValidation(Either.ok(NoOutput()))
 
     def _expander(output: BlockInstanceOutput) -> list[BlockExpansion]:
@@ -172,10 +172,9 @@ def test_compile_builder_fails_missing_config_before_plugin_compile(monkeypatch:
     monkeypatch.setattr(PluginManager, "plugins", pmap({plugin_id: plugin}))
     blueprint = BlueprintBuilder(
         blocks={
-            BlockInstanceId("source_requires_amount"): BlockInstance(
+            BlockInstanceId("source_requires_amount"): RoutedBlock(
                 factory_id=PluginBlockFactoryId(plugin=plugin_id, factory=factory_id),
-                configuration_values={},
-                input_ids={},
+                instance=BlockInstance(configuration_values={}, input_ids={}),
             )
         }
     )

--- a/backend/tests/unit/domain/run/test_compile.py
+++ b/backend/tests/unit/domain/run/test_compile.py
@@ -13,13 +13,12 @@ from fiab_core.fable import (
     BlockInstanceOutput,
     ConfigurationOptionId,
     NoOutput,
-    PluginBlockFactoryId,
     PluginCompositeId,
 )
 from fiab_core.plugin import BlockValidation, Plugin
 from pyrsistent import pmap
 
-from forecastbox.domain.blueprint.service import BlueprintBuilder, RoutedBlock
+from forecastbox.domain.blueprint.service import BlueprintBuilder, RoutableBlock
 from forecastbox.domain.glyphs.resolution import merge_glyph_values
 from forecastbox.domain.plugin.manager import PluginManager
 from forecastbox.domain.run.compile import compile_builder
@@ -171,12 +170,14 @@ def test_compile_builder_fails_missing_config_before_plugin_compile(monkeypatch:
     )
     monkeypatch.setattr(PluginManager, "plugins", pmap({plugin_id: plugin}))
     blueprint = BlueprintBuilder(
-        blocks={
-            BlockInstanceId("source_requires_amount"): RoutedBlock(
-                factory_id=PluginBlockFactoryId(plugin=plugin_id, factory=factory_id),
+        blocks=[
+            RoutableBlock(
+                instance_id=BlockInstanceId("source_requires_amount"),
+                plugin=plugin_id,
+                factory=factory_id,
                 instance=BlockInstance(configuration_values={}, input_ids={}),
             )
-        }
+        ]
     )
 
     with pytest.raises(ValueError, match="missing configuration options"):

--- a/backend/tests/unit/routes/test_plugins.py
+++ b/backend/tests/unit/routes/test_plugins.py
@@ -21,8 +21,8 @@ from fiab_core.fable import (
     BlockInstance,
     BlockInstanceId,
     BlueprintTemplate,
+    BlueprintTemplateBlock,
     ConfigurationOptionId,
-    LocalBlock,
     PluginCompositeId,
     PluginId,
     PluginStoreId,
@@ -197,7 +197,7 @@ _TEMPLATE_WITH_EXAMPLES = BlueprintTemplate(
     display_name="myTemplate",
     display_description="desc",
     blocks={
-        _BLOCK_A: LocalBlock(
+        _BLOCK_A: BlueprintTemplateBlock(
             factory_id=BlockFactoryId("source_text"),
             instance=BlockInstance(configuration_values={_TEXT: "fixed"}, input_ids={}),
         ),

--- a/backend/tests/unit/routes/test_plugins.py
+++ b/backend/tests/unit/routes/test_plugins.py
@@ -22,11 +22,10 @@ from fiab_core.fable import (
     BlockInstanceId,
     BlueprintTemplate,
     ConfigurationOptionId,
-    PluginBlockFactoryId,
+    LocalBlock,
     PluginCompositeId,
     PluginId,
     PluginStoreId,
-    SelfPluginId,
 )
 from fiab_core.plugin import Plugin
 from packaging.specifiers import SpecifierSet
@@ -198,10 +197,9 @@ _TEMPLATE_WITH_EXAMPLES = BlueprintTemplate(
     display_name="myTemplate",
     display_description="desc",
     blocks={
-        _BLOCK_A: BlockInstance(
-            factory_id=PluginBlockFactoryId(plugin=SelfPluginId, factory=BlockFactoryId("source_text")),
-            configuration_values={_TEXT: "fixed"},
-            input_ids={},
+        _BLOCK_A: LocalBlock(
+            factory_id=BlockFactoryId("source_text"),
+            instance=BlockInstance(configuration_values={_TEXT: "fixed"}, input_ids={}),
         ),
     },
     example_values={_BLOCK_A: {_TEXT: "${exampleGlyph}"}},
@@ -218,9 +216,9 @@ _TEMPLATE_NO_EXAMPLES = BlueprintTemplate(
 def _make_plugin(*templates: BlueprintTemplate) -> Plugin:
     return Plugin(
         catalogue=BlockFactoryCatalogue(factories={}),
-        validator=lambda inst, inputs: (_ for _ in ()).throw(NotImplementedError),  # type: ignore[return-value]
+        validator=lambda factory_id, inst, inputs: (_ for _ in ()).throw(NotImplementedError),  # type: ignore[return-value]
         expander=lambda output: [],
-        compiler=lambda lookup, inst: (_ for _ in ()).throw(NotImplementedError),  # type: ignore[return-value]
+        compiler=lambda lookup, factory_id, inst: (_ for _ in ()).throw(NotImplementedError),  # type: ignore[return-value]
         blueprint_templates=templates,
     )
 

--- a/frontend/mocks/handlers/fable.handlers.ts
+++ b/frontend/mocks/handlers/fable.handlers.ts
@@ -20,7 +20,11 @@ import type {
   FableBuilderV1,
   FableUpsertRequest,
 } from '@/api/types/fable.types'
-import { getFactory } from '@/api/types/fable.types'
+import {
+  FableBuilderV1Schema,
+  getFactory,
+  serializeFable,
+} from '@/api/types/fable.types'
 import { API_ENDPOINTS } from '@/api/endpoints'
 
 interface SavedFableEntry {
@@ -154,7 +158,7 @@ export const fableHandlers = [
 
     let fable: FableBuilderV1
     try {
-      fable = (await request.json()) as FableBuilderV1
+      fable = FableBuilderV1Schema.parse(await request.json())
     } catch {
       return HttpResponse.json(
         { message: 'Invalid request body' },
@@ -180,7 +184,16 @@ export const fableHandlers = [
       )
     }
 
-    const { builder, display_name, display_description, tags, parent_id } = body
+    const {
+      builder: rawBuilder,
+      display_name,
+      display_description,
+      tags,
+      parent_id,
+    } = body
+
+    // Parse API-format builder (list of routable blocks) to internal format.
+    const builder = FableBuilderV1Schema.parse(rawBuilder)
 
     // Tags are now sent as {key, value} objects; extract the key for internal storage.
     const storedTags = (tags as Array<string | { key: string }>).map((t) =>
@@ -255,7 +268,7 @@ export const fableHandlers = [
 
     savedFablesState[body.blueprint_id] = {
       ...existing,
-      fable: body.builder,
+      fable: FableBuilderV1Schema.parse(body.builder),
       display_name: body.display_name ?? existing.display_name,
       display_description:
         body.display_description ?? existing.display_description,
@@ -518,7 +531,7 @@ export const fableHandlers = [
     return HttpResponse.json({
       blueprint_id: fableId,
       version: fableVersions[fableId] ?? 1,
-      builder: saved.fable,
+      builder: serializeFable(saved.fable),
       display_name: saved.display_name,
       display_description: saved.display_description,
       tags: saved.tags.map((k) => ({ key: k, value: '' })),

--- a/frontend/src/api/endpoints/fable.ts
+++ b/frontend/src/api/endpoints/fable.ts
@@ -42,6 +42,7 @@ import {
   GlyphFunctionsResponseSchema,
   GlyphListResponseSchema,
   normalizeCatalogueKeys,
+  serializeFable,
 } from '@/api/types/fable.types'
 
 /**
@@ -73,7 +74,7 @@ export async function getCatalogue(
 export async function expandFable(
   fable: FableBuilderV1,
 ): Promise<FableValidationExpansion> {
-  return apiClient.put(API_ENDPOINTS.fable.expand, fable, {
+  return apiClient.put(API_ENDPOINTS.fable.expand, serializeFable(fable), {
     schema: FableValidationExpansionSchema,
   })
 }
@@ -105,7 +106,11 @@ export async function upsertFable(
 ): Promise<FableUpsertResponse> {
   return apiClient.post(
     API_ENDPOINTS.fable.create,
-    { ...request, tags: request.tags.map((k) => ({ key: k })) },
+    {
+      ...request,
+      builder: serializeFable(request.builder),
+      tags: request.tags.map((k) => ({ key: k })),
+    },
     { schema: FableUpsertResponseSchema },
   )
 }
@@ -147,6 +152,7 @@ export async function updateBlueprint(
     API_ENDPOINTS.fable.update,
     {
       ...request,
+      builder: serializeFable(request.builder),
       tags: request.tags?.map((k) => ({ key: k })),
     },
     { schema: FableUpsertResponseSchema },

--- a/frontend/src/api/types/fable.types.ts
+++ b/frontend/src/api/types/fable.types.ts
@@ -21,6 +21,7 @@ import {
 import type { QubeNode } from './artifacts.types'
 import type { LucideIcon } from 'lucide-react'
 import type { PluginCompositeId } from './plugins.types'
+import type { EnvironmentSpecification } from './job.types'
 
 export type PluginId = string
 export type BlockFactoryId = string
@@ -100,21 +101,49 @@ export const BlockFactoryCatalogueSchema = z.record(
 
 export type BlockFactoryCatalogue = z.infer<typeof BlockFactoryCatalogueSchema>
 
-export const BlockInstanceSchema = z.object({
-  factory_id: PluginBlockFactoryIdSchema,
-  configuration_values: z.record(z.string(), z.string()),
-  input_ids: z.record(z.string(), z.string()),
+export interface BlockInstance {
+  factory_id: PluginBlockFactoryId
+  configuration_values: Record<string, string>
+  input_ids: Record<string, string>
+}
+
+/** API-level block schema (what the backend sends and expects in BlueprintBuilder.blocks). */
+const RoutableBlockApiSchema = z.object({
+  instance_id: z.string(),
+  plugin: PluginCompositeIdSchema,
+  factory: z.string(),
+  instance: z.object({
+    configuration_values: z.record(z.string(), z.string()),
+    input_ids: z.record(z.string(), z.string()).optional().default({}),
+  }),
 })
 
-export type BlockInstance = z.infer<typeof BlockInstanceSchema>
-
+/**
+ * Parses the backend BlueprintBuilder into the internal dict-based representation.
+ * The backend sends blocks as a list of RoutableBlocks; the frontend stores them
+ * as a Record keyed by instance_id with factory_id hoisted onto each BlockInstance.
+ */
 export const FableBuilderV1Schema = z.object({
-  blocks: z.record(z.string(), BlockInstanceSchema),
+  blocks: z.array(RoutableBlockApiSchema).transform((routableBlocks) => {
+    const dict: Record<BlockInstanceId, BlockInstance> = {}
+    for (const b of routableBlocks) {
+      dict[b.instance_id] = {
+        factory_id: { plugin: b.plugin, factory: b.factory },
+        configuration_values: b.instance.configuration_values,
+        input_ids: b.instance.input_ids,
+      }
+    }
+    return dict
+  }),
   environment: EnvironmentSpecificationSchema.nullable().optional(),
   local_glyphs: z.record(z.string(), z.string()).optional(),
 })
 
-export type FableBuilderV1 = z.infer<typeof FableBuilderV1Schema>
+export type FableBuilderV1 = {
+  blocks: Record<BlockInstanceId, BlockInstance>
+  environment?: EnvironmentSpecification | null
+  local_glyphs?: Record<string, string>
+}
 
 /**
  * Intrinsic glyph item from GET /api/v1/blueprint/glyphs/list?glyph_type=intrinsic
@@ -498,6 +527,38 @@ export function createEmptyFable(): FableBuilderV1 {
   return {
     blocks: {},
     local_glyphs: {},
+  }
+}
+
+/**
+ * Serialize an internal FableBuilderV1 to the API wire format (BlueprintBuilder).
+ * The backend expects blocks as a list of RoutableBlocks, not a dict.
+ */
+export function serializeFable(fable: FableBuilderV1): {
+  blocks: Array<{
+    instance_id: string
+    plugin: PluginCompositeId
+    factory: string
+    instance: {
+      configuration_values: Record<string, string>
+      input_ids: Record<string, string>
+    }
+  }>
+  environment?: EnvironmentSpecification | null
+  local_glyphs?: Record<string, string>
+} {
+  return {
+    blocks: Object.entries(fable.blocks).map(([instanceId, instance]) => ({
+      instance_id: instanceId,
+      plugin: instance.factory_id.plugin,
+      factory: instance.factory_id.factory,
+      instance: {
+        configuration_values: instance.configuration_values,
+        input_ids: instance.input_ids,
+      },
+    })),
+    environment: fable.environment,
+    local_glyphs: fable.local_glyphs,
   }
 }
 

--- a/frontend/tests/integration/features/dashboard/config-presets.test.tsx
+++ b/frontend/tests/integration/features/dashboard/config-presets.test.tsx
@@ -345,7 +345,7 @@ describe('PresetsPage — template lineage', () => {
           return HttpResponse.json({
             blueprint_id: 'bp-001',
             version: 1,
-            builder: { blocks: {} },
+            builder: { blocks: [] },
             display_name: 'European Forecast',
             display_description: null,
             tags: [],
@@ -356,7 +356,7 @@ describe('PresetsPage — template lineage', () => {
           return HttpResponse.json({
             blueprint_id: 'tpl-001',
             version: 1,
-            builder: { blocks: {} },
+            builder: { blocks: [] },
             display_name: 'Fast Map',
             display_description: null,
             tags: [],
@@ -396,7 +396,7 @@ describe('PresetsPage — delete preset', () => {
           return HttpResponse.json({
             blueprint_id: 'bp-001',
             version: 1,
-            builder: { blocks: {} },
+            builder: { blocks: [] },
             display_name: 'European Forecast',
             display_description: null,
             tags: [],

--- a/frontend/tests/integration/features/fable-builder/timezone-base-time.test.tsx
+++ b/frontend/tests/integration/features/fable-builder/timezone-base-time.test.tsx
@@ -90,7 +90,14 @@ describe('Fable Builder — base time wire contract', () => {
       .poll(() => useFableBuilderStore.getState().isDirty, { timeout: 3000 })
       .toBe(false)
 
-    expect(body()?.builder.blocks.source1.configuration_values.base_time).toBe(
+    const blocks1 = body()?.builder.blocks as
+      | Array<{
+          instance_id: string
+          instance: { configuration_values: Record<string, string> }
+        }>
+      | undefined
+    const source1Block1 = blocks1?.find((b) => b.instance_id === 'source1')
+    expect(source1Block1?.instance.configuration_values.base_time).toBe(
       '2026-05-15T00:00:00',
     )
   })
@@ -115,7 +122,14 @@ describe('Fable Builder — base time wire contract', () => {
       .poll(() => useFableBuilderStore.getState().isDirty, { timeout: 3000 })
       .toBe(false)
 
-    expect(body()?.builder.blocks.source1.configuration_values.base_time).toBe(
+    const blocks2 = body()?.builder.blocks as
+      | Array<{
+          instance_id: string
+          instance: { configuration_values: Record<string, string> }
+        }>
+      | undefined
+    const source1Block2 = blocks2?.find((b) => b.instance_id === 'source1')
+    expect(source1Block2?.instance.configuration_values.base_time).toBe(
       '2026-05-14T22:00:00',
     )
   })

--- a/frontend/tests/unit/api/endpoints/fable.test.ts
+++ b/frontend/tests/unit/api/endpoints/fable.test.ts
@@ -39,6 +39,21 @@ const mockFable: FableBuilderV1 = {
   },
 }
 
+/** API wire format for mockFable (new backend format with list-based blocks). */
+const mockApiFable = {
+  blocks: [
+    {
+      instance_id: 'block-1',
+      plugin: { store: 'ecmwf', local: 'core' },
+      factory: 'model',
+      instance: {
+        configuration_values: { param1: 'value1' },
+        input_ids: {},
+      },
+    },
+  ],
+}
+
 describe('getCatalogue', () => {
   afterEach(() => {
     worker.resetHandlers()
@@ -166,7 +181,7 @@ describe('expandFable', () => {
     )
 
     await expandFable(mockFable)
-    expect(capturedBody).toEqual(mockFable)
+    expect(capturedBody).toEqual(mockApiFable)
   })
 })
 
@@ -179,7 +194,7 @@ describe('retrieveFable', () => {
     const mockResponse = {
       blueprint_id: 'fable-123',
       version: 1,
-      builder: mockFable,
+      builder: mockApiFable,
       display_name: 'My Config',
       display_description: 'Some description',
       tags: [{ key: 'tag1', value: '' }],
@@ -209,7 +224,7 @@ describe('retrieveFable', () => {
         HttpResponse.json({
           blueprint_id: 'fable-oneoff',
           version: 1,
-          builder: mockFable,
+          builder: mockApiFable,
           display_name: 'One-off run',
           display_description: null,
           tags: [{ key: '__fiab:oneoff__', value: null }],
@@ -231,7 +246,7 @@ describe('retrieveFable', () => {
         HttpResponse.json({
           blueprint_id: 'fable-mismatch',
           version: 1,
-          builder: mockFable,
+          builder: mockApiFable,
           display_name: 'Stale config',
           display_description: null,
           tags: [
@@ -256,7 +271,7 @@ describe('retrieveFable', () => {
         return HttpResponse.json({
           blueprint_id: 'fable-456',
           version: 1,
-          builder: mockFable,
+          builder: mockApiFable,
           display_name: 'Test',
           display_description: '',
           tags: [],
@@ -298,7 +313,7 @@ describe('upsertFable', () => {
     expect(result.blueprint_id).toBe('new-fable-id')
     expect(result.version).toBe(1)
     expect(capturedBody).toMatchObject({
-      builder: mockFable,
+      builder: mockApiFable,
       display_name: 'My Config',
       display_description: 'Some notes',
     })

--- a/frontend/tests/unit/api/hooks/useFable.test.tsx
+++ b/frontend/tests/unit/api/hooks/useFable.test.tsx
@@ -60,6 +60,21 @@ const mockFable: FableBuilderV1 = {
   },
 }
 
+/** API wire format for mockFable (new backend format with list-based blocks). */
+const mockApiFable = {
+  blocks: [
+    {
+      instance_id: 'block-1',
+      plugin: { store: 'ecmwf', local: 'core-plugin' },
+      factory: 'model',
+      instance: {
+        configuration_values: { param1: 'value1' },
+        input_ids: {},
+      },
+    },
+  ],
+}
+
 const mockExpansion = {
   global_errors: [],
   block_errors: {},
@@ -200,7 +215,7 @@ describe('useFable', () => {
     const mockRetrieveResponse = {
       blueprint_id: 'test-fable-id',
       version: 1,
-      builder: mockFable,
+      builder: mockApiFable,
       display_name: 'Test Config',
       display_description: '',
       tags: [],


### PR DESCRIPTION
…tedBlock

BlockInstance is now pure content (configuration_values + input_ids only).

- LocalBlock (fiab_core/fable.py): factory_id: BlockFactoryId + instance: BlockInstance -- used in BlueprintTemplate.blocks by plugin authors
- RoutedBlock (forecastbox/domain/blueprint/service.py): factory_id: PluginBlockFactoryId + instance: BlockInstance -- used in BlueprintBuilder and the API wire format; includes backward-compat model_validator for stored blueprints in the old flat format
- SelfPluginId sentinel removed; no longer needed since LocalBlock uses BlockFactoryId directly and template_to_builder combines it with the plugin id straightforwardly
- Validator and Compiler callback types updated: factory_id: BlockFactoryId is now an explicit first argument, so plugin code never touches routing types
- BlockInstanceRich.from_block gains factory_id as first arg; private _factory_id attr used for error messages
- background.py, compile.py, service.py all updated to use routed.instance when calling into glyphs/resolution helpers that expect BlockInstance
- All unit tests, largeE2E blueprint, and MCP server schema updated

The only test failure in the full parallel suite is test_artifacts.py which is a pre-existing flaky network test unrelated to this change.

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
