### PR TITLE
[frontend] Fix/fable builder url state 

### DIFF
--- a/.github/skills/frontend-impact/SKILL.md
+++ b/.github/skills/frontend-impact/SKILL.md
@@ -18,6 +18,7 @@ You have full power to run git commands, view files, make direct code edits, run
 2. **Trace Impact on Frontend:**
    - Search the `frontend/` codebase for whether they use affected routes and Request/Response classes, and note all affected files.
    - Note that you need to cover *both* the production code as well as the mock tests which simulate the backend.
+   - When a change touches a *shared* symbol (a zod schema, exported type, or (de)serializer), grep for *every* usage across `frontend/`, not just the route/API callers -- these get reused by non-route consumers (URL-state, `localStorage`/drafts, stores) that break just as silently. A passing type-check won't reveal it.
    - You may notice at this stage that despite the change on the backend is formally breaking, the frontend was actually not using that -- you can then ignore those.
 
 3. **Formulate and Execute Fixes:**

--- a/frontend/src/features/fable-builder/utils/url-state.ts
+++ b/frontend/src/features/fable-builder/utils/url-state.ts
@@ -14,12 +14,14 @@ import {
   encodeStateToURL,
   isStateTooLarge,
 } from '@/lib/url-state'
-import { FableBuilderV1Schema } from '@/api/types/fable.types'
+import { FableBuilderV1Schema, serializeFable } from '@/api/types/fable.types'
 
 export { isStateTooLarge }
 
+// FableBuilderV1Schema parses the list wire-format into a dict, so the URL must
+// hold the wire-format too — serialize on encode to keep decode symmetric.
 export function encodeFableToURL(fable: FableBuilderV1): string {
-  return encodeStateToURL(fable)
+  return encodeStateToURL(serializeFable(fable))
 }
 
 export function decodeFableFromURL(encoded: string): FableBuilderV1 | null {

--- a/frontend/tests/unit/features/fable-builder/utils/url-state.test.ts
+++ b/frontend/tests/unit/features/fable-builder/utils/url-state.test.ts
@@ -1,0 +1,72 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import type { FableBuilderV1 } from '@/api/types/fable.types'
+import {
+  decodeFableFromURL,
+  encodeFableToURL,
+} from '@/features/fable-builder/utils/url-state'
+import { encodeStateToURL } from '@/lib/url-state'
+
+// Silence the expected decode warning on the legacy-format case.
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}))
+
+const fableWithBlocks: FableBuilderV1 = {
+  blocks: {
+    source1: {
+      factory_id: {
+        plugin: { store: 'ecmwf', local: 'core' },
+        factory: 'mars',
+      },
+      configuration_values: { base_time: '2026-05-15T00:00:00' },
+      input_ids: {},
+    },
+    sink1: {
+      factory_id: {
+        plugin: { store: 'ecmwf', local: 'core' },
+        factory: 'plot',
+      },
+      configuration_values: { param: '2t' },
+      input_ids: { data: 'source1' },
+    },
+  },
+  local_glyphs: { region: 'europe' },
+}
+
+describe('fable URL state round-trip', () => {
+  // Guards the schema asymmetry: encode must emit the list form decode expects.
+  it('round-trips a fable with blocks through encode → decode', () => {
+    const decoded = decodeFableFromURL(encodeFableToURL(fableWithBlocks))
+    expect(decoded).toEqual(fableWithBlocks)
+  })
+
+  it('round-trips an empty fable', () => {
+    const empty: FableBuilderV1 = { blocks: {}, local_glyphs: {} }
+    expect(decodeFableFromURL(encodeFableToURL(empty))).toEqual(empty)
+  })
+
+  it('rejects the legacy dict-form payload rather than mis-parsing it', () => {
+    // Pre-#534 URLs encoded blocks as a dict; the schema now expects a list.
+    const legacy = encodeStateToURL({ blocks: fableWithBlocks.blocks })
+    expect(decodeFableFromURL(legacy)).toBeNull()
+  })
+
+  it('returns null for undecodable input', () => {
+    expect(decodeFableFromURL('not-a-valid-encoded-state')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Backend #534 changed `BlueprintBuilder.blocks` from a dict to a list on the wire, making the frontend's `FableBuilderV1Schema` asymmetric (it now parses the list into the internal dict, with `serializeFable()` for the reverse). 

The API send sites, mocks, and endpoint tests were updated, but `fable-builder/utils/url-state.ts` was missed: `encodeFableToURL` still wrote the dict form while `decodeFableFromURL` now expects the list, so every fable URL decoded to `null`, silently breaking builder state persistence (`useURLStateSync`) and the plugin "open in builder" deep-link. `tsc` stayed green and no test exercised the real round-trip, so it shipped unnoticed. 

Fix: encode via `serializeFable()` so the round-trip is symmetric, plus a real encode→decode test that fails if the one-line fix is reverted.

## Skill hardening

The `frontend-impact` skill that drove the #534 adaptation scoped its search to affected routes and Request/Response classes, which is why a schema-reusing consumer slipped through. Added one step in 577579d5f2a9c396250839080c953d5b1268c337: once a shared symbol changes, grep every usage across `frontend/`, not just route/API callers. 


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
