### PR TITLE
Feat/expand blueprint template

### DIFF
--- a/backend/packages/fiab-core/src/fiab_core/fable.py
+++ b/backend/packages/fiab-core/src/fiab_core/fable.py
@@ -195,7 +195,18 @@ class BlueprintTemplateExampleInput(FiabCoreBaseModel):
     example_value: str
     display_name: str | None = None
     display_description: str | None = None
-    type_hint: str | None = None  # TODO validator -- if not None, then it must be a valid FableType
+    type_hint: str | None = None
+
+    @model_validator(mode="after")
+    def _validate_type_hint(self) -> Self:
+        if self.type_hint is not None:
+            try:
+                _, remainder = parse(self.type_hint)
+                if remainder.strip():
+                    raise NotFableType(f"Unexpected trailing content in type expression: {remainder!r}")
+            except NotFableType as exc:
+                raise ValueError(str(exc)) from exc
+        return self
 
 
 class BlueprintTemplate(FiabCoreBaseModel):

--- a/backend/packages/fiab-core/src/fiab_core/fable.py
+++ b/backend/packages/fiab-core/src/fiab_core/fable.py
@@ -173,6 +173,31 @@ class BlueprintTemplateBlock(FiabCoreBaseModel):
     instance: BlockInstance
 
 
+class BlueprintTemplateExampleInput(FiabCoreBaseModel):
+    """Regular blueprints have local glyphs and configuration options,
+    which in the latter case have a type and a description. In blueprint
+    templates, we allow for adding type and description to glyphs and
+    overriding those for configuration options.
+
+    These do *not* affect the blueprint persistence and execution. It only
+    plays a role in the user interface, when using the template as high-level
+    ready-to-go Job Preset, and when communicating the intent behind the
+    template.
+
+    The motivation for this is that in blueprints, the local glyphs
+    plays purely a role of variable *value*, whereas in templates, the
+    meaning shifts towards variable *definition*.
+
+    If the display_* or type_hint are not given here, the consumer of this
+    is assumed to take them from the underlying configuration option, or,
+    in the glyph case, assume no data."""
+
+    example_value: str
+    display_name: str | None = None
+    display_description: str | None = None
+    type_hint: str | None = None  # TODO validator -- if not None, then it must be a valid FableType
+
+
 class BlueprintTemplate(FiabCoreBaseModel):
     """A partial, ready-to-customise blueprint shipped by a plugin.
 
@@ -187,5 +212,5 @@ class BlueprintTemplate(FiabCoreBaseModel):
     blocks: dict[BlockInstanceId, BlueprintTemplateBlock]
     environment: BlueprintTemplateEnvironment | None = None
     local_glyphs: dict[str, str] = Field(default_factory=dict)
-    example_values: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = Field(default_factory=dict)
-    example_glyphs: dict[str, str] = Field(default_factory=dict)
+    example_values: dict[BlockInstanceId, dict[ConfigurationOptionId, BlueprintTemplateExampleInput]] = Field(default_factory=dict)
+    example_glyphs: dict[str, BlueprintTemplateExampleInput] = Field(default_factory=dict)

--- a/backend/packages/fiab-core/tests/test_fable.py
+++ b/backend/packages/fiab-core/tests/test_fable.py
@@ -18,6 +18,7 @@ from fiab_core.fable import (
     BlueprintTemplate,
     BlueprintTemplateBlock,
     BlueprintTemplateEnvironment,
+    BlueprintTemplateExampleInput,
     ConfigurationOptionId,
     PluginCompositeId,
     PluginId,
@@ -95,8 +96,8 @@ def test_blueprint_template_round_trips_model_dump() -> None:
     tmpl = _make_template(
         environment=BlueprintTemplateEnvironment(environment_variables={"K": "V"}),
         local_glyphs={"g": "v"},
-        example_values={_BLOCK_ID: {_TEXT: "world"}},
-        example_glyphs={"g": "world"},
+        example_values={_BLOCK_ID: {_TEXT: BlueprintTemplateExampleInput(example_value="world", display_name="World")}},
+        example_glyphs={"g": BlueprintTemplateExampleInput(example_value="world")},
     )
 
     dumped = tmpl.model_dump()
@@ -106,10 +107,30 @@ def test_blueprint_template_round_trips_model_dump() -> None:
     assert restored.environment is not None
     assert restored.environment.environment_variables == {"K": "V"}
     assert restored.local_glyphs == {"g": "v"}
-    assert restored.example_values == {_BLOCK_ID: {_TEXT: "world"}}
-    assert restored.example_glyphs == {"g": "world"}
+    assert restored.example_values == {_BLOCK_ID: {_TEXT: BlueprintTemplateExampleInput(example_value="world", display_name="World")}}
+    assert restored.example_glyphs == {"g": BlueprintTemplateExampleInput(example_value="world")}
 
 
 def test_blueprint_template_environment_rejects_unknown_field() -> None:
     with pytest.raises(ValidationError):
         BlueprintTemplateEnvironment(environment_variables={}, unexpected="x")  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# BlueprintTemplateExampleInput
+# ---------------------------------------------------------------------------
+
+
+def test_blueprint_template_example_input_accepts_valid_type_hint() -> None:
+    inp = BlueprintTemplateExampleInput(example_value="hello", type_hint="str")
+    assert inp.type_hint == "str"
+
+
+def test_blueprint_template_example_input_accepts_none_type_hint() -> None:
+    inp = BlueprintTemplateExampleInput(example_value="hello")
+    assert inp.type_hint is None
+
+
+def test_blueprint_template_example_input_rejects_invalid_type_hint() -> None:
+    with pytest.raises(ValidationError):
+        BlueprintTemplateExampleInput(example_value="hello", type_hint="not-a-fable-type")

--- a/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
+++ b/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
@@ -15,6 +15,7 @@ from fiab_core.fable import (
     BlockInstanceOutput,
     BlueprintTemplate,
     BlueprintTemplateBlock,
+    BlueprintTemplateExampleInput,
     ConfigurationOptionId,
     ConfigurationOptionRestriction,
     NoOutput,
@@ -223,8 +224,22 @@ _testBasic = BlueprintTemplate(
         _BLOCK_EXAMPLE: _make_source_text_block(""),
     },
     local_glyphs={"greeting": "hello"},
-    example_values={_BLOCK_EXAMPLE: {TEXT: "text from example values"}},
-    example_glyphs={"name": "world"},
+    example_values={
+        _BLOCK_EXAMPLE: {
+            TEXT: BlueprintTemplateExampleInput(
+                example_value="text from example values",
+                display_name="Message",
+                display_description="The text that the source block will output.",
+            )
+        }
+    },
+    example_glyphs={
+        "name": BlueprintTemplateExampleInput(
+            example_value="world",
+            display_name="Name",
+            display_description="The name to greet.",
+        )
+    },
 )
 
 _BLOCK_EXCL = BlockInstanceId("text_excl")

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -32,6 +32,7 @@ from fiab_core.fable import (
     BlockInstanceOutput,
     BlockKind,
     BlueprintTemplate,
+    BlueprintTemplateExampleInput,
     ConfigurationOptionId,
     NoOutput,
     PluginCompositeId,
@@ -405,8 +406,8 @@ def template_to_builder(template: BlueprintTemplate, plugin_id: PluginCompositeI
 
 def resolve_builder_with_examples(
     builder: BlueprintBuilder,
-    example_values: dict[BlockInstanceId, dict[ConfigurationOptionId, str]],
-    example_glyphs: dict[str, str],
+    example_values: dict[BlockInstanceId, dict[ConfigurationOptionId, BlueprintTemplateExampleInput]],
+    example_glyphs: dict[str, BlueprintTemplateExampleInput],
 ) -> BlueprintBuilder:
     """Return a copy of ``builder`` with example values/glyphs overlaid for validation only.
 
@@ -429,7 +430,10 @@ def resolve_builder_with_examples(
     for routable in copy.blocks:
         if routable.instance_id in example_values:
             # Merge: example values override existing template configuration values.
-            merged_config = {**routable.instance.configuration_values, **example_values[routable.instance_id]}
+            # Only the example_value string is used for execution; the other fields
+            # (display_name, display_description, type_hint) are UI metadata only.
+            example_str_values = {opt: inp.example_value for opt, inp in example_values[routable.instance_id].items()}
+            merged_config = {**routable.instance.configuration_values, **example_str_values}
             new_blocks.append(
                 routable.model_copy(update={"instance": routable.instance.model_copy(update={"configuration_values": merged_config})})
             )
@@ -437,7 +441,7 @@ def resolve_builder_with_examples(
             new_blocks.append(routable)
 
     # Merge example_glyphs into local_glyphs; example glyphs take precedence.
-    merged_local_glyphs: dict[str, str] = {**copy.local_glyphs, **example_glyphs}
+    merged_local_glyphs: dict[str, str] = {**copy.local_glyphs, **{k: v.example_value for k, v in example_glyphs.items()}}
 
     return copy.model_copy(update={"blocks": new_blocks, "local_glyphs": merged_local_glyphs})
 

--- a/backend/src/forecastbox/routes/plugins.py
+++ b/backend/src/forecastbox/routes/plugins.py
@@ -19,7 +19,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import Response
-from fiab_core.fable import BlockInstanceId, ConfigurationOptionId, PluginCompositeId
+from fiab_core.fable import BlockInstanceId, BlueprintTemplateExampleInput, ConfigurationOptionId, PluginCompositeId
 from packaging.version import InvalidVersion, Version
 
 from forecastbox.domain.auth.users import UserRead
@@ -186,9 +186,9 @@ async def update_plugin_settings_endpoint(
 
 
 class TemplateExampleValuesResponse(FiabBaseModel):
-    example_values: dict[BlockInstanceId, dict[ConfigurationOptionId, str]]
+    example_values: dict[BlockInstanceId, dict[ConfigurationOptionId, BlueprintTemplateExampleInput]]
     """Per-block example configuration values, keyed by block instance id then option id."""
-    example_glyphs: dict[str, str]
+    example_glyphs: dict[str, BlueprintTemplateExampleInput]
     """Example glyph name-to-value pairs the user is expected to override."""
 
 
@@ -225,15 +225,19 @@ async def get_template_example_values(
 
     glyph_remapping: dict[str, str] = dict(plugin_state.glyph_remapping) if plugin_state.glyph_remapping else {}  # type: ignore[no-matching-overload]
 
-    remapped_example_values: dict[str, dict[str, str]] = {
-        block_id: {opt_id: remap_glyph_names(val, glyph_remapping) for opt_id, val in opts.items()}
+    remapped_example_values: dict[BlockInstanceId, dict[ConfigurationOptionId, BlueprintTemplateExampleInput]] = {
+        BlockInstanceId(block_id): {
+            ConfigurationOptionId(opt_id): inp.model_copy(update={"example_value": remap_glyph_names(inp.example_value, glyph_remapping)})
+            for opt_id, inp in opts.items()
+        }
         for block_id, opts in template.example_values.items()
     }
-    remapped_example_glyphs: dict[str, str] = {
-        glyph_remapping.get(key, key): remap_glyph_names(val, glyph_remapping) for key, val in template.example_glyphs.items()
+    remapped_example_glyphs: dict[str, BlueprintTemplateExampleInput] = {
+        glyph_remapping.get(key, key): inp.model_copy(update={"example_value": remap_glyph_names(inp.example_value, glyph_remapping)})
+        for key, inp in template.example_glyphs.items()
     }
 
     return TemplateExampleValuesResponse(
-        example_values=remapped_example_values,  # ty:ignore[invalid-argument-type]
+        example_values=remapped_example_values,
         example_glyphs=remapped_example_glyphs,
     )

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -288,7 +288,9 @@ def test_plugin_template_in_blueprint_list(backend_client_user: httpx.Client) ->
     data = response.json()
     assert "example_values" in data
     assert "example_glyphs" in data
-    assert data["example_glyphs"].get("name") == "world", f"Expected name=world in example_glyphs, got: {data['example_glyphs']}"
+    name_entry = data["example_glyphs"].get("name")
+    assert name_entry is not None, f"Expected 'name' key in example_glyphs, got: {data['example_glyphs']}"
+    assert name_entry.get("example_value") == "world", f"Expected name.example_value=world in example_glyphs, got: {name_entry}"
 
 
 def test_plugin_template_exclusion(backend_client_user: httpx.Client, backend_client_admin: httpx.Client) -> None:

--- a/backend/tests/unit/domain/blueprint/test_blueprint_service.py
+++ b/backend/tests/unit/domain/blueprint/test_blueprint_service.py
@@ -17,6 +17,7 @@ from fiab_core.fable import (
     BlueprintTemplate,
     BlueprintTemplateBlock,
     BlueprintTemplateEnvironment,
+    BlueprintTemplateExampleInput,
     ConfigurationOptionId,
     PluginCompositeId,
     PluginId,
@@ -119,8 +120,8 @@ def test_template_to_builder_example_values_not_in_configuration_values() -> Non
         display_name="t",
         display_description="d",
         blocks={example_block: block},
-        example_values={example_block: {opt: "example text"}},
-        example_glyphs={"name": "world"},
+        example_values={example_block: {opt: BlueprintTemplateExampleInput(example_value="example text")}},
+        example_glyphs={"name": BlueprintTemplateExampleInput(example_value="world")},
     )
     builder = template_to_builder(template, _REAL_PLUGIN_ID)
     result = next(b for b in builder.blocks if b.instance_id == example_block)
@@ -185,14 +186,14 @@ def _get_block(builder: BlueprintBuilder, block_id: BlockInstanceId) -> Routable
 def test_resolve_builder_with_examples_fills_missing_config_value() -> None:
     """Example values fill in config options absent from the template block."""
     builder = _make_builder(block_text=None)
-    result = resolve_builder_with_examples(builder, {_BLOCK_A: {_OPT: "from example"}}, {})
+    result = resolve_builder_with_examples(builder, {_BLOCK_A: {_OPT: BlueprintTemplateExampleInput(example_value="from example")}}, {})
     assert _get_block(result, _BLOCK_A).instance.configuration_values[_OPT] == "from example"
 
 
 def test_resolve_builder_with_examples_overrides_existing_config_value() -> None:
     """Example values override existing template values for validation purposes."""
     builder = _make_builder(block_text="template value")
-    result = resolve_builder_with_examples(builder, {_BLOCK_A: {_OPT: "example value"}}, {})
+    result = resolve_builder_with_examples(builder, {_BLOCK_A: {_OPT: BlueprintTemplateExampleInput(example_value="example value")}}, {})
     assert _get_block(result, _BLOCK_A).instance.configuration_values[_OPT] == "example value"
 
 
@@ -200,5 +201,5 @@ def test_resolve_builder_with_examples_does_not_mutate_original() -> None:
     """resolve_builder_with_examples must not mutate the caller's builder."""
     builder = _make_builder(block_text="original")
     original_config = dict(_get_block(builder, _BLOCK_A).instance.configuration_values)
-    resolve_builder_with_examples(builder, {_BLOCK_A: {_OPT: "override"}}, {})
+    resolve_builder_with_examples(builder, {_BLOCK_A: {_OPT: BlueprintTemplateExampleInput(example_value="override")}}, {})
     assert _get_block(builder, _BLOCK_A).instance.configuration_values == original_config

--- a/backend/tests/unit/routes/test_plugins.py
+++ b/backend/tests/unit/routes/test_plugins.py
@@ -21,6 +21,7 @@ from fiab_core.fable import (
     BlockInstanceId,
     BlueprintTemplate,
     BlueprintTemplateBlock,
+    BlueprintTemplateExampleInput,
     ConfigurationOptionId,
     PluginCompositeId,
     PluginId,
@@ -201,8 +202,8 @@ _TEMPLATE_WITH_EXAMPLES = BlueprintTemplate(
             instance=BlockInstance(configuration_values={_TEXT: "fixed"}, input_ids={}),
         ),
     },
-    example_values={_BLOCK_A: {_TEXT: "${exampleGlyph}"}},
-    example_glyphs={"exampleGlyph": "hello world"},
+    example_values={_BLOCK_A: {_TEXT: BlueprintTemplateExampleInput(example_value="${exampleGlyph}")}},
+    example_glyphs={"exampleGlyph": BlueprintTemplateExampleInput(example_value="hello world")},
 )
 
 _TEMPLATE_NO_EXAMPLES = BlueprintTemplate(
@@ -239,8 +240,8 @@ async def test_template_example_values_returns_examples() -> None:
     ):
         mock_pm.plugins = pmap({_PLUGIN_ID: plugin})
         result = await get_template_example_values(_PLUGIN_ID, "myTemplate")
-    assert result.example_values == {_BLOCK_A: {_TEXT: "${exampleGlyph}"}}
-    assert result.example_glyphs == {"exampleGlyph": "hello world"}
+    assert result.example_values == {_BLOCK_A: {_TEXT: BlueprintTemplateExampleInput(example_value="${exampleGlyph}")}}
+    assert result.example_glyphs == {"exampleGlyph": BlueprintTemplateExampleInput(example_value="hello world")}
 
 
 @pytest.mark.asyncio
@@ -254,9 +255,9 @@ async def test_template_example_values_applies_remapping() -> None:
         mock_pm.plugins = pmap({_PLUGIN_ID: plugin})
         result = await get_template_example_values(_PLUGIN_ID, "myTemplate")
     # Key renamed, value's glyph reference renamed
-    assert result.example_glyphs == {"renamedGlyph": "hello world"}
+    assert result.example_glyphs == {"renamedGlyph": BlueprintTemplateExampleInput(example_value="hello world")}
     # The example_value string referencing ${exampleGlyph} must be rewritten
-    assert result.example_values[_BLOCK_A][_TEXT] == "${renamedGlyph}"
+    assert result.example_values[_BLOCK_A][_TEXT] == BlueprintTemplateExampleInput(example_value="${renamedGlyph}")
 
 
 @pytest.mark.asyncio

--- a/frontend/mocks/handlers/plugins.handlers.ts
+++ b/frontend/mocks/handlers/plugins.handlers.ts
@@ -286,9 +286,9 @@ export const pluginsHandlers = [
 
     return HttpResponse.json({
       example_values: {
-        block_source_1: { base_time: '2026-07-01T00:00:00' },
+        block_source_1: { base_time: { example_value: '2026-07-01T00:00:00' } },
       },
-      example_glyphs: { leadtime: '48' },
+      example_glyphs: { leadtime: { example_value: '48' } },
     })
   }),
 ]

--- a/frontend/src/api/types/plugins.types.ts
+++ b/frontend/src/api/types/plugins.types.ts
@@ -265,14 +265,32 @@ export function derivePluginStatus(detail: PluginDetail): PluginStatus {
 }
 
 /**
+ * Example input for a single parameter or glyph in a blueprint template.
+ * The `example_value` is the actual string value; the other fields are UI metadata.
+ */
+export const BlueprintTemplateExampleInputSchema = z.object({
+  example_value: z.string(),
+  display_name: z.string().nullable().optional(),
+  display_description: z.string().nullable().optional(),
+  type_hint: z.string().nullable().optional(),
+})
+
+export type BlueprintTemplateExampleInput = z.infer<
+  typeof BlueprintTemplateExampleInputSchema
+>
+
+/**
  * Example data for a blueprint template from GET /plugin/templateExampleValues.
  * Mirrors what the backend overlays during template ingest validation.
  */
 export const TemplateExampleValuesSchema = z.object({
   /** Per-block example configuration values, keyed by block instance id then option id */
-  example_values: z.record(z.string(), z.record(z.string(), z.string())),
+  example_values: z.record(
+    z.string(),
+    z.record(z.string(), BlueprintTemplateExampleInputSchema),
+  ),
   /** Example glyph name-to-value pairs the user is expected to override */
-  example_glyphs: z.record(z.string(), z.string()),
+  example_glyphs: z.record(z.string(), BlueprintTemplateExampleInputSchema),
 })
 
 export type TemplateExampleValues = z.infer<typeof TemplateExampleValuesSchema>

--- a/frontend/src/features/fable-builder/components/FableBuilderPage.tsx
+++ b/frontend/src/features/fable-builder/components/FableBuilderPage.tsx
@@ -304,10 +304,19 @@ export function FableBuilderPage({
   function applyTemplateExampleValues() {
     if (!templateExamples) return
     const { blocks } = useFableBuilderStore.getState().fable
-    for (const [blockId, values] of Object.entries(
+    for (const [blockId, inputs] of Object.entries(
       templateExamples.example_values,
     )) {
-      if (blockId in blocks) updateBlockConfigBatch(blockId, values)
+      if (blockId in blocks)
+        updateBlockConfigBatch(
+          blockId,
+          Object.fromEntries(
+            Object.entries(inputs).map(([optId, inp]) => [
+              optId,
+              inp.example_value,
+            ]),
+          ),
+        )
     }
   }
 
@@ -322,10 +331,10 @@ export function FableBuilderPage({
 
   function handleTemplateSkip() {
     applyTemplateExampleValues()
-    for (const [key, value] of Object.entries(
+    for (const [key, inp] of Object.entries(
       templateExamples?.example_glyphs ?? {},
     )) {
-      setLocalGlyph(key, value)
+      setLocalGlyph(key, inp.example_value)
     }
     setTemplateParamsDone(true)
     showToast.info(t('template.prefilled'))
@@ -344,15 +353,24 @@ export function FableBuilderPage({
     if (!templateMode || templateParamsDone) return
     if (templateParams === null || !examplesSettled || templateHasParams) return
     const { blocks } = useFableBuilderStore.getState().fable
-    for (const [blockId, values] of Object.entries(
+    for (const [blockId, inputs] of Object.entries(
       templateExamples?.example_values ?? {},
     )) {
-      if (blockId in blocks) updateBlockConfigBatch(blockId, values)
+      if (blockId in blocks)
+        updateBlockConfigBatch(
+          blockId,
+          Object.fromEntries(
+            Object.entries(inputs).map(([optId, inp]) => [
+              optId,
+              inp.example_value,
+            ]),
+          ),
+        )
     }
-    for (const [key, value] of Object.entries(
+    for (const [key, inp] of Object.entries(
       templateExamples?.example_glyphs ?? {},
     )) {
-      setLocalGlyph(key, value)
+      setLocalGlyph(key, inp.example_value)
     }
     setTemplateParamsDone(true)
     if (templateExamples) showToast.info(t('template.prefilled'))

--- a/frontend/src/features/fable-builder/components/TemplateParamsDialog.tsx
+++ b/frontend/src/features/fable-builder/components/TemplateParamsDialog.tsx
@@ -79,7 +79,7 @@ export function TemplateParamsDialog({
     if (!open) return
     const seeded: Record<string, string> = {}
     for (const name of params.required) {
-      seeded[name] = examples?.example_glyphs[name] ?? ''
+      seeded[name] = examples?.example_glyphs[name]?.example_value ?? ''
     }
     for (const [name, value] of Object.entries(params.prefilled)) {
       seeded[name] = value
@@ -100,7 +100,11 @@ export function TemplateParamsDialog({
               ...block,
               configuration_values: {
                 ...block.configuration_values,
-                ...examples.example_values[blockId],
+                ...Object.fromEntries(
+                  Object.entries(examples.example_values[blockId]).map(
+                    ([optId, inp]) => [optId, inp.example_value],
+                  ),
+                ),
               },
             }
           : block,

--- a/frontend/tests/unit/api/endpoints/plugins.test.ts
+++ b/frontend/tests/unit/api/endpoints/plugins.test.ts
@@ -258,8 +258,10 @@ describe('getTemplateExampleValues', () => {
           displayName: url.searchParams.get('displayName'),
         }
         return HttpResponse.json({
-          example_values: { block_1: { area: '[-10, 40, 10, 60]' } },
-          example_glyphs: { leadtime: '48' },
+          example_values: {
+            block_1: { area: { example_value: '[-10, 40, 10, 60]' } },
+          },
+          example_glyphs: { leadtime: { example_value: '48' } },
         })
       }),
     )
@@ -273,7 +275,9 @@ describe('getTemplateExampleValues', () => {
       local: 'plugin-test',
       displayName: 'testBasic',
     })
-    expect(result.example_values.block_1).toEqual({ area: '[-10, 40, 10, 60]' })
-    expect(result.example_glyphs).toEqual({ leadtime: '48' })
+    expect(result.example_values.block_1).toEqual({
+      area: { example_value: '[-10, 40, 10, 60]' },
+    })
+    expect(result.example_glyphs).toEqual({ leadtime: { example_value: '48' } })
   })
 })


### PR DESCRIPTION
Changes the BlueprintTemplate from only holding values of the example glyphs/confOptions to provide the full display name/description and type hint