### PR TITLE
fix: reorder drawn bbox to earthkit's [W, E, S, N] in map_plot

### DIFF
--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/runtime/plots.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/runtime/plots.py
@@ -91,6 +91,11 @@ def map_plot(
 
     resolved_domain = None if (isinstance(domain, str) and domain in UnrestrictedGeoDomainAlias.items) else domain
 
+    # bbox: reorder wire [W, S, E, N] to earthkit's [W, E, S, N]
+    if isinstance(resolved_domain, list) and len(resolved_domain) == 4 and all(isinstance(c, int) for c in resolved_domain):
+        west, south, east, north = resolved_domain
+        resolved_domain = [west, east, south, north]
+
     if groupby and groupby != "none":
         unique_values = iter_utils.flatten(arg.metadata(groupby) for arg in fields)
         unique_values = list(dict.fromkeys(unique_values))


### PR DESCRIPTION
The refactor in PR #543 dropped the reorder that parse_geodomain used to do, so a drawn bounding box reached add_map in wire order [W, S, E, N] but earthkit requires [W, E, S, N]  resulting in cropping the wrong region. 

Restore the reorder for the four-int bbox case, named regions and the `auto` are unaffected.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
