### PR TITLE
fix(plugins): reflect plugin_enabled in toggle, badge, and status filter

### DIFF
--- a/frontend/src/api/hooks/usePlugins.ts
+++ b/frontend/src/api/hooks/usePlugins.ts
@@ -113,13 +113,16 @@ export function usePlugins(catalogue?: BlockFactoryCatalogue) {
   // reads, so spreading re-renders on every field.
   const query = usePluginDetails()
   const listing = query.data
+  // plugin_enabled lives on a separate endpoint — join it so the toggle
+  // reflects real enabled state, not just whether the module loaded.
+  const enabledMap = usePluginStatus().data?.plugin_enabled
 
   const plugins = useMemo<Array<PluginInfo>>(() => {
     if (!listing) return []
 
     const capabilitiesMap = deriveCapabilitiesFromCatalogue(catalogue)
-    return toPluginInfoList(listing, capabilitiesMap)
-  }, [listing, catalogue])
+    return toPluginInfoList(listing, capabilitiesMap, enabledMap)
+  }, [listing, catalogue, enabledMap])
 
   return {
     data: listing ? { plugins } : undefined,
@@ -174,9 +177,11 @@ function usePluginMutation<TVariables>(
       await action(variables)
       // Poll until the catalogue is available again (plugins finished reloading)
       await waitForCatalogue()
-      // Now refresh both caches — catalogue is ready so these will succeed
+      // Refresh caches. Status carries plugin_enabled, so it must refresh too
+      // or the toggle sticks.
       await queryClient.invalidateQueries({ queryKey: fableKeys.catalogue() })
       await queryClient.invalidateQueries({ queryKey: pluginKeys.details() })
+      await queryClient.invalidateQueries({ queryKey: pluginKeys.status() })
     },
   })
 }

--- a/frontend/src/api/types/plugins.types.ts
+++ b/frontend/src/api/types/plugins.types.ts
@@ -169,6 +169,40 @@ export function pluginErrorsMaxSeverity(
   return max
 }
 
+/** The single visual state a plugin's status badge conveys. */
+export type PluginBadgeKind =
+  | 'loaded'
+  | 'disabled'
+  | 'warning'
+  | 'errored'
+  | 'update'
+  | 'available'
+
+/**
+ * The one badge a plugin shows. Badge and status filter both derive from this,
+ * so they can't drift. Precedence: disabled → update → warning → errored →
+ * available → loaded.
+ */
+export function pluginBadgeKind(plugin: {
+  status: PluginStatus
+  isEnabled?: boolean
+  hasUpdate?: boolean
+  errorSeverity?: PluginErrorSeverity | null
+}): PluginBadgeKind {
+  // Disabled dominates — blocks stay out of the catalogue until re-enabled.
+  // (Uninstalled 'available' plugins keep their own badge.)
+  if (plugin.isEnabled === false && plugin.status !== 'available') {
+    return 'disabled'
+  }
+  if (plugin.hasUpdate && plugin.status === 'loaded') return 'update'
+  // Severity drives the badge, not status — a warning is amber whether the
+  // plugin loaded or errored.
+  if (plugin.errorSeverity === 'warning') return 'warning'
+  if (plugin.status === 'errored') return 'errored'
+  if (plugin.status === 'available') return 'available'
+  return 'loaded'
+}
+
 /**
  * Plugin detail - full plugin information from backend
  */
@@ -250,7 +284,8 @@ export interface PluginInfo {
   capabilities: Array<PluginCapability>
   /** Current status from backend */
   status: PluginStatus
-  /** Whether plugin is enabled (loaded or errored) */
+  /** Enabled = its blocks appear in the catalogue. Reflects `plugin_enabled`,
+   *  not merely whether it loaded. */
   isEnabled: boolean
   /** Whether plugin is installed (not available) */
   isInstalled: boolean
@@ -313,11 +348,15 @@ export function isUnstampedVersion(version: string): boolean {
 
 /**
  * Transform a PluginDetail to UI-friendly PluginInfo
+ *
+ * @param enabled - The `plugin_enabled` flag (/plugin/status). Orthogonal to
+ *   `status`; omit to infer from `status`.
  */
 export function toPluginInfo(
   id: PluginCompositeId,
   detail: PluginDetail,
   capabilities: Array<PluginCapability> = [],
+  enabled?: boolean,
 ): PluginInfo {
   const isInstalled = detail.status !== 'available'
   const hasUpdate =
@@ -340,7 +379,10 @@ export function toPluginInfo(
     latestVersion: detail.remote_info?.version ?? null,
     capabilities,
     status: detail.status,
-    isEnabled: detail.status === 'loaded' || detail.status === 'errored',
+    // Prefer plugin_enabled; fall back to status when it's absent. `??` so an
+    // explicit `false` wins.
+    isEnabled:
+      enabled ?? (detail.status === 'loaded' || detail.status === 'errored'),
     isInstalled,
     hasUpdate,
     updatedAt: detail.update_datetime
@@ -368,16 +410,20 @@ function toUtcIsoOrNull(dateStr: string): string | null {
 
 /**
  * Transform PluginListing response to array of PluginInfo
+ *
+ * @param enabledMap - `plugin_enabled` from /plugin/status, keyed like
+ *   `listing.plugins`. Drives each plugin's `isEnabled`.
  */
 export function toPluginInfoList(
   listing: PluginListing,
   capabilitiesMap: Map<string, Array<PluginCapability>> = new Map(),
+  enabledMap: Record<string, boolean> = {},
 ): Array<PluginInfo> {
   return Object.entries(listing.plugins).map(([key, detail]) => {
     const id = parsePluginKey(key)
     const displayId = toPluginDisplayId(id)
     const capabilities = capabilitiesMap.get(displayId) ?? []
-    return toPluginInfo(id, detail, capabilities)
+    return toPluginInfo(id, detail, capabilities, enabledMap[key])
   })
 }
 

--- a/frontend/src/features/plugins/components/PluginCard.tsx
+++ b/frontend/src/features/plugins/components/PluginCard.tsx
@@ -34,14 +34,16 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { Switch } from '@/components/ui/switch'
 import { Spinner } from '@/components/ui/spinner'
 import { P } from '@/components/base/typography'
+import { PluginToggle } from '@/features/plugins/components/PluginToggle'
 import { cn } from '@/lib/utils'
 
 interface PluginCardProps {
   plugin: PluginInfo
   onToggle: (compositeId: PluginCompositeId, enabled: boolean) => void
+  /** Target enabled value while a toggle is in flight; undefined when idle. */
+  pendingEnabled?: boolean
   onInstall: (compositeId: PluginCompositeId) => void
   onUninstall: (compositeId: PluginCompositeId) => void
   onUpdate: (compositeId: PluginCompositeId) => void
@@ -54,6 +56,7 @@ interface PluginCardProps {
 export function PluginCard({
   plugin,
   onToggle,
+  pendingEnabled,
   onInstall,
   onUninstall,
   onUpdate,
@@ -73,8 +76,8 @@ export function PluginCard({
   // Use compact layout for uninstalled plugins
   const isCompact = !plugin.isInstalled
 
-  // Show error state
-  const hasError = plugin.status === 'errored'
+  // Any diagnostic, or a bare `errored` state; severity picks the amber vs red border.
+  const hasDiagnostics = !!plugin.errorDetail || plugin.status === 'errored'
 
   // PyPI URL derived from the pip source, when one exists
   const pypiUrl = getPyPIUrl(plugin.pipSource)
@@ -87,7 +90,7 @@ export function PluginCard({
         !plugin.isEnabled &&
           plugin.isInstalled &&
           'opacity-80 hover:opacity-100',
-        hasError &&
+        hasDiagnostics &&
           (plugin.errorSeverity === 'warning'
             ? 'border-amber-200 dark:border-amber-800'
             : 'border-red-200 dark:border-red-800'),
@@ -122,6 +125,7 @@ export function PluginCard({
           status={plugin.status}
           hasUpdate={plugin.hasUpdate}
           severity={plugin.errorSeverity}
+          isEnabled={plugin.isEnabled}
           className="shrink-0"
         />
       </div>
@@ -216,12 +220,10 @@ export function PluginCard({
                 {t('actions.viewDetails')}
               </Button>
             )}
-            <Switch
-              checked={plugin.isEnabled}
-              onCheckedChange={(checked) => onToggle(plugin.id, checked)}
-              aria-label={
-                plugin.isEnabled ? t('actions.disable') : t('actions.enable')
-              }
+            <PluginToggle
+              plugin={plugin}
+              pendingEnabled={pendingEnabled}
+              onToggle={onToggle}
             />
           </>
         ) : (

--- a/frontend/src/features/plugins/components/PluginDetailPage.tsx
+++ b/frontend/src/features/plugins/components/PluginDetailPage.tsx
@@ -148,6 +148,7 @@ export function PluginDetailPage({ plugin, catalogue }: PluginDetailPageProps) {
               status={plugin.status}
               hasUpdate={plugin.hasUpdate}
               severity={plugin.errorSeverity}
+              isEnabled={plugin.isEnabled}
             />
           </div>
         </div>

--- a/frontend/src/features/plugins/components/PluginRow.tsx
+++ b/frontend/src/features/plugins/components/PluginRow.tsx
@@ -37,18 +37,20 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { Switch } from '@/components/ui/switch'
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { H4, P } from '@/components/base/typography'
+import { PluginToggle } from '@/features/plugins/components/PluginToggle'
 import { cn } from '@/lib/utils'
 
 interface PluginRowProps {
   plugin: PluginInfo
   onToggle: (compositeId: PluginCompositeId, enabled: boolean) => void
+  /** Target enabled value while a toggle is in flight; undefined when idle. */
+  pendingEnabled?: boolean
   onUninstall: (compositeId: PluginCompositeId) => void
   onViewDetails?: (plugin: PluginInfo) => void
 }
@@ -56,6 +58,7 @@ interface PluginRowProps {
 export function PluginRow({
   plugin,
   onToggle,
+  pendingEnabled,
   onUninstall,
   onViewDetails,
 }: PluginRowProps) {
@@ -66,7 +69,8 @@ export function PluginRow({
     ? formatDistanceToNow(new Date(plugin.updatedAt), { addSuffix: true })
     : null
 
-  const hasError = plugin.status === 'errored'
+  // Any diagnostic, or a bare `errored` state; severity (below) picks amber vs red.
+  const hasDiagnostics = !!plugin.errorDetail || plugin.status === 'errored'
   const isWarningOnly = plugin.errorSeverity === 'warning'
   const pypiUrl = getPyPIUrl(plugin.pipSource)
 
@@ -79,7 +83,7 @@ export function PluginRow({
       className={cn(
         'group grid grid-cols-1 items-center gap-4 px-6 py-5 transition-colors hover:bg-muted/50 sm:grid-cols-12',
         !plugin.isEnabled && 'opacity-75 hover:opacity-100',
-        hasError &&
+        hasDiagnostics &&
           (isWarningOnly
             ? 'bg-amber-50/50 dark:bg-amber-950/20'
             : 'bg-red-50/50 dark:bg-red-950/20'),
@@ -92,7 +96,7 @@ export function PluginRow({
           <div className="flex items-center gap-2">
             <H4 className="text-sm font-semibold">{plugin.name}</H4>
             {/* Diagnostics icon — also shown for loaded plugins carrying warnings */}
-            {(hasError || plugin.errorDetail) && (
+            {hasDiagnostics && (
               <Tooltip>
                 <TooltipTrigger>
                   {isWarningOnly ? (
@@ -152,6 +156,7 @@ export function PluginRow({
           status={plugin.status}
           hasUpdate={plugin.hasUpdate}
           severity={plugin.errorSeverity}
+          isEnabled={plugin.isEnabled}
         />
       </div>
 
@@ -172,12 +177,10 @@ export function PluginRow({
 
         {/* Toggle Switch */}
         {plugin.isInstalled && (
-          <Switch
-            checked={plugin.isEnabled}
-            onCheckedChange={(checked) => onToggle(plugin.id, checked)}
-            aria-label={
-              plugin.isEnabled ? t('actions.disable') : t('actions.enable')
-            }
+          <PluginToggle
+            plugin={plugin}
+            pendingEnabled={pendingEnabled}
+            onToggle={onToggle}
           />
         )}
 

--- a/frontend/src/features/plugins/components/PluginStatusBadge.tsx
+++ b/frontend/src/features/plugins/components/PluginStatusBadge.tsx
@@ -65,7 +65,10 @@ export function PluginStatusBadge({
 
   const variantByKind: Record<PluginBadgeKind, StatusBadgeVariant> = {
     loaded: { label: t('status.loaded'), ...STATUS_BADGE_VARIANTS.active },
-    disabled: { label: t('status.disabled'), ...STATUS_BADGE_VARIANTS.disabled },
+    disabled: {
+      label: t('status.disabled'),
+      ...STATUS_BADGE_VARIANTS.disabled,
+    },
     warning: { label: t('status.warning'), ...STATUS_BADGE_VARIANTS.warning },
     errored: { label: t('status.errored'), ...STATUS_BADGE_VARIANTS.error },
     update: {

--- a/frontend/src/features/plugins/components/PluginStatusBadge.tsx
+++ b/frontend/src/features/plugins/components/PluginStatusBadge.tsx
@@ -22,10 +22,12 @@
 
 import { useTranslation } from 'react-i18next'
 import type {
+  PluginBadgeKind,
   PluginErrorSeverity,
   PluginStatus,
 } from '@/api/types/plugins.types'
 import type { StatusBadgeVariant } from '@/components/common/StatusBadge'
+import { pluginBadgeKind } from '@/api/types/plugins.types'
 import {
   STATUS_BADGE_VARIANTS,
   StatusBadge,
@@ -35,8 +37,12 @@ interface PluginStatusBadgeProps {
   status: PluginStatus
   /** Whether an update is available (shown as visual indicator) */
   hasUpdate?: boolean
-  /** Max diagnostic severity — softens 'errored' to a Warning badge when warning-only */
+  /** Max diagnostic severity; drives the badge directly (a warning is amber
+   *  whether the plugin loaded or errored). */
   severity?: PluginErrorSeverity | null
+  /** `plugin_enabled` flag. Explicit `false` → "Disabled" regardless of load
+   *  status. Omit to drive the badge by `status` alone. */
+  isEnabled?: boolean
   className?: string
 }
 
@@ -44,29 +50,33 @@ export function PluginStatusBadge({
   status,
   hasUpdate,
   severity,
+  isEnabled,
   className,
 }: PluginStatusBadgeProps) {
   const { t } = useTranslation('plugins')
 
-  const statusConfig: Record<PluginStatus, StatusBadgeVariant> = {
+  // Shared with the status filter so the two can't drift.
+  const kind = pluginBadgeKind({
+    status,
+    isEnabled,
+    hasUpdate,
+    errorSeverity: severity,
+  })
+
+  const variantByKind: Record<PluginBadgeKind, StatusBadgeVariant> = {
     loaded: { label: t('status.loaded'), ...STATUS_BADGE_VARIANTS.active },
-    disabled: {
-      label: t('status.disabled'),
-      ...STATUS_BADGE_VARIANTS.disabled,
+    disabled: { label: t('status.disabled'), ...STATUS_BADGE_VARIANTS.disabled },
+    warning: { label: t('status.warning'), ...STATUS_BADGE_VARIANTS.warning },
+    errored: { label: t('status.errored'), ...STATUS_BADGE_VARIANTS.error },
+    update: {
+      label: t('status.updateAvailable'),
+      ...STATUS_BADGE_VARIANTS.warning,
     },
     available: {
       label: t('status.available'),
       ...STATUS_BADGE_VARIANTS.available,
     },
-    errored: { label: t('status.errored'), ...STATUS_BADGE_VARIANTS.error },
   }
 
-  const variant: StatusBadgeVariant =
-    hasUpdate && status === 'loaded'
-      ? { label: t('status.updateAvailable'), ...STATUS_BADGE_VARIANTS.warning }
-      : status === 'errored' && severity === 'warning'
-        ? { label: t('status.warning'), ...STATUS_BADGE_VARIANTS.warning }
-        : statusConfig[status]
-
-  return <StatusBadge variant={variant} className={className} />
+  return <StatusBadge variant={variantByKind[kind]} className={className} />
 }

--- a/frontend/src/features/plugins/components/PluginToggle.tsx
+++ b/frontend/src/features/plugins/components/PluginToggle.tsx
@@ -1,0 +1,50 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { useTranslation } from 'react-i18next'
+import type { PluginCompositeId, PluginInfo } from '@/api/types/plugins.types'
+import { Spinner } from '@/components/ui/spinner'
+import { Switch } from '@/components/ui/switch'
+
+interface PluginToggleProps {
+  plugin: PluginInfo
+  /** Target enabled value while a toggle is in flight; undefined when idle. */
+  pendingEnabled?: boolean
+  onToggle: (compositeId: PluginCompositeId, enabled: boolean) => void
+}
+
+/**
+ * Enable/disable switch. While the async toggle settles it shows the target
+ * position optimistically, disables input, and spins — so the click gets
+ * immediate feedback despite the catalogue reload behind it.
+ */
+export function PluginToggle({
+  plugin,
+  pendingEnabled,
+  onToggle,
+}: PluginToggleProps) {
+  const { t } = useTranslation('plugins')
+  const isToggling = pendingEnabled !== undefined
+
+  return (
+    <div className="flex items-center gap-2">
+      {isToggling && <Spinner className="text-muted-foreground" />}
+      <Switch
+        checked={isToggling ? pendingEnabled : plugin.isEnabled}
+        disabled={isToggling}
+        onCheckedChange={(checked) => onToggle(plugin.id, checked)}
+        aria-busy={isToggling}
+        aria-label={
+          plugin.isEnabled ? t('actions.disable') : t('actions.enable')
+        }
+      />
+    </div>
+  )
+}

--- a/frontend/src/features/plugins/components/PluginsFilters.tsx
+++ b/frontend/src/features/plugins/components/PluginsFilters.tsx
@@ -28,10 +28,9 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 
-/**
- * Status filter includes all backend statuses plus 'all' and 'hasUpdate'
- */
-export type StatusFilter = 'all' | 'hasUpdate' | PluginStatus
+/** Matches the badge a plugin shows (`pluginBadgeKind`), not raw `status` — so
+ *  "Disabled" catches loaded-but-disabled plugins and "Warning" is filterable. */
+export type StatusFilter = 'all' | 'hasUpdate' | 'warning' | PluginStatus
 
 export type CapabilityFilter = 'all' | PluginCapability
 
@@ -87,6 +86,9 @@ export function PluginsFilters({
             <SelectItem value="loaded">{t('filters.status.loaded')}</SelectItem>
             <SelectItem value="disabled">
               {t('filters.status.disabled')}
+            </SelectItem>
+            <SelectItem value="warning">
+              {t('filters.status.warning')}
             </SelectItem>
             <SelectItem value="errored">
               {t('filters.status.errored')}

--- a/frontend/src/features/plugins/components/PluginsList.tsx
+++ b/frontend/src/features/plugins/components/PluginsList.tsx
@@ -33,6 +33,8 @@ interface PluginsListProps {
   plugins: Array<PluginInfo>
   viewMode: AdminViewMode
   onToggle: (compositeId: PluginCompositeId, enabled: boolean) => void
+  /** Plugins mid-toggle, keyed `store/local` → target enabled value. */
+  pendingToggles?: ReadonlyMap<string, boolean>
   onInstall: (compositeId: PluginCompositeId) => void
   onUninstall: (compositeId: PluginCompositeId) => void
   onUpdate: (compositeId: PluginCompositeId) => void
@@ -45,6 +47,7 @@ export function PluginsList({
   plugins,
   viewMode,
   onToggle,
+  pendingToggles,
   onInstall,
   onUninstall,
   onUpdate,
@@ -53,6 +56,9 @@ export function PluginsList({
   shadow,
 }: PluginsListProps) {
   const { t } = useTranslation('plugins')
+
+  const pendingEnabledFor = (plugin: PluginInfo): boolean | undefined =>
+    pendingToggles?.get(`${plugin.id.store}/${plugin.id.local}`)
 
   // Force card view on mobile (below Tailwind's sm breakpoint)
   const isMobile = useMedia('(max-width: 639px)')
@@ -77,6 +83,7 @@ export function PluginsList({
             key={plugin.displayId}
             plugin={plugin}
             onToggle={onToggle}
+            pendingEnabled={pendingEnabledFor(plugin)}
             onInstall={onInstall}
             onUninstall={onUninstall}
             onUpdate={onUpdate}
@@ -109,6 +116,7 @@ export function PluginsList({
             key={plugin.displayId}
             plugin={plugin}
             onToggle={onToggle}
+            pendingEnabled={pendingEnabledFor(plugin)}
             onUninstall={onUninstall}
             onViewDetails={onViewDetails}
           />

--- a/frontend/src/features/plugins/components/UpdatesAvailableSection.tsx
+++ b/frontend/src/features/plugins/components/UpdatesAvailableSection.tsx
@@ -67,6 +67,7 @@ export function UpdatesAvailableSection({
                       <PluginStatusBadge
                         status={plugin.status}
                         severity={plugin.errorSeverity}
+                        isEnabled={plugin.isEnabled}
                       />
                     )}
                     <span className="rounded-full border border-amber-200 bg-amber-100 px-2 py-0.5 text-sm font-bold text-amber-800 dark:border-amber-800 dark:bg-amber-900/40 dark:text-amber-300">

--- a/frontend/src/locales/en/plugins.json
+++ b/frontend/src/locales/en/plugins.json
@@ -33,6 +33,7 @@
       "active": "Active",
       "loaded": "Loaded",
       "disabled": "Disabled",
+      "warning": "Warning",
       "updates": "Updates Available",
       "uninstalled": "Uninstalled",
       "available": "Available",

--- a/frontend/src/routes/_authenticated/admin/plugins.index.tsx
+++ b/frontend/src/routes/_authenticated/admin/plugins.index.tsx
@@ -34,7 +34,7 @@ import {
   useUpdatePlugin,
 } from '@/api/hooks/usePlugins'
 import { useStatus } from '@/api/hooks/useStatus'
-import { encodePluginId } from '@/api/types/plugins.types'
+import { encodePluginId, pluginBadgeKind } from '@/api/types/plugins.types'
 import { H3 } from '@/components/base/typography'
 import { Button } from '@/components/ui/button'
 import { ListPageContainer } from '@/components/common/ListPageContainer'
@@ -86,6 +86,13 @@ function PluginsPage() {
   const updatePlugin = useUpdatePlugin()
   const refreshPlugins = useRefreshPlugins()
 
+  // Plugins mid-toggle → their target enabled value. enable/disable are single
+  // shared mutations, so we track per-plugin here to drive the optimistic
+  // switch + spinner while the async op settles.
+  const [pendingToggles, setPendingToggles] = useState<Map<string, boolean>>(
+    () => new Map(),
+  )
+
   // Separate plugins by status
   const {
     pluginsWithUpdates,
@@ -125,13 +132,14 @@ function PluginsPage() {
 
     let filteredPlugins = plugins.filter((p) => p.isInstalled)
 
-    // Apply status filter (for installed plugins only)
+    // Filter by the badge the user sees (pluginBadgeKind), not raw status —
+    // else a loaded-but-disabled plugin wouldn't show under Disabled.
     if (statusFilter !== 'all' && statusFilter !== 'available') {
       if (statusFilter === 'hasUpdate') {
         filteredPlugins = filteredPlugins.filter((p) => p.hasUpdate)
       } else {
         filteredPlugins = filteredPlugins.filter(
-          (p) => p.status === statusFilter,
+          (p) => pluginBadgeKind(p) === statusFilter,
         )
       }
     }
@@ -211,11 +219,16 @@ function PluginsPage() {
 
   // Handlers
   const handleToggle = (compositeId: PluginCompositeId, enabled: boolean) => {
-    if (enabled) {
-      enablePlugin.mutate(compositeId)
-    } else {
-      disablePlugin.mutate(compositeId)
-    }
+    const key = `${compositeId.store}/${compositeId.local}`
+    setPendingToggles((prev) => new Map(prev).set(key, enabled))
+    const mutation = enabled ? enablePlugin : disablePlugin
+    mutation.mutateAsync(compositeId).finally(() => {
+      setPendingToggles((prev) => {
+        const next = new Map(prev)
+        next.delete(key)
+        return next
+      })
+    })
   }
 
   const handleInstall = (compositeId: PluginCompositeId) => {
@@ -335,6 +348,7 @@ function PluginsPage() {
             plugins={installedPlugins}
             viewMode={pluginsViewMode}
             onToggle={handleToggle}
+            pendingToggles={pendingToggles}
             onInstall={handleInstall}
             onUninstall={handleUninstall}
             onUpdate={handleUpdate}

--- a/frontend/tests/integration/features/plugins/plugin-detail.test.tsx
+++ b/frontend/tests/integration/features/plugins/plugin-detail.test.tsx
@@ -75,6 +75,16 @@ describe('Plugin Detail Page', () => {
 
       await expect.element(screen.getByText('Loaded')).toBeVisible()
     })
+
+    it('shows a Disabled badge for a loaded-but-disabled plugin', async () => {
+      // Loaded-but-disabled: surface "Disabled", not the misleading "Loaded".
+      const disabled: PluginInfo = { ...mockPlugin, isEnabled: false }
+      const screen = await renderWithRouter(
+        <PluginDetailPage plugin={disabled} catalogue={mockCatalogue} />,
+      )
+
+      await expect.element(screen.getByText('Disabled')).toBeVisible()
+    })
   })
 
   describe('Plugin Description', () => {

--- a/frontend/tests/integration/features/plugins/plugin-toggle.test.tsx
+++ b/frontend/tests/integration/features/plugins/plugin-toggle.test.tsx
@@ -1,0 +1,79 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * PluginToggle Integration Tests
+ *
+ * The enable/disable switch and its in-flight feedback: while a toggle is
+ * pending it shows the target position optimistically, disables input, and
+ * spins.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { renderWithRouter } from '@tests/utils/render'
+import type { PluginInfo } from '@/api/types/plugins.types'
+import { PluginToggle } from '@/features/plugins/components/PluginToggle'
+
+const basePlugin: PluginInfo = {
+  id: { store: 'ecmwf', local: 'ecmwf-base' },
+  displayId: 'ecmwf/ecmwf-base',
+  name: 'ECMWF Plugin',
+  description: '',
+  author: 'ECMWF',
+  version: '0.0.1',
+  latestVersion: '0.0.1',
+  capabilities: [],
+  status: 'loaded',
+  isEnabled: true,
+  isInstalled: true,
+  hasUpdate: false,
+  updatedAt: null,
+  errorDetail: null,
+  errorSeverity: null,
+  comment: null,
+  pipSource: null,
+  moduleName: null,
+}
+
+describe('PluginToggle', () => {
+  it('is idle when no toggle is pending — enabled, no spinner', async () => {
+    const screen = await renderWithRouter(
+      <PluginToggle plugin={basePlugin} onToggle={vi.fn()} />,
+    )
+    await expect.element(screen.getByRole('switch')).not.toBeDisabled()
+    expect(screen.getByRole('status').query()).toBeNull()
+  })
+
+  it('while enabling: shows the target ON optimistically, disabled, spinning', async () => {
+    const disabled: PluginInfo = { ...basePlugin, isEnabled: false }
+    const screen = await renderWithRouter(
+      <PluginToggle plugin={disabled} pendingEnabled onToggle={vi.fn()} />,
+    )
+    const toggle = screen.getByRole('switch')
+    await expect.element(toggle).toBeDisabled()
+    // Optimistic: reads ON even though the plugin is still disabled in data.
+    await expect.element(toggle).toHaveAttribute('aria-checked', 'true')
+    await expect.element(screen.getByRole('status')).toBeVisible()
+  })
+
+  it('while disabling: shows the target OFF optimistically, disabled', async () => {
+    const screen = await renderWithRouter(
+      <PluginToggle
+        plugin={basePlugin}
+        pendingEnabled={false}
+        onToggle={vi.fn()}
+      />,
+    )
+    const toggle = screen.getByRole('switch')
+    await expect.element(toggle).toBeDisabled()
+    await expect.element(toggle).toHaveAttribute('aria-checked', 'false')
+    await expect.element(screen.getByRole('status')).toBeVisible()
+  })
+})

--- a/frontend/tests/integration/features/plugins/plugins-management.test.tsx
+++ b/frontend/tests/integration/features/plugins/plugins-management.test.tsx
@@ -31,6 +31,7 @@ import type {
   CapabilityFilter,
   StatusFilter,
 } from '@/features/plugins/components/PluginsFilters'
+import { pluginBadgeKind } from '@/api/types/plugins.types'
 import {
   useDisablePlugin,
   useEnablePlugin,
@@ -115,7 +116,10 @@ function TestPluginsPage() {
       statusFilter !== 'available' &&
       statusFilter !== 'hasUpdate'
     ) {
-      filteredPlugins = filteredPlugins.filter((p) => p.status === statusFilter)
+      // Mirrors plugins.index.tsx: filter by the badge kind, not raw status.
+      filteredPlugins = filteredPlugins.filter(
+        (p) => pluginBadgeKind(p) === statusFilter,
+      )
     }
 
     if (statusFilter === 'hasUpdate') {
@@ -533,7 +537,7 @@ describe('Plugins Management Integration', () => {
       await expect.element(screen.getByText('Template ingestion')).toBeVisible()
     })
 
-    it('shows warnings on a loaded plugin', async () => {
+    it('badges a loaded plugin carrying a warning as amber Warning (severity-driven)', async () => {
       worker.use(
         http.get(API_ENDPOINTS.plugin.details, () =>
           detailsResponse({
@@ -555,7 +559,12 @@ describe('Plugins Management Integration', () => {
         .element(screen.getByRole('heading', { name: 'Plugin Store' }))
         .toBeVisible()
 
-      await expect.element(screen.getByText('Loaded')).toBeVisible()
+      // Loaded + warning → amber "Warning" (severity-driven), not green
+      // "Loaded"; the diagnostic is still listed below.
+      await expect
+        .element(screen.getByText('Warning', { exact: true }))
+        .toBeVisible()
+      await expect.element(screen.getByText('Loaded')).not.toBeInTheDocument()
       await expect.element(screen.getByText(/version mismatch/)).toBeVisible()
     })
   })

--- a/frontend/tests/unit/api/types/plugins.types.test.ts
+++ b/frontend/tests/unit/api/types/plugins.types.test.ts
@@ -161,9 +161,9 @@ describe('toPluginInfoList — joins plugin_enabled by backend key', () => {
 
 describe('pluginBadgeKind — one source of truth for badge + filter', () => {
   it('disabled dominates a loaded module (badge + filter agree)', () => {
-    expect(
-      pluginBadgeKind({ status: 'loaded', isEnabled: false }),
-    ).toBe('disabled')
+    expect(pluginBadgeKind({ status: 'loaded', isEnabled: false })).toBe(
+      'disabled',
+    )
   })
 
   it('disabled dominates over a pending update and a warning', () => {
@@ -178,9 +178,9 @@ describe('pluginBadgeKind — one source of truth for badge + filter', () => {
   })
 
   it('an uninstalled (available) plugin is not "disabled"', () => {
-    expect(
-      pluginBadgeKind({ status: 'available', isEnabled: false }),
-    ).toBe('available')
+    expect(pluginBadgeKind({ status: 'available', isEnabled: false })).toBe(
+      'available',
+    )
   })
 
   it('a pending update on a loaded, enabled plugin → update', () => {
@@ -199,13 +199,15 @@ describe('pluginBadgeKind — one source of truth for badge + filter', () => {
   })
 
   it('an error/critical diagnostic → errored', () => {
-    expect(
-      pluginBadgeKind({ status: 'errored', errorSeverity: 'error' }),
-    ).toBe('errored')
+    expect(pluginBadgeKind({ status: 'errored', errorSeverity: 'error' })).toBe(
+      'errored',
+    )
   })
 
   it('falls through to the plain status when nothing else applies', () => {
-    expect(pluginBadgeKind({ status: 'loaded', isEnabled: true })).toBe('loaded')
+    expect(pluginBadgeKind({ status: 'loaded', isEnabled: true })).toBe(
+      'loaded',
+    )
     expect(pluginBadgeKind({ status: 'available' })).toBe('available')
     expect(pluginBadgeKind({ status: 'errored' })).toBe('errored')
   })

--- a/frontend/tests/unit/api/types/plugins.types.test.ts
+++ b/frontend/tests/unit/api/types/plugins.types.test.ts
@@ -14,8 +14,10 @@ import {
   PluginDetailSchema,
   isNewerVersion,
   isUnstampedVersion,
+  pluginBadgeKind,
   pluginErrorsMaxSeverity,
   toPluginInfo,
+  toPluginInfoList,
 } from '@/api/types/plugins.types'
 
 const ID: PluginCompositeId = { store: 'ecmwf', local: 'anemoi-inference' }
@@ -116,6 +118,96 @@ describe('toPluginInfo — errorDetail normalization', () => {
     })
     expect(info.errorDetail).toEqual(errors)
     expect(info.errorSeverity).toBe('error')
+  })
+})
+
+describe('toPluginInfo — isEnabled reflects the plugin_enabled flag', () => {
+  const loaded = detailWith(null) // status: 'loaded'
+
+  it('honours an explicit enabled=false even when the module loaded', () => {
+    // The bug this fixes: a loaded-but-disabled plugin used to read as enabled.
+    expect(toPluginInfo(ID, loaded, [], false).isEnabled).toBe(false)
+  })
+
+  it('honours an explicit enabled=true', () => {
+    const errored: PluginDetail = { ...loaded, status: 'errored' }
+    expect(toPluginInfo(ID, errored, [], true).isEnabled).toBe(true)
+  })
+
+  it('falls back to status when the flag is absent (loaded → enabled)', () => {
+    expect(toPluginInfo(ID, loaded).isEnabled).toBe(true)
+  })
+
+  it('falls back to status when the flag is absent (available → disabled)', () => {
+    const available: PluginDetail = { ...loaded, status: 'available' }
+    expect(toPluginInfo(ID, available).isEnabled).toBe(false)
+  })
+})
+
+describe('toPluginInfoList — joins plugin_enabled by backend key', () => {
+  const key = "store='ecmwf' local='anemoi-inference'"
+  const listing = { plugins: { [key]: detailWith(null) } }
+
+  it('applies the enabledMap entry to the matching plugin', () => {
+    const [info] = toPluginInfoList(listing, new Map(), { [key]: false })
+    expect(info.isEnabled).toBe(false)
+  })
+
+  it('falls back to status when a plugin is missing from the map', () => {
+    const [info] = toPluginInfoList(listing, new Map(), {})
+    expect(info.isEnabled).toBe(true) // status 'loaded'
+  })
+})
+
+describe('pluginBadgeKind — one source of truth for badge + filter', () => {
+  it('disabled dominates a loaded module (badge + filter agree)', () => {
+    expect(
+      pluginBadgeKind({ status: 'loaded', isEnabled: false }),
+    ).toBe('disabled')
+  })
+
+  it('disabled dominates over a pending update and a warning', () => {
+    expect(
+      pluginBadgeKind({
+        status: 'loaded',
+        isEnabled: false,
+        hasUpdate: true,
+        errorSeverity: 'warning',
+      }),
+    ).toBe('disabled')
+  })
+
+  it('an uninstalled (available) plugin is not "disabled"', () => {
+    expect(
+      pluginBadgeKind({ status: 'available', isEnabled: false }),
+    ).toBe('available')
+  })
+
+  it('a pending update on a loaded, enabled plugin → update', () => {
+    expect(
+      pluginBadgeKind({ status: 'loaded', isEnabled: true, hasUpdate: true }),
+    ).toBe('update')
+  })
+
+  it('a warning drives the badge regardless of loaded/errored status', () => {
+    expect(
+      pluginBadgeKind({ status: 'loaded', errorSeverity: 'warning' }),
+    ).toBe('warning')
+    expect(
+      pluginBadgeKind({ status: 'errored', errorSeverity: 'warning' }),
+    ).toBe('warning')
+  })
+
+  it('an error/critical diagnostic → errored', () => {
+    expect(
+      pluginBadgeKind({ status: 'errored', errorSeverity: 'error' }),
+    ).toBe('errored')
+  })
+
+  it('falls through to the plain status when nothing else applies', () => {
+    expect(pluginBadgeKind({ status: 'loaded', isEnabled: true })).toBe('loaded')
+    expect(pluginBadgeKind({ status: 'available' })).toBe('available')
+    expect(pluginBadgeKind({ status: 'errored' })).toBe('errored')
   })
 })
 


### PR DESCRIPTION
## Summary

The Plugin Store derived a plugin's state from its load `status` alone, so a plugin that had loaded but was disabled (`plugin_enabled: false`) showed a green **Loaded** badge with its toggle **on** — while its blocks were actually excluded from the catalogue. The badge, the toggle, and the status filter each re-derived plugin state independently and had drifted apart. This PR makes them all read from the same source and fills the gaps that discrepancy exposed.

## What changed

- **Toggle reflects real enabled state.** Join `plugin_enabled` (from `/plugin/status`) into `PluginInfo.isEnabled`, falling back to `status` only when the flag is absent. Invalidate `/plugin/status` after settings mutations so the toggle no longer sticks on stale state.
- **One source of truth for the badge.** New `pluginBadgeKind()` decides a plugin's badge, shared by `PluginStatusBadge` and the status filter so they can't drift again.
- **Severity-driven badge/tint.** The badge and row/card tint follow the max diagnostic severity rather than `status`, so a warning reads amber whether the plugin is `loaded` or `errored`.
- **In-flight toggle feedback.** Extracted `PluginToggle` (de-dups the switch across row and card): while an enable/disable settles it shows the target position optimistically, disables input to block double-toggles, and spins (shadcn `Spinner`) — closing the previously-blank async gap.

## User-facing additions 

- A grey **Disabled** badge now appears for plugins that loaded but are turned off (previously mislabelled "Loaded").
- A new **Warning** option in the status filter, so warning-badged plugins are filterable and the filter matches the badges 1:1.
### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
