### PR TITLE
[frontend] Feat/blueprint templates ux

### DIFF
--- a/frontend/mocks/handlers/fable.handlers.ts
+++ b/frontend/mocks/handlers/fable.handlers.ts
@@ -32,23 +32,44 @@ interface SavedFableEntry {
   user_id: string
   created_at: string
   updated_at: string
+  /** Blueprint source; plugin templates use 'plugin_template' */
+  source?: string | null
+  /** Forked-from lineage (e.g. the template a preset was created from) */
+  parent_id?: string | null
 }
 
 function seedSavedFables(): Record<string, SavedFableEntry | undefined> {
-  return Object.fromEntries(
-    Object.entries(mockSavedFables).map(([id, entry]) => [
-      id,
-      {
-        ...entry,
-        display_name: entry.name,
-        display_description: '',
-      },
-    ]),
-  )
+  const seeded: Record<string, SavedFableEntry | undefined> =
+    Object.fromEntries(
+      Object.entries(mockSavedFables).map(([id, entry]) => [
+        id,
+        {
+          ...entry,
+          display_name: entry.name,
+          display_description: '',
+        },
+      ]),
+    )
+
+  // Plugin-shipped blueprint template (created_by = "store:local")
+  const templateBase = Object.values(mockSavedFables)[0]
+  seeded['template-basic-map'] = {
+    ...templateBase,
+    display_name: 'testBasic',
+    display_description: 'Ready-made starting point shipped by a plugin',
+    tags: [],
+    user_id: 'local:plugin-test',
+    source: 'plugin_template',
+  }
+
+  return seeded
 }
 
 function seedFableVersions(): Record<string, number> {
-  return Object.fromEntries(Object.keys(mockSavedFables).map((id) => [id, 1]))
+  return {
+    ...Object.fromEntries(Object.keys(mockSavedFables).map((id) => [id, 1])),
+    'template-basic-map': 1,
+  }
 }
 
 let savedFablesState: Record<string, SavedFableEntry | undefined> =
@@ -184,33 +205,7 @@ export const fableHandlers = [
       .replace('T', ' ')
       .replace(/\.\d{3}Z$/, '+00:00')
 
-    if (parent_id) {
-      const existing = savedFablesState[parent_id]
-      if (!existing) {
-        return HttpResponse.json(
-          { message: 'Fable not found' },
-          { status: 404 },
-        )
-      }
-
-      const newVersion = (fableVersions[parent_id] ?? 1) + 1
-      fableVersions[parent_id] = newVersion
-
-      savedFablesState[parent_id] = {
-        ...existing,
-        fable: builder,
-        display_name,
-        display_description,
-        tags: storedTags.length > 0 ? storedTags : existing.tags,
-        updated_at: now,
-      }
-
-      return HttpResponse.json({
-        blueprint_id: parent_id,
-        version: newVersion,
-      })
-    }
-
+    // Real-backend semantics: create mints a new blueprint; parent_id is lineage only
     const newId = `fable-${String(fableIdCounter++).padStart(3, '0')}`
     fableVersions[newId] = 1
 
@@ -223,6 +218,7 @@ export const fableHandlers = [
       user_id: 'mock-user-123',
       created_at: now,
       updated_at: now,
+      parent_id: parent_id ?? null,
     }
 
     return HttpResponse.json({ blueprint_id: newId, version: 1 })
@@ -268,6 +264,8 @@ export const fableHandlers = [
             typeof t === 'string' ? t : t.key,
           )
         : existing.tags,
+      // Real-backend semantics: omitted parent_id wipes lineage
+      parent_id: body.parent_id ?? null,
       updated_at: new Date().toISOString(),
     }
 
@@ -277,12 +275,39 @@ export const fableHandlers = [
     })
   }),
 
-  http.get(API_ENDPOINTS.fable.list, async () => {
+  http.post(API_ENDPOINTS.fable.delete, async ({ request }) => {
     await delay(200)
+    const body = (await request.json()) as {
+      blueprint_id: string
+      version: number
+    }
+    if (!savedFablesState[body.blueprint_id]) {
+      return HttpResponse.json(
+        { detail: `Blueprint '${body.blueprint_id}' not found` },
+        { status: 404 },
+      )
+    }
+    delete savedFablesState[body.blueprint_id]
+    delete fableVersions[body.blueprint_id]
+    return HttpResponse.json({ success: true })
+  }),
+
+  http.get(API_ENDPOINTS.fable.list, async ({ request }) => {
+    await delay(200)
+
+    const url = new URL(request.url)
+    const sourceFilter = url.searchParams.get('source')
+    const createdByFilter = url.searchParams.get('created_by')
 
     const blueprints = Object.entries(savedFablesState)
       .filter(
         (pair): pair is [string, SavedFableEntry] => pair[1] !== undefined,
+      )
+      .filter(
+        ([, entry]) => !sourceFilter || (entry.source ?? null) === sourceFilter,
+      )
+      .filter(
+        ([, entry]) => !createdByFilter || entry.user_id === createdByFilter,
       )
       .map(([id, entry]) => ({
         blueprint_id: id,
@@ -290,7 +315,7 @@ export const fableHandlers = [
         display_name: entry.display_name,
         display_description: entry.display_description,
         tags: entry.tags.map((k) => ({ key: k, value: '' })),
-        source: null,
+        source: entry.source ?? null,
         created_by: entry.user_id,
       }))
 
@@ -497,6 +522,7 @@ export const fableHandlers = [
       display_name: saved.display_name,
       display_description: saved.display_description,
       tags: saved.tags.map((k) => ({ key: k, value: '' })),
+      parent_id: saved.parent_id ?? null,
       created_at: saved.created_at,
       updated_at: saved.updated_at,
     })

--- a/frontend/mocks/handlers/plugins.handlers.ts
+++ b/frontend/mocks/handlers/plugins.handlers.ts
@@ -302,4 +302,26 @@ export const pluginsHandlers = [
 
     return HttpResponse.json({ success: true })
   }),
+
+  // GET /api/v1/plugin/templateExampleValues
+  http.get(API_ENDPOINTS.plugin.templateExampleValues, async ({ request }) => {
+    await delay(200)
+    const url = new URL(request.url)
+    const displayName = url.searchParams.get('displayName')
+
+    // Matches the 'template-basic-map' blueprint fixture in fable.handlers.ts
+    if (displayName !== 'testBasic') {
+      return new HttpResponse(
+        JSON.stringify({ detail: `Template ${displayName} not found` }),
+        { status: 404 },
+      )
+    }
+
+    return HttpResponse.json({
+      example_values: {
+        block_source_1: { base_time: '2026-07-01T00:00:00' },
+      },
+      example_glyphs: { leadtime: '48' },
+    })
+  }),
 ]

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -121,6 +121,8 @@ export const API_ENDPOINTS = {
     update: `${API_PREFIX}/plugin/update`,
     /** POST - Update plugin settings, e.g. enable/disable (body: PluginSettingsUpdateRequest) */
     settings: `${API_PREFIX}/plugin/settings`,
+    /** GET - Example values/glyphs for a blueprint template (query: store, local, displayName) */
+    templateExampleValues: `${API_PREFIX}/plugin/templateExampleValues`,
   },
 
   /**

--- a/frontend/src/api/endpoints/fable.ts
+++ b/frontend/src/api/endpoints/fable.ts
@@ -110,15 +110,29 @@ export async function upsertFable(
   )
 }
 
+/** Optional server-side filters for the blueprint list endpoint */
+export interface BlueprintListFilters {
+  /** Restrict to blueprints with this source (e.g. 'plugin_template', 'user_defined') */
+  source?: string
+  /** Restrict to blueprints owned by this user or plugin */
+  createdBy?: string
+}
+
 /**
  * List all saved blueprints (paginated)
  */
 export async function listBlueprints(
   page: number = 1,
   pageSize: number = 10,
+  filters?: BlueprintListFilters,
 ): Promise<BlueprintListResponse> {
   return apiClient.get(API_ENDPOINTS.fable.list, {
-    params: { page, page_size: pageSize },
+    params: {
+      page,
+      page_size: pageSize,
+      ...(filters?.source && { source: filters.source }),
+      ...(filters?.createdBy && { created_by: filters.createdBy }),
+    },
     schema: BlueprintListResponseSchema,
   })
 }

--- a/frontend/src/api/endpoints/plugins.ts
+++ b/frontend/src/api/endpoints/plugins.ts
@@ -20,12 +20,14 @@ import type {
   PluginListing,
   PluginSettingsUpdate,
   PluginsStatus,
+  TemplateExampleValues,
 } from '@/api/types/plugins.types'
 import { apiClient } from '@/api/client'
 import { API_ENDPOINTS } from '@/api/endpoints'
 import {
   PluginListingSchema,
   PluginsStatusSchema,
+  TemplateExampleValuesSchema,
 } from '@/api/types/plugins.types'
 
 /**
@@ -92,6 +94,25 @@ export async function updatePluginSettings(
   await apiClient.post(API_ENDPOINTS.plugin.settings, {
     pluginCompositeId: compositeId,
     ...settings,
+  })
+}
+
+/**
+ * Get example values/glyphs for a blueprint template from a loaded plugin
+ * @param compositeId - The plugin composite ID { store, local }
+ * @param displayName - The template's display name within the plugin
+ */
+export async function getTemplateExampleValues(
+  compositeId: PluginCompositeId,
+  displayName: string,
+): Promise<TemplateExampleValues> {
+  return apiClient.get(API_ENDPOINTS.plugin.templateExampleValues, {
+    params: {
+      store: compositeId.store,
+      local: compositeId.local,
+      displayName,
+    },
+    schema: TemplateExampleValuesSchema,
   })
 }
 

--- a/frontend/src/api/hooks/useFable.ts
+++ b/frontend/src/api/hooks/useFable.ts
@@ -30,6 +30,7 @@ import type {
   IntrinsicGlyphItem,
   PluginBlockFactoryId,
 } from '@/api/types/fable.types'
+import type { BlueprintListFilters } from '@/api/endpoints/fable'
 import {
   createGlobalGlyph,
   deleteBlueprint,
@@ -44,7 +45,6 @@ import {
   updateBlueprint,
   upsertFable,
 } from '@/api/endpoints/fable'
-import type { BlueprintListFilters } from '@/api/endpoints/fable'
 import { getFactory } from '@/api/types/fable.types'
 import { ApiClientError } from '@/api/client'
 import { QUERY_CONSTANTS } from '@/utils/constants'

--- a/frontend/src/api/hooks/useFable.ts
+++ b/frontend/src/api/hooks/useFable.ts
@@ -44,6 +44,7 @@ import {
   updateBlueprint,
   upsertFable,
 } from '@/api/endpoints/fable'
+import type { BlueprintListFilters } from '@/api/endpoints/fable'
 import { getFactory } from '@/api/types/fable.types'
 import { ApiClientError } from '@/api/client'
 import { QUERY_CONSTANTS } from '@/utils/constants'
@@ -53,8 +54,8 @@ export const fableKeys = {
   catalogue: () => [...fableKeys.all, 'catalogue'] as const,
   // Prefix shared by every paginated blueprint-list query — invalidate to refresh all of them.
   blueprintsBase: () => [...fableKeys.all, 'blueprints'] as const,
-  blueprints: (page?: number, pageSize?: number) =>
-    [...fableKeys.all, 'blueprints', page, pageSize] as const,
+  blueprints: (page?: number, pageSize?: number, filters?: object) =>
+    [...fableKeys.all, 'blueprints', page, pageSize, filters ?? null] as const,
   detail: (id: string) => [...fableKeys.all, 'detail', id] as const,
   validation: (fable: FableBuilderV1) =>
     [...fableKeys.all, 'validation', JSON.stringify(fable)] as const,
@@ -159,10 +160,14 @@ export function useFableValidation(
   })
 }
 
-export function useListBlueprints(page: number = 1, pageSize: number = 50) {
+export function useListBlueprints(
+  page: number = 1,
+  pageSize: number = 50,
+  filters?: BlueprintListFilters,
+) {
   return useQuery<BlueprintListResponse>({
-    queryKey: fableKeys.blueprints(page, pageSize),
-    queryFn: () => listBlueprints(page, pageSize),
+    queryKey: fableKeys.blueprints(page, pageSize, filters),
+    queryFn: () => listBlueprints(page, pageSize, filters),
     staleTime: QUERY_CONSTANTS.STALE_TIMES.DEFAULT,
   })
 }
@@ -192,7 +197,8 @@ export function useUpsertFable() {
       display_description,
       tags,
     }) => {
-      // Update existing blueprint when we have both ID and version
+      // Update when we have ID + version. parent_id is re-sent — the
+      // backend replaces the metadata row and omitting it wipes lineage.
       if (fableId && fableVersion != null) {
         return updateBlueprint({
           blueprint_id: fableId,
@@ -201,6 +207,7 @@ export function useUpsertFable() {
           display_name,
           display_description,
           tags: tags ?? [],
+          parent_id: parentId ?? null,
         })
       }
       // Create new blueprint (parentId tracks "forked from" lineage)
@@ -233,10 +240,10 @@ export function useDeleteBlueprint() {
 
   return useMutation<void, Error, BlueprintDeleteRequest>({
     mutationFn: deleteBlueprint,
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: fableKeys.detail(variables.blueprint_id),
-      })
+    onSuccess: () => {
+      // Only refresh lists. Invalidating the deleted blueprint's detail
+      // would refetch a 404 from still-mounted rows and toast an error;
+      // the stale cache entry is unreachable once the lists update.
       queryClient.invalidateQueries({
         queryKey: fableKeys.blueprintsBase(),
       })

--- a/frontend/src/api/hooks/usePlugins.ts
+++ b/frontend/src/api/hooks/usePlugins.ts
@@ -36,9 +36,11 @@ import {
   updatePlugin,
   updatePluginSettings,
 } from '@/api/endpoints/plugins'
-import { parsePluginIdString } from '@/api/types/plugins.types'
+import {
+  parsePluginIdString,
+  toPluginInfoList,
+} from '@/api/types/plugins.types'
 import { getCatalogue } from '@/api/endpoints/fable'
-import { toPluginInfoList } from '@/api/types/plugins.types'
 import { fableKeys } from '@/api/hooks/useFable'
 import { createLogger } from '@/lib/logger'
 

--- a/frontend/src/api/hooks/usePlugins.ts
+++ b/frontend/src/api/hooks/usePlugins.ts
@@ -30,11 +30,13 @@ import {
   enablePlugin,
   getPluginDetails,
   getPluginStatus,
+  getTemplateExampleValues,
   installPlugin,
   uninstallPlugin,
   updatePlugin,
   updatePluginSettings,
 } from '@/api/endpoints/plugins'
+import { parsePluginIdString } from '@/api/types/plugins.types'
 import { getCatalogue } from '@/api/endpoints/fable'
 import { toPluginInfoList } from '@/api/types/plugins.types'
 import { fableKeys } from '@/api/hooks/useFable'
@@ -216,6 +218,31 @@ export function useUpdatePluginSettings() {
       settings: PluginSettingsUpdate
     }) => updatePluginSettings(compositeId, settings),
   )
+}
+
+/**
+ * Example values/glyphs for a blueprint template.
+ * @param pluginId - "store:local" composite string (blueprint `created_by` format)
+ * @param displayName - The template's display name within the plugin
+ */
+export function useTemplateExampleValues(
+  pluginId: string | undefined,
+  displayName: string | undefined,
+) {
+  return useQuery({
+    queryKey: [
+      ...pluginKeys.all,
+      'templateExampleValues',
+      pluginId,
+      displayName,
+    ],
+    queryFn: () =>
+      getTemplateExampleValues(parsePluginIdString(pluginId!), displayName!),
+    enabled: !!pluginId && !!displayName,
+    staleTime: Infinity,
+    // 403 (excluded) / 404 (plugin unloaded) are terminal — don't retry
+    retry: false,
+  })
 }
 
 /**

--- a/frontend/src/api/types/plugins.types.ts
+++ b/frontend/src/api/types/plugins.types.ts
@@ -245,6 +245,34 @@ export const PluginsStatusSchema = z.object({
 export type PluginsStatus = z.infer<typeof PluginsStatusSchema>
 
 /**
+ * Example data for a blueprint template from GET /plugin/templateExampleValues.
+ * Mirrors what the backend overlays during template ingest validation.
+ */
+export const TemplateExampleValuesSchema = z.object({
+  /** Per-block example configuration values, keyed by block instance id then option id */
+  example_values: z.record(z.string(), z.record(z.string(), z.string())),
+  /** Example glyph name-to-value pairs the user is expected to override */
+  example_glyphs: z.record(z.string(), z.string()),
+})
+
+export type TemplateExampleValues = z.infer<typeof TemplateExampleValuesSchema>
+
+/**
+ * Parse a "store:local" composite string (the blueprint `created_by` format
+ * for plugin templates). Splits on the first colon.
+ */
+export function parsePluginIdString(id: string): PluginCompositeId {
+  const separatorIndex = id.indexOf(':')
+  if (separatorIndex === -1) {
+    return { store: id, local: '' }
+  }
+  return {
+    store: id.slice(0, separatorIndex),
+    local: id.slice(separatorIndex + 1),
+  }
+}
+
+/**
  * Payload fields for POST /plugin/settings (backend PluginSettingsUpdateRequest).
  * Omitted fields leave the stored value unchanged; an empty list/dict clears it.
  */

--- a/frontend/src/features/dashboard/components/PresetCard.tsx
+++ b/frontend/src/features/dashboard/components/PresetCard.tsx
@@ -29,8 +29,10 @@ export function PresetCard({
   preset: PresetEntry
   onToggleFavourite: () => void
 }) {
-  const { t } = useTranslation('journal')
+  const { t } = useTranslation(['journal', 'dashboard'])
   const { data: blueprint } = useFableRetrieve(preset.blueprintId)
+  // Forked-from lineage (e.g. the template this preset was created from)
+  const { data: parent } = useFableRetrieve(blueprint?.parent_id ?? null)
   const [metadataOpen, setMetadataOpen] = useState(false)
 
   const builder = blueprint?.builder
@@ -79,6 +81,8 @@ export function PresetCard({
 
       <p className="text-sm text-muted-foreground">
         {t('item.outputs', { count: outputCount })}
+        {parent?.display_name &&
+          ` · ${t('dashboard:presets.basedOn', { name: parent.display_name })}`}
       </p>
 
       {preset.coreVersionMismatch && (

--- a/frontend/src/features/dashboard/components/PresetsPage.tsx
+++ b/frontend/src/features/dashboard/components/PresetsPage.tsx
@@ -15,7 +15,9 @@ import { Bookmark, MoreVertical, Pencil, Star, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Link } from '@tanstack/react-router'
 import { useConfigPresets } from '../hooks/useConfigPresets'
+import { useTemplatePresets } from '../hooks/useTemplatePresets'
 import type { PresetEntry } from '../hooks/useConfigPresets'
+import type { TemplateEntry } from '../hooks/useTemplatePresets'
 import type {
   FacetKey,
   FacetToken,
@@ -65,6 +67,8 @@ const PresetRow = memo(function ({
   const showFlow = useUiStore((state) => state.journalShowFlow)
   // Cache-shared with useConfigPresets — a hit, not a new request.
   const { data: blueprint } = useFableRetrieve(preset.blueprintId)
+  // Forked-from lineage (e.g. the template this preset was created from)
+  const { data: parent } = useFableRetrieve(blueprint?.parent_id ?? null)
   const [metadataOpen, setMetadataOpen] = useState(false)
 
   const builder = blueprint?.builder
@@ -103,6 +107,8 @@ const PresetRow = memo(function ({
           )}
           <div className="mb-2 truncate text-sm text-muted-foreground">
             {t('journal:item.outputs', { count: preset.outputCount })}
+            {parent?.display_name &&
+              ` · ${t('presets.basedOn', { name: parent.display_name })}`}
           </div>
           {hasChips && (
             <div className="flex flex-wrap items-center gap-2">
@@ -209,9 +215,78 @@ const PresetRow = memo(function ({
   )
 })
 
+/**
+ * One plugin-template row — a starting point offered by a plugin. Read-only:
+ * no favourite/edit/delete; the only action is forking it into the builder.
+ */
+const TemplateRow = memo(function ({ template }: { template: TemplateEntry }) {
+  const { t } = useTranslation(['dashboard', 'journal'])
+  const showFlow = useUiStore((state) => state.journalShowFlow)
+  const { data: blueprint } = useFableRetrieve(template.blueprintId)
+
+  const builder = blueprint?.builder
+  const title = template.displayName || t('journal:item.untitled')
+  const useTemplateSearch = {
+    fableId: template.blueprintId,
+    template: true,
+    ...(template.pluginId && { templatePlugin: template.pluginId }),
+    ...(template.displayName && { templateName: template.displayName }),
+  }
+
+  return (
+    <div className="group/row p-6 transition-colors hover:bg-muted/50">
+      <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center">
+        <div className="min-w-0 grow">
+          <div className="mb-1 flex min-w-0 items-center gap-2">
+            <Link
+              to="/configure"
+              search={useTemplateSearch}
+              className="min-w-0 truncate text-sm font-medium hover:underline"
+            >
+              {title}
+            </Link>
+            <JournalChip label={t('presets.templates.chip')} variant="tag" />
+          </div>
+          {template.displayDescription && (
+            <p className="mb-1 truncate text-sm text-muted-foreground">
+              {template.displayDescription}
+            </p>
+          )}
+          {template.pluginLabel && (
+            <div className="truncate text-sm text-muted-foreground">
+              {t('presets.templates.fromPlugin', {
+                plugin: template.pluginLabel,
+              })}
+            </div>
+          )}
+        </div>
+
+        {showFlow && builder && (
+          <FableMiniFlow
+            builder={builder}
+            className="max-w-[18rem] shrink-0"
+            monochrome
+          />
+        )}
+
+        <div className="mt-2 flex w-full items-center justify-end sm:mt-0 sm:w-auto">
+          <Button
+            variant="outline"
+            size="sm"
+            render={<Link to="/configure" search={useTemplateSearch} />}
+            nativeButton={false}
+          >
+            {t('presets.templates.use')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+})
+
 const PAGE_SIZE = 10
 
-type PresetFilter = 'all' | 'bookmarked'
+type PresetFilter = 'all' | 'bookmarked' | 'templates'
 
 /** Case-insensitive substring test of a preset against one facet token. */
 function matchesPresetFacet(
@@ -261,6 +336,7 @@ export function PresetsPage() {
   const setShowFlow = useUiStore((state) => state.setJournalShowFlow)
 
   const { presets, deletePreset, toggleFavourite } = useConfigPresets()
+  const { templates } = useTemplatePresets()
   const [query, setQuery] = useState('')
   const [filter, setFilter] = useState<PresetFilter>('all')
   const [page, setPage] = useState(1)
@@ -271,19 +347,34 @@ export function PresetsPage() {
     () => filterPresets(presets, filter, parseQuery(deferredQuery)),
     [presets, filter, deferredQuery],
   )
+  // Templates support plain-text search only (no model/output/tag facets).
+  const filteredTemplates = useMemo(() => {
+    const text = parseQuery(deferredQuery).text.toLowerCase()
+    if (!text) return templates
+    return templates.filter(
+      (template) =>
+        (template.displayName ?? '').toLowerCase().includes(text) ||
+        (template.displayDescription ?? '').toLowerCase().includes(text) ||
+        (template.pluginLabel ?? '').toLowerCase().includes(text),
+    )
+  }, [templates, deferredQuery])
 
   const handleAddFacet = useCallback((token: FacetToken) => {
     setQuery((current) => addToken(current, token))
     setPage(1)
   }, [])
 
-  const totalPages = Math.max(1, Math.ceil(filteredPresets.length / PAGE_SIZE))
+  const showTemplates = filter === 'templates'
+  const activeCount = showTemplates
+    ? filteredTemplates.length
+    : filteredPresets.length
+  const totalPages = Math.max(1, Math.ceil(activeCount / PAGE_SIZE))
   // Clamp: a delete (or any list shrink) can leave `page` past the last page.
   const currentPage = Math.min(page, totalPages)
-  const paginatedPresets = filteredPresets.slice(
-    (currentPage - 1) * PAGE_SIZE,
-    currentPage * PAGE_SIZE,
-  )
+  const pageSlice = <T,>(items: Array<T>) =>
+    items.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE)
+  const paginatedPresets = pageSlice(filteredPresets)
+  const paginatedTemplates = pageSlice(filteredTemplates)
 
   return (
     <ListPageContainer>
@@ -323,7 +414,7 @@ export function PresetsPage() {
             />
 
             <div className="flex items-center gap-1 text-sm font-medium text-muted-foreground">
-              {(['all', 'bookmarked'] as const).map((f) => (
+              {(['all', 'bookmarked', 'templates'] as const).map((f) => (
                 <button
                   key={f}
                   type="button"
@@ -347,7 +438,21 @@ export function PresetsPage() {
 
         {/* List */}
         <div className="divide-y divide-border">
-          {paginatedPresets.length > 0 ? (
+          {showTemplates ? (
+            paginatedTemplates.length > 0 ? (
+              paginatedTemplates.map((template) => (
+                <TemplateRow key={template.blueprintId} template={template} />
+              ))
+            ) : query ? (
+              <EmptyState icon={Bookmark} title={t('presets.empty.filtered')} />
+            ) : (
+              <EmptyState
+                icon={Bookmark}
+                title={t('presets.templates.empty.title')}
+                description={t('presets.templates.empty.description')}
+              />
+            )
+          ) : paginatedPresets.length > 0 ? (
             paginatedPresets.map((preset) => (
               <PresetRow
                 key={preset.blueprintId}

--- a/frontend/src/features/dashboard/hooks/useConfigPresets.ts
+++ b/frontend/src/features/dashboard/hooks/useConfigPresets.ts
@@ -10,6 +10,7 @@
 
 import { useMemo } from 'react'
 import { useQueries } from '@tanstack/react-query'
+import i18n from 'i18next'
 import type { BlueprintListItem } from '@/api/types/fable.types'
 import { getBlocksByKind } from '@/api/types/fable.types'
 import { retrieveFable } from '@/api/endpoints/fable'
@@ -19,7 +20,6 @@ import {
   useDeleteBlueprint,
   useListBlueprints,
 } from '@/api/hooks/useFable'
-import i18n from 'i18next'
 import { deriveModelLabel, deriveSinkKinds } from '@/features/journal/adapters'
 import { showToast } from '@/lib/toast'
 import { useLocalStorage } from '@/hooks/useLocalStorage'

--- a/frontend/src/features/dashboard/hooks/useConfigPresets.ts
+++ b/frontend/src/features/dashboard/hooks/useConfigPresets.ts
@@ -19,7 +19,9 @@ import {
   useDeleteBlueprint,
   useListBlueprints,
 } from '@/api/hooks/useFable'
+import i18n from 'i18next'
 import { deriveModelLabel, deriveSinkKinds } from '@/features/journal/adapters'
+import { showToast } from '@/lib/toast'
 import { useLocalStorage } from '@/hooks/useLocalStorage'
 import { STORAGE_KEYS } from '@/lib/storage-keys'
 import { isOneoffBlueprint, stripSystemTags } from '@/lib/system-tags'
@@ -104,7 +106,12 @@ export function useConfigPresets() {
   // Functional setFavourites updates keep these callbacks stable (favourites is
   // not in the closure) so memoised preset rows don't re-render on every render.
   function deletePreset(blueprintId: string, version: number) {
-    deleteMutation.mutate({ blueprint_id: blueprintId, version })
+    deleteMutation.mutate(
+      { blueprint_id: blueprintId, version },
+      {
+        onSuccess: () => showToast.success(i18n.t('dashboard:presets.deleted')),
+      },
+    )
     // Clean up favourite flag
     const { [blueprintId]: _, ...rest } = favourites
     setFavourites(rest)

--- a/frontend/src/features/dashboard/hooks/useTemplatePresets.ts
+++ b/frontend/src/features/dashboard/hooks/useTemplatePresets.ts
@@ -1,0 +1,54 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { useMemo } from 'react'
+import { useListBlueprints } from '@/api/hooks/useFable'
+import { parsePluginIdString } from '@/api/types/plugins.types'
+
+/** A plugin-shipped blueprint template, offered as a starting point */
+export interface TemplateEntry {
+  blueprintId: string
+  version: number
+  displayName: string | null
+  displayDescription: string | null
+  /** Owning plugin as a "store:local" composite string (from created_by) */
+  pluginId: string | null
+  /** Short plugin label for chips (the local part of the composite id) */
+  pluginLabel: string | null
+  /** Version-mismatch detail when built on a different fiab-core major, else null. */
+  coreVersionMismatch: string | null
+}
+
+export function useTemplatePresets() {
+  const { data, isLoading } = useListBlueprints(1, 50, {
+    source: 'plugin_template',
+  })
+
+  const templates = useMemo<Array<TemplateEntry>>(() => {
+    if (!data?.blueprints) return []
+    return data.blueprints.map((bp) => ({
+      blueprintId: bp.blueprint_id,
+      version: bp.version,
+      displayName: bp.display_name,
+      displayDescription: bp.display_description,
+      pluginId: bp.created_by,
+      pluginLabel: bp.created_by
+        ? parsePluginIdString(bp.created_by).local || bp.created_by
+        : null,
+      coreVersionMismatch: bp.coreVersionMismatch,
+    }))
+  }, [data])
+
+  return {
+    templates,
+    hasTemplates: templates.length > 0,
+    isLoading,
+  }
+}

--- a/frontend/src/features/fable-builder/components/FableBuilderPage.tsx
+++ b/frontend/src/features/fable-builder/components/FableBuilderPage.tsx
@@ -20,11 +20,11 @@ import { ThreeColumnLayout } from './layout/ThreeColumnLayout'
 import { FableGraphCanvas } from './graph-mode/FableGraphCanvas'
 import { FableFormCanvas } from './form-mode/FableFormCanvas'
 import { ReviewStep as ReviewStepComponent } from './review/ReviewStep'
+import { TemplateParamsDialog } from './TemplateParamsDialog'
 import type { TFunction } from 'i18next'
 import type { PresetId } from '@/features/fable-builder/presets/presets'
 import type { BlockFactoryCatalogue } from '@/api/types/fable.types'
 import { SubmitRunDialog } from '@/features/executions/components/SubmitRunDialog'
-import { TemplateParamsDialog } from './TemplateParamsDialog'
 import { deriveTemplateParameters } from '@/features/fable-builder/utils/template-parameters'
 import { useAllGlyphs } from '@/features/fable-builder/hooks/useAllGlyphs'
 import { useURLStateSync } from '@/features/fable-builder/hooks/useURLStateSync'
@@ -307,7 +307,7 @@ export function FableBuilderPage({
     for (const [blockId, values] of Object.entries(
       templateExamples.example_values,
     )) {
-      if (blocks[blockId]) updateBlockConfigBatch(blockId, values)
+      if (blockId in blocks) updateBlockConfigBatch(blockId, values)
     }
   }
 
@@ -347,7 +347,7 @@ export function FableBuilderPage({
     for (const [blockId, values] of Object.entries(
       templateExamples?.example_values ?? {},
     )) {
-      if (blocks[blockId]) updateBlockConfigBatch(blockId, values)
+      if (blockId in blocks) updateBlockConfigBatch(blockId, values)
     }
     for (const [key, value] of Object.entries(
       templateExamples?.example_glyphs ?? {},

--- a/frontend/src/features/fable-builder/components/FableBuilderPage.tsx
+++ b/frontend/src/features/fable-builder/components/FableBuilderPage.tsx
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-import React, { useEffect, useMemo, useRef } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 import { AlertCircle, Package } from 'lucide-react'
@@ -24,6 +24,9 @@ import type { TFunction } from 'i18next'
 import type { PresetId } from '@/features/fable-builder/presets/presets'
 import type { BlockFactoryCatalogue } from '@/api/types/fable.types'
 import { SubmitRunDialog } from '@/features/executions/components/SubmitRunDialog'
+import { TemplateParamsDialog } from './TemplateParamsDialog'
+import { deriveTemplateParameters } from '@/features/fable-builder/utils/template-parameters'
+import { useAllGlyphs } from '@/features/fable-builder/hooks/useAllGlyphs'
 import { useURLStateSync } from '@/features/fable-builder/hooks/useURLStateSync'
 import {
   clearDraft,
@@ -133,6 +136,8 @@ export function FableBuilderPage({
   const setIsValidating = useFableBuilderStore((state) => state.setIsValidating)
 
   const initializedRef = useRef(false)
+  const [templateInitialized, setTemplateInitialized] = useState(false)
+  const [templateParamsDone, setTemplateParamsDone] = useState(false)
 
   // Auto-persist drafts to localStorage + beforeunload guard
   useDraftPersistence()
@@ -198,6 +203,7 @@ export function FableBuilderPage({
         }),
       })
       initializedRef.current = true
+      setTemplateInitialized(true)
       return
     }
 
@@ -269,45 +275,104 @@ export function FableBuilderPage({
     t,
   ])
 
-  // Template mode: overlay the plugin's example values/glyphs once the
-  // builder is initialized — mirrors the backend's ingest-validation overlay.
-  const { data: templateExamples, error: templateExamplesError } =
-    useTemplateExampleValues(
-      templateMode ? templatePlugin : undefined,
-      templateMode ? templateName : undefined,
-    )
-  const templateExamplesApplied = useRef(false)
+  // Template mode: collect parameters via a dialog once builder + examples
+  // are ready, then overlay values (mirrors the backend's ingest overlay).
+  const examplesQuery = useTemplateExampleValues(
+    templateMode ? templatePlugin : undefined,
+    templateMode ? templateName : undefined,
+  )
+  const templateExamples = examplesQuery.data
+  const { glyphs: knownGlyphs, isLoading: knownGlyphsLoading } = useAllGlyphs()
 
-  useEffect(() => {
-    if (!templateMode || templateExamplesApplied.current) return
-    if (!initializedRef.current || !templateExamples) return
-    templateExamplesApplied.current = true
+  // Settled when fetched/errored — or unfetchable (deep link without params)
+  const examplesSettled =
+    !templatePlugin ||
+    !templateName ||
+    examplesQuery.isFetched ||
+    examplesQuery.isError
+
+  // Derive once from the freshly-forked builder, with intrinsics/globals
+  // subtracted so the dialog never asks for e.g. ${runId}.
+  const templateParams = useMemo(() => {
+    if (!templateInitialized || knownGlyphsLoading) return null
+    return deriveTemplateParameters(
+      useFableBuilderStore.getState().fable,
+      new Set(knownGlyphs.map((glyph) => glyph.name)),
+    )
+  }, [templateInitialized, knownGlyphs, knownGlyphsLoading])
+
+  function applyTemplateExampleValues() {
+    if (!templateExamples) return
     const { blocks } = useFableBuilderStore.getState().fable
     for (const [blockId, values] of Object.entries(
       templateExamples.example_values,
     )) {
       if (blocks[blockId]) updateBlockConfigBatch(blockId, values)
     }
+  }
+
+  function handleTemplateApply(values: Record<string, string>) {
+    applyTemplateExampleValues()
+    for (const [key, value] of Object.entries(values)) {
+      if (value !== '') setLocalGlyph(key, value)
+    }
+    setTemplateParamsDone(true)
+    showToast.success(t('template.applied'))
+  }
+
+  function handleTemplateSkip() {
+    applyTemplateExampleValues()
     for (const [key, value] of Object.entries(
-      templateExamples.example_glyphs,
+      templateExamples?.example_glyphs ?? {},
     )) {
       setLocalGlyph(key, value)
     }
-    showToast.info(t('configure:template.prefilled'))
+    setTemplateParamsDone(true)
+    showToast.info(t('template.prefilled'))
+  }
+
+  const templateHasParams =
+    templateParams !== null &&
+    (templateParams.required.length > 0 ||
+      Object.keys(templateParams.prefilled).length > 0)
+
+  const templateDialogOpen =
+    templateMode && templateHasParams && examplesSettled && !templateParamsDone
+
+  // Nothing user-facing to ask — apply any examples silently and continue
+  useEffect(() => {
+    if (!templateMode || templateParamsDone) return
+    if (templateParams === null || !examplesSettled || templateHasParams) return
+    const { blocks } = useFableBuilderStore.getState().fable
+    for (const [blockId, values] of Object.entries(
+      templateExamples?.example_values ?? {},
+    )) {
+      if (blocks[blockId]) updateBlockConfigBatch(blockId, values)
+    }
+    for (const [key, value] of Object.entries(
+      templateExamples?.example_glyphs ?? {},
+    )) {
+      setLocalGlyph(key, value)
+    }
+    setTemplateParamsDone(true)
+    if (templateExamples) showToast.info(t('template.prefilled'))
   }, [
     templateMode,
+    templateParamsDone,
+    templateParams,
+    examplesSettled,
+    templateHasParams,
     templateExamples,
-    existingFable,
     updateBlockConfigBatch,
     setLocalGlyph,
     t,
   ])
 
   useEffect(() => {
-    if (templateMode && templateExamplesError) {
-      showToast.warning(t('configure:template.examplesUnavailable'))
+    if (templateMode && examplesQuery.isError) {
+      showToast.warning(t('template.examplesUnavailable'))
     }
-  }, [templateMode, templateExamplesError, t])
+  }, [templateMode, examplesQuery.isError, t])
 
   // Sync React Query validation state → Zustand store for sibling components
   useEffect(() => {
@@ -406,6 +471,17 @@ export function FableBuilderPage({
         fableId={storeFableId}
         initialMode={submitDialogMode}
       />
+
+      {templateMode && templateParams && (
+        <TemplateParamsDialog
+          open={templateDialogOpen}
+          params={templateParams}
+          baseFable={fable}
+          examples={templateExamples}
+          onApply={handleTemplateApply}
+          onSkip={handleTemplateSkip}
+        />
+      )}
     </GlyphProvider>
   )
 }

--- a/frontend/src/features/fable-builder/components/FableBuilderPage.tsx
+++ b/frontend/src/features/fable-builder/components/FableBuilderPage.tsx
@@ -44,6 +44,7 @@ import {
   useFableRetrieve,
   useFableValidation,
 } from '@/api/hooks/useFable'
+import { useTemplateExampleValues } from '@/api/hooks/usePlugins'
 import { H2, P } from '@/components/base/typography'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
@@ -89,18 +90,31 @@ interface FableBuilderPageProps {
   fableId?: string
   preset?: PresetId
   encodedState?: string
+  /** Open fableId as a template: fork (create-on-save) and prefill example values */
+  templateMode?: boolean
+  /** Owning plugin ("store:local") for the example-values lookup */
+  templatePlugin?: string
+  /** Template display name for the example-values lookup */
+  templateName?: string
 }
 
 export function FableBuilderPage({
   fableId,
   preset,
   encodedState,
+  templateMode = false,
+  templatePlugin,
+  templateName,
 }: FableBuilderPageProps) {
   const { t } = useTranslation(['configure', 'common'])
   const fable = useFableBuilderStore((state) => state.fable)
   const setFable = useFableBuilderStore((state) => state.setFable)
   const newFable = useFableBuilderStore((state) => state.newFable)
   const setFableName = useFableBuilderStore((state) => state.setFableName)
+  const updateBlockConfigBatch = useFableBuilderStore(
+    (state) => state.updateBlockConfigBatch,
+  )
+  const setLocalGlyph = useFableBuilderStore((state) => state.setLocalGlyph)
   const mode = useFableBuilderStore((state) => state.mode)
   const step = useFableBuilderStore((state) => state.step)
   const storeFableId = useFableBuilderStore((state) => state.fableId)
@@ -172,6 +186,21 @@ export function FableBuilderPage({
   useEffect(() => {
     if (initializedRef.current) return
 
+    // Template mode: fork — load the template's builder without adopting its
+    // identity, so saving creates a new blueprint (parent_id = the template).
+    if (templateMode && fableId) {
+      if (!existingFable) return
+      setFable(existingFable, null)
+      useFableBuilderStore.setState({
+        forkParentId: fableId,
+        ...(fableRetrieveData?.display_name && {
+          fableName: fableRetrieveData.display_name,
+        }),
+      })
+      initializedRef.current = true
+      return
+    }
+
     // Check for a recoverable draft before normal initialization
     const draft = readDraft()
     if (draft) {
@@ -230,7 +259,55 @@ export function FableBuilderPage({
       // URL state sync will handle this case
       initializedRef.current = true
     }
-  }, [fableId, existingFable, fableRetrieveData, preset, encodedState, t])
+  }, [
+    fableId,
+    existingFable,
+    fableRetrieveData,
+    preset,
+    encodedState,
+    templateMode,
+    t,
+  ])
+
+  // Template mode: overlay the plugin's example values/glyphs once the
+  // builder is initialized — mirrors the backend's ingest-validation overlay.
+  const { data: templateExamples, error: templateExamplesError } =
+    useTemplateExampleValues(
+      templateMode ? templatePlugin : undefined,
+      templateMode ? templateName : undefined,
+    )
+  const templateExamplesApplied = useRef(false)
+
+  useEffect(() => {
+    if (!templateMode || templateExamplesApplied.current) return
+    if (!initializedRef.current || !templateExamples) return
+    templateExamplesApplied.current = true
+    const { blocks } = useFableBuilderStore.getState().fable
+    for (const [blockId, values] of Object.entries(
+      templateExamples.example_values,
+    )) {
+      if (blocks[blockId]) updateBlockConfigBatch(blockId, values)
+    }
+    for (const [key, value] of Object.entries(
+      templateExamples.example_glyphs,
+    )) {
+      setLocalGlyph(key, value)
+    }
+    showToast.info(t('configure:template.prefilled'))
+  }, [
+    templateMode,
+    templateExamples,
+    existingFable,
+    updateBlockConfigBatch,
+    setLocalGlyph,
+    t,
+  ])
+
+  useEffect(() => {
+    if (templateMode && templateExamplesError) {
+      showToast.warning(t('configure:template.examplesUnavailable'))
+    }
+  }, [templateMode, templateExamplesError, t])
 
   // Sync React Query validation state → Zustand store for sibling components
   useEffect(() => {
@@ -292,7 +369,10 @@ export function FableBuilderPage({
         className="flex min-w-0 flex-col"
         style={{ height: 'calc(100vh - 7rem)' }}
       >
-        <FableBuilderHeader fableId={fableId} catalogue={catalogue} />
+        <FableBuilderHeader
+          fableId={templateMode ? undefined : fableId}
+          catalogue={catalogue}
+        />
 
         {/* Wrapper is relative so the validation banner overlays absolutely —
             toggling it must not shift the canvas. */}

--- a/frontend/src/features/fable-builder/components/SaveConfigPopover.tsx
+++ b/frontend/src/features/fable-builder/components/SaveConfigPopover.tsx
@@ -115,6 +115,8 @@ export function SaveConfigPopover({
   const fable = useFableBuilderStore((s) => s.fable)
   const storeFableId = useFableBuilderStore((s) => s.fableId)
   const storeFableVersion = useFableBuilderStore((s) => s.fableVersion)
+  const forkParentId = useFableBuilderStore((s) => s.forkParentId)
+  const storeFableName = useFableBuilderStore((s) => s.fableName)
   const markSaved = useFableBuilderStore((s) => s.markSaved)
 
   const upsertFable = useUpsertFable()
@@ -140,6 +142,7 @@ export function SaveConfigPopover({
     if (nextOpen) {
       setTitle(
         fableData?.display_name ||
+          storeFableName ||
           t('configure:save.defaultTitle', generateDefaultTitleParts()),
       )
       setComments(fableData?.display_description || '')
@@ -160,13 +163,17 @@ export function SaveConfigPopover({
         t('configure:save.defaultTitle', generateDefaultTitleParts())
       const result = await upsertFable.mutateAsync({
         fable,
-        // Update: pass ID + version for in-place update
-        // Save as New: pass ID as parentId for lineage tracking
+        // Update: ID + version + stored parent_id (backend replaces the row).
+        // Save as New / template fork: the origin becomes parentId.
         fableId: isExistingUpdate ? effectiveFableId : undefined,
         fableVersion: isExistingUpdate
           ? (storeFableVersion ?? fableData?.version)
           : undefined,
-        parentId: asCopy ? (effectiveFableId ?? undefined) : undefined,
+        parentId: isExistingUpdate
+          ? (fableData?.parent_id ?? undefined)
+          : asCopy
+            ? (effectiveFableId ?? undefined)
+            : (forkParentId ?? undefined),
         display_name: displayTitle,
         display_description: comments.trim(),
         tags,

--- a/frontend/src/features/fable-builder/components/TemplateParamsDialog.tsx
+++ b/frontend/src/features/fable-builder/components/TemplateParamsDialog.tsx
@@ -25,10 +25,7 @@ import {
   TriangleAlert,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import type {
-  ParameterUsage,
-  TemplateParameters,
-} from '@/features/fable-builder/utils/template-parameters'
+import type { TemplateParameters } from '@/features/fable-builder/utils/template-parameters'
 import type { FableBuilderV1 } from '@/api/types/fable.types'
 import type { TemplateExampleValues } from '@/api/types/plugins.types'
 import { useFableValidation } from '@/api/hooks/useFable'
@@ -135,12 +132,14 @@ export function TemplateParamsDialog({
 
   /** Backend-resolved value at the parameter's first usage site */
   function resolvedPreview(name: string): string | null {
-    const site: ParameterUsage | undefined = params.usage[name]?.[0]
-    if (!site || !expansion) return null
-    return (
-      expansion.resolved_configuration_options[site.blockId]?.[site.optionId] ??
-      null
-    )
+    // `in` guards, not `?.`: index access is typed non-nullable here
+    // (noUncheckedIndexedAccess off), so `?.`/`??` would read as unnecessary.
+    if (!expansion || !(name in params.usage)) return null
+    const site = params.usage[name][0]
+    const resolved = expansion.resolved_configuration_options
+    if (!(site.blockId in resolved)) return null
+    const options = resolved[site.blockId]
+    return site.optionId in options ? options[site.optionId] : null
   }
 
   /** True when the backend still reports this glyph as missing */

--- a/frontend/src/features/fable-builder/components/TemplateParamsDialog.tsx
+++ b/frontend/src/features/fable-builder/components/TemplateParamsDialog.tsx
@@ -1,0 +1,257 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * TemplateParamsDialog Component
+ *
+ * Collects a template's parameters when forking: required glyphs (seeded
+ * from plugin examples) plus the template's own defaults, collapsed.
+ * Values validate live against /blueprint/expand on a candidate builder;
+ * plain text inputs until the backend ships per-parameter metadata.
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import {
+  CheckCircle2,
+  ChevronRight,
+  Loader2,
+  TriangleAlert,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import type {
+  ParameterUsage,
+  TemplateParameters,
+} from '@/features/fable-builder/utils/template-parameters'
+import type { FableBuilderV1 } from '@/api/types/fable.types'
+import type { TemplateExampleValues } from '@/api/types/plugins.types'
+import { useFableValidation } from '@/api/hooks/useFable'
+import { hasUnterminatedGlyph } from '@/features/fable-builder/utils/glyph-display'
+import { Button } from '@/components/ui/button'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { useDebounce } from '@/hooks/useDebounce'
+import { cn } from '@/lib/utils'
+
+interface TemplateParamsDialogProps {
+  open: boolean
+  params: TemplateParameters
+  /** The forked template builder the values are validated against */
+  baseFable: FableBuilderV1
+  /** The plugin's example data: glyph suggestions + block config overlays */
+  examples: TemplateExampleValues | undefined
+  /** Apply the collected glyph values and continue into the builder */
+  onApply: (values: Record<string, string>) => void
+  /** Continue with the plugin's examples applied silently */
+  onSkip: () => void
+}
+
+export function TemplateParamsDialog({
+  open,
+  params,
+  baseFable,
+  examples,
+  onApply,
+  onSkip,
+}: TemplateParamsDialogProps) {
+  const { t } = useTranslation('configure')
+  const [values, setValues] = useState<Record<string, string>>({})
+  const [showPrefilled, setShowPrefilled] = useState(false)
+
+  // Re-seed the form whenever the dialog opens for a template
+  useEffect(() => {
+    if (!open) return
+    const seeded: Record<string, string> = {}
+    for (const name of params.required) {
+      seeded[name] = examples?.example_glyphs[name] ?? ''
+    }
+    for (const [name, value] of Object.entries(params.prefilled)) {
+      seeded[name] = value
+    }
+    setValues(seeded)
+    setShowPrefilled(false)
+  }, [open, params, examples])
+
+  // Candidate builder: fork + example block values + the dialog's glyphs —
+  // the same overlay Apply performs, validated before the user commits.
+  const debouncedValues = useDebounce(values, 300)
+  const candidateFable = useMemo<FableBuilderV1>(() => {
+    const blocks = Object.fromEntries(
+      Object.entries(baseFable.blocks).map(([blockId, block]) => [
+        blockId,
+        examples?.example_values[blockId]
+          ? {
+              ...block,
+              configuration_values: {
+                ...block.configuration_values,
+                ...examples.example_values[blockId],
+              },
+            }
+          : block,
+      ]),
+    )
+    const glyphs = Object.fromEntries(
+      Object.entries(debouncedValues).filter(([, value]) => value !== ''),
+    )
+    return {
+      ...baseFable,
+      blocks,
+      local_glyphs: { ...baseFable.local_glyphs, ...glyphs },
+    }
+  }, [baseFable, examples, debouncedValues])
+
+  const valuesTyping = Object.values(values).some(hasUnterminatedGlyph)
+  const { data: expansion, isFetching: isValidating } = useFableValidation(
+    candidateFable,
+    open && !valuesTyping,
+  )
+
+  const errorCount = expansion
+    ? expansion.global_errors.length +
+      Object.values(expansion.block_errors).reduce(
+        (total, errors) => total + errors.length,
+        0,
+      )
+    : 0
+
+  /** Backend-resolved value at the parameter's first usage site */
+  function resolvedPreview(name: string): string | null {
+    const site: ParameterUsage | undefined = params.usage[name]?.[0]
+    if (!site || !expansion) return null
+    return (
+      expansion.resolved_configuration_options[site.blockId]?.[site.optionId] ??
+      null
+    )
+  }
+
+  /** True when the backend still reports this glyph as missing */
+  function isMissing(name: string): boolean {
+    if (!expansion) return false
+    return Object.values(expansion.missing_glyphs).some((options) =>
+      Object.values(options).some((names) => names.includes(name)),
+    )
+  }
+
+  const setValue = (name: string, value: string) =>
+    setValues((current) => ({ ...current, [name]: value }))
+
+  const renderField = (name: string) => {
+    const preview = resolvedPreview(name)
+    const missing = isMissing(name)
+    return (
+      <div key={name} className="flex flex-col gap-1.5">
+        <Label htmlFor={`template-param-${name}`} className="font-mono text-xs">
+          {name}
+        </Label>
+        <Input
+          id={`template-param-${name}`}
+          value={values[name] ?? ''}
+          onChange={(e) => setValue(name, e.target.value)}
+          aria-invalid={missing || undefined}
+          className={cn(missing && 'border-amber-400')}
+        />
+        {missing ? (
+          <p className="text-xs text-amber-600 dark:text-amber-400">
+            {t('template.dialog.missingValue')}
+          </p>
+        ) : (
+          preview !== null && (
+            <p className="truncate text-xs text-muted-foreground">
+              → {preview}
+            </p>
+          )
+        )}
+      </div>
+    )
+  }
+
+  const prefilledNames = Object.keys(params.prefilled)
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onSkip()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t('template.dialog.title')}</DialogTitle>
+          <DialogDescription>
+            {t('template.dialog.description')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          {params.required.length > 0 && (
+            <div className="flex flex-col gap-3">
+              {params.required.map(renderField)}
+            </div>
+          )}
+
+          {prefilledNames.length > 0 && (
+            <Collapsible open={showPrefilled} onOpenChange={setShowPrefilled}>
+              <CollapsibleTrigger className="flex items-center gap-1 text-sm font-medium text-muted-foreground hover:text-foreground">
+                <ChevronRight
+                  className={cn(
+                    'h-4 w-4 transition-transform',
+                    showPrefilled && 'rotate-90',
+                  )}
+                />
+                {t('template.dialog.prefilled', {
+                  count: prefilledNames.length,
+                })}
+              </CollapsibleTrigger>
+              <CollapsibleContent className="mt-3 flex flex-col gap-3">
+                {prefilledNames.map(renderField)}
+              </CollapsibleContent>
+            </Collapsible>
+          )}
+
+          {/* Live validation status of the candidate configuration */}
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            {isValidating ? (
+              <>
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                {t('template.dialog.validating')}
+              </>
+            ) : expansion && errorCount === 0 ? (
+              <>
+                <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />
+                {t('template.dialog.valid')}
+              </>
+            ) : expansion ? (
+              <>
+                <TriangleAlert className="h-3.5 w-3.5 text-amber-500" />
+                {t('template.dialog.issues', { count: errorCount })}
+              </>
+            ) : null}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onSkip}>
+            {t('template.dialog.skip')}
+          </Button>
+          <Button onClick={() => onApply(values)}>
+            {t('template.dialog.apply')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/features/fable-builder/stores/fableBuilderStore.ts
+++ b/frontend/src/features/fable-builder/stores/fableBuilderStore.ts
@@ -102,6 +102,9 @@ interface FableBuilderState {
   fable: FableBuilderV1
   fableId: string | null
   fableVersion: number | null
+  /** Blueprint this session was forked from (e.g. a plugin template) —
+   *  passed as parent_id when saving creates a new blueprint. */
+  forkParentId: string | null
   fableName: string
   mode: BuilderMode
   step: BuilderStep
@@ -232,6 +235,7 @@ function createInitialState() {
     fable: createEmptyFable(),
     fableId: null,
     fableVersion: null,
+    forkParentId: null as string | null,
     // Blank by default; FableBuilderHeader renders a translated placeholder.
     fableName: '',
     mode: 'graph' as BuilderMode,
@@ -345,6 +349,7 @@ export const useFableBuilderStore = create<FableBuilderState>()(
               fable,
               fableId: id,
               fableVersion: null,
+              forkParentId: null,
               isDirty: false,
               selectedBlockId: null,
               validationState: null,
@@ -719,6 +724,8 @@ export const useFableBuilderStore = create<FableBuilderState>()(
             set({
               fableId: id,
               fableVersion: version,
+              // The saved blueprint has its own identity now
+              forkParentId: null,
               isDirty: false,
               lastSavedAt: Date.now(),
               ...(name !== undefined && { fableName: name }),

--- a/frontend/src/features/fable-builder/utils/template-parameters.ts
+++ b/frontend/src/features/fable-builder/utils/template-parameters.ts
@@ -1,0 +1,84 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Template parameter derivation
+ *
+ * A template's user-facing parameters are the glyphs it references but does
+ * not define. Derived client-side until the backend ships per-parameter
+ * metadata (label, type, description).
+ */
+
+import { findGlyphSpans } from './glyph-display'
+import type { FableBuilderV1 } from '@/api/types/fable.types'
+
+/** Leading identifier of each `${...}` expression, e.g. "${dt | add_days(7)}" → "dt".
+ *  Complex expressions may under-detect; builder validation catches the rest. */
+export function referencedGlyphNames(value: string): Array<string> {
+  const names: Array<string> = []
+  for (const span of findGlyphSpans(value)) {
+    const expression = value.slice(span.start + 2, span.end - 1)
+    const match = expression.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)/)
+    if (match) names.push(match[1])
+  }
+  return names
+}
+
+/** A block config option that references a parameter */
+export interface ParameterUsage {
+  blockId: string
+  optionId: string
+}
+
+export interface TemplateParameters {
+  /** Referenced but defined nowhere — the user must provide these */
+  required: Array<string>
+  /** The template's own glyph defaults, overridable */
+  prefilled: Record<string, string>
+  /** Block config sites referencing each parameter (for previews/errors) */
+  usage: Record<string, Array<ParameterUsage>>
+}
+
+/**
+ * Derive the parameter surface of a template builder.
+ * @param knownGlyphs - names resolvable outside the template (intrinsics, globals)
+ */
+export function deriveTemplateParameters(
+  fable: FableBuilderV1,
+  knownGlyphs: ReadonlySet<string>,
+): TemplateParameters {
+  const referenced = new Set<string>()
+  const usage: Record<string, Array<ParameterUsage>> = {}
+  for (const [blockId, block] of Object.entries(fable.blocks)) {
+    for (const [optionId, value] of Object.entries(
+      block.configuration_values,
+    )) {
+      for (const name of referencedGlyphNames(value)) {
+        referenced.add(name)
+        ;(usage[name] ??= []).push({ blockId, optionId })
+      }
+    }
+  }
+  // Environment variables may reference glyphs too (no preview site)
+  for (const value of Object.values(
+    fable.environment?.environment_variables ?? {},
+  )) {
+    for (const name of referencedGlyphNames(value)) referenced.add(name)
+  }
+  const prefilled = fable.local_glyphs ?? {}
+  // Glyph values may reference further glyphs
+  for (const value of Object.values(prefilled)) {
+    for (const name of referencedGlyphNames(value)) referenced.add(name)
+  }
+  const required = [...referenced]
+    .filter((name) => !(name in prefilled) && !knownGlyphs.has(name))
+    .sort()
+  return { required, prefilled, usage }
+}

--- a/frontend/src/features/journal/components/RunMetadataDialog.tsx
+++ b/frontend/src/features/journal/components/RunMetadataDialog.tsx
@@ -70,6 +70,8 @@ export function RunMetadataDialog({
         fable: blueprint.builder,
         fableId: blueprint.blueprint_id,
         fableVersion: blueprint.version,
+        // Re-send lineage — the backend update replaces the metadata row
+        parentId: blueprint.parent_id ?? undefined,
         display_name: name.trim() || (blueprint.display_name ?? ''),
         display_description: description.trim(),
         // Keep the one-off marker — editing details must not promote a run

--- a/frontend/src/locales/en/configure.json
+++ b/frontend/src/locales/en/configure.json
@@ -291,6 +291,19 @@
   },
   "template": {
     "prefilled": "Example values applied — adjust and save as your own preset",
-    "examplesUnavailable": "Template examples couldn't be loaded — starting without prefilled values"
+    "examplesUnavailable": "Template examples couldn't be loaded — starting without prefilled values",
+    "applied": "Template parameters applied",
+    "dialog": {
+      "title": "Template parameters",
+      "description": "Provide values for this template's placeholders — everything can still be changed in the builder.",
+      "prefilled": "Prefilled by the template ({{count}})",
+      "apply": "Apply",
+      "skip": "Skip",
+      "missingValue": "Needs a value",
+      "validating": "Validating…",
+      "valid": "Configuration validates",
+      "issues": "{{count}} validation issue",
+      "issues_other": "{{count}} validation issues"
+    }
   }
 }

--- a/frontend/src/locales/en/configure.json
+++ b/frontend/src/locales/en/configure.json
@@ -288,5 +288,9 @@
       "label": "Output",
       "description": "Store or visualize results"
     }
+  },
+  "template": {
+    "prefilled": "Example values applied — adjust and save as your own preset",
+    "examplesUnavailable": "Template examples couldn't be loaded — starting without prefilled values"
   }
 }

--- a/frontend/src/locales/en/dashboard.json
+++ b/frontend/src/locales/en/dashboard.json
@@ -132,7 +132,8 @@
     "searchPlaceholder": "Search presets...",
     "filters": {
       "all": "All",
-      "bookmarked": "Bookmarked"
+      "bookmarked": "Bookmarked",
+      "templates": "Templates"
     },
     "page": {
       "title": "Configuration Presets",
@@ -147,7 +148,18 @@
       "previous": "Previous",
       "next": "Next",
       "page": "Page {{current}} of {{total}}"
-    }
+    },
+    "templates": {
+      "chip": "Template",
+      "fromPlugin": "From plugin: {{plugin}}",
+      "use": "Use template",
+      "empty": {
+        "title": "No templates available",
+        "description": "Installed plugins can ship blueprint templates as ready-made starting points."
+      }
+    },
+    "basedOn": "Based on: {{name}}",
+    "deleted": "Preset deleted"
   },
   "notification": {
     "newModels": "New models and model versions have been published in the",

--- a/frontend/src/routes/_authenticated/configure.tsx
+++ b/frontend/src/routes/_authenticated/configure.tsx
@@ -26,6 +26,12 @@ const searchSchema = z.object({
     .optional(),
   state: z.string().optional(),
   fableId: z.string().optional(),
+  /** Open fableId as a template: fork (create-on-save) and prefill example values */
+  template: z.boolean().optional(),
+  /** Owning plugin ("store:local") for the example-values lookup */
+  templatePlugin: z.string().optional(),
+  /** Template display name for the example-values lookup */
+  templateName: z.string().optional(),
 })
 
 export type ConfigureSearch = z.infer<typeof searchSchema>
@@ -36,13 +42,17 @@ export const Route = createFileRoute('/_authenticated/configure')({
 })
 
 function ConfigurePage() {
-  const { preset, state, fableId } = Route.useSearch()
+  const { preset, state, fableId, template, templatePlugin, templateName } =
+    Route.useSearch()
   return (
     <FableBuilderPage
       key={fableId}
       fableId={fableId}
       preset={preset}
       encodedState={state}
+      templateMode={template}
+      templatePlugin={templatePlugin}
+      templateName={templateName}
     />
   )
 }

--- a/frontend/tests/integration/features/dashboard/config-presets.test.tsx
+++ b/frontend/tests/integration/features/dashboard/config-presets.test.tsx
@@ -25,6 +25,7 @@ import { worker } from '@tests/test-extend'
 import { ConfigPresetsSection } from '@/features/dashboard/components/ConfigPresetsSection'
 import { PresetsPage } from '@/features/dashboard/components/PresetsPage'
 import { API_ENDPOINTS } from '@/api/endpoints'
+import { ToastProvider } from '@/providers/ToastProvider'
 import { ONEOFF_TAG } from '@/lib/system-tags'
 
 // Mock useMedia to simulate desktop layout
@@ -95,6 +96,34 @@ function useBlueprintListHandler(
 
 function useEmptyBlueprintListHandler() {
   useBlueprintListHandler([])
+}
+
+const mockTemplates: Array<WireBlueprint> = [
+  {
+    blueprint_id: 'tpl-001',
+    version: 1,
+    display_name: 'Fast Map',
+    display_description: 'Ready-made starting point',
+    tags: null,
+    source: 'plugin_template',
+    created_by: 'local:plugin-test',
+  },
+]
+
+/** List handler that honours the ?source= filter, like the real backend. */
+function useSourceAwareListHandler(all: Array<WireBlueprint>) {
+  worker.use(
+    http.get(API_ENDPOINTS.fable.list, ({ request }) => {
+      const source = new URL(request.url).searchParams.get('source')
+      const blueprints = source ? all.filter((b) => b.source === source) : all
+      return HttpResponse.json({
+        blueprints,
+        total: blueprints.length,
+        page: 1,
+        page_size: 50,
+      })
+    }),
+  )
 }
 
 describe('ConfigPresetsSection', () => {
@@ -263,5 +292,144 @@ describe('PresetsPage', () => {
 
     const loadButtons = screen.getByText('Use this Preset')
     await expect.element(loadButtons.first()).toBeVisible()
+  })
+})
+
+describe('PresetsPage — Templates tab', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('lists plugin templates with chip, plugin label and a Use template action', async () => {
+    useSourceAwareListHandler([...mockBlueprints, ...mockTemplates])
+
+    const screen = await renderWithRouter(<PresetsPage />)
+
+    await screen.getByRole('button', { name: 'Templates' }).click()
+
+    await expect.element(screen.getByText('Fast Map')).toBeVisible()
+    await expect
+      .element(screen.getByText('Template', { exact: true }))
+      .toBeVisible()
+    await expect
+      .element(screen.getByText('From plugin: plugin-test'))
+      .toBeVisible()
+    await expect.element(screen.getByText('Use template')).toBeVisible()
+    // User presets don't render on the Templates tab
+    await expect
+      .element(screen.getByText('European Forecast'))
+      .not.toBeInTheDocument()
+  })
+
+  it('does not leak templates into the All tab', async () => {
+    useSourceAwareListHandler([...mockBlueprints, ...mockTemplates])
+
+    const screen = await renderWithRouter(<PresetsPage />)
+
+    await expect.element(screen.getByText('European Forecast')).toBeVisible()
+    await expect.element(screen.getByText('Fast Map')).not.toBeInTheDocument()
+  })
+})
+
+describe('PresetsPage — template lineage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('shows a "Based on" hint for presets forked from a template', async () => {
+    useSourceAwareListHandler(mockBlueprints.slice(0, 1))
+    worker.use(
+      http.get(API_ENDPOINTS.fable.get, ({ request }) => {
+        const id = new URL(request.url).searchParams.get('blueprint_id')
+        if (id === 'bp-001') {
+          return HttpResponse.json({
+            blueprint_id: 'bp-001',
+            version: 1,
+            builder: { blocks: {} },
+            display_name: 'European Forecast',
+            display_description: null,
+            tags: [],
+            parent_id: 'tpl-001',
+          })
+        }
+        if (id === 'tpl-001') {
+          return HttpResponse.json({
+            blueprint_id: 'tpl-001',
+            version: 1,
+            builder: { blocks: {} },
+            display_name: 'Fast Map',
+            display_description: null,
+            tags: [],
+            parent_id: null,
+          })
+        }
+        return HttpResponse.json({ message: 'not found' }, { status: 404 })
+      }),
+    )
+
+    const screen = await renderWithRouter(<PresetsPage />)
+
+    await expect.element(screen.getByText('European Forecast')).toBeVisible()
+    await expect.element(screen.getByText(/Based on: Fast Map/)).toBeVisible()
+  })
+})
+
+describe('PresetsPage — delete preset', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('shows a success toast and no refresh error after deleting', async () => {
+    let list = mockBlueprints.slice(0, 1)
+    worker.use(
+      http.get(API_ENDPOINTS.fable.list, () =>
+        HttpResponse.json({
+          blueprints: list,
+          total: list.length,
+          page: 1,
+          page_size: 50,
+        }),
+      ),
+      http.get(API_ENDPOINTS.fable.get, ({ request }) => {
+        const id = new URL(request.url).searchParams.get('blueprint_id')
+        if (id === 'bp-001' && list.length > 0) {
+          return HttpResponse.json({
+            blueprint_id: 'bp-001',
+            version: 1,
+            builder: { blocks: {} },
+            display_name: 'European Forecast',
+            display_description: null,
+            tags: [],
+            parent_id: null,
+          })
+        }
+        return HttpResponse.json(
+          { detail: `Blueprint '${id}' not found` },
+          { status: 404 },
+        )
+      }),
+      http.post(API_ENDPOINTS.fable.delete, () => {
+        list = []
+        return HttpResponse.json({ success: true })
+      }),
+    )
+
+    const screen = await renderWithRouter(
+      <ToastProvider>
+        <PresetsPage />
+      </ToastProvider>,
+    )
+    await expect.element(screen.getByText('European Forecast')).toBeVisible()
+
+    await screen.getByRole('button', { name: 'More options' }).click()
+    await screen.getByText('Delete').click()
+
+    await expect.element(screen.getByText('Preset deleted')).toBeVisible()
+    await expect
+      .element(screen.getByText('European Forecast'))
+      .not.toBeInTheDocument()
+    await expect
+      .element(screen.getByText(/Failed to refresh data/))
+      .not.toBeInTheDocument()
   })
 })

--- a/frontend/tests/unit/api/endpoints/fable.test.ts
+++ b/frontend/tests/unit/api/endpoints/fable.test.ts
@@ -16,6 +16,7 @@ import {
   expandFable,
   getCatalogue,
   retrieveFable,
+  updateBlueprint,
   upsertFable,
 } from '@/api/endpoints/fable'
 import { API_ENDPOINTS } from '@/api/endpoints'
@@ -324,5 +325,33 @@ describe('upsertFable', () => {
       parent_id: 'existing-id',
     })
     expect(capturedBody).toMatchObject({ parent_id: 'existing-id' })
+  })
+})
+
+describe('updateBlueprint', () => {
+  afterEach(() => {
+    worker.resetHandlers()
+  })
+
+  it('re-sends parent_id so the version bump keeps its lineage', async () => {
+    let capturedBody: unknown = null
+
+    worker.use(
+      http.post(API_ENDPOINTS.fable.update, async ({ request }) => {
+        capturedBody = await request.json()
+        return HttpResponse.json({ blueprint_id: 'bp-1', version: 3 })
+      }),
+    )
+
+    await updateBlueprint({
+      blueprint_id: 'bp-1',
+      version: 2,
+      builder: mockFable,
+      display_name: 'Renamed',
+      display_description: '',
+      tags: [],
+      parent_id: 'tpl-001',
+    })
+    expect(capturedBody).toMatchObject({ parent_id: 'tpl-001' })
   })
 })

--- a/frontend/tests/unit/api/endpoints/plugins.test.ts
+++ b/frontend/tests/unit/api/endpoints/plugins.test.ts
@@ -294,3 +294,41 @@ describe('updatePlugin', () => {
     // If we get here without error, the test passes
   })
 })
+
+describe('getTemplateExampleValues', () => {
+  afterEach(() => {
+    worker.resetHandlers()
+  })
+
+  it('fetches example values with store/local/displayName query params', async () => {
+    const { getTemplateExampleValues } = await import('@/api/endpoints/plugins')
+    let receivedParams: Record<string, string | null> = {}
+
+    worker.use(
+      http.get(API_ENDPOINTS.plugin.templateExampleValues, ({ request }) => {
+        const url = new URL(request.url)
+        receivedParams = {
+          store: url.searchParams.get('store'),
+          local: url.searchParams.get('local'),
+          displayName: url.searchParams.get('displayName'),
+        }
+        return HttpResponse.json({
+          example_values: { block_1: { area: '[-10, 40, 10, 60]' } },
+          example_glyphs: { leadtime: '48' },
+        })
+      }),
+    )
+
+    const result = await getTemplateExampleValues(
+      { store: 'local', local: 'plugin-test' },
+      'testBasic',
+    )
+    expect(receivedParams).toEqual({
+      store: 'local',
+      local: 'plugin-test',
+      displayName: 'testBasic',
+    })
+    expect(result.example_values.block_1).toEqual({ area: '[-10, 40, 10, 60]' })
+    expect(result.example_glyphs).toEqual({ leadtime: '48' })
+  })
+})

--- a/frontend/tests/unit/api/types/plugins.types.test.ts
+++ b/frontend/tests/unit/api/types/plugins.types.test.ts
@@ -324,3 +324,21 @@ describe('isUnstampedVersion', () => {
     expect(isUnstampedVersion('unknown')).toBe(false)
   })
 })
+
+describe('parsePluginIdString', () => {
+  it('splits a "store:local" composite string on the first colon', async () => {
+    const { parsePluginIdString } = await import('@/api/types/plugins.types')
+    expect(parsePluginIdString('local:plugin-test')).toEqual({
+      store: 'local',
+      local: 'plugin-test',
+    })
+    expect(parsePluginIdString('ecmwf:some:name')).toEqual({
+      store: 'ecmwf',
+      local: 'some:name',
+    })
+    expect(parsePluginIdString('no-colon')).toEqual({
+      store: 'no-colon',
+      local: '',
+    })
+  })
+})

--- a/frontend/tests/unit/features/dashboard/hooks/useConfigPresets.test.ts
+++ b/frontend/tests/unit/features/dashboard/hooks/useConfigPresets.test.ts
@@ -245,10 +245,11 @@ describe('useConfigPresets', () => {
         result.current.deletePreset('bp-001', 1)
       })
 
-      expect(mockDeleteBlueprint).toHaveBeenCalledWith({
-        blueprint_id: 'bp-001',
-        version: 1,
-      })
+      // mutate(payload, { onSuccess }) — assert the payload, allow the callback.
+      expect(mockDeleteBlueprint).toHaveBeenCalledWith(
+        { blueprint_id: 'bp-001', version: 1 },
+        expect.objectContaining({ onSuccess: expect.any(Function) }),
+      )
     })
 
     it('cleans up favourite flag on delete', () => {

--- a/frontend/tests/unit/features/fable-builder/template-parameters.test.ts
+++ b/frontend/tests/unit/features/fable-builder/template-parameters.test.ts
@@ -1,0 +1,104 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { FableBuilderV1 } from '@/api/types/fable.types'
+import {
+  deriveTemplateParameters,
+  referencedGlyphNames,
+} from '@/features/fable-builder/utils/template-parameters'
+
+describe('referencedGlyphNames', () => {
+  it('extracts identifiers from ${...} expressions', () => {
+    expect(referencedGlyphNames('${greeting} ${name}')).toEqual([
+      'greeting',
+      'name',
+    ])
+  })
+
+  it('takes the leading identifier of filter expressions', () => {
+    expect(referencedGlyphNames('/data/${dt | add_days(7)}/out')).toEqual([
+      'dt',
+    ])
+  })
+
+  it('returns nothing for plain text', () => {
+    expect(referencedGlyphNames('fixed text')).toEqual([])
+  })
+})
+
+describe('deriveTemplateParameters', () => {
+  // Mirrors the plugin-test 'testBasic' template shape
+  const templateFable: FableBuilderV1 = {
+    blocks: {
+      text_fixed: {
+        factory_id: {
+          plugin: { store: 'local', local: 'plugin-test' },
+          factory: 'source_text',
+        },
+        configuration_values: { text: 'fixed text' },
+        input_ids: {},
+      },
+      text_glyphs: {
+        factory_id: {
+          plugin: { store: 'local', local: 'plugin-test' },
+          factory: 'source_text',
+        },
+        configuration_values: { text: '${greeting} ${name} on ${runId}' },
+        input_ids: {},
+      },
+    },
+    local_glyphs: { greeting: 'hello' },
+  }
+
+  it('splits references into required and template-prefilled', () => {
+    const params = deriveTemplateParameters(templateFable, new Set(['runId']))
+    expect(params.required).toEqual(['name'])
+    expect(params.prefilled).toEqual({ greeting: 'hello' })
+  })
+
+  it('does not ask for intrinsics or globals', () => {
+    const params = deriveTemplateParameters(
+      templateFable,
+      new Set(['runId', 'name']),
+    )
+    expect(params.required).toEqual([])
+  })
+
+  it('follows references inside the template glyph values', () => {
+    const fable: FableBuilderV1 = {
+      blocks: {},
+      local_glyphs: { path: '/data/${region}' },
+    }
+    const params = deriveTemplateParameters(fable, new Set())
+    expect(params.required).toEqual(['region'])
+  })
+
+  it('follows references inside environment variables', () => {
+    const fable: FableBuilderV1 = {
+      blocks: {},
+      environment: {
+        hosts: null,
+        workers_per_host: null,
+        environment_variables: { OUTPUT_DIR: '/out/${experiment}' },
+        runtime_artifacts: [],
+      },
+    }
+    const params = deriveTemplateParameters(fable, new Set())
+    expect(params.required).toEqual(['experiment'])
+  })
+
+  it('records block usage sites for previews', () => {
+    const params = deriveTemplateParameters(templateFable, new Set(['runId']))
+    expect(params.usage.name).toEqual([
+      { blockId: 'text_glyphs', optionId: 'text' },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

Adds **blueprint templates** (presets) to the dashboard and builder: a reusable, shareable starting-point config a user can browse, fork into the builder, and fill in — with lineage back to the source template. Includes a **template parameter dialog** that collects a forked template's parameters (the glyphs it references but doesn't define, seeded from the plugin's example values) and validates them live before you land in the builder.

## What's included

- **Templates list & fork** (`PresetsPage`, `PresetCard`, `useConfigPresets`, `useTemplatePresets`) — browse saved configs and plugin-shipped templates, fork one into the builder prefilled, and track lineage (which template a config came from).
- **Template parameter dialog** (`TemplateParamsDialog`, `template-parameters.ts`) — on fork, surfaces required glyphs (seeded from the plugin's `templateExampleValues`) plus the template's own defaults (collapsed); values validate live against `/blueprint/expand` on a candidate builder, with backend-resolved previews at each parameter's first usage site.
- **Builder template mode** (`FableBuilderPage`, `fableBuilderStore`, `SaveConfigPopover`) — wires template forking, prefill/skip flows, and local-glyph seeding into the builder.
- **API + types** — blueprint list/get/create/update/delete alignment (`endpoints/fable.ts`, `useFable`), plugin `templateExampleValues` (`endpoints/plugins.ts`, `usePlugins`, `plugins.types`), plus MSW mocks and unit tests for each.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
