### PR TITLE
Refactor plugin routes: merge status_full into /plugin/list detail

### DIFF
--- a/.github/skills/adapt-pr-comments/SKILL.md
+++ b/.github/skills/adapt-pr-comments/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: adapt-pr-comments
+description: Analyzes the changes made in the current branch to the codebase in `backend/`, determines how those changes impact the `frontend/` codebase, and writes minimalistic fixes to resolve compatibility issues.
+description: Fetches unresolved comments from the specified PR and applies the fixes.
+argument-hint: <PR-number>
+---
+
+# Context Discovery
+When the user invokes this skill, they will supply a PR number which you should use when calling github API.
+
+# Adapt PR comments
+The recent changes you did were pushed to the repo, under the pull request #<PR-number>, and reviewed by the user.
+
+1. Fetch all currently unresolved comments from the repository. If you fail to fetch any, report it and wait for next input.
+
+2. **If** you have successfully fetched the comments, think critically about them -- some of the comments may be posed as questions, some may not be informed.
+If even a single comments raises a doubts on your side -- the comment is not clear, the user perhaps didnt realize there is a side-effect, the comment suggest an approach you tried and decided not to pursue, do not make any code changes, but instead describe your thoughts, and wait for next input.
+
+3. **If**, on the other hand, everything will seem clear and spot on, proceed with applying relevant fixes to the codebase.
+Once `just val` passes, make a commit, dont push, describe your changes in brief to the user, then wait for next input.

--- a/.github/skills/adapt-pr-comments/SKILL.md
+++ b/.github/skills/adapt-pr-comments/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: adapt-pr-comments
-description: Analyzes the changes made in the current branch to the codebase in `backend/`, determines how those changes impact the `frontend/` codebase, and writes minimalistic fixes to resolve compatibility issues.
 description: Fetches unresolved comments from the specified PR and applies the fixes.
 argument-hint: <PR-number>
 ---

--- a/.github/skills/frontend-impact/SKILL.md
+++ b/.github/skills/frontend-impact/SKILL.md
@@ -24,7 +24,7 @@ You have full power to run git commands, view files, make direct code edits, run
 3. **Formulate and Execute Fixes:**
    - Ideate the changes. You should be minimalistic! Do not introduce new UI elements, do not change inner workings of the frontend. If possible, coerce via some sort of adapter the new contract into the original one, so that the blast radius is minimized. The goal is not to improve the frontend, it is only to *maintain existing functionality*.
    - Modify the code in the `frontend/` codebase and tests and mocks to accommodate the changes. Make sure you respect the frontend style guide and local conventions.
-   - Do *not* modify the `backend/` codebase! If you believe you have identified a bug in the backend codebase, stop making any further edits, output description of the bug, and wait for user input.
+   - Do *not* modify the `backend/` codebase! If you believe you have identified a bug in the backend codebase, stop making any further edits, output description of the bug, and wait for user input. Similarly, if you believe the frontend cannot be modified without any feature loss or major restructuring or UX change given the current backend state, do not attempt the change, but output a description of the blocker, and wait for user input.
 
 4. **Verification:**
     - Run all the tests and linting as specified in the `frontend/AGENTS.md`. Once all of that passes, commit, don't push.

--- a/backend/src/forecastbox/domain/plugin/detail.py
+++ b/backend/src/forecastbox/domain/plugin/detail.py
@@ -1,0 +1,210 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Plugin listing detail -- response classes and handler for the GET /plugin/list route.
+
+These classes are both frontend-exposed (serialised as JSON in HTTP responses) and
+consumed internally by the service layer.  Changes to field names or structure affect
+the frontend contract; coordinate with frontend consumers before making breaking changes.
+
+The public entry-point is ``build_plugin_listing()``.  It acquires the PluginManager
+lock for the duration of the in-memory snapshot capture *and* the database reads, so
+that both are taken from the same logical point in time.  This is not a fully
+transactional read (the SQLite reads are not inside a DB transaction), but it is
+sufficient for a consistent UI snapshot.  The lock is held only for the duration of
+these fast operations; long-running work must not be done under it.
+"""
+
+import logging
+
+from fiab_core.fable import PluginCompositeId
+from fiab_core.plugin import Plugin
+
+from forecastbox.domain.plugin.db import get_all_plugin_states
+from forecastbox.domain.plugin.errors import PluginError, PluginErrors
+from forecastbox.domain.plugin.exceptions import PluginManagerBusy
+from forecastbox.domain.plugin.manager import PluginManager
+from forecastbox.domain.plugin.store import PluginRemoteInfo, PluginStoreEntry, get_plugins_detail
+from forecastbox.utility.concurrent import timed_acquire
+from forecastbox.utility.pydantic import FiabBaseModel
+from forecastbox.utility.time import value_dt2str
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Response model hierarchy
+# ---------------------------------------------------------------------------
+
+
+class PluginGenericData(FiabBaseModel):
+    store_info: PluginStoreEntry | None = None
+    """Info about the plugin from the respective store. None if the plugin was configured
+    outside of any store (e.g. direct config edit without going through the install flow)."""
+    remote_info: PluginRemoteInfo | None = None
+    """Dynamic remote information such as the most recent published version. None if the
+    plugin is an install from a local path or if no remote data is available."""
+
+
+class PluginInstallSettings(FiabBaseModel):
+    isEnabled: bool
+    """Whether the user configured the plugin to be loaded."""
+    excluded_templates: list[str]
+    """Templates the user configured to be excluded. Empty list if none configured."""
+    included_templates: list[str]
+    """Templates that are available for use. If the plugin is disabled or not loaded, this is an empty list."""
+    glyph_remapping: dict[str, str]
+    """Glyph remapping the user applied during installation. Empty map if disabled or not configured."""
+
+
+class PluginInstallData(FiabBaseModel):
+    local_version: str
+    """The installed version, as declared by the python package."""
+    update_datetime: str
+    """The most recent update datetime -- when was the python package locally modified."""
+    install_errors: PluginErrors
+    """Errors that appear exclusively during the install phase. If any entry has a severity
+    higher than warning, the install has failed and the plugin cannot be used."""
+
+
+class PluginDetail(FiabBaseModel):
+    generic_data: PluginGenericData
+    """Always available for every configured plugin, regardless of its status."""
+    install_data: PluginInstallData | None = None
+    """Available only if the plugin was installed (i.e. a DB record exists).
+    Contains possible error messages from the installation phase."""
+    settings_data: PluginInstallSettings | None = None
+    """Available only if the plugin was successfully installed (no install-phase errors
+    of severity error or critical)."""
+    load_errors: PluginErrors
+    """Load and template-ingestion errors accumulated since the last successful install.
+    Always a list; non-empty only when the plugin is installed and enabled. Maximum
+    severity determines whether the plugin can be used."""
+
+
+class PluginListing(FiabBaseModel):
+    plugins: dict[PluginCompositeId, PluginDetail]
+
+
+# ---------------------------------------------------------------------------
+# Listing builder
+# ---------------------------------------------------------------------------
+
+
+def _install_failed(install_errors: PluginErrors) -> bool:
+    """Return True if any install error has severity error or critical."""
+    return any(e.severity in ("error", "critical") for e in install_errors)
+
+
+def _build_detail(
+    plugin_id: PluginCompositeId,
+    store_entry: PluginStoreEntry | None,
+    remote_info: PluginRemoteInfo | None,
+    plugin_in_memory: Plugin | None,
+    in_memory_errors: PluginErrors,
+    db_state: object,  # PluginState ORM row or None
+) -> PluginDetail:
+    generic_data = PluginGenericData(store_info=store_entry, remote_info=remote_info)
+
+    if db_state is None:
+        return PluginDetail(
+            generic_data=generic_data,
+            load_errors=PluginErrors(list(in_memory_errors)),
+        )
+
+    # install_data
+    install_errors = PluginErrors(
+        [PluginError(**e) for e in (db_state.plugin_errors or [])]  # type: ignore[union-attr]
+    )
+    install_data = PluginInstallData(
+        local_version=db_state.plugin_version,  # type: ignore[attr-defined]
+        update_datetime=value_dt2str(db_state.updated_at),  # type: ignore[attr-defined]
+        install_errors=install_errors,
+    )
+
+    # settings_data -- only if install succeeded
+    settings_data = None
+    if not _install_failed(install_errors):
+        is_enabled = bool(db_state.enabled)  # type: ignore[attr-defined]
+        excluded: list[str] = list(db_state.excluded_templates) if db_state.excluded_templates else []  # type: ignore[union-attr]
+        excluded_set = set(excluded)
+        if plugin_in_memory is not None and is_enabled:
+            all_names = [t.display_name for t in plugin_in_memory.blueprint_templates]
+            included = [n for n in all_names if n not in excluded_set]
+        else:
+            included = []
+        settings_data = PluginInstallSettings(
+            isEnabled=is_enabled,
+            excluded_templates=excluded,
+            included_templates=included,
+            glyph_remapping=dict(db_state.glyph_remapping) if db_state.glyph_remapping else {},  # type: ignore[arg-type]
+        )
+
+    # load_errors -- in-memory errors + template-ingest errors from DB
+    load_error_list: list[PluginError] = list(in_memory_errors)
+    if db_state.template_errors:  # type: ignore[truthy-bool]
+        load_error_list += [
+            PluginError(source="template_ingest", severity="warning", detail=f"template {name!r}: {msg}")
+            for name, msg in db_state.template_errors.items()  # type: ignore[union-attr]
+        ]
+
+    return PluginDetail(
+        generic_data=generic_data,
+        install_data=install_data,
+        settings_data=settings_data,
+        load_errors=PluginErrors(load_error_list),
+    )
+
+
+async def build_plugin_listing() -> PluginListing:
+    """Build and return the full plugin listing.
+
+    Acquires the PluginManager lock, captures in-memory plugin and error snapshots,
+    then performs all DB reads while still holding the lock to ensure a consistent
+    view.  Raises ``PluginManagerBusy`` if the lock cannot be acquired within the
+    timeout, which the route layer translates to a 503 response.
+    """
+    with timed_acquire(PluginManager.lock, 0.5) as acquired:
+        if not acquired:
+            raise PluginManagerBusy("plugin manager lock could not be acquired; retry later")
+        plugins_snapshot: dict[PluginCompositeId, Plugin] = dict(PluginManager.plugins)
+        errors_snapshot: dict[PluginCompositeId, PluginErrors] = dict(PluginManager.errors)
+        db_states = await get_all_plugin_states()
+
+    store_detail = get_plugins_detail()
+
+    # Index DB states by parsed PluginCompositeId
+    states_by_id: dict[PluginCompositeId, object] = {}
+    for state in db_states:
+        try:
+            pid = PluginCompositeId.from_str(state.plugin_id)  # type: ignore[arg-type]
+        except Exception:
+            logger.warning(f"could not parse plugin_id {state.plugin_id!r} from DB; skipping")
+            continue
+        states_by_id[pid] = state
+
+    all_ids = set(store_detail.keys()) | set(states_by_id.keys()) | set(plugins_snapshot.keys())
+
+    plugins: dict[PluginCompositeId, PluginDetail] = {}
+    for plugin_id in all_ids:
+        store_entry: PluginStoreEntry | None = None
+        remote_info: PluginRemoteInfo | None = None
+        if plugin_id in store_detail:
+            store_entry, remote_info = store_detail[plugin_id]
+
+        plugins[plugin_id] = _build_detail(
+            plugin_id=plugin_id,
+            store_entry=store_entry,
+            remote_info=remote_info,
+            plugin_in_memory=plugins_snapshot.get(plugin_id),
+            in_memory_errors=errors_snapshot.get(plugin_id, PluginErrors([])),
+            db_state=states_by_id.get(plugin_id),
+        )
+
+    return PluginListing(plugins=plugins)

--- a/backend/src/forecastbox/domain/plugin/detail.py
+++ b/backend/src/forecastbox/domain/plugin/detail.py
@@ -25,12 +25,14 @@ import logging
 
 from fiab_core.fable import PluginCompositeId
 from fiab_core.plugin import Plugin
+from pydantic import Field
 
 from forecastbox.domain.plugin.db import get_all_plugin_states
 from forecastbox.domain.plugin.errors import PluginError, PluginErrors
 from forecastbox.domain.plugin.exceptions import PluginManagerBusy
 from forecastbox.domain.plugin.manager import PluginManager
 from forecastbox.domain.plugin.store import PluginRemoteInfo, PluginStoreEntry, get_plugins_detail
+from forecastbox.schemata.jobs import PluginState
 from forecastbox.utility.concurrent import timed_acquire
 from forecastbox.utility.pydantic import FiabBaseModel
 from forecastbox.utility.time import value_dt2str
@@ -82,7 +84,7 @@ class PluginDetail(FiabBaseModel):
     settings_data: PluginInstallSettings | None = None
     """Available only if the plugin was successfully installed (no install-phase errors
     of severity error or critical)."""
-    load_errors: PluginErrors
+    load_errors: PluginErrors = Field(default_factory=lambda: PluginErrors([]))
     """Load and template-ingestion errors accumulated since the last successful install.
     Always a list; non-empty only when the plugin is installed and enabled. Maximum
     severity determines whether the plugin can be used."""
@@ -108,20 +110,23 @@ def _build_detail(
     remote_info: PluginRemoteInfo | None,
     plugin_in_memory: Plugin | None,
     in_memory_errors: PluginErrors,
-    db_state: object,  # PluginState ORM row or None
+    db_state: PluginState | None,
 ) -> PluginDetail:
     generic_data = PluginGenericData(store_info=store_entry, remote_info=remote_info)
 
     if db_state is None:
-        return PluginDetail(
-            generic_data=generic_data,
-            load_errors=PluginErrors(list(in_memory_errors)),
-        )
+        if in_memory_errors:
+            logger.warning(
+                f"plugin {PluginCompositeId.to_str(plugin_id)!r} has in-memory errors but no DB state; "
+                "this is unexpected -- errors will not be surfaced"
+            )
+        return PluginDetail(generic_data=generic_data)
 
-    # install_data
-    install_errors = PluginErrors(
-        [PluginError(**e) for e in (db_state.plugin_errors or [])]  # type: ignore[union-attr]
-    )
+    # Separate persisted errors by source: install-phase errors go to install_data,
+    # load/template_ingest errors go to load_errors.
+    all_db_errors = PluginErrors([PluginError(**e) for e in (db_state.plugin_errors or [])])  # type: ignore[union-attr]
+    install_errors = PluginErrors([e for e in all_db_errors if e.source == "install"])
+    db_load_errors = PluginErrors([e for e in all_db_errors if e.source != "install"])
     install_data = PluginInstallData(
         local_version=db_state.plugin_version,  # type: ignore[attr-defined]
         update_datetime=value_dt2str(db_state.updated_at),  # type: ignore[attr-defined]
@@ -146,8 +151,8 @@ def _build_detail(
             glyph_remapping=dict(db_state.glyph_remapping) if db_state.glyph_remapping else {},  # type: ignore[arg-type]
         )
 
-    # load_errors -- in-memory errors + template-ingest errors from DB
-    load_error_list: list[PluginError] = list(in_memory_errors)
+    # load_errors -- db non-install errors + in-memory errors + template-ingest errors from DB
+    load_error_list: list[PluginError] = list(db_load_errors) + list(in_memory_errors)
     if db_state.template_errors:  # type: ignore[truthy-bool]
         load_error_list += [
             PluginError(source="template_ingest", severity="warning", detail=f"template {name!r}: {msg}")
@@ -180,7 +185,7 @@ async def build_plugin_listing() -> PluginListing:
     store_detail = get_plugins_detail()
 
     # Index DB states by parsed PluginCompositeId
-    states_by_id: dict[PluginCompositeId, object] = {}
+    states_by_id: dict[PluginCompositeId, PluginState] = {}
     for state in db_states:
         try:
             pid = PluginCompositeId.from_str(state.plugin_id)  # type: ignore[arg-type]

--- a/backend/src/forecastbox/domain/plugin/exceptions.py
+++ b/backend/src/forecastbox/domain/plugin/exceptions.py
@@ -16,3 +16,11 @@ HTTP responses at the router boundary.
 
 class PluginNotFound(Exception):
     """Raised when a requested plugin is not found in the DB and cannot be eg updated"""
+
+
+class PluginManagerBusy(Exception):
+    """Raised when the PluginManager lock cannot be acquired within the allowed timeout.
+
+    The caller should translate this to an HTTP 503 (Service Unavailable / Retry Later)
+    response so the client can retry the request after a short back-off.
+    """

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -17,7 +17,7 @@ The synchronization logic is handled by a PluginManager with a single lock.
 Pyrsistent immutable structures are used for shared state (plugins, errors),
 making reads safe without locks. The lock is only acquired when swapping the
 top-level structure pointers on writes. Plugin versions and timestamps are
-persisted in the DB and read back by status_full; they are not held in memory.
+persisted in the DB and read back via domain.plugin.detail; they are not held in memory.
 
 There is at most one thread at any time doing any pip/importlib operations,
 thus inside these updater threads we don't need any other critical sections.
@@ -33,9 +33,8 @@ import re
 import threading
 import time
 from concurrent.futures import Future
-from typing import Literal
 
-from cascade.low.func import Either, assert_never
+from cascade.low.func import Either
 from fiab_core.fable import BlockFactoryCatalogue, PluginCompositeId
 from fiab_core.plugin import Plugin
 from packaging.version import Version
@@ -45,7 +44,6 @@ from pyrsistent.typing import PMap
 from forecastbox.domain.plugin.compatibility import install_plugin_compatibly
 from forecastbox.domain.plugin.db import (
     clear_asset_ingest_needed,
-    get_all_plugin_states,
     get_plugin_state,
     update_template_errors,
     upsert_plugin_state,
@@ -54,8 +52,6 @@ from forecastbox.domain.plugin.errors import PluginError, PluginErrors
 from forecastbox.utility.concurrent import delayed_thread, timed_acquire
 from forecastbox.utility.config import PluginSettings, PluginsSettings, config, config_edit_lock
 from forecastbox.utility.packages import try_import, try_version
-from forecastbox.utility.pydantic import FiabBaseModel
-from forecastbox.utility.time import value_dt2str
 
 logger = logging.getLogger(__name__)
 
@@ -396,22 +392,6 @@ def submit_load_plugins(start_after: Future[None]) -> None:
             PluginManager.updater.start()
 
 
-class PluginsStatus(FiabBaseModel):
-    # TODO Change these fields to use pyrsistent types (PMap) instead of dict once we solve pydantic serialization.
-    # However, no immediate hotfix is needed as this class is constructed with a lock, ie, consistently
-    updater_status: Literal["ok", "running", "retrieving"] | str
-    plugin_errors: dict[PluginCompositeId, PluginErrors]
-    plugin_versions: dict[PluginCompositeId, str]
-    plugin_updatedatetime: dict[PluginCompositeId, str]
-    plugin_enabled: dict[PluginCompositeId, bool]
-    plugin_excluded_templates: dict[PluginCompositeId, list[str]]
-    plugin_glyph_remapping: dict[PluginCompositeId, dict[str, str]]
-    plugin_active_templates: dict[PluginCompositeId, list[str]]
-    """For each currently loaded plugin: template names that are not excluded. Absent for disabled/unloaded plugins."""
-    plugin_excluded_template_names: dict[PluginCompositeId, list[str]]
-    """For each currently loaded plugin: template names that are excluded by admin settings. Absent for disabled/unloaded plugins."""
-
-
 def status_brief() -> str:
     # NOTE this may be called without locking, we don't risk collection mutation during iteration
     if PluginManager.updater_error is not None:
@@ -424,74 +404,6 @@ def status_brief() -> str:
 
 def plugins_ready() -> bool:
     return status_brief() == "ok"
-
-
-async def status_full() -> PluginsStatus:
-    plugins_snapshot: dict[PluginCompositeId, Plugin] = {}
-    with timed_acquire(PluginManager.lock, 0.2) as result:
-        if not result:
-            status = "retrieving"
-            plugin_errors: dict[PluginCompositeId, PluginErrors] = {}
-        else:
-            status = status_brief()
-            plugin_errors = dict(PluginManager.errors)
-            plugins_snapshot = dict(PluginManager.plugins)
-    plugin_versions: dict[PluginCompositeId, str] = {}
-    plugin_updatedatetime: dict[PluginCompositeId, str] = {}
-    plugin_enabled: dict[PluginCompositeId, bool] = {}
-    plugin_excluded_templates: dict[PluginCompositeId, list[str]] = {}
-    plugin_glyph_remapping: dict[PluginCompositeId, dict[str, str]] = {}
-    try:
-        states = await get_all_plugin_states()
-        for state in states:
-            try:
-                plugin_id = PluginCompositeId.from_str(state.plugin_id)  # type: ignore[arg-type]
-            except Exception:
-                logger.warning(f"could not parse plugin_id {state.plugin_id!r} from DB; skipping")
-                continue
-            db_plugin_errors: PluginErrors = PluginErrors(
-                [
-                    PluginError(**e)  # type: ignore[arg-type]
-                    for e in (state.plugin_errors or [])  # type: ignore[union-attr]
-                ]
-            )
-            if db_plugin_errors:
-                existing = plugin_errors.get(plugin_id, [])
-                plugin_errors[plugin_id] = PluginErrors(existing + db_plugin_errors)
-            plugin_versions[plugin_id] = state.plugin_version  # type: ignore[assignment]
-            plugin_updatedatetime[plugin_id] = value_dt2str(state.updated_at)  # type: ignore[arg-type]
-            plugin_enabled[plugin_id] = bool(state.enabled)
-            plugin_excluded_templates[plugin_id] = list(state.excluded_templates) if state.excluded_templates else []  # type: ignore[arg-type]
-            plugin_glyph_remapping[plugin_id] = dict(state.glyph_remapping) if state.glyph_remapping else {}  # type: ignore[arg-type]
-            if state.template_errors:  # type: ignore[truthy-bool]
-                template_errs: PluginErrors = PluginErrors(
-                    [
-                        PluginError(source="template_ingest", severity="warning", detail=f"template {name!r}: {msg}")
-                        for name, msg in state.template_errors.items()  # type: ignore[union-attr]
-                    ]
-                )
-                existing = plugin_errors.get(plugin_id, [])
-                plugin_errors[plugin_id] = PluginErrors(existing + template_errs)
-    except Exception:
-        logger.warning("failed to load plugin states from DB; status may be incomplete", exc_info=True)
-    plugin_active_templates: dict[PluginCompositeId, list[str]] = {}
-    plugin_excluded_template_names: dict[PluginCompositeId, list[str]] = {}
-    for plugin_id, plugin in plugins_snapshot.items():
-        all_names = [t.display_name for t in plugin.blueprint_templates]
-        excluded_set = set(plugin_excluded_templates.get(plugin_id, []))
-        plugin_active_templates[plugin_id] = [n for n in all_names if n not in excluded_set]
-        plugin_excluded_template_names[plugin_id] = [n for n in all_names if n in excluded_set]
-    return PluginsStatus(
-        updater_status=status,
-        plugin_errors=plugin_errors,
-        plugin_versions=plugin_versions,
-        plugin_updatedatetime=plugin_updatedatetime,
-        plugin_enabled=plugin_enabled,
-        plugin_excluded_templates=plugin_excluded_templates,
-        plugin_glyph_remapping=plugin_glyph_remapping,
-        plugin_active_templates=plugin_active_templates,
-        plugin_excluded_template_names=plugin_excluded_template_names,
-    )
 
 
 def catalogue_view() -> dict[PluginCompositeId, BlockFactoryCatalogue] | bool:

--- a/backend/src/forecastbox/routes/plugins.py
+++ b/backend/src/forecastbox/routes/plugins.py
@@ -15,7 +15,7 @@ Contains:
 """
 
 import logging
-from typing import Annotated, Literal
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import Response
@@ -26,17 +26,15 @@ from forecastbox.domain.auth.users import UserRead
 from forecastbox.domain.glyphs.resolution import remap_glyph_names
 from forecastbox.domain.plugin.compatibility import get_compatible_versions
 from forecastbox.domain.plugin.db import get_plugin_state, upsert_plugin_state
-from forecastbox.domain.plugin.errors import PluginErrors
-from forecastbox.domain.plugin.exceptions import PluginNotFound
+from forecastbox.domain.plugin.detail import PluginListing, build_plugin_listing
+from forecastbox.domain.plugin.exceptions import PluginManagerBusy, PluginNotFound
 from forecastbox.domain.plugin.manager import (
     PluginManager,
-    PluginsStatus,
-    status_full,
     submit_update_single,
     uninstall_plugin,
     unload_single,
 )
-from forecastbox.domain.plugin.store import PluginRemoteInfo, PluginStoreEntry, get_plugins_detail, submit_install_plugin
+from forecastbox.domain.plugin.store import get_plugins_detail, submit_install_plugin
 from forecastbox.routes.admin import get_admin_user
 from forecastbox.utility.config import PluginSettings, config
 from forecastbox.utility.packages import get_package_versions
@@ -52,78 +50,21 @@ router = APIRouter(
 )
 
 
-class PluginDetail(FiabBaseModel):
-    status: Literal["available", "disabled", "errored", "loaded"]
-    """Status of the plugin, mutually exclusive. All of (disabled, errored, loaded) imply that the plugin is installed"""
-    store_info: PluginStoreEntry | None = None
-    """Info about the plugin from the respective store. None if the plugin was installed locally"""
-    remote_info: PluginRemoteInfo | None = None
-    """Dynamic remote information such as the most recent published version. None if the plugin was installed locally"""
-    errored_detail: PluginErrors | None = None
-    """In case the plugin is errored or has warnings, this displays structured diagnostics"""
-    loaded_version: str | None = None
-    """In case the plugin is loaded, this shows the version"""
-    update_datetime: str | None = None
-    """In case the plugin is installed, this shows the most recent update datetime"""
-    # TODO add here the remapping/exclusion data
-
-
-class PluginListing(FiabBaseModel):
-    plugins: dict[PluginCompositeId, PluginDetail]
-
-
-# ---------------------------------------------------------------------------
-# Operational routes
-# ---------------------------------------------------------------------------
-
-
-@router.get("/status")
-async def get_plugins_status_full() -> PluginsStatus:
-    return await status_full()
-
-
 # ---------------------------------------------------------------------------
 # CRUD routes
 # ---------------------------------------------------------------------------
 
 
-@router.get("/details")
-async def get_plugin_details(forceRefresh: bool = False) -> PluginListing:
-    # TODO implement forceRefresh -- we would need to prod the thread to update the store, but await its completion here
-    if forceRefresh:
-        raise NotImplementedError
-    rv = {}
-    statuses = await status_full()
-    disabled = {plugin_id for plugin_id, enabled in statuses.plugin_enabled.items() if not enabled}
-    errored = set(statuses.plugin_errors.keys())
-    loaded = set(statuses.plugin_versions.keys())
-    installed = errored.union(loaded).union(disabled)
-    for pluginCompositeId, (storeEntry, remoteInfo) in get_plugins_detail().items():
-        rv[pluginCompositeId] = PluginDetail(
-            status="available",
-            store_info=storeEntry,
-            remote_info=remoteInfo,
+@router.get("/list")
+async def get_plugin_list() -> PluginListing:
+    """Return a full listing of all known plugins with install, settings, and error detail."""
+    try:
+        return await build_plugin_listing()
+    except PluginManagerBusy:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Plugin manager is busy; retry later",
         )
-    for pluginCompositeId in installed:
-        if pluginCompositeId in errored:
-            status = "errored"
-        elif pluginCompositeId in loaded:
-            status = "loaded"
-        elif pluginCompositeId in disabled:
-            status = "disabled"
-        else:
-            status = "available"
-        update = {
-            "status": status,
-            "errored_detail": statuses.plugin_errors.get(pluginCompositeId, None),  # ty:ignore[no-matching-overload]
-            "loaded_version": statuses.plugin_versions.get(pluginCompositeId, None),  # ty:ignore[no-matching-overload]
-            "update_datetime": statuses.plugin_updatedatetime.get(pluginCompositeId, None),  # ty:ignore[no-matching-overload]
-        }
-        if pluginCompositeId not in rv:
-            rv[pluginCompositeId] = PluginDetail(**update)  # ty:ignore[invalid-argument-type]
-        else:
-            rv[pluginCompositeId] = rv[pluginCompositeId].model_copy(update=update)
-    return PluginListing(plugins=rv)
 
 
 # TODO ideally we'd return the redirect here, but that is basically guaranteed to end up with a 503 because

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -247,12 +247,12 @@ def test_plugin_template_in_blueprint_list(backend_client_user: httpx.Client) ->
     from .conftest import testPluginId
 
     def do_action() -> dict:
-        response = backend_client_user.get("/plugin/status", timeout=10)
+        response = backend_client_user.get("/status", timeout=10)
         assert response.is_success
         return response.json()
 
     def verify_ok(data: dict) -> dict | None:
-        return data if data.get("updater_status") == "ok" else None
+        return data if data.get("plugins") == "ok" else None
 
     retry_until(do_action, verify_ok, attempts=30, sleep=1.0, error_msg="Plugin loader did not reach 'ok' status")
 
@@ -322,12 +322,12 @@ def test_plugin_template_exclusion(backend_client_user: httpx.Client, backend_cl
 
     # Wait for the re-ingest to complete.
     def do_action() -> dict:
-        resp = backend_client_user.get("/plugin/status", timeout=10)
+        resp = backend_client_user.get("/status", timeout=10)
         assert resp.is_success
         return resp.json()
 
     def verify_ok(data: dict) -> dict | None:
-        return data if data.get("updater_status") == "ok" else None
+        return data if data.get("plugins") == "ok" else None
 
     retry_until(do_action, verify_ok, attempts=30, sleep=1.0, error_msg="Plugin re-ingest did not reach 'ok' status")
 
@@ -340,17 +340,19 @@ def test_plugin_template_exclusion(backend_client_user: httpx.Client, backend_cl
     assert "testBasic" in names, f"testBasic should still be present, but found: {names}"
     assert "testRemapping" in names, f"testRemapping should be present, but found: {names}"
 
-    # Verify that /plugin/status reflects the active/excluded template split correctly.
+    # Verify that /plugin/list reflects the active/excluded template split correctly.
     plugin_id_key = str(testPluginId)
-    status_response = backend_client_user.get("/plugin/status", timeout=10)
-    assert status_response.is_success, status_response.text
-    status_data = status_response.json()
-    active = status_data.get("plugin_active_templates", {}).get(plugin_id_key, [])
-    excluded_names = status_data.get("plugin_excluded_template_names", {}).get(plugin_id_key, [])
+    list_response = backend_client_user.get("/plugin/list", timeout=10)
+    assert list_response.is_success, list_response.text
+    list_data = list_response.json()
+    plugin_detail = list_data.get("plugins", {}).get(plugin_id_key, {})
+    settings = plugin_detail.get("settings_data", {}) or {}
+    active = settings.get("included_templates", [])
+    excluded_config = settings.get("excluded_templates", [])
     assert "testExclusion" not in active, f"testExclusion should not be active, got: {active}"
     assert "testBasic" in active, f"testBasic should be active, got: {active}"
     assert "testRemapping" in active, f"testRemapping should be active, got: {active}"
-    assert "testExclusion" in excluded_names, f"testExclusion should appear in excluded_template_names, got: {excluded_names}"
+    assert "testExclusion" in excluded_config, f"testExclusion should appear in excluded_templates, got: {excluded_config}"
 
     # Excluded template must return 403 from templateExampleValues.
     response = backend_client_user.get(
@@ -399,19 +401,19 @@ def test_plugin_template_exclusion(backend_client_user: httpx.Client, backend_cl
 
 def test_plugin_template_validation_failure(backend_client_user: httpx.Client) -> None:
     """Templates that fail validation with their example values are absent from the blueprint list
-    and their error is reported in plugin_errors in the plugin status."""
+    and their error is reported in load_errors in the plugin listing."""
     from .conftest import testPluginId
 
     # Wait for the initial plugin load to finish.
     def do_action() -> dict:
-        response = backend_client_user.get("/plugin/status", timeout=10)
+        response = backend_client_user.get("/status", timeout=10)
         assert response.is_success
         return response.json()
 
     def verify_ok(data: dict) -> dict | None:
-        return data if data.get("updater_status") == "ok" else None
+        return data if data.get("plugins") == "ok" else None
 
-    status = retry_until(do_action, verify_ok, attempts=30, sleep=1.0, error_msg="Plugin loader did not reach 'ok' status")
+    retry_until(do_action, verify_ok, attempts=30, sleep=1.0, error_msg="Plugin loader did not reach 'ok' status")
 
     # testFailValidation must NOT appear in the blueprint list.
     response = backend_client_user.get("/blueprint/list", timeout=10)
@@ -420,15 +422,14 @@ def test_plugin_template_validation_failure(backend_client_user: httpx.Client) -
     names = [b.get("display_name") for b in blueprints if b.get("source") == "plugin_template"]
     assert "testFailValidation" not in names, f"testFailValidation should have been rejected but found in: {names}"
 
-    # Its error must be reported in plugin_errors (merged alongside install errors).
-    # PluginsStatus dict keys for PluginCompositeId are serialized via str(plugin_id).
+    # Its error must be reported in load_errors for the plugin in /plugin/list.
     plugin_id_key = str(testPluginId)
-    plugin_errors = status.get("plugin_errors", {})
-    plugin_error_entries = plugin_errors.get(plugin_id_key, [])
-    details = " ".join(e.get("detail", "") for e in plugin_error_entries)
-    assert "testFailValidation" in details, (
-        f"Expected 'testFailValidation' in plugin_errors[{plugin_id_key!r}], got: {plugin_error_entries!r}"
-    )
+    list_response = backend_client_user.get("/plugin/list", timeout=10)
+    assert list_response.is_success, list_response.text
+    plugin_detail = list_response.json().get("plugins", {}).get(plugin_id_key, {})
+    load_errors = plugin_detail.get("load_errors", [])
+    details = " ".join(e.get("detail", "") for e in load_errors)
+    assert "testFailValidation" in details, f"Expected 'testFailValidation' in load_errors for {plugin_id_key!r}, got: {load_errors!r}"
 
 
 def test_blueprint_expand(tmpdir: Any, backend_client_user: httpx.Client) -> None:

--- a/backend/tests/integration/test_db_startup.py
+++ b/backend/tests/integration/test_db_startup.py
@@ -24,17 +24,29 @@ def test_dbs_created(backend_client: httpx.Client) -> None:
 
 
 def test_plugin_install_state_persisted(backend_client: httpx.Client) -> None:
-    """Verify the test plugin install is reported via /plugin/status with no install error."""
+    """Verify the test plugin install is reported via /status with no install error."""
+    from .conftest import testPluginId
 
     def do_action() -> dict:
-        response = backend_client.get("/plugin/status", timeout=10)
+        response = backend_client.get("/status", timeout=10)
         assert response.is_success
         return response.json()
 
     def verify_ok(data: dict) -> dict | None:
-        return data if data.get("updater_status") == "ok" else None
+        return data if data.get("plugins") == "ok" else None
 
-    status = retry_until(do_action, verify_ok, attempts=30, sleep=1.0, error_msg="Plugin loader did not reach 'ok' status")
+    retry_until(do_action, verify_ok, attempts=30, sleep=1.0, error_msg="Plugin loader did not reach 'ok' status")
 
-    plugin_errors = status.get("plugin_errors", {})
-    assert "localTest:single" not in plugin_errors, f"Test plugin reported an error: {plugin_errors.get('localTest:single')}"
+    listing_response = backend_client.get("/plugin/list", timeout=10)
+    assert listing_response.is_success
+    plugins = listing_response.json().get("plugins", {})
+    plugin_key = str(testPluginId)
+    plugin_detail = plugins.get(plugin_key, None)
+    assert plugin_detail is not None, f"Test plugin {plugin_key!r} not found in /plugin/list"
+    install_data = plugin_detail.get("install_data", None)
+    assert install_data is not None, f"Test plugin has no install_data in /plugin/list"
+    install_errors = install_data.get("install_errors", [])
+    error_severities = [e.get("severity") for e in install_errors]
+    assert "error" not in error_severities and "critical" not in error_severities, (
+        f"Test plugin reported install error(s): {install_errors}"
+    )

--- a/backend/tests/unit/domain/plugins/test_plugin_detail.py
+++ b/backend/tests/unit/domain/plugins/test_plugin_detail.py
@@ -1,0 +1,486 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Unit tests for build_plugin_listing() in domain/plugin/detail.py.
+
+Covers the included_templates / excluded_templates / load_errors / install_data
+fields derived from the in-memory plugin state and DB rows.
+"""
+
+import asyncio
+import threading
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fiab_core.fable import (
+    BlockFactoryCatalogue,
+    BlueprintTemplate,
+    PluginCompositeId,
+    PluginId,
+    PluginStoreId,
+)
+from fiab_core.plugin import Plugin
+from pyrsistent import pmap
+
+from forecastbox.domain.plugin.detail import build_plugin_listing
+from forecastbox.domain.plugin.errors import PluginError, PluginErrors
+from forecastbox.domain.plugin.exceptions import PluginManagerBusy
+
+# ---------------------------------------------------------------------------
+# Shared test fixtures
+# ---------------------------------------------------------------------------
+
+_STORE = PluginStoreId("testStore")
+_PLUGIN_A = PluginCompositeId(store=_STORE, local=PluginId("pluginA"))
+_PLUGIN_B = PluginCompositeId(store=_STORE, local=PluginId("pluginB"))
+
+
+def _make_template(name: str) -> BlueprintTemplate:
+    return BlueprintTemplate(
+        display_name=name,
+        display_description="",
+        blocks={},
+    )
+
+
+def _make_plugin(*template_names: str) -> Plugin:
+    return Plugin(
+        catalogue=BlockFactoryCatalogue(factories={}),
+        validator=lambda factory_id, inst, inputs: (_ for _ in ()).throw(NotImplementedError),  # type: ignore[return-value]
+        expander=lambda output: [],
+        compiler=lambda lookup, factory_id, inst: (_ for _ in ()).throw(NotImplementedError),  # type: ignore[return-value]
+        blueprint_templates=tuple(_make_template(n) for n in template_names),
+    )
+
+
+def _make_db_state(
+    plugin_id: PluginCompositeId,
+    *,
+    excluded: list[str] | None = None,
+    enabled: bool = True,
+    version: str = "1.0.0",
+    plugin_errors: list[dict] | None = None,
+    template_errors: dict[str, str] | None = None,
+    glyph_remapping: dict[str, str] | None = None,
+) -> MagicMock:
+    state = MagicMock()
+    state.plugin_id = PluginCompositeId.to_str(plugin_id)
+    state.plugin_version = version
+    state.updated_at = MagicMock()
+    state.plugin_errors = plugin_errors or []
+    state.excluded_templates = excluded or []
+    state.glyph_remapping = glyph_remapping or {}
+    state.template_errors = template_errors or {}
+    state.enabled = enabled
+    return state
+
+
+def _run(coro: object) -> object:  # type: ignore[type-arg]
+    return asyncio.run(coro)  # type: ignore[arg-type]
+
+
+def _patch_db(states: list[MagicMock]) -> object:
+    return patch("forecastbox.domain.plugin.detail.get_all_plugin_states", new=AsyncMock(return_value=states))
+
+
+def _patch_store(detail: dict | None = None) -> object:
+    return patch("forecastbox.domain.plugin.detail.get_plugins_detail", return_value=detail or {})
+
+
+def _patch_time() -> object:
+    return patch("forecastbox.domain.plugin.detail.value_dt2str", return_value="2024-01-01T00:00:00")
+
+
+def _patch_manager(plugins: dict, errors: dict) -> object:
+    lock = threading.Lock()
+
+    def _ctx_manager(pm: MagicMock) -> None:
+        pm.lock = lock
+        pm.plugins = pmap(plugins)
+        pm.errors = pmap(errors)
+
+    return _ctx_manager
+
+
+# ---------------------------------------------------------------------------
+# included_templates / excluded_templates
+# ---------------------------------------------------------------------------
+
+
+def test_included_templates_all_when_no_exclusions() -> None:
+    plugin = _make_plugin("alpha", "beta", "gamma")
+    state = _make_db_state(_PLUGIN_A, excluded=[])
+
+    with (
+        patch("forecastbox.domain.plugin.detail.PluginManager") as mock_pm,
+        _patch_db([state]),
+        _patch_store(),
+        _patch_time(),
+    ):
+        mock_pm.lock = threading.Lock()
+        mock_pm.plugins = pmap({_PLUGIN_A: plugin})
+        mock_pm.errors = pmap()
+
+        result = _run(build_plugin_listing())
+
+    detail = result.plugins[_PLUGIN_A]
+    assert detail.settings_data is not None
+    assert detail.settings_data.included_templates == ["alpha", "beta", "gamma"]
+    assert detail.settings_data.excluded_templates == []
+
+
+def test_excluded_template_removed_from_included() -> None:
+    plugin = _make_plugin("alpha", "beta", "gamma")
+    state = _make_db_state(_PLUGIN_A, excluded=["beta"])
+
+    with (
+        patch("forecastbox.domain.plugin.detail.PluginManager") as mock_pm,
+        _patch_db([state]),
+        _patch_store(),
+        _patch_time(),
+    ):
+        mock_pm.lock = threading.Lock()
+        mock_pm.plugins = pmap({_PLUGIN_A: plugin})
+        mock_pm.errors = pmap()
+
+        result = _run(build_plugin_listing())
+
+    sd = result.plugins[_PLUGIN_A].settings_data
+    assert sd is not None
+    assert sd.included_templates == ["alpha", "gamma"]
+    assert sd.excluded_templates == ["beta"]
+
+
+def test_all_templates_excluded_gives_empty_included() -> None:
+    plugin = _make_plugin("t1", "t2")
+    state = _make_db_state(_PLUGIN_A, excluded=["t1", "t2"])
+
+    with (
+        patch("forecastbox.domain.plugin.detail.PluginManager") as mock_pm,
+        _patch_db([state]),
+        _patch_store(),
+        _patch_time(),
+    ):
+        mock_pm.lock = threading.Lock()
+        mock_pm.plugins = pmap({_PLUGIN_A: plugin})
+        mock_pm.errors = pmap()
+
+        result = _run(build_plugin_listing())
+
+    sd = result.plugins[_PLUGIN_A].settings_data
+    assert sd is not None
+    assert sd.included_templates == []
+    assert set(sd.excluded_templates) == {"t1", "t2"}
+
+
+def test_nonexistent_excluded_name_does_not_affect_included() -> None:
+    """A name in excluded_templates that doesn't match any template is still stored but doesn't remove any included."""
+    plugin = _make_plugin("alpha", "beta")
+    state = _make_db_state(_PLUGIN_A, excluded=["nonexistent", "beta"])
+
+    with (
+        patch("forecastbox.domain.plugin.detail.PluginManager") as mock_pm,
+        _patch_db([state]),
+        _patch_store(),
+        _patch_time(),
+    ):
+        mock_pm.lock = threading.Lock()
+        mock_pm.plugins = pmap({_PLUGIN_A: plugin})
+        mock_pm.errors = pmap()
+
+        result = _run(build_plugin_listing())
+
+    sd = result.plugins[_PLUGIN_A].settings_data
+    assert sd is not None
+    assert sd.included_templates == ["alpha"]
+    assert set(sd.excluded_templates) == {"nonexistent", "beta"}
+
+
+def test_disabled_plugin_has_empty_included_templates() -> None:
+    """A disabled plugin should have settings_data with included_templates=[]."""
+    state = _make_db_state(_PLUGIN_B, excluded=["something"], enabled=False)
+
+    with (
+        patch("forecastbox.domain.plugin.detail.PluginManager") as mock_pm,
+        _patch_db([state]),
+        _patch_store(),
+        _patch_time(),
+    ):
+        mock_pm.lock = threading.Lock()
+        mock_pm.plugins = pmap()  # not loaded
+        mock_pm.errors = pmap()
+
+        result = _run(build_plugin_listing())
+
+    detail = result.plugins[_PLUGIN_B]
+    assert detail.settings_data is not None
+    assert detail.settings_data.isEnabled is False
+    assert detail.settings_data.included_templates == []
+
+
+def test_multiple_plugins_computed_independently() -> None:
+    plugin_a = _make_plugin("x", "y")
+    plugin_b = _make_plugin("p", "q", "r")
+    state_a = _make_db_state(_PLUGIN_A, excluded=["x"])
+    state_b = _make_db_state(_PLUGIN_B, excluded=["q", "r"])
+
+    with (
+        patch("forecastbox.domain.plugin.detail.PluginManager") as mock_pm,
+        _patch_db([state_a, state_b]),
+        _patch_store(),
+        _patch_time(),
+    ):
+        mock_pm.lock = threading.Lock()
+        mock_pm.plugins = pmap({_PLUGIN_A: plugin_a, _PLUGIN_B: plugin_b})
+        mock_pm.errors = pmap()
+
+        result = _run(build_plugin_listing())
+
+    sd_a = result.plugins[_PLUGIN_A].settings_data
+    sd_b = result.plugins[_PLUGIN_B].settings_data
+    assert sd_a is not None and sd_b is not None
+    assert sd_a.included_templates == ["y"]
+    assert sd_b.included_templates == ["p"]
+    assert set(sd_b.excluded_templates) == {"q", "r"}
+
+
+def test_plugin_with_no_templates_gives_empty_included() -> None:
+    plugin = _make_plugin()
+    state = _make_db_state(_PLUGIN_A)
+
+    with (
+        patch("forecastbox.domain.plugin.detail.PluginManager") as mock_pm,
+        _patch_db([state]),
+        _patch_store(),
+        _patch_time(),
+    ):
+        mock_pm.lock = threading.Lock()
+        mock_pm.plugins = pmap({_PLUGIN_A: plugin})
+        mock_pm.errors = pmap()
+
+        result = _run(build_plugin_listing())
+
+    sd = result.plugins[_PLUGIN_A].settings_data
+    assert sd is not None
+    assert sd.included_templates == []
+
+
+def test_plugin_in_memory_without_db_state_has_no_install_data() -> None:
+    """A plugin loaded in memory but without a DB row should have install_data=None and settings_data=None."""
+    plugin = _make_plugin("alpha", "beta")
+
+    with (
+        patch("forecastbox.domain.plugin.detail.PluginManager") as mock_pm,
+        _patch_db([]),
+        _patch_store(),
+        _patch_time(),
+    ):
+        mock_pm.lock = threading.Lock()
+        mock_pm.plugins = pmap({_PLUGIN_A: plugin})
+        mock_pm.errors = pmap()
+
+        result = _run(build_plugin_listing())
+
+    detail = result.plugins[_PLUGIN_A]
+    assert detail.install_data is None
+    assert detail.settings_data is None
+    assert detail.load_errors == []
+
+
+# ---------------------------------------------------------------------------
+# install_data and settings_data availability
+# ---------------------------------------------------------------------------
+
+
+def test_install_data_populated_when_db_state_exists() -> None:
+    state = _make_db_state(_PLUGIN_A, version="2.3.1")
+
+    with (
+        patch("forecastbox.domain.plugin.detail.PluginManager") as mock_pm,
+        _patch_db([state]),
+        _patch_store(),
+        _patch_time(),
+    ):
+        mock_pm.lock = threading.Lock()
+        mock_pm.plugins = pmap()
+        mock_pm.errors = pmap()
+
+        result = _run(build_plugin_listing())
+
+    detail = result.plugins[_PLUGIN_A]
+    assert detail.install_data is not None
+    assert detail.install_data.local_version == "2.3.1"
+    assert detail.install_data.update_datetime == "2024-01-01T00:00:00"
+    assert detail.install_data.install_errors == []
+
+
+def test_settings_data_absent_when_install_failed() -> None:
+    """If install_errors contain an error-severity entry, settings_data must be None."""
+    state = _make_db_state(
+        _PLUGIN_A,
+        version="install failed",
+        plugin_errors=[{"source": "install", "severity": "error", "detail": "pip exploded"}],
+    )
+
+    with (
+        patch("forecastbox.domain.plugin.detail.PluginManager") as mock_pm,
+        _patch_db([state]),
+        _patch_store(),
+        _patch_time(),
+    ):
+        mock_pm.lock = threading.Lock()
+        mock_pm.plugins = pmap()
+        mock_pm.errors = pmap()
+
+        result = _run(build_plugin_listing())
+
+    detail = result.plugins[_PLUGIN_A]
+    assert detail.install_data is not None
+    assert len(detail.install_data.install_errors) == 1
+    assert detail.install_data.install_errors[0].severity == "error"
+    assert detail.settings_data is None
+
+
+def test_settings_data_present_when_only_warnings() -> None:
+    """Install warnings should not suppress settings_data."""
+    state = _make_db_state(
+        _PLUGIN_A,
+        plugin_errors=[{"source": "install", "severity": "warning", "detail": "minor issue"}],
+    )
+
+    with (
+        patch("forecastbox.domain.plugin.detail.PluginManager") as mock_pm,
+        _patch_db([state]),
+        _patch_store(),
+        _patch_time(),
+    ):
+        mock_pm.lock = threading.Lock()
+        mock_pm.plugins = pmap()
+        mock_pm.errors = pmap()
+
+        result = _run(build_plugin_listing())
+
+    detail = result.plugins[_PLUGIN_A]
+    assert detail.settings_data is not None
+
+
+# ---------------------------------------------------------------------------
+# load_errors
+# ---------------------------------------------------------------------------
+
+
+def test_load_errors_from_in_memory_errors() -> None:
+    state = _make_db_state(_PLUGIN_A)
+    in_mem_err = PluginErrors([PluginError(source="load", severity="error", detail="import failed")])
+
+    with (
+        patch("forecastbox.domain.plugin.detail.PluginManager") as mock_pm,
+        _patch_db([state]),
+        _patch_store(),
+        _patch_time(),
+    ):
+        mock_pm.lock = threading.Lock()
+        mock_pm.plugins = pmap()
+        mock_pm.errors = pmap({_PLUGIN_A: in_mem_err})
+
+        result = _run(build_plugin_listing())
+
+    detail = result.plugins[_PLUGIN_A]
+    assert len(detail.load_errors) == 1
+    assert detail.load_errors[0].source == "load"
+    assert detail.load_errors[0].severity == "error"
+
+
+def test_load_errors_include_template_errors_from_db() -> None:
+    state = _make_db_state(_PLUGIN_A, template_errors={"myTemplate": "validation failed"})
+
+    with (
+        patch("forecastbox.domain.plugin.detail.PluginManager") as mock_pm,
+        _patch_db([state]),
+        _patch_store(),
+        _patch_time(),
+    ):
+        mock_pm.lock = threading.Lock()
+        mock_pm.plugins = pmap()
+        mock_pm.errors = pmap()
+
+        result = _run(build_plugin_listing())
+
+    detail = result.plugins[_PLUGIN_A]
+    assert len(detail.load_errors) == 1
+    assert detail.load_errors[0].source == "template_ingest"
+    assert detail.load_errors[0].severity == "warning"
+    assert "myTemplate" in detail.load_errors[0].detail
+
+
+def test_load_errors_combined_from_memory_and_db() -> None:
+    in_mem_err = PluginErrors([PluginError(source="load", severity="warning", detail="minor")])
+    state = _make_db_state(_PLUGIN_A, template_errors={"tmpl": "bad"})
+
+    with (
+        patch("forecastbox.domain.plugin.detail.PluginManager") as mock_pm,
+        _patch_db([state]),
+        _patch_store(),
+        _patch_time(),
+    ):
+        mock_pm.lock = threading.Lock()
+        mock_pm.plugins = pmap()
+        mock_pm.errors = pmap({_PLUGIN_A: in_mem_err})
+
+        result = _run(build_plugin_listing())
+
+    detail = result.plugins[_PLUGIN_A]
+    sources = {e.source for e in detail.load_errors}
+    assert sources == {"load", "template_ingest"}
+
+
+# ---------------------------------------------------------------------------
+# PluginManagerBusy
+# ---------------------------------------------------------------------------
+
+
+def test_raises_plugin_manager_busy_when_lock_not_acquired() -> None:
+    """If the PluginManager lock cannot be acquired, PluginManagerBusy is raised."""
+    busy_lock = threading.Lock()
+    busy_lock.acquire()  # hold the lock so timed_acquire times out
+
+    with patch("forecastbox.domain.plugin.detail.PluginManager") as mock_pm:
+        mock_pm.lock = busy_lock
+        mock_pm.plugins = pmap()
+        mock_pm.errors = pmap()
+
+        with pytest.raises(PluginManagerBusy):
+            _run(build_plugin_listing())
+
+    busy_lock.release()
+
+
+# ---------------------------------------------------------------------------
+# glyph_remapping
+# ---------------------------------------------------------------------------
+
+
+def test_glyph_remapping_propagated_to_settings() -> None:
+    state = _make_db_state(_PLUGIN_A, glyph_remapping={"old": "new"})
+
+    with (
+        patch("forecastbox.domain.plugin.detail.PluginManager") as mock_pm,
+        _patch_db([state]),
+        _patch_store(),
+        _patch_time(),
+    ):
+        mock_pm.lock = threading.Lock()
+        mock_pm.plugins = pmap()
+        mock_pm.errors = pmap()
+
+        result = _run(build_plugin_listing())
+
+    sd = result.plugins[_PLUGIN_A].settings_data
+    assert sd is not None
+    assert sd.glyph_remapping == {"old": "new"}

--- a/backend/tests/unit/domain/plugins/test_plugin_detail.py
+++ b/backend/tests/unit/domain/plugins/test_plugin_detail.py
@@ -13,7 +13,6 @@ Covers the included_templates / excluded_templates / load_errors / install_data
 fields derived from the in-memory plugin state and DB rows.
 """
 
-import asyncio
 import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -81,10 +80,6 @@ def _make_db_state(
     return state
 
 
-def _run(coro: object) -> object:  # type: ignore[type-arg]
-    return asyncio.run(coro)  # type: ignore[arg-type]
-
-
 def _patch_db(states: list[MagicMock]) -> object:
     return patch("forecastbox.domain.plugin.detail.get_all_plugin_states", new=AsyncMock(return_value=states))
 
@@ -113,7 +108,8 @@ def _patch_manager(plugins: dict, errors: dict) -> object:
 # ---------------------------------------------------------------------------
 
 
-def test_included_templates_all_when_no_exclusions() -> None:
+@pytest.mark.asyncio
+async def test_included_templates_all_when_no_exclusions() -> None:
     plugin = _make_plugin("alpha", "beta", "gamma")
     state = _make_db_state(_PLUGIN_A, excluded=[])
 
@@ -127,7 +123,7 @@ def test_included_templates_all_when_no_exclusions() -> None:
         mock_pm.plugins = pmap({_PLUGIN_A: plugin})
         mock_pm.errors = pmap()
 
-        result = _run(build_plugin_listing())
+        result = await build_plugin_listing()
 
     detail = result.plugins[_PLUGIN_A]
     assert detail.settings_data is not None
@@ -135,7 +131,8 @@ def test_included_templates_all_when_no_exclusions() -> None:
     assert detail.settings_data.excluded_templates == []
 
 
-def test_excluded_template_removed_from_included() -> None:
+@pytest.mark.asyncio
+async def test_excluded_template_removed_from_included() -> None:
     plugin = _make_plugin("alpha", "beta", "gamma")
     state = _make_db_state(_PLUGIN_A, excluded=["beta"])
 
@@ -149,7 +146,7 @@ def test_excluded_template_removed_from_included() -> None:
         mock_pm.plugins = pmap({_PLUGIN_A: plugin})
         mock_pm.errors = pmap()
 
-        result = _run(build_plugin_listing())
+        result = await build_plugin_listing()
 
     sd = result.plugins[_PLUGIN_A].settings_data
     assert sd is not None
@@ -157,7 +154,8 @@ def test_excluded_template_removed_from_included() -> None:
     assert sd.excluded_templates == ["beta"]
 
 
-def test_all_templates_excluded_gives_empty_included() -> None:
+@pytest.mark.asyncio
+async def test_all_templates_excluded_gives_empty_included() -> None:
     plugin = _make_plugin("t1", "t2")
     state = _make_db_state(_PLUGIN_A, excluded=["t1", "t2"])
 
@@ -171,7 +169,7 @@ def test_all_templates_excluded_gives_empty_included() -> None:
         mock_pm.plugins = pmap({_PLUGIN_A: plugin})
         mock_pm.errors = pmap()
 
-        result = _run(build_plugin_listing())
+        result = await build_plugin_listing()
 
     sd = result.plugins[_PLUGIN_A].settings_data
     assert sd is not None
@@ -179,7 +177,8 @@ def test_all_templates_excluded_gives_empty_included() -> None:
     assert set(sd.excluded_templates) == {"t1", "t2"}
 
 
-def test_nonexistent_excluded_name_does_not_affect_included() -> None:
+@pytest.mark.asyncio
+async def test_nonexistent_excluded_name_does_not_affect_included() -> None:
     """A name in excluded_templates that doesn't match any template is still stored but doesn't remove any included."""
     plugin = _make_plugin("alpha", "beta")
     state = _make_db_state(_PLUGIN_A, excluded=["nonexistent", "beta"])
@@ -194,7 +193,7 @@ def test_nonexistent_excluded_name_does_not_affect_included() -> None:
         mock_pm.plugins = pmap({_PLUGIN_A: plugin})
         mock_pm.errors = pmap()
 
-        result = _run(build_plugin_listing())
+        result = await build_plugin_listing()
 
     sd = result.plugins[_PLUGIN_A].settings_data
     assert sd is not None
@@ -202,7 +201,8 @@ def test_nonexistent_excluded_name_does_not_affect_included() -> None:
     assert set(sd.excluded_templates) == {"nonexistent", "beta"}
 
 
-def test_disabled_plugin_has_empty_included_templates() -> None:
+@pytest.mark.asyncio
+async def test_disabled_plugin_has_empty_included_templates() -> None:
     """A disabled plugin should have settings_data with included_templates=[]."""
     state = _make_db_state(_PLUGIN_B, excluded=["something"], enabled=False)
 
@@ -216,7 +216,7 @@ def test_disabled_plugin_has_empty_included_templates() -> None:
         mock_pm.plugins = pmap()  # not loaded
         mock_pm.errors = pmap()
 
-        result = _run(build_plugin_listing())
+        result = await build_plugin_listing()
 
     detail = result.plugins[_PLUGIN_B]
     assert detail.settings_data is not None
@@ -224,7 +224,8 @@ def test_disabled_plugin_has_empty_included_templates() -> None:
     assert detail.settings_data.included_templates == []
 
 
-def test_multiple_plugins_computed_independently() -> None:
+@pytest.mark.asyncio
+async def test_multiple_plugins_computed_independently() -> None:
     plugin_a = _make_plugin("x", "y")
     plugin_b = _make_plugin("p", "q", "r")
     state_a = _make_db_state(_PLUGIN_A, excluded=["x"])
@@ -240,7 +241,7 @@ def test_multiple_plugins_computed_independently() -> None:
         mock_pm.plugins = pmap({_PLUGIN_A: plugin_a, _PLUGIN_B: plugin_b})
         mock_pm.errors = pmap()
 
-        result = _run(build_plugin_listing())
+        result = await build_plugin_listing()
 
     sd_a = result.plugins[_PLUGIN_A].settings_data
     sd_b = result.plugins[_PLUGIN_B].settings_data
@@ -250,7 +251,8 @@ def test_multiple_plugins_computed_independently() -> None:
     assert set(sd_b.excluded_templates) == {"q", "r"}
 
 
-def test_plugin_with_no_templates_gives_empty_included() -> None:
+@pytest.mark.asyncio
+async def test_plugin_with_no_templates_gives_empty_included() -> None:
     plugin = _make_plugin()
     state = _make_db_state(_PLUGIN_A)
 
@@ -264,14 +266,15 @@ def test_plugin_with_no_templates_gives_empty_included() -> None:
         mock_pm.plugins = pmap({_PLUGIN_A: plugin})
         mock_pm.errors = pmap()
 
-        result = _run(build_plugin_listing())
+        result = await build_plugin_listing()
 
     sd = result.plugins[_PLUGIN_A].settings_data
     assert sd is not None
     assert sd.included_templates == []
 
 
-def test_plugin_in_memory_without_db_state_has_no_install_data() -> None:
+@pytest.mark.asyncio
+async def test_plugin_in_memory_without_db_state_has_no_install_data() -> None:
     """A plugin loaded in memory but without a DB row should have install_data=None and settings_data=None."""
     plugin = _make_plugin("alpha", "beta")
 
@@ -285,7 +288,7 @@ def test_plugin_in_memory_without_db_state_has_no_install_data() -> None:
         mock_pm.plugins = pmap({_PLUGIN_A: plugin})
         mock_pm.errors = pmap()
 
-        result = _run(build_plugin_listing())
+        result = await build_plugin_listing()
 
     detail = result.plugins[_PLUGIN_A]
     assert detail.install_data is None
@@ -298,7 +301,8 @@ def test_plugin_in_memory_without_db_state_has_no_install_data() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_install_data_populated_when_db_state_exists() -> None:
+@pytest.mark.asyncio
+async def test_install_data_populated_when_db_state_exists() -> None:
     state = _make_db_state(_PLUGIN_A, version="2.3.1")
 
     with (
@@ -311,7 +315,7 @@ def test_install_data_populated_when_db_state_exists() -> None:
         mock_pm.plugins = pmap()
         mock_pm.errors = pmap()
 
-        result = _run(build_plugin_listing())
+        result = await build_plugin_listing()
 
     detail = result.plugins[_PLUGIN_A]
     assert detail.install_data is not None
@@ -320,7 +324,8 @@ def test_install_data_populated_when_db_state_exists() -> None:
     assert detail.install_data.install_errors == []
 
 
-def test_settings_data_absent_when_install_failed() -> None:
+@pytest.mark.asyncio
+async def test_settings_data_absent_when_install_failed() -> None:
     """If install_errors contain an error-severity entry, settings_data must be None."""
     state = _make_db_state(
         _PLUGIN_A,
@@ -338,7 +343,7 @@ def test_settings_data_absent_when_install_failed() -> None:
         mock_pm.plugins = pmap()
         mock_pm.errors = pmap()
 
-        result = _run(build_plugin_listing())
+        result = await build_plugin_listing()
 
     detail = result.plugins[_PLUGIN_A]
     assert detail.install_data is not None
@@ -347,7 +352,8 @@ def test_settings_data_absent_when_install_failed() -> None:
     assert detail.settings_data is None
 
 
-def test_settings_data_present_when_only_warnings() -> None:
+@pytest.mark.asyncio
+async def test_settings_data_present_when_only_warnings() -> None:
     """Install warnings should not suppress settings_data."""
     state = _make_db_state(
         _PLUGIN_A,
@@ -364,7 +370,7 @@ def test_settings_data_present_when_only_warnings() -> None:
         mock_pm.plugins = pmap()
         mock_pm.errors = pmap()
 
-        result = _run(build_plugin_listing())
+        result = await build_plugin_listing()
 
     detail = result.plugins[_PLUGIN_A]
     assert detail.settings_data is not None
@@ -375,7 +381,8 @@ def test_settings_data_present_when_only_warnings() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_load_errors_from_in_memory_errors() -> None:
+@pytest.mark.asyncio
+async def test_load_errors_from_in_memory_errors() -> None:
     state = _make_db_state(_PLUGIN_A)
     in_mem_err = PluginErrors([PluginError(source="load", severity="error", detail="import failed")])
 
@@ -389,7 +396,7 @@ def test_load_errors_from_in_memory_errors() -> None:
         mock_pm.plugins = pmap()
         mock_pm.errors = pmap({_PLUGIN_A: in_mem_err})
 
-        result = _run(build_plugin_listing())
+        result = await build_plugin_listing()
 
     detail = result.plugins[_PLUGIN_A]
     assert len(detail.load_errors) == 1
@@ -397,7 +404,8 @@ def test_load_errors_from_in_memory_errors() -> None:
     assert detail.load_errors[0].severity == "error"
 
 
-def test_load_errors_include_template_errors_from_db() -> None:
+@pytest.mark.asyncio
+async def test_load_errors_include_template_errors_from_db() -> None:
     state = _make_db_state(_PLUGIN_A, template_errors={"myTemplate": "validation failed"})
 
     with (
@@ -410,7 +418,7 @@ def test_load_errors_include_template_errors_from_db() -> None:
         mock_pm.plugins = pmap()
         mock_pm.errors = pmap()
 
-        result = _run(build_plugin_listing())
+        result = await build_plugin_listing()
 
     detail = result.plugins[_PLUGIN_A]
     assert len(detail.load_errors) == 1
@@ -419,7 +427,8 @@ def test_load_errors_include_template_errors_from_db() -> None:
     assert "myTemplate" in detail.load_errors[0].detail
 
 
-def test_load_errors_combined_from_memory_and_db() -> None:
+@pytest.mark.asyncio
+async def test_load_errors_combined_from_memory_and_db() -> None:
     in_mem_err = PluginErrors([PluginError(source="load", severity="warning", detail="minor")])
     state = _make_db_state(_PLUGIN_A, template_errors={"tmpl": "bad"})
 
@@ -433,7 +442,7 @@ def test_load_errors_combined_from_memory_and_db() -> None:
         mock_pm.plugins = pmap()
         mock_pm.errors = pmap({_PLUGIN_A: in_mem_err})
 
-        result = _run(build_plugin_listing())
+        result = await build_plugin_listing()
 
     detail = result.plugins[_PLUGIN_A]
     sources = {e.source for e in detail.load_errors}
@@ -445,7 +454,8 @@ def test_load_errors_combined_from_memory_and_db() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_raises_plugin_manager_busy_when_lock_not_acquired() -> None:
+@pytest.mark.asyncio
+async def test_raises_plugin_manager_busy_when_lock_not_acquired() -> None:
     """If the PluginManager lock cannot be acquired, PluginManagerBusy is raised."""
     busy_lock = threading.Lock()
     busy_lock.acquire()  # hold the lock so timed_acquire times out
@@ -456,7 +466,7 @@ def test_raises_plugin_manager_busy_when_lock_not_acquired() -> None:
         mock_pm.errors = pmap()
 
         with pytest.raises(PluginManagerBusy):
-            _run(build_plugin_listing())
+            await build_plugin_listing()
 
     busy_lock.release()
 
@@ -466,7 +476,8 @@ def test_raises_plugin_manager_busy_when_lock_not_acquired() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_glyph_remapping_propagated_to_settings() -> None:
+@pytest.mark.asyncio
+async def test_glyph_remapping_propagated_to_settings() -> None:
     state = _make_db_state(_PLUGIN_A, glyph_remapping={"old": "new"})
 
     with (
@@ -479,7 +490,7 @@ def test_glyph_remapping_propagated_to_settings() -> None:
         mock_pm.plugins = pmap()
         mock_pm.errors = pmap()
 
-        result = _run(build_plugin_listing())
+        result = await build_plugin_listing()
 
     sd = result.plugins[_PLUGIN_A].settings_data
     assert sd is not None

--- a/backend/tests/unit/domain/plugins/test_plugin_manager.py
+++ b/backend/tests/unit/domain/plugins/test_plugin_manager.py
@@ -7,251 +7,59 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-"""Unit tests for status_full() -- specifically the plugin_active_templates and
-plugin_excluded_template_names fields derived from the in-memory plugin state."""
+"""Unit tests for PluginManager utility functions -- status_brief and plugins_ready."""
 
-import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
-from fiab_core.fable import (
-    BlockFactoryCatalogue,
-    BlueprintTemplate,
-    PluginCompositeId,
-    PluginId,
-    PluginStoreId,
-)
-from fiab_core.plugin import Plugin
-from pyrsistent import pmap
-
-from forecastbox.domain.plugin.manager import status_full
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-_STORE = PluginStoreId("testStore")
-_PLUGIN_A = PluginCompositeId(store=_STORE, local=PluginId("pluginA"))
-_PLUGIN_B = PluginCompositeId(store=_STORE, local=PluginId("pluginB"))
+from forecastbox.domain.plugin.manager import plugins_ready, status_brief
 
 
-def _make_template(name: str) -> BlueprintTemplate:
-    return BlueprintTemplate(
-        display_name=name,
-        display_description="",
-        blocks={},
-    )
+def _make_manager(*, updater_error: str | None, alive: bool) -> MagicMock:
+    mock = MagicMock()
+    mock.updater_error = updater_error
+    mock.updater = MagicMock(is_alive=MagicMock(return_value=alive))
+    return mock
 
 
-def _make_plugin(*template_names: str) -> Plugin:
-    return Plugin(
-        catalogue=BlockFactoryCatalogue(factories={}),
-        validator=lambda factory_id, inst, inputs: (_ for _ in ()).throw(NotImplementedError),  # type: ignore[return-value]
-        expander=lambda output: [],
-        compiler=lambda lookup, factory_id, inst: (_ for _ in ()).throw(NotImplementedError),  # type: ignore[return-value]
-        blueprint_templates=tuple(_make_template(n) for n in template_names),
-    )
-
-
-def _make_plugin_state(plugin_id: PluginCompositeId, excluded: list[str] | None = None) -> MagicMock:
-    state = MagicMock()
-    state.plugin_id = PluginCompositeId.to_str(plugin_id)
-    state.plugin_version = "1.0.0"
-    state.updated_at = None
-    state.plugin_errors = []
-    state.excluded_templates = excluded or []
-    state.glyph_remapping = {}
-    state.template_errors = {}
-    state.enabled = True
-    return state
-
-
-def _run(coro: object) -> object:  # type: ignore[type-arg]
-    return asyncio.run(coro)  # type: ignore[arg-type]
-
-
-def _patch_db(states: list[MagicMock]) -> object:
-    return patch("forecastbox.domain.plugin.manager.get_all_plugin_states", new=AsyncMock(return_value=states))
-
-
-def _patch_time() -> object:
-    return patch("forecastbox.domain.plugin.manager.value_dt2str", return_value="2024-01-01T00:00:00")
-
-
-# ---------------------------------------------------------------------------
-# Tests for plugin_active_templates and plugin_excluded_template_names
-# ---------------------------------------------------------------------------
-
-
-def test_active_templates_all_present_when_no_exclusions() -> None:
-    plugin = _make_plugin("alpha", "beta", "gamma")
-    state = _make_plugin_state(_PLUGIN_A, excluded=[])
-
-    with (
-        patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm,
-        _patch_db([state]),
-        _patch_time(),
-    ):
-        mock_pm.lock = __import__("threading").Lock()
-        mock_pm.plugins = pmap({_PLUGIN_A: plugin})
-        mock_pm.errors = pmap()
-        mock_pm.updater = MagicMock(is_alive=lambda: False)
+def test_status_brief_ok() -> None:
+    with patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm:
         mock_pm.updater_error = None
-
-        result = _run(status_full())
-
-    assert result.plugin_active_templates[_PLUGIN_A] == ["alpha", "beta", "gamma"]
-    assert result.plugin_excluded_template_names[_PLUGIN_A] == []
+        mock_pm.updater = MagicMock(is_alive=MagicMock(return_value=False))
+        assert status_brief() == "ok"
 
 
-def test_excluded_templates_split_correctly() -> None:
-    plugin = _make_plugin("alpha", "beta", "gamma")
-    state = _make_plugin_state(_PLUGIN_A, excluded=["beta"])
-
-    with (
-        patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm,
-        _patch_db([state]),
-        _patch_time(),
-    ):
-        mock_pm.lock = __import__("threading").Lock()
-        mock_pm.plugins = pmap({_PLUGIN_A: plugin})
-        mock_pm.errors = pmap()
-        mock_pm.updater = MagicMock(is_alive=lambda: False)
+def test_status_brief_running() -> None:
+    with patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm:
         mock_pm.updater_error = None
-
-        result = _run(status_full())
-
-    assert result.plugin_active_templates[_PLUGIN_A] == ["alpha", "gamma"]
-    assert result.plugin_excluded_template_names[_PLUGIN_A] == ["beta"]
+        mock_pm.updater = MagicMock(is_alive=MagicMock(return_value=True))
+        assert status_brief() == "running"
 
 
-def test_all_templates_excluded() -> None:
-    plugin = _make_plugin("t1", "t2")
-    state = _make_plugin_state(_PLUGIN_A, excluded=["t1", "t2"])
+def test_status_brief_failure() -> None:
+    with patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm:
+        mock_pm.updater_error = "some error"
+        mock_pm.updater = MagicMock(is_alive=MagicMock(return_value=False))
+        result = status_brief()
+        assert result.startswith("failure:")
+        assert "some error" in result
 
-    with (
-        patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm,
-        _patch_db([state]),
-        _patch_time(),
-    ):
-        mock_pm.lock = __import__("threading").Lock()
-        mock_pm.plugins = pmap({_PLUGIN_A: plugin})
-        mock_pm.errors = pmap()
-        mock_pm.updater = MagicMock(is_alive=lambda: False)
+
+def test_plugins_ready_true_when_ok() -> None:
+    with patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm:
         mock_pm.updater_error = None
-
-        result = _run(status_full())
-
-    assert result.plugin_active_templates[_PLUGIN_A] == []
-    assert set(result.plugin_excluded_template_names[_PLUGIN_A]) == {"t1", "t2"}
+        mock_pm.updater = MagicMock(is_alive=MagicMock(return_value=False))
+        assert plugins_ready() is True
 
 
-def test_excluded_name_not_in_plugin_templates_is_ignored() -> None:
-    """A name in excluded_templates that doesn't match any actual template is silently ignored."""
-    plugin = _make_plugin("alpha", "beta")
-    state = _make_plugin_state(_PLUGIN_A, excluded=["nonexistent", "beta"])
-
-    with (
-        patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm,
-        _patch_db([state]),
-        _patch_time(),
-    ):
-        mock_pm.lock = __import__("threading").Lock()
-        mock_pm.plugins = pmap({_PLUGIN_A: plugin})
-        mock_pm.errors = pmap()
-        mock_pm.updater = MagicMock(is_alive=lambda: False)
+def test_plugins_ready_false_when_running() -> None:
+    with patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm:
         mock_pm.updater_error = None
-
-        result = _run(status_full())
-
-    assert result.plugin_active_templates[_PLUGIN_A] == ["alpha"]
-    assert result.plugin_excluded_template_names[_PLUGIN_A] == ["beta"]
+        mock_pm.updater = MagicMock(is_alive=MagicMock(return_value=True))
+        assert plugins_ready() is False
 
 
-def test_disabled_plugin_absent_from_template_dicts() -> None:
-    """Disabled plugins are not in PluginManager.plugins, so they are absent from the template dicts."""
-    # Plugin B is in the DB but not loaded (disabled)
-    state_b = _make_plugin_state(_PLUGIN_B, excluded=["something"])
-    state_b.enabled = False
-
-    with (
-        patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm,
-        _patch_db([state_b]),
-        _patch_time(),
-    ):
-        mock_pm.lock = __import__("threading").Lock()
-        mock_pm.plugins = pmap()  # no loaded plugins
-        mock_pm.errors = pmap()
-        mock_pm.updater = MagicMock(is_alive=lambda: False)
-        mock_pm.updater_error = None
-
-        result = _run(status_full())
-
-    assert _PLUGIN_B not in result.plugin_active_templates
-    assert _PLUGIN_B not in result.plugin_excluded_template_names
-
-
-def test_multiple_plugins_each_computed_independently() -> None:
-    plugin_a = _make_plugin("x", "y")
-    plugin_b = _make_plugin("p", "q", "r")
-    state_a = _make_plugin_state(_PLUGIN_A, excluded=["x"])
-    state_b = _make_plugin_state(_PLUGIN_B, excluded=["q", "r"])
-
-    with (
-        patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm,
-        _patch_db([state_a, state_b]),
-        _patch_time(),
-    ):
-        mock_pm.lock = __import__("threading").Lock()
-        mock_pm.plugins = pmap({_PLUGIN_A: plugin_a, _PLUGIN_B: plugin_b})
-        mock_pm.errors = pmap()
-        mock_pm.updater = MagicMock(is_alive=lambda: False)
-        mock_pm.updater_error = None
-
-        result = _run(status_full())
-
-    assert result.plugin_active_templates[_PLUGIN_A] == ["y"]
-    assert result.plugin_excluded_template_names[_PLUGIN_A] == ["x"]
-    assert result.plugin_active_templates[_PLUGIN_B] == ["p"]
-    assert set(result.plugin_excluded_template_names[_PLUGIN_B]) == {"q", "r"}
-
-
-def test_plugin_with_no_templates_gives_empty_lists() -> None:
-    plugin = _make_plugin()  # no templates
-    state = _make_plugin_state(_PLUGIN_A, excluded=[])
-
-    with (
-        patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm,
-        _patch_db([state]),
-        _patch_time(),
-    ):
-        mock_pm.lock = __import__("threading").Lock()
-        mock_pm.plugins = pmap({_PLUGIN_A: plugin})
-        mock_pm.errors = pmap()
-        mock_pm.updater = MagicMock(is_alive=lambda: False)
-        mock_pm.updater_error = None
-
-        result = _run(status_full())
-
-    assert result.plugin_active_templates[_PLUGIN_A] == []
-    assert result.plugin_excluded_template_names[_PLUGIN_A] == []
-
-
-def test_loaded_plugin_without_db_state_uses_empty_exclusions() -> None:
-    """A plugin loaded in memory but without a DB state entry should have all templates active."""
-    plugin = _make_plugin("alpha", "beta")
-
-    with (
-        patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm,
-        _patch_db([]),  # no DB state rows at all
-        _patch_time(),
-    ):
-        mock_pm.lock = __import__("threading").Lock()
-        mock_pm.plugins = pmap({_PLUGIN_A: plugin})
-        mock_pm.errors = pmap()
-        mock_pm.updater = MagicMock(is_alive=lambda: False)
-        mock_pm.updater_error = None
-
-        result = _run(status_full())
-
-    assert result.plugin_active_templates[_PLUGIN_A] == ["alpha", "beta"]
-    assert result.plugin_excluded_template_names[_PLUGIN_A] == []
+def test_plugins_ready_false_when_failed() -> None:
+    with patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm:
+        mock_pm.updater_error = "crash"
+        mock_pm.updater = MagicMock(is_alive=MagicMock(return_value=False))
+        assert plugins_ready() is False

--- a/backend/tests/unit/routes/test_plugins.py
+++ b/backend/tests/unit/routes/test_plugins.py
@@ -9,7 +9,6 @@
 
 """Unit tests for plugin route helpers — version/specifier parsing logic and /versions route."""
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -230,11 +229,8 @@ def _make_plugin_state(excluded: list[str] | None = None, remapping: dict[str, s
     return state
 
 
-def _run(coro: object) -> object:  # type: ignore[type-arg]
-    return asyncio.run(coro)  # type: ignore[arg-type]
-
-
-def test_template_example_values_returns_examples() -> None:
+@pytest.mark.asyncio
+async def test_template_example_values_returns_examples() -> None:
     plugin = _make_plugin(_TEMPLATE_WITH_EXAMPLES)
     state = _make_plugin_state()
     with (
@@ -242,12 +238,13 @@ def test_template_example_values_returns_examples() -> None:
         patch("forecastbox.routes.plugins.get_plugin_state", new=AsyncMock(return_value=state)),
     ):
         mock_pm.plugins = pmap({_PLUGIN_ID: plugin})
-        result = _run(get_template_example_values(_PLUGIN_ID, "myTemplate"))
+        result = await get_template_example_values(_PLUGIN_ID, "myTemplate")
     assert result.example_values == {_BLOCK_A: {_TEXT: "${exampleGlyph}"}}
     assert result.example_glyphs == {"exampleGlyph": "hello world"}
 
 
-def test_template_example_values_applies_remapping() -> None:
+@pytest.mark.asyncio
+async def test_template_example_values_applies_remapping() -> None:
     plugin = _make_plugin(_TEMPLATE_WITH_EXAMPLES)
     state = _make_plugin_state(remapping={"exampleGlyph": "renamedGlyph"})
     with (
@@ -255,31 +252,34 @@ def test_template_example_values_applies_remapping() -> None:
         patch("forecastbox.routes.plugins.get_plugin_state", new=AsyncMock(return_value=state)),
     ):
         mock_pm.plugins = pmap({_PLUGIN_ID: plugin})
-        result = _run(get_template_example_values(_PLUGIN_ID, "myTemplate"))
+        result = await get_template_example_values(_PLUGIN_ID, "myTemplate")
     # Key renamed, value's glyph reference renamed
     assert result.example_glyphs == {"renamedGlyph": "hello world"}
     # The example_value string referencing ${exampleGlyph} must be rewritten
     assert result.example_values[_BLOCK_A][_TEXT] == "${renamedGlyph}"
 
 
-def test_template_example_values_404_unknown_plugin() -> None:
+@pytest.mark.asyncio
+async def test_template_example_values_404_unknown_plugin() -> None:
     with patch("forecastbox.routes.plugins.PluginManager") as mock_pm:
         mock_pm.plugins = pmap()
         with pytest.raises(HTTPException) as exc_info:
-            _run(get_template_example_values(_PLUGIN_ID, "myTemplate"))
+            await get_template_example_values(_PLUGIN_ID, "myTemplate")
     assert exc_info.value.status_code == 404
 
 
-def test_template_example_values_404_unknown_display_name() -> None:
+@pytest.mark.asyncio
+async def test_template_example_values_404_unknown_display_name() -> None:
     plugin = _make_plugin(_TEMPLATE_WITH_EXAMPLES)
     with patch("forecastbox.routes.plugins.PluginManager") as mock_pm:
         mock_pm.plugins = pmap({_PLUGIN_ID: plugin})
         with pytest.raises(HTTPException) as exc_info:
-            _run(get_template_example_values(_PLUGIN_ID, "nonExistent"))
+            await get_template_example_values(_PLUGIN_ID, "nonExistent")
     assert exc_info.value.status_code == 404
 
 
-def test_template_example_values_403_excluded() -> None:
+@pytest.mark.asyncio
+async def test_template_example_values_403_excluded() -> None:
     plugin = _make_plugin(_TEMPLATE_WITH_EXAMPLES)
     state = _make_plugin_state(excluded=["myTemplate"])
     with (
@@ -288,5 +288,5 @@ def test_template_example_values_403_excluded() -> None:
     ):
         mock_pm.plugins = pmap({_PLUGIN_ID: plugin})
         with pytest.raises(HTTPException) as exc_info:
-            _run(get_template_example_values(_PLUGIN_ID, "myTemplate"))
+            await get_template_example_values(_PLUGIN_ID, "myTemplate")
     assert exc_info.value.status_code == 403

--- a/frontend/mocks/data/plugins.data.ts
+++ b/frontend/mocks/data/plugins.data.ts
@@ -25,188 +25,263 @@ function createPluginKey(store: string, local: string): string {
 }
 
 /**
- * Mock plugin data in backend format
+ * Mock plugin data in backend format (new nested structure from GET /plugin/list)
  */
 export const mockPluginListing: PluginListing = {
   plugins: {
-    // ECMWF Plugin - loaded and installed (matches live backend exactly)
+    // ECMWF Plugin - loaded and installed
     [createPluginKey('ecmwf', 'ecmwf-base')]: {
-      status: 'loaded',
-      store_info: {
-        pip_source: 'fiab-plugin-ecmwf',
-        module_name: 'fiab_plugin_ecmwf',
-        display_title: 'ECMWF Plugin',
-        display_description:
-          'ECMWF plugin for Earthkit-data sources and products',
-        display_author: 'ECMWF',
-        comment: '',
+      generic_data: {
+        store_info: {
+          pip_source: 'fiab-plugin-ecmwf',
+          module_name: 'fiab_plugin_ecmwf',
+          display_title: 'ECMWF Plugin',
+          display_description:
+            'ECMWF plugin for Earthkit-data sources and products',
+          display_author: 'ECMWF',
+          comment: '',
+        },
+        remote_info: { version: '0.0.1' },
       },
-      remote_info: { version: '0.0.1' },
-      errored_detail: null,
-      loaded_version: '0.0.1',
-      update_datetime: '2026-02-03T00:00:00+00:00',
+      install_data: {
+        local_version: '0.0.1',
+        update_datetime: '2026-02-03T00:00:00+00:00',
+        install_errors: [],
+      },
+      settings_data: {
+        isEnabled: true,
+        excluded_templates: [],
+        included_templates: [],
+        glyph_remapping: {},
+      },
+      load_errors: [],
     },
 
     // Disabled plugins (installed but not enabled)
     [createPluginKey('ecmwf', 'anemoi-inference')]: {
-      status: 'disabled',
-      store_info: {
-        pip_source: 'anemoi-inference',
-        module_name: 'anemoi_inference',
-        display_title: 'Anemoi Inference',
-        display_description:
-          'ECMWF Anemoi machine learning inference engine for running AI weather models.',
-        display_author: 'ECMWF',
-        comment: 'Core plugin for ML inference',
+      generic_data: {
+        store_info: {
+          pip_source: 'anemoi-inference',
+          module_name: 'anemoi_inference',
+          display_title: 'Anemoi Inference',
+          display_description:
+            'ECMWF Anemoi machine learning inference engine for running AI weather models.',
+          display_author: 'ECMWF',
+          comment: 'Core plugin for ML inference',
+        },
+        remote_info: { version: '1.0.0' },
       },
-      remote_info: { version: '1.0.0' },
-      errored_detail: null,
-      loaded_version: '1.0.0',
-      update_datetime: '2025-01-01T00:00:00+00:00',
+      install_data: {
+        local_version: '1.0.0',
+        update_datetime: '2025-01-01T00:00:00+00:00',
+        install_errors: [],
+      },
+      settings_data: {
+        isEnabled: false,
+        excluded_templates: [],
+        included_templates: [],
+        glyph_remapping: {},
+      },
+      load_errors: [],
     },
     [createPluginKey('ecmwf', 'aifs-dataset')]: {
-      status: 'disabled',
-      store_info: {
-        pip_source: 'aifs-dataset',
-        module_name: 'aifs_dataset',
-        display_title: 'AIFS Forecast Dataset',
-        display_description:
-          'Access ECMWF AIFS (Artificial Intelligence Forecasting System) forecast datasets as input source.',
-        display_author: 'ECMWF',
-        comment: '',
+      generic_data: {
+        store_info: {
+          pip_source: 'aifs-dataset',
+          module_name: 'aifs_dataset',
+          display_title: 'AIFS Forecast Dataset',
+          display_description:
+            'Access ECMWF AIFS (Artificial Intelligence Forecasting System) forecast datasets as input source.',
+          display_author: 'ECMWF',
+          comment: '',
+        },
+        remote_info: { version: '1.0.0' },
       },
-      remote_info: { version: '1.0.0' },
-      errored_detail: null,
-      loaded_version: '1.0.0',
-      update_datetime: '2025-01-01T00:00:00+00:00',
+      install_data: {
+        local_version: '1.0.0',
+        update_datetime: '2025-01-01T00:00:00+00:00',
+        install_errors: [],
+      },
+      settings_data: {
+        isEnabled: false,
+        excluded_templates: [],
+        included_templates: [],
+        glyph_remapping: {},
+      },
+      load_errors: [],
     },
     [createPluginKey('ecmwf', 'regridding')]: {
-      status: 'disabled',
-      store_info: {
-        pip_source: 'ecmwf-regridding',
-        module_name: 'ecmwf_regridding',
-        display_title: 'ECMWF Regridding',
-        display_description:
-          'High-performance regridding and interpolation for forecast datasets.',
-        display_author: 'ECMWF',
-        comment: '',
+      generic_data: {
+        store_info: {
+          pip_source: 'ecmwf-regridding',
+          module_name: 'ecmwf_regridding',
+          display_title: 'ECMWF Regridding',
+          display_description:
+            'High-performance regridding and interpolation for forecast datasets.',
+          display_author: 'ECMWF',
+          comment: '',
+        },
+        remote_info: { version: '2.0.5' },
       },
-      remote_info: { version: '2.0.5' },
-      errored_detail: null,
-      loaded_version: '2.0.5',
-      update_datetime: '2025-12-04T00:00:00+00:00',
+      install_data: {
+        local_version: '2.0.5',
+        update_datetime: '2025-12-04T00:00:00+00:00',
+        install_errors: [],
+      },
+      settings_data: {
+        isEnabled: false,
+        excluded_templates: [],
+        included_templates: [],
+        glyph_remapping: {},
+      },
+      load_errors: [],
     },
     [createPluginKey('ecmwf', 'grib-export')]: {
-      status: 'disabled',
-      store_info: {
-        pip_source: 'grib-export',
-        module_name: 'grib_export',
-        display_title: 'GRIB Export',
-        display_description:
-          'Export forecast data in GRIB format for meteorological use.',
-        display_author: 'ECMWF',
-        comment: '',
+      generic_data: {
+        store_info: {
+          pip_source: 'grib-export',
+          module_name: 'grib_export',
+          display_title: 'GRIB Export',
+          display_description:
+            'Export forecast data in GRIB format for meteorological use.',
+          display_author: 'ECMWF',
+          comment: '',
+        },
+        remote_info: { version: '2.1.0' },
       },
-      remote_info: { version: '2.1.0' },
-      errored_detail: null,
-      loaded_version: '2.1.0',
-      update_datetime: '2025-10-20T00:00:00+00:00',
+      install_data: {
+        local_version: '2.1.0',
+        update_datetime: '2025-10-20T00:00:00+00:00',
+        install_errors: [],
+      },
+      settings_data: {
+        isEnabled: false,
+        excluded_templates: [],
+        included_templates: [],
+        glyph_remapping: {},
+      },
+      load_errors: [],
     },
     [createPluginKey('ecmwf', 'ensemble-forecast')]: {
-      status: 'disabled',
-      store_info: {
-        pip_source: 'ecmwf-ensemble',
-        module_name: 'ecmwf_ensemble',
-        display_title: 'ECMWF Ensemble',
-        display_description:
-          'AI-based ensemble forecasting using ECMWF model architecture.',
-        display_author: 'ECMWF',
-        comment: '',
+      generic_data: {
+        store_info: {
+          pip_source: 'ecmwf-ensemble',
+          module_name: 'ecmwf_ensemble',
+          display_title: 'ECMWF Ensemble',
+          display_description:
+            'AI-based ensemble forecasting using ECMWF model architecture.',
+          display_author: 'ECMWF',
+          comment: '',
+        },
+        remote_info: { version: '2.4.0' },
       },
-      remote_info: { version: '2.4.0' },
-      errored_detail: null,
-      loaded_version: '2.1.0',
-      update_datetime: '2025-09-01T00:00:00+00:00',
+      install_data: {
+        local_version: '2.1.0',
+        update_datetime: '2025-09-01T00:00:00+00:00',
+        install_errors: [],
+      },
+      settings_data: {
+        isEnabled: false,
+        excluded_templates: [],
+        included_templates: [],
+        glyph_remapping: {},
+      },
+      load_errors: [],
     },
     [createPluginKey('ecmwf', 'precipitation')]: {
-      status: 'disabled',
-      store_info: {
-        pip_source: 'precipitation-viz',
-        module_name: 'precipitation_viz',
-        display_title: 'Precipitation Visualizer',
-        display_description: 'Legacy module for rain density visualization.',
-        display_author: 'ECMWF',
-        comment: 'Deprecated - use new visualizer instead',
+      generic_data: {
+        store_info: {
+          pip_source: 'precipitation-viz',
+          module_name: 'precipitation_viz',
+          display_title: 'Precipitation Visualizer',
+          display_description: 'Legacy module for rain density visualization.',
+          display_author: 'ECMWF',
+          comment: 'Deprecated - use new visualizer instead',
+        },
+        remote_info: { version: '1.2.0' },
       },
-      remote_info: { version: '1.2.0' },
-      errored_detail: null,
-      loaded_version: '1.2.0',
-      update_datetime: '2025-11-01T00:00:00+00:00',
+      install_data: {
+        local_version: '1.2.0',
+        update_datetime: '2025-11-01T00:00:00+00:00',
+        install_errors: [],
+      },
+      settings_data: {
+        isEnabled: false,
+        excluded_templates: [],
+        included_templates: [],
+        glyph_remapping: {},
+      },
+      load_errors: [],
     },
 
     // Available plugins (not installed)
     [createPluginKey('ecmwf', 'anemoi-storm-tracker')]: {
-      status: 'available',
-      store_info: {
-        pip_source: 'anemoi-storm-tracker',
-        module_name: 'anemoi_storm_tracker',
-        display_title: 'Anemoi Storm Tracker',
-        display_description:
-          'ML-based severe weather tracking module for Anemoi inference pipelines.',
-        display_author: 'ECMWF',
-        comment: 'New plugin!',
+      generic_data: {
+        store_info: {
+          pip_source: 'anemoi-storm-tracker',
+          module_name: 'anemoi_storm_tracker',
+          display_title: 'Anemoi Storm Tracker',
+          display_description:
+            'ML-based severe weather tracking module for Anemoi inference pipelines.',
+          display_author: 'ECMWF',
+          comment: 'New plugin!',
+        },
+        remote_info: { version: '3.0.0' },
       },
-      remote_info: { version: '3.0.0' },
-      errored_detail: null,
-      loaded_version: null,
-      update_datetime: null,
+      install_data: null,
+      settings_data: null,
+      load_errors: [],
     },
     [createPluginKey('ecmwf', 'snow-analysis')]: {
-      status: 'available',
-      store_info: {
-        pip_source: 'snow-analysis',
-        module_name: 'snow_analysis',
-        display_title: 'Snow Analysis',
-        display_description: 'Analyze and forecast snow accumulation patterns.',
-        display_author: 'ECMWF',
-        comment: '',
+      generic_data: {
+        store_info: {
+          pip_source: 'snow-analysis',
+          module_name: 'snow_analysis',
+          display_title: 'Snow Analysis',
+          display_description:
+            'Analyze and forecast snow accumulation patterns.',
+          display_author: 'ECMWF',
+          comment: '',
+        },
+        remote_info: { version: '2.0.0' },
       },
-      remote_info: { version: '2.0.0' },
-      errored_detail: null,
-      loaded_version: null,
-      update_datetime: null,
+      install_data: null,
+      settings_data: null,
+      load_errors: [],
     },
     [createPluginKey('ecmwf', 'netcdf-export')]: {
-      status: 'available',
-      store_info: {
-        pip_source: 'netcdf-export',
-        module_name: 'netcdf_export',
-        display_title: 'NetCDF Export',
-        display_description:
-          'Export forecast data in NetCDF format for scientific analysis.',
-        display_author: 'ECMWF',
-        comment: '',
+      generic_data: {
+        store_info: {
+          pip_source: 'netcdf-export',
+          module_name: 'netcdf_export',
+          display_title: 'NetCDF Export',
+          display_description:
+            'Export forecast data in NetCDF format for scientific analysis.',
+          display_author: 'ECMWF',
+          comment: '',
+        },
+        remote_info: { version: '1.5.0' },
       },
-      remote_info: { version: '1.5.0' },
-      errored_detail: null,
-      loaded_version: null,
-      update_datetime: null,
+      install_data: null,
+      settings_data: null,
+      load_errors: [],
     },
     [createPluginKey('ecmwf', 'pdf-export')]: {
-      status: 'available',
-      store_info: {
-        pip_source: 'pdf-report-generator',
-        module_name: 'pdf_export',
-        display_title: 'PDF Report Generator',
-        display_description:
-          'Generate professional PDF reports from forecast data.',
-        display_author: 'ECMWF',
-        comment: '',
+      generic_data: {
+        store_info: {
+          pip_source: 'pdf-report-generator',
+          module_name: 'pdf_export',
+          display_title: 'PDF Report Generator',
+          display_description:
+            'Generate professional PDF reports from forecast data.',
+          display_author: 'ECMWF',
+          comment: '',
+        },
+        remote_info: { version: '1.5.0' },
       },
-      remote_info: { version: '1.5.0' },
-      errored_detail: null,
-      loaded_version: null,
-      update_datetime: null,
+      install_data: null,
+      settings_data: null,
+      load_errors: [],
     },
   },
 }

--- a/frontend/mocks/handlers/plugins.handlers.ts
+++ b/frontend/mocks/handlers/plugins.handlers.ts
@@ -11,9 +11,8 @@
 /**
  * MSW Handlers for Plugin API
  *
- * These handlers match the new backend API exactly:
- * - GET /api/v1/plugin/status
- * - GET /api/v1/plugin/details
+ * These handlers match the new backend API:
+ * - GET /api/v1/plugin/list
  * - POST /api/v1/plugin/install
  * - POST /api/v1/plugin/uninstall
  * - POST /api/v1/plugin/update
@@ -27,7 +26,6 @@ import type {
   PluginDetail,
   PluginListing,
   PluginSettingsUpdate,
-  PluginsStatus,
 } from '@/api/types/plugins.types'
 import { API_ENDPOINTS } from '@/api/endpoints'
 
@@ -86,53 +84,9 @@ function getCurrentDatetime(): string {
 }
 
 export const pluginsHandlers = [
-  // GET /api/v1/plugin/status
-  http.get(API_ENDPOINTS.plugin.status, async () => {
-    await delay(200)
-
-    // Build status response from current state
-    const status: PluginsStatus = {
-      updater_status: 'idle',
-      plugin_errors: {},
-      plugin_versions: {},
-      plugin_updatedatetime: {},
-      plugin_enabled: {},
-      plugin_excluded_templates: {},
-      plugin_glyph_remapping: {},
-    }
-
-    for (const [key, detail] of Object.entries(pluginsState.plugins)) {
-      if (detail.status === 'errored' && detail.errored_detail) {
-        status.plugin_errors[key] = detail.errored_detail
-      }
-      if (detail.loaded_version) {
-        status.plugin_versions[key] = detail.loaded_version
-      }
-      if (detail.update_datetime) {
-        status.plugin_updatedatetime[key] = detail.update_datetime
-      }
-      if (detail.status !== 'available') {
-        status.plugin_enabled[key] = detail.status !== 'disabled'
-        status.plugin_excluded_templates[key] = []
-        status.plugin_glyph_remapping[key] = {}
-      }
-    }
-
-    return HttpResponse.json(status)
-  }),
-
-  // GET /api/v1/plugin/details
-  http.get(API_ENDPOINTS.plugin.details, async ({ request }) => {
+  // GET /api/v1/plugin/list
+  http.get(API_ENDPOINTS.plugin.list, async () => {
     await delay(300)
-
-    // Check for forceRefresh query param (optional)
-    const url = new URL(request.url)
-    const forceRefresh = url.searchParams.get('forceRefresh') === 'true'
-
-    if (forceRefresh) {
-      // Simulate refresh - in real backend this would re-fetch from PyPI
-      await delay(500)
-    }
 
     return HttpResponse.json(pluginsState)
   }),
@@ -154,19 +108,29 @@ export const pluginsHandlers = [
       )
     }
 
-    if (plugin.status !== 'available') {
+    if (plugin.install_data !== null) {
       return new HttpResponse(
         JSON.stringify({ detail: 'Plugin is already installed' }),
         { status: 400 },
       )
     }
 
+    const newVersion = plugin.generic_data.remote_info?.version ?? '1.0.0'
     // Update plugin state
     pluginsState.plugins[key] = {
       ...plugin,
-      status: 'loaded',
-      loaded_version: plugin.remote_info?.version ?? '1.0.0',
-      update_datetime: getCurrentDatetime(),
+      install_data: {
+        local_version: newVersion,
+        update_datetime: getCurrentDatetime(),
+        install_errors: [],
+      },
+      settings_data: {
+        isEnabled: true,
+        excluded_templates: [],
+        included_templates: [],
+        glyph_remapping: {},
+      },
+      load_errors: [],
     }
 
     // Simulate backend reload: catalogue will 503 once while plugins restart
@@ -192,7 +156,7 @@ export const pluginsHandlers = [
       )
     }
 
-    if (plugin.status === 'available') {
+    if (plugin.install_data === null) {
       return new HttpResponse(
         JSON.stringify({ detail: 'Plugin is not installed' }),
         { status: 400 },
@@ -202,10 +166,9 @@ export const pluginsHandlers = [
     // Update plugin state
     pluginsState.plugins[key] = {
       ...plugin,
-      status: 'available',
-      loaded_version: null,
-      update_datetime: null,
-      errored_detail: null,
+      install_data: null,
+      settings_data: null,
+      load_errors: [],
     }
 
     // Simulate backend reload: catalogue will 503 once while plugins restart
@@ -231,15 +194,15 @@ export const pluginsHandlers = [
       )
     }
 
-    if (plugin.status === 'available') {
+    if (plugin.install_data === null) {
       return new HttpResponse(
         JSON.stringify({ detail: 'Plugin is not installed' }),
         { status: 400 },
       )
     }
 
-    const newVersion = plugin.remote_info?.version
-    if (!newVersion || newVersion === plugin.loaded_version) {
+    const newVersion = plugin.generic_data.remote_info?.version
+    if (!newVersion || newVersion === plugin.install_data.local_version) {
       return new HttpResponse(
         JSON.stringify({ detail: 'No update available' }),
         { status: 400 },
@@ -249,10 +212,12 @@ export const pluginsHandlers = [
     // Update plugin state
     pluginsState.plugins[key] = {
       ...plugin,
-      status: 'loaded',
-      loaded_version: newVersion,
-      update_datetime: getCurrentDatetime(),
-      errored_detail: null,
+      install_data: {
+        ...plugin.install_data,
+        local_version: newVersion,
+        update_datetime: getCurrentDatetime(),
+      },
+      load_errors: [],
     }
 
     // Simulate backend reload: catalogue will 503 once while plugins restart
@@ -284,7 +249,7 @@ export const pluginsHandlers = [
       )
     }
 
-    if (plugin.status === 'available') {
+    if (plugin.install_data === null) {
       return new HttpResponse(
         JSON.stringify({ detail: 'Plugin must be installed first' }),
         { status: 400 },
@@ -292,11 +257,13 @@ export const pluginsHandlers = [
     }
 
     // Update plugin state if isEnabled was provided
-    if (isEnabled !== undefined) {
+    if (isEnabled !== undefined && plugin.settings_data !== null) {
       pluginsState.plugins[key] = {
         ...plugin,
-        status: isEnabled ? 'loaded' : 'disabled',
-        errored_detail: isEnabled ? null : plugin.errored_detail,
+        settings_data: {
+          ...plugin.settings_data,
+          isEnabled,
+        },
       }
     }
 

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -109,10 +109,8 @@ export const API_ENDPOINTS = {
    * POST endpoints use request body for PluginCompositeId.
    */
   plugin: {
-    /** GET - Get plugin system status */
-    status: `${API_PREFIX}/plugin/status`,
     /** GET - Get all plugin details */
-    details: `${API_PREFIX}/plugin/details`,
+    list: `${API_PREFIX}/plugin/list`,
     /** POST - Install a plugin (body: PluginCompositeId) */
     install: `${API_PREFIX}/plugin/install`,
     /** POST - Uninstall a plugin (body: PluginCompositeId) */

--- a/frontend/src/api/endpoints/plugins.ts
+++ b/frontend/src/api/endpoints/plugins.ts
@@ -19,35 +19,20 @@ import type {
   PluginCompositeId,
   PluginListing,
   PluginSettingsUpdate,
-  PluginsStatus,
   TemplateExampleValues,
 } from '@/api/types/plugins.types'
 import { apiClient } from '@/api/client'
 import { API_ENDPOINTS } from '@/api/endpoints'
 import {
   PluginListingSchema,
-  PluginsStatusSchema,
   TemplateExampleValuesSchema,
 } from '@/api/types/plugins.types'
 
 /**
- * Get plugin system status
- */
-export async function getPluginStatus(): Promise<PluginsStatus> {
-  return apiClient.get(API_ENDPOINTS.plugin.status, {
-    schema: PluginsStatusSchema,
-  })
-}
-
-/**
  * Get all plugin details
- * @param forceRefresh - If true, forces a refresh from the backend
  */
-export async function getPluginDetails(
-  forceRefresh?: boolean,
-): Promise<PluginListing> {
-  return apiClient.get(API_ENDPOINTS.plugin.details, {
-    params: forceRefresh ? { forceRefresh: 'true' } : undefined,
+export async function getPluginList(): Promise<PluginListing> {
+  return apiClient.get(API_ENDPOINTS.plugin.list, {
     schema: PluginListingSchema,
   })
 }

--- a/frontend/src/api/hooks/usePlugins.ts
+++ b/frontend/src/api/hooks/usePlugins.ts
@@ -23,13 +23,11 @@ import type {
   PluginInfo,
   PluginListing,
   PluginSettingsUpdate,
-  PluginsStatus,
 } from '@/api/types/plugins.types'
 import {
   disablePlugin,
   enablePlugin,
-  getPluginDetails,
-  getPluginStatus,
+  getPluginList,
   getTemplateExampleValues,
   installPlugin,
   uninstallPlugin,
@@ -49,29 +47,16 @@ const log = createLogger('usePlugins')
 /** Query keys for plugins */
 export const pluginKeys = {
   all: ['plugin'] as const,
-  status: () => [...pluginKeys.all, 'status'] as const,
-  details: (forceRefresh?: boolean) =>
-    [...pluginKeys.all, 'details', { forceRefresh }] as const,
-}
-
-/**
- * Hook to get plugin system status
- */
-export function usePluginStatus() {
-  return useQuery<PluginsStatus>({
-    queryKey: pluginKeys.status(),
-    queryFn: getPluginStatus,
-    staleTime: 30 * 1000, // 30 seconds
-  })
+  list: () => [...pluginKeys.all, 'list'] as const,
 }
 
 /**
  * Hook to get all plugin details (raw backend response)
  */
-export function usePluginDetails(forceRefresh?: boolean) {
+export function usePluginList() {
   return useQuery<PluginListing>({
-    queryKey: pluginKeys.details(forceRefresh),
-    queryFn: () => getPluginDetails(forceRefresh),
+    queryKey: pluginKeys.list(),
+    queryFn: getPluginList,
     staleTime: 60 * 1000, // 1 minute
   })
 }
@@ -115,18 +100,15 @@ export function deriveCapabilitiesFromCatalogue(
 export function usePlugins(catalogue?: BlockFactoryCatalogue) {
   // Forward fields by explicit access, not rest/spread — Query tracks per-field
   // reads, so spreading re-renders on every field.
-  const query = usePluginDetails()
+  const query = usePluginList()
   const listing = query.data
-  // plugin_enabled lives on a separate endpoint — join it so the toggle
-  // reflects real enabled state, not just whether the module loaded.
-  const enabledMap = usePluginStatus().data?.plugin_enabled
 
   const plugins = useMemo<Array<PluginInfo>>(() => {
     if (!listing) return []
 
     const capabilitiesMap = deriveCapabilitiesFromCatalogue(catalogue)
-    return toPluginInfoList(listing, capabilitiesMap, enabledMap)
-  }, [listing, catalogue, enabledMap])
+    return toPluginInfoList(listing, capabilitiesMap)
+  }, [listing, catalogue])
 
   return {
     data: listing ? { plugins } : undefined,
@@ -184,8 +166,7 @@ function usePluginMutation<TVariables>(
       // Refresh caches. Status carries plugin_enabled, so it must refresh too
       // or the toggle sticks.
       await queryClient.invalidateQueries({ queryKey: fableKeys.catalogue() })
-      await queryClient.invalidateQueries({ queryKey: pluginKeys.details() })
-      await queryClient.invalidateQueries({ queryKey: pluginKeys.status() })
+      await queryClient.invalidateQueries({ queryKey: pluginKeys.list() })
     },
   })
 }
@@ -248,15 +229,15 @@ export function useTemplateExampleValues(
 }
 
 /**
- * Hook to refresh plugin details (force refresh from backend)
+ * Hook to refresh plugin list from backend
  */
 export function useRefreshPlugins() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: () => getPluginDetails(true),
+    mutationFn: () => getPluginList(),
     onSuccess: (data) => {
-      queryClient.setQueryData(pluginKeys.details(), data)
+      queryClient.setQueryData(pluginKeys.list(), data)
     },
   })
 }

--- a/frontend/src/api/types/plugins.types.ts
+++ b/frontend/src/api/types/plugins.types.ts
@@ -204,15 +204,40 @@ export function pluginBadgeKind(plugin: {
 }
 
 /**
- * Plugin detail - full plugin information from backend
+ * Generic plugin data - always present, regardless of install status
  */
-export const PluginDetailSchema = z.object({
-  status: z.enum(pluginStatusValues),
+export const PluginGenericDataSchema = z.object({
   store_info: PluginStoreEntrySchema.nullable(),
   remote_info: PluginRemoteInfoSchema.nullable(),
-  errored_detail: z.array(PluginErrorSchema).nullable(),
-  loaded_version: z.string().nullable(),
-  update_datetime: z.string().nullable(), // UTC ISO with offset, e.g. "...+00:00"
+})
+
+/**
+ * Plugin install data - present when the plugin has a DB record (i.e. was installed)
+ */
+export const PluginInstallDataSchema = z.object({
+  local_version: z.string(),
+  update_datetime: z.string(), // UTC ISO with offset, e.g. "...+00:00"
+  install_errors: z.array(PluginErrorSchema),
+})
+
+/**
+ * Plugin install settings - present when install succeeded (no error/critical install errors)
+ */
+export const PluginInstallSettingsSchema = z.object({
+  isEnabled: z.boolean(),
+  excluded_templates: z.array(z.string()),
+  included_templates: z.array(z.string()),
+  glyph_remapping: z.record(z.string(), z.string()),
+})
+
+/**
+ * Plugin detail - full plugin information from backend (GET /plugin/list)
+ */
+export const PluginDetailSchema = z.object({
+  generic_data: PluginGenericDataSchema,
+  install_data: PluginInstallDataSchema.nullable(),
+  settings_data: PluginInstallSettingsSchema.nullable(),
+  load_errors: z.array(PluginErrorSchema),
 })
 
 export type PluginDetail = z.infer<typeof PluginDetailSchema>
@@ -227,22 +252,17 @@ export const PluginListingSchema = z.object({
 export type PluginListing = z.infer<typeof PluginListingSchema>
 
 /**
- * Plugin status response from /plugin/status endpoint
+ * Derive the logical plugin status from the new nested PluginDetail structure.
+ * - No install_data → not installed → available
+ * - install_data present, settings_data absent → install failed → errored
+ * - settings_data.isEnabled false → disabled
+ * - settings_data.isEnabled true → loaded
  */
-export const PluginsStatusSchema = z.object({
-  updater_status: z.string(),
-  plugin_errors: z.record(z.string(), z.array(PluginErrorSchema)),
-  plugin_versions: z.record(z.string(), z.string()),
-  plugin_updatedatetime: z.record(z.string(), z.string()),
-  plugin_enabled: z.record(z.string(), z.boolean()),
-  plugin_excluded_templates: z.record(z.string(), z.array(z.string())),
-  plugin_glyph_remapping: z.record(
-    z.string(),
-    z.record(z.string(), z.string()),
-  ),
-})
-
-export type PluginsStatus = z.infer<typeof PluginsStatusSchema>
+export function derivePluginStatus(detail: PluginDetail): PluginStatus {
+  if (detail.install_data === null) return 'available'
+  if (detail.settings_data === null) return 'errored'
+  return detail.settings_data.isEnabled ? 'loaded' : 'disabled'
+}
 
 /**
  * Example data for a blueprint template from GET /plugin/templateExampleValues.
@@ -376,51 +396,48 @@ export function isUnstampedVersion(version: string): boolean {
 
 /**
  * Transform a PluginDetail to UI-friendly PluginInfo
- *
- * @param enabled - The `plugin_enabled` flag (/plugin/status). Orthogonal to
- *   `status`; omit to infer from `status`.
  */
 export function toPluginInfo(
   id: PluginCompositeId,
   detail: PluginDetail,
   capabilities: Array<PluginCapability> = [],
-  enabled?: boolean,
 ): PluginInfo {
-  const isInstalled = detail.status !== 'available'
+  const status = derivePluginStatus(detail)
+  const isInstalled = detail.install_data !== null
+  const loadedVersion = detail.install_data?.local_version ?? null
   const hasUpdate =
     isInstalled &&
-    detail.loaded_version !== null &&
-    !isUnstampedVersion(detail.loaded_version) &&
-    detail.remote_info !== null &&
-    isNewerVersion(detail.remote_info.version, detail.loaded_version)
-  const errorDetail = detail.errored_detail?.length
-    ? detail.errored_detail
-    : null
+    loadedVersion !== null &&
+    !isUnstampedVersion(loadedVersion) &&
+    detail.generic_data.remote_info !== null &&
+    isNewerVersion(detail.generic_data.remote_info.version, loadedVersion)
+  const allErrors: Array<PluginError> = [
+    ...(detail.install_data?.install_errors ?? []),
+    ...detail.load_errors,
+  ]
+  const errorDetail = allErrors.length ? allErrors : null
 
   return {
     id,
     displayId: toPluginDisplayId(id),
-    name: detail.store_info?.display_title ?? id.local,
-    description: detail.store_info?.display_description ?? '',
-    author: detail.store_info?.display_author ?? '',
-    version: detail.loaded_version === 'unknown' ? null : detail.loaded_version,
-    latestVersion: detail.remote_info?.version ?? null,
+    name: detail.generic_data.store_info?.display_title ?? id.local,
+    description: detail.generic_data.store_info?.display_description ?? '',
+    author: detail.generic_data.store_info?.display_author ?? '',
+    version: loadedVersion === 'unknown' ? null : loadedVersion,
+    latestVersion: detail.generic_data.remote_info?.version ?? null,
     capabilities,
-    status: detail.status,
-    // Prefer plugin_enabled; fall back to status when it's absent. `??` so an
-    // explicit `false` wins.
-    isEnabled:
-      enabled ?? (detail.status === 'loaded' || detail.status === 'errored'),
+    status,
+    isEnabled: detail.settings_data?.isEnabled ?? status === 'errored',
     isInstalled,
     hasUpdate,
-    updatedAt: detail.update_datetime
-      ? toUtcIsoOrNull(detail.update_datetime)
+    updatedAt: detail.install_data?.update_datetime
+      ? toUtcIsoOrNull(detail.install_data.update_datetime)
       : null,
     errorDetail,
     errorSeverity: errorDetail ? pluginErrorsMaxSeverity(errorDetail) : null,
-    comment: detail.store_info?.comment ?? null,
-    pipSource: detail.store_info?.pip_source ?? null,
-    moduleName: detail.store_info?.module_name ?? null,
+    comment: detail.generic_data.store_info?.comment ?? null,
+    pipSource: detail.generic_data.store_info?.pip_source ?? null,
+    moduleName: detail.generic_data.store_info?.module_name ?? null,
   }
 }
 
@@ -438,20 +455,16 @@ function toUtcIsoOrNull(dateStr: string): string | null {
 
 /**
  * Transform PluginListing response to array of PluginInfo
- *
- * @param enabledMap - `plugin_enabled` from /plugin/status, keyed like
- *   `listing.plugins`. Drives each plugin's `isEnabled`.
  */
 export function toPluginInfoList(
   listing: PluginListing,
   capabilitiesMap: Map<string, Array<PluginCapability>> = new Map(),
-  enabledMap: Record<string, boolean> = {},
 ): Array<PluginInfo> {
   return Object.entries(listing.plugins).map(([key, detail]) => {
     const id = parsePluginKey(key)
     const displayId = toPluginDisplayId(id)
     const capabilities = capabilitiesMap.get(displayId) ?? []
-    return toPluginInfo(id, detail, capabilities, enabledMap[key])
+    return toPluginInfo(id, detail, capabilities)
   })
 }
 

--- a/frontend/tests/integration/features/plugins/plugin-updates.test.tsx
+++ b/frontend/tests/integration/features/plugins/plugin-updates.test.tsx
@@ -383,29 +383,34 @@ describe('Plugin Updates Integration', () => {
 
     it('shows an errored updatable plugin in both sections with its diagnostics', async () => {
       worker.use(
-        http.get(API_ENDPOINTS.plugin.details, () =>
+        http.get(API_ENDPOINTS.plugin.list, () =>
           HttpResponse.json({
             plugins: {
               "store='ecmwf' local='broken-ensemble'": {
-                status: 'errored',
-                store_info: {
-                  pip_source: 'fiab-plugin-broken',
-                  module_name: 'fiab_plugin_broken',
-                  display_title: 'Broken Ensemble',
-                  display_description: 'Errored plugin that has an update',
-                  display_author: 'ECMWF',
-                  comment: '',
+                generic_data: {
+                  store_info: {
+                    pip_source: 'fiab-plugin-broken',
+                    module_name: 'fiab_plugin_broken',
+                    display_title: 'Broken Ensemble',
+                    display_description: 'Errored plugin that has an update',
+                    display_author: 'ECMWF',
+                    comment: '',
+                  },
+                  remote_info: { version: '2.4.0' },
                 },
-                remote_info: { version: '2.4.0' },
-                errored_detail: [
+                install_data: {
+                  local_version: '2.1.0',
+                  update_datetime: '2026-02-03T00:00:00+00:00',
+                  install_errors: [],
+                },
+                settings_data: null,
+                load_errors: [
                   {
                     source: 'load',
                     detail: 'import failed: incompatible core',
                     severity: 'error',
                   },
                 ],
-                loaded_version: '2.1.0',
-                update_datetime: '2026-02-03T00:00:00+00:00',
               },
             },
           }),

--- a/frontend/tests/integration/features/plugins/plugins-management.test.tsx
+++ b/frontend/tests/integration/features/plugins/plugins-management.test.tsx
@@ -464,26 +464,36 @@ describe('Plugins Management Integration', () => {
     }
 
     const baseDetail = {
-      store_info: {
-        pip_source: 'fiab-plugin-diag',
-        module_name: 'fiab_plugin_diag',
-        display_title: 'Diag Test',
-        display_description: 'Plugin for diagnostics rendering',
-        display_author: 'ECMWF',
-        comment: '',
+      generic_data: {
+        store_info: {
+          pip_source: 'fiab-plugin-diag',
+          module_name: 'fiab_plugin_diag',
+          display_title: 'Diag Test',
+          display_description: 'Plugin for diagnostics rendering',
+          display_author: 'ECMWF',
+          comment: '',
+        },
+        remote_info: null,
       },
-      remote_info: null,
-      loaded_version: '1.0.0',
-      update_datetime: null,
+      install_data: {
+        local_version: '1.0.0',
+        update_datetime: '2025-01-15T00:00:00+00:00',
+        install_errors: [],
+      },
+      settings_data: {
+        isEnabled: true,
+        excluded_templates: [],
+        included_templates: [],
+        glyph_remapping: {},
+      },
     }
 
     it('softens a warning-only errored plugin to an amber Warning badge', async () => {
       worker.use(
-        http.get(API_ENDPOINTS.plugin.details, () =>
+        http.get(API_ENDPOINTS.plugin.list, () =>
           detailsResponse({
             ...baseDetail,
-            status: 'errored',
-            errored_detail: [
+            load_errors: [
               {
                 source: 'template_ingest',
                 detail: "template 'x' failed validation",
@@ -510,12 +520,18 @@ describe('Plugins Management Integration', () => {
 
     it('keeps the red Errored badge when any diagnostic is an error', async () => {
       worker.use(
-        http.get(API_ENDPOINTS.plugin.details, () =>
+        http.get(API_ENDPOINTS.plugin.list, () =>
           detailsResponse({
             ...baseDetail,
-            status: 'errored',
-            errored_detail: [
-              { source: 'install', detail: 'pip failed', severity: 'error' },
+            install_data: {
+              local_version: '1.0.0',
+              update_datetime: '2025-01-15T00:00:00+00:00',
+              install_errors: [
+                { source: 'install', detail: 'pip failed', severity: 'error' },
+              ],
+            },
+            settings_data: null,
+            load_errors: [
               {
                 source: 'template_ingest',
                 detail: 'bad template',
@@ -539,11 +555,10 @@ describe('Plugins Management Integration', () => {
 
     it('badges a loaded plugin carrying a warning as amber Warning (severity-driven)', async () => {
       worker.use(
-        http.get(API_ENDPOINTS.plugin.details, () =>
+        http.get(API_ENDPOINTS.plugin.list, () =>
           detailsResponse({
             ...baseDetail,
-            status: 'loaded',
-            errored_detail: [
+            load_errors: [
               {
                 source: 'load',
                 detail: 'version mismatch: DB has 0.9',
@@ -572,7 +587,7 @@ describe('Plugins Management Integration', () => {
   describe('Error Handling', () => {
     it('handles plugin details API returning 500', async () => {
       worker.use(
-        http.get(API_ENDPOINTS.plugin.details, () => {
+        http.get(API_ENDPOINTS.plugin.list, () => {
           return HttpResponse.json(
             { error: 'Internal server error' },
             { status: 500 },
@@ -591,7 +606,7 @@ describe('Plugins Management Integration', () => {
 
     it('handles empty plugin list', async () => {
       worker.use(
-        http.get(API_ENDPOINTS.plugin.details, () => {
+        http.get(API_ENDPOINTS.plugin.list, () => {
           return HttpResponse.json({ plugins: {} })
         }),
       )

--- a/frontend/tests/unit/api/endpoints/plugins.test.ts
+++ b/frontend/tests/unit/api/endpoints/plugins.test.ts
@@ -17,8 +17,7 @@ import type {
   PluginSettingsUpdate,
 } from '@/api/types/plugins.types'
 import {
-  getPluginDetails,
-  getPluginStatus,
+  getPluginList,
   installPlugin,
   uninstallPlugin,
   updatePlugin,
@@ -45,121 +44,67 @@ function createPluginKey(store: string, local: string): string {
   return `store='${store}' local='${local}'`
 }
 
-describe('getPluginStatus', () => {
+describe('getPluginList', () => {
   afterEach(() => {
     worker.resetHandlers()
   })
 
-  it('fetches plugin status successfully', async () => {
-    const mockResponse = {
-      updater_status: 'idle',
-      plugin_errors: {
-        [createPluginKey('ecmwf', 'legacy-viz')]: [
-          {
-            source: 'load',
-            detail: 'Failed to load: incompatible version',
-            severity: 'error',
-          },
-        ],
-      },
-      plugin_versions: {
-        [createPluginKey('ecmwf', 'anemoi-inference')]: '1.0.0',
-      },
-      plugin_updatedatetime: {
-        [createPluginKey('ecmwf', 'anemoi-inference')]: '2025-01-15T00:00:00',
-      },
-      plugin_enabled: {
-        [createPluginKey('ecmwf', 'anemoi-inference')]: true,
-        [createPluginKey('ecmwf', 'legacy-viz')]: true,
-      },
-      plugin_excluded_templates: {
-        [createPluginKey('ecmwf', 'anemoi-inference')]: ['Excluded Template'],
-      },
-      plugin_glyph_remapping: {
-        [createPluginKey('ecmwf', 'anemoi-inference')]: {
-          old_name: 'new_name',
-        },
-      },
-    }
-
-    worker.use(
-      http.get(API_ENDPOINTS.plugin.status, () => {
-        return HttpResponse.json(mockResponse)
-      }),
-    )
-
-    const result = await getPluginStatus()
-    expect(result.updater_status).toBe('idle')
-    expect(result.plugin_errors).toBeDefined()
-    expect(result.plugin_versions).toBeDefined()
-  })
-})
-
-describe('getPluginDetails', () => {
-  afterEach(() => {
-    worker.resetHandlers()
-  })
-
-  it('fetches plugin details successfully', async () => {
+  it('fetches plugin list successfully', async () => {
     const mockResponse: PluginListing = {
       plugins: {
         [createPluginKey('ecmwf', 'anemoi-inference')]: {
-          status: 'loaded',
-          store_info: {
-            pip_source: 'anemoi-inference',
-            module_name: 'anemoi_inference',
-            display_title: 'Anemoi Inference',
-            display_description: 'ML inference engine',
-            display_author: 'ECMWF',
-            comment: '',
+          generic_data: {
+            store_info: {
+              pip_source: 'anemoi-inference',
+              module_name: 'anemoi_inference',
+              display_title: 'Anemoi Inference',
+              display_description: 'ML inference engine',
+              display_author: 'ECMWF',
+              comment: '',
+            },
+            remote_info: { version: '1.0.0' },
           },
-          remote_info: { version: '1.0.0' },
-          errored_detail: null,
-          loaded_version: '1.0.0',
-          update_datetime: '2025-01-15T00:00:00+00:00',
+          install_data: {
+            local_version: '1.0.0',
+            update_datetime: '2025-01-15T00:00:00+00:00',
+            install_errors: [],
+          },
+          settings_data: {
+            isEnabled: true,
+            excluded_templates: [],
+            included_templates: [],
+            glyph_remapping: {},
+          },
+          load_errors: [],
         },
         [createPluginKey('ecmwf', 'storm-tracker')]: {
-          status: 'available',
-          store_info: {
-            pip_source: 'storm-tracker',
-            module_name: 'storm_tracker',
-            display_title: 'Storm Tracker',
-            display_description: 'Track severe weather',
-            display_author: 'ECMWF',
-            comment: 'New plugin!',
+          generic_data: {
+            store_info: {
+              pip_source: 'storm-tracker',
+              module_name: 'storm_tracker',
+              display_title: 'Storm Tracker',
+              display_description: 'Track severe weather',
+              display_author: 'ECMWF',
+              comment: 'New plugin!',
+            },
+            remote_info: { version: '2.0.0' },
           },
-          remote_info: { version: '2.0.0' },
-          errored_detail: null,
-          loaded_version: null,
-          update_datetime: null,
+          install_data: null,
+          settings_data: null,
+          load_errors: [],
         },
       },
     }
 
     worker.use(
-      http.get(API_ENDPOINTS.plugin.details, () => {
+      http.get(API_ENDPOINTS.plugin.list, () => {
         return HttpResponse.json(mockResponse)
       }),
     )
 
-    const result = await getPluginDetails()
+    const result = await getPluginList()
     expect(result.plugins).toBeDefined()
     expect(Object.keys(result.plugins)).toHaveLength(2)
-  })
-
-  it('passes forceRefresh parameter', async () => {
-    let receivedForceRefresh = false
-
-    worker.use(
-      http.get(API_ENDPOINTS.plugin.details, ({ request }) => {
-        const url = new URL(request.url)
-        receivedForceRefresh = url.searchParams.get('forceRefresh') === 'true'
-        return HttpResponse.json({ plugins: {} })
-      }),
-    )
-
-    await getPluginDetails(true)
-    expect(receivedForceRefresh).toBe(true)
   })
 })
 

--- a/frontend/tests/unit/api/types/plugins.types.test.ts
+++ b/frontend/tests/unit/api/types/plugins.types.test.ts
@@ -23,15 +23,34 @@ import {
 const ID: PluginCompositeId = { store: 'ecmwf', local: 'anemoi-inference' }
 
 function detailWith(update_datetime: string | null): PluginDetail {
+  if (update_datetime === null) {
+    // Available (not installed) plugin — no install_data → updatedAt is null
+    return {
+      generic_data: { store_info: null, remote_info: null },
+      install_data: null,
+      settings_data: null,
+      load_errors: [],
+    }
+  }
   return {
-    status: 'loaded',
-    store_info: null,
-    remote_info: null,
-    errored_detail: null,
-    loaded_version: '1.0.0',
-    update_datetime,
+    generic_data: { store_info: null, remote_info: null },
+    install_data: {
+      local_version: '1.0.0',
+      update_datetime,
+      install_errors: [],
+    },
+    settings_data: {
+      isEnabled: true,
+      excluded_templates: [],
+      included_templates: [],
+      glyph_remapping: {},
+    },
+    load_errors: [],
   }
 }
+
+/** A loaded plugin with a fixed datetime — use as base where datetime is irrelevant */
+const loadedDetail: PluginDetail = detailWith('2025-01-15T00:00:00+00:00')
 
 describe('toPluginInfo — updatedAt timezone normalization', () => {
   // Naive backend datetime → append Z so it reads as UTC, not local.
@@ -70,92 +89,136 @@ describe('toPluginInfo — updatedAt timezone normalization', () => {
 })
 
 const baseRaw = {
-  status: 'loaded' as const,
-  store_info: null,
-  remote_info: null,
-  loaded_version: '1.0.0',
-  update_datetime: null,
+  generic_data: { store_info: null, remote_info: null },
+  install_data: {
+    local_version: '1.0.0',
+    update_datetime: '2025-01-15T00:00:00+00:00',
+    install_errors: [],
+  },
+  settings_data: {
+    isEnabled: true,
+    excluded_templates: [],
+    included_templates: [],
+    glyph_remapping: {},
+  },
+  load_errors: [],
 }
 
-describe('PluginDetailSchema — errored_detail parsing', () => {
-  it('accepts null and outputs null', () => {
-    const result = PluginDetailSchema.parse({
-      ...baseRaw,
-      errored_detail: null,
-    })
-    expect(result.errored_detail).toBeNull()
+describe('PluginDetailSchema — load_errors parsing', () => {
+  it('accepts an empty load_errors array', () => {
+    const result = PluginDetailSchema.parse({ ...baseRaw, load_errors: [] })
+    expect(result.load_errors).toEqual([])
   })
 
-  it('preserves structured errors', () => {
+  it('preserves structured load errors', () => {
     const errors = [
-      { source: 'install', detail: 'pip failed', severity: 'error' },
+      { source: 'load', detail: 'module failed', severity: 'error' },
       {
         source: 'template_ingest',
         detail: 'bad template',
         severity: 'warning',
       },
     ]
-    const result = PluginDetailSchema.parse({
-      ...baseRaw,
-      errored_detail: errors,
-    })
-    expect(result.errored_detail).toEqual(errors)
+    const result = PluginDetailSchema.parse({ ...baseRaw, load_errors: errors })
+    expect(result.load_errors).toEqual(errors)
   })
 })
 
 describe('toPluginInfo — errorDetail normalization', () => {
-  it('normalizes an empty error list to null', () => {
-    const info = toPluginInfo(ID, { ...detailWith(null), errored_detail: [] })
+  it('normalizes empty install and load errors to null', () => {
+    const info = toPluginInfo(ID, loadedDetail)
     expect(info.errorDetail).toBeNull()
     expect(info.errorSeverity).toBeNull()
   })
 
-  it('passes structured errors through and derives the max severity', () => {
-    const errors = [{ source: 'load', detail: 'boom', severity: 'error' }]
-    const info = toPluginInfo(ID, {
-      ...detailWith(null),
-      errored_detail: errors,
-    })
-    expect(info.errorDetail).toEqual(errors)
+  it('surfaces load_errors and derives max severity', () => {
+    const detail: PluginDetail = {
+      ...loadedDetail,
+      load_errors: [{ source: 'load', detail: 'boom', severity: 'error' }],
+    }
+    const info = toPluginInfo(ID, detail)
+    expect(info.errorDetail).toEqual(detail.load_errors)
+    expect(info.errorSeverity).toBe('error')
+  })
+
+  it('combines install_errors and load_errors', () => {
+    const detail: PluginDetail = {
+      ...loadedDetail,
+      install_data: {
+        local_version: '1.0.0',
+        update_datetime: '2025-01-15T00:00:00+00:00',
+        install_errors: [
+          { source: 'install', detail: 'pip failed', severity: 'warning' },
+        ],
+      },
+      load_errors: [{ source: 'load', detail: 'boom', severity: 'error' }],
+    }
+    const info = toPluginInfo(ID, detail)
+    expect(info.errorDetail).toHaveLength(2)
     expect(info.errorSeverity).toBe('error')
   })
 })
 
-describe('toPluginInfo — isEnabled reflects the plugin_enabled flag', () => {
-  const loaded = detailWith(null) // status: 'loaded'
-
-  it('honours an explicit enabled=false even when the module loaded', () => {
-    // The bug this fixes: a loaded-but-disabled plugin used to read as enabled.
-    expect(toPluginInfo(ID, loaded, [], false).isEnabled).toBe(false)
+describe('toPluginInfo — isEnabled reflects settings_data.isEnabled', () => {
+  it('is true for a loaded (enabled) plugin', () => {
+    expect(toPluginInfo(ID, loadedDetail).isEnabled).toBe(true)
   })
 
-  it('honours an explicit enabled=true', () => {
-    const errored: PluginDetail = { ...loaded, status: 'errored' }
-    expect(toPluginInfo(ID, errored, [], true).isEnabled).toBe(true)
+  it('is false for a disabled plugin (settings_data.isEnabled = false)', () => {
+    const disabled: PluginDetail = {
+      ...loadedDetail,
+      settings_data: {
+        isEnabled: false,
+        excluded_templates: [],
+        included_templates: [],
+        glyph_remapping: {},
+      },
+    }
+    expect(toPluginInfo(ID, disabled).isEnabled).toBe(false)
   })
 
-  it('falls back to status when the flag is absent (loaded → enabled)', () => {
-    expect(toPluginInfo(ID, loaded).isEnabled).toBe(true)
-  })
-
-  it('falls back to status when the flag is absent (available → disabled)', () => {
-    const available: PluginDetail = { ...loaded, status: 'available' }
-    expect(toPluginInfo(ID, available).isEnabled).toBe(false)
+  it('is true for an errored plugin (install failed) to preserve errored badge', () => {
+    const errored: PluginDetail = {
+      generic_data: { store_info: null, remote_info: null },
+      install_data: {
+        local_version: '1.0.0',
+        update_datetime: '2025-01-15T00:00:00+00:00',
+        install_errors: [
+          { source: 'install', detail: 'fail', severity: 'error' },
+        ],
+      },
+      settings_data: null,
+      load_errors: [],
+    }
+    expect(toPluginInfo(ID, errored).isEnabled).toBe(true)
   })
 })
 
-describe('toPluginInfoList — joins plugin_enabled by backend key', () => {
+describe('toPluginInfoList — derives isEnabled from settings_data', () => {
   const key = "store='ecmwf' local='anemoi-inference'"
-  const listing = { plugins: { [key]: detailWith(null) } }
 
-  it('applies the enabledMap entry to the matching plugin', () => {
-    const [info] = toPluginInfoList(listing, new Map(), { [key]: false })
+  it('reads isEnabled=false from settings_data', () => {
+    const listing = {
+      plugins: {
+        [key]: {
+          ...loadedDetail,
+          settings_data: {
+            isEnabled: false,
+            excluded_templates: [],
+            included_templates: [],
+            glyph_remapping: {},
+          },
+        },
+      },
+    }
+    const [info] = toPluginInfoList(listing)
     expect(info.isEnabled).toBe(false)
   })
 
-  it('falls back to status when a plugin is missing from the map', () => {
-    const [info] = toPluginInfoList(listing, new Map(), {})
-    expect(info.isEnabled).toBe(true) // status 'loaded'
+  it('reads isEnabled=true from settings_data', () => {
+    const listing = { plugins: { [key]: loadedDetail } }
+    const [info] = toPluginInfoList(listing)
+    expect(info.isEnabled).toBe(true)
   })
 })
 
@@ -281,9 +344,19 @@ describe('isNewerVersion', () => {
 describe('toPluginInfo — hasUpdate', () => {
   function installedWith(loaded: string, remote: string): PluginDetail {
     return {
-      ...detailWith(null),
-      loaded_version: loaded,
-      remote_info: { version: remote },
+      generic_data: { store_info: null, remote_info: { version: remote } },
+      install_data: {
+        local_version: loaded,
+        update_datetime: '2025-01-15T00:00:00+00:00',
+        install_errors: [],
+      },
+      settings_data: {
+        isEnabled: true,
+        excluded_templates: [],
+        included_templates: [],
+        glyph_remapping: {},
+      },
+      load_errors: [],
     }
   }
 


### PR DESCRIPTION
- Add PluginManagerBusy exception to domain/plugin/exceptions.py
- Create domain/plugin/detail.py with the PluginDetail class hierarchy (PluginGenericData, PluginInstallSettings, PluginInstallData, PluginDetail, PluginListing) and the build_plugin_listing() handler.  These classes are both frontend-exposed and used internally; see module docstring.
- Remove PluginsStatus and status_full() from manager.py (logic subsumed by detail.py).  status_brief() and everything else in manager.py is untouched.
- Remove the /plugin/status route and the old /plugin/details route from routes/plugins.py; add GET /plugin/list backed by build_plugin_listing(), returning 503 on PluginManagerBusy.
- Update integration tests to poll GET /status (plugins field from status_brief()) for readiness, and use /plugin/list for plugin-specific assertions (install_data, settings_data, load_errors).
- Relocate status_full unit tests from test_plugin_manager.py to new test_plugin_detail.py covering build_plugin_listing(); replace test_plugin_manager.py content with tests for status_brief/plugins_ready.

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
