### PR TITLE
[frontend] artifact tags & plugin badge severity

### DIFF
--- a/frontend/mocks/handlers/artifacts.handlers.ts
+++ b/frontend/mocks/handlers/artifacts.handlers.ts
@@ -216,6 +216,7 @@ const mockModels: Array<MlModelDetail> = [
     display_author: 'ECMWF',
     disk_size_bytes: 2_147_483_648,
     supported_platforms: ['cpu', 'cuda'],
+    tags: { resolution: 'o96', deterministic: null },
     is_available: true,
     is_locally_compatible: true,
     local_compatibility_detail: null,
@@ -249,6 +250,13 @@ const mockModels: Array<MlModelDetail> = [
     display_author: 'ECMWF',
     disk_size_bytes: 993_937_386,
     supported_platforms: ['linux', 'macos'],
+    // exercises the "+N" overflow and long-detail tooltip paths
+    tags: {
+      resolution: 'n320',
+      experimental: null,
+      attention: 'scaled dot-product attention (sdpa) variant',
+      mse: null,
+    },
     is_available: false,
     is_locally_compatible: false,
     local_compatibility_detail:
@@ -287,6 +295,7 @@ const mockModels: Array<MlModelDetail> = [
     display_author: 'ECMWF',
     disk_size_bytes: 921_584_533,
     supported_platforms: ['linux', 'macos'],
+    tags: { resolution: 'n320', ensemble: null },
     is_available: true,
     is_locally_compatible: true,
     local_compatibility_detail: null,
@@ -297,6 +306,8 @@ const mockModels: Array<MlModelDetail> = [
       'anemoi-models==0.6.0',
       'torch>=2.6.0',
       'torch_geometric==2.4.0',
+      // wheel-URL constraint as in the real catalog — exercises truncation + copy
+      'https://github.com/cathalobrien/get-flash-attn/releases/download/v0.1-alpha/flash_attn-2.7.4.post1+cu12torch2.6cxx11abiFALSE-cp310-cp310-linux_x86_64.whl',
     ],
     input_qube: buildAifsQube({
       pressureParams: STANDARD_PRESSURE_PARAMS,
@@ -325,6 +336,8 @@ const mockModels: Array<MlModelDetail> = [
     display_author: 'ECMWF',
     disk_size_bytes: 3_221_225_472,
     supported_platforms: ['cuda'],
+    // empty tags: chips render nothing
+    tags: {},
     is_available: false,
     is_locally_compatible: false,
     local_compatibility_detail: 'No compatible GPU detected on this host.',

--- a/frontend/src/api/hooks/usePlugins.ts
+++ b/frontend/src/api/hooks/usePlugins.ts
@@ -163,8 +163,7 @@ function usePluginMutation<TVariables>(
       await action(variables)
       // Poll until the catalogue is available again (plugins finished reloading)
       await waitForCatalogue()
-      // Refresh caches. Status carries plugin_enabled, so it must refresh too
-      // or the toggle sticks.
+      // Refresh caches: catalogue for block availability, list for plugin state.
       await queryClient.invalidateQueries({ queryKey: fableKeys.catalogue() })
       await queryClient.invalidateQueries({ queryKey: pluginKeys.list() })
     },

--- a/frontend/src/api/types/artifacts.types.ts
+++ b/frontend/src/api/types/artifacts.types.ts
@@ -59,6 +59,8 @@ export const MlModelOverviewSchema = z.object({
   display_author: z.string(),
   disk_size_bytes: z.number(),
   supported_platforms: z.array(z.string()),
+  /** Arbitrary key → optional-detail labels from the store catalog. */
+  tags: z.record(z.string(), z.string().nullable()),
   is_available: z.boolean(),
   is_locally_compatible: z.boolean(),
   local_compatibility_detail: z.string().nullable(),
@@ -151,6 +153,7 @@ export interface ArtifactInfo {
   diskSize: string
   diskSizeBytes: number
   platforms: Array<string>
+  tags: Record<string, string | null>
   isAvailable: boolean
   isLocallyCompatible: boolean
   localCompatibilityDetail: string | null
@@ -168,6 +171,7 @@ export function toArtifactInfo(model: MlModelOverview): ArtifactInfo {
     diskSize: formatBytes(model.disk_size_bytes),
     diskSizeBytes: model.disk_size_bytes,
     platforms: model.supported_platforms,
+    tags: model.tags,
     isAvailable: model.is_available,
     isLocallyCompatible: model.is_locally_compatible,
     localCompatibilityDetail: model.local_compatibility_detail,

--- a/frontend/src/api/types/plugins.types.ts
+++ b/frontend/src/api/types/plugins.types.ts
@@ -180,8 +180,8 @@ export type PluginBadgeKind =
 
 /**
  * The one badge a plugin shows. Badge and status filter both derive from this,
- * so they can't drift. Precedence: disabled → update → warning → errored →
- * available → loaded.
+ * so they can't drift. Precedence: disabled → errored (severe diagnostics) →
+ * update → warning → errored (status) → available → loaded.
  */
 export function pluginBadgeKind(plugin: {
   status: PluginStatus
@@ -194,9 +194,12 @@ export function pluginBadgeKind(plugin: {
   if (plugin.isEnabled === false && plugin.status !== 'available') {
     return 'disabled'
   }
+  // Severity drives the badge, not status — error/critical diagnostics are red
+  // even when install succeeded but the module failed to load; warnings amber.
+  if (plugin.errorSeverity === 'error' || plugin.errorSeverity === 'critical') {
+    return 'errored'
+  }
   if (plugin.hasUpdate && plugin.status === 'loaded') return 'update'
-  // Severity drives the badge, not status — a warning is amber whether the
-  // plugin loaded or errored.
   if (plugin.errorSeverity === 'warning') return 'warning'
   if (plugin.status === 'errored') return 'errored'
   if (plugin.status === 'available') return 'available'
@@ -340,7 +343,7 @@ export interface PluginInfo {
   description: string
   /** Author name from store_info.display_author */
   author: string
-  /** Currently installed version (loaded_version) */
+  /** Currently installed version (install_data.local_version) */
   version: string | null
   /** Latest available version (remote_info.version) */
   latestVersion: string | null
@@ -350,8 +353,8 @@ export interface PluginInfo {
   capabilities: Array<PluginCapability>
   /** Current status from backend */
   status: PluginStatus
-  /** Enabled = its blocks appear in the catalogue. Reflects `plugin_enabled`,
-   *  not merely whether it loaded. */
+  /** Enabled = its blocks appear in the catalogue. Reflects
+   *  `settings_data.isEnabled`, not merely whether it loaded. */
   isEnabled: boolean
   /** Whether plugin is installed (not available) */
   isInstalled: boolean

--- a/frontend/src/features/artifacts/components/ArtifactCard.tsx
+++ b/frontend/src/features/artifacts/components/ArtifactCard.tsx
@@ -18,6 +18,7 @@ import { Download, HardDrive, Trash2, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { ArtifactCompatibilityBadge } from './ArtifactCompatibilityBadge'
 import { ArtifactStatusBadge } from './ArtifactStatusBadge'
+import { ArtifactTagChips } from './ArtifactTagChips'
 import type {
   ArtifactInfo,
   CompositeArtifactId,
@@ -99,6 +100,7 @@ export function ArtifactCard({
             {platform}
           </span>
         ))}
+        <ArtifactTagChips tags={artifact.tags} max={3} />
         <ArtifactCompatibilityBadge artifact={artifact} />
       </div>
 

--- a/frontend/src/features/artifacts/components/ArtifactCompatibilityBadge.tsx
+++ b/frontend/src/features/artifacts/components/ArtifactCompatibilityBadge.tsx
@@ -18,7 +18,10 @@ import type { ArtifactInfo } from '@/api/types/artifacts.types'
 import { cn } from '@/lib/utils'
 
 interface ArtifactCompatibilityBadgeProps {
-  artifact: ArtifactInfo
+  artifact: Pick<
+    ArtifactInfo,
+    'isLocallyCompatible' | 'localCompatibilityDetail'
+  >
   className?: string
 }
 

--- a/frontend/src/features/artifacts/components/ArtifactDetailPage.tsx
+++ b/frontend/src/features/artifacts/components/ArtifactDetailPage.tsx
@@ -17,27 +17,36 @@
 
 import {
   ArrowLeft,
+  Check,
+  Copy,
   Download,
   ExternalLink,
   HardDrive,
   Trash2,
+  TriangleAlert,
   X,
 } from 'lucide-react'
+import { useState } from 'react'
 import { Link } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
+import { ArtifactCompatibilityBadge } from './ArtifactCompatibilityBadge'
 import { ArtifactStatusBadge } from './ArtifactStatusBadge'
+import { ArtifactTagChips } from './ArtifactTagChips'
 import { QubeTree } from './QubeTree'
 import type {
   CompositeArtifactId,
   MlModelDetail,
 } from '@/api/types/artifacts.types'
 import { formatBytes } from '@/api/types/artifacts.types'
+import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Progress } from '@/components/ui/progress'
 import { Separator } from '@/components/ui/separator'
 import { Spinner } from '@/components/ui/spinner'
 import { H1, H2, P } from '@/components/base/typography'
+import { copyToClipboard } from '@/lib/utils'
+import { showToast } from '@/lib/toast'
 import { isHttpUrl } from '@/utils/url'
 
 export interface ArtifactDetailPageProps {
@@ -98,21 +107,13 @@ export function ArtifactDetailPage({
                 {platform}
               </span>
             ))}
-            <span
-              className={
-                detail.is_locally_compatible
-                  ? 'inline-flex items-center rounded bg-green-100 px-2 py-0.5 text-sm font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400'
-                  : 'inline-flex items-center rounded bg-yellow-100 px-2 py-0.5 text-sm font-medium text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
-              }
-            >
-              {detail.is_locally_compatible
-                ? t('compatibility.compatible')
-                : detail.local_compatibility_detail
-                  ? t('compatibility.notCompatibleDetail', {
-                      detail: detail.local_compatibility_detail,
-                    })
-                  : t('compatibility.notCompatible')}
-            </span>
+            <ArtifactTagChips tags={detail.tags} />
+            <ArtifactCompatibilityBadge
+              artifact={{
+                isLocallyCompatible: detail.is_locally_compatible,
+                localCompatibilityDetail: detail.local_compatibility_detail,
+              }}
+            />
           </div>
         </div>
         <div className="flex gap-2">
@@ -174,6 +175,18 @@ export function ArtifactDetailPage({
         </div>
       </div>
 
+      {/* Full incompatibility reason from the backend */}
+      {!detail.is_locally_compatible && detail.local_compatibility_detail && (
+        <Alert className="border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-900/50 dark:bg-amber-900/20 dark:text-amber-400">
+          <TriangleAlert />
+          <AlertDescription className="text-amber-800 dark:text-amber-400">
+            {t('compatibility.notCompatibleDetail', {
+              detail: detail.local_compatibility_detail,
+            })}
+          </AlertDescription>
+        </Alert>
+      )}
+
       {/* Download Progress Bar */}
       {isDownloading && downloadProgress !== undefined && (
         <Progress value={Math.round(downloadProgress)} />
@@ -194,12 +207,7 @@ export function ArtifactDetailPage({
         {detail.pip_package_constraints.length > 0 ? (
           <div className="flex flex-wrap gap-2">
             {detail.pip_package_constraints.map((constraint) => (
-              <span
-                key={constraint}
-                className="rounded bg-muted px-2.5 py-1 font-mono text-sm text-muted-foreground"
-              >
-                {constraint}
-              </span>
+              <ConstraintChip key={constraint} value={constraint} />
             ))}
           </div>
         ) : (
@@ -241,6 +249,47 @@ export function ArtifactDetailPage({
         )}
       </div>
     </div>
+  )
+}
+
+/** Truncating mono chip; long values (wheel URLs) get a tooltip + copy button. */
+function ConstraintChip({ value }: { value: string }) {
+  const { t } = useTranslation('artifacts')
+  const [copied, setCopied] = useState(false)
+  const showCopy = value.length > 40
+
+  const handleCopy = () => {
+    void copyToClipboard(value).then((ok) => {
+      if (ok) {
+        setCopied(true)
+        window.setTimeout(() => setCopied(false), 1500)
+      } else {
+        showToast.error(t('detail.constraintCopyFailed'))
+      }
+    })
+  }
+
+  return (
+    <span
+      title={value}
+      className="inline-flex max-w-full min-w-0 items-center gap-1.5 rounded bg-muted px-2.5 py-1 font-mono text-sm text-muted-foreground"
+    >
+      <span className="truncate">{value}</span>
+      {showCopy && (
+        <button
+          type="button"
+          onClick={handleCopy}
+          aria-label={t('detail.copyConstraint')}
+          className="shrink-0 rounded p-0.5 transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+        >
+          {copied ? (
+            <Check className="h-3.5 w-3.5" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" />
+          )}
+        </button>
+      )}
+    </span>
   )
 }
 

--- a/frontend/src/features/artifacts/components/ArtifactRow.tsx
+++ b/frontend/src/features/artifacts/components/ArtifactRow.tsx
@@ -19,6 +19,7 @@ import { Eye, HardDrive, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { ArtifactCompatibilityBadge } from './ArtifactCompatibilityBadge'
 import { ArtifactStatusBadge } from './ArtifactStatusBadge'
+import { ArtifactTagChips } from './ArtifactTagChips'
 import type {
   ArtifactInfo,
   CompositeArtifactId,
@@ -60,6 +61,11 @@ export function ArtifactRow({
                 {platform}
               </span>
             ))}
+            <ArtifactTagChips
+              tags={artifact.tags}
+              max={2}
+              className="px-1.5 text-xs"
+            />
             <ArtifactCompatibilityBadge
               artifact={artifact}
               className="px-1.5 text-xs"

--- a/frontend/src/features/artifacts/components/ArtifactTagChips.tsx
+++ b/frontend/src/features/artifacts/components/ArtifactTagChips.tsx
@@ -1,0 +1,65 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * ArtifactTagChips
+ *
+ * Store-catalog tags (key → optional detail) as outline chips; long details
+ * move to the tooltip. Renders nothing when there are no tags.
+ */
+
+import { useTranslation } from 'react-i18next'
+import { Badge } from '@/components/ui/badge'
+
+export interface ArtifactTagChipsProps {
+  tags: Record<string, string | null>
+  /** Show at most this many chips, collapsing the rest into a "+N" chip. */
+  max?: number
+  className?: string
+}
+
+export function ArtifactTagChips({
+  tags,
+  max,
+  className,
+}: ArtifactTagChipsProps) {
+  const { t } = useTranslation('artifacts')
+  const entries = Object.entries(tags)
+  if (entries.length === 0) return null
+
+  const visible = max !== undefined ? entries.slice(0, max) : entries
+  const hidden = max !== undefined ? entries.slice(max) : []
+
+  return (
+    <>
+      {visible.map(([key, value]) => (
+        <Badge
+          key={key}
+          variant="outline"
+          className={className}
+          title={value && value.length > 24 ? `${key}: ${value}` : undefined}
+        >
+          {value && value.length <= 24 ? `${key}: ${value}` : key}
+        </Badge>
+      ))}
+      {hidden.length > 0 && (
+        <Badge
+          variant="outline"
+          className={className}
+          title={hidden
+            .map(([key, value]) => (value ? `${key}: ${value}` : key))
+            .join('\n')}
+        >
+          {t('tags.overflow', { count: hidden.length })}
+        </Badge>
+      )}
+    </>
+  )
+}

--- a/frontend/src/features/artifacts/components/ConfirmDeleteArtifactDialog.tsx
+++ b/frontend/src/features/artifacts/components/ConfirmDeleteArtifactDialog.tsx
@@ -1,0 +1,79 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * ConfirmDeleteArtifactDialog
+ *
+ * Confirmation gate for deleting a downloaded model's files. Controlled:
+ * the routes hold the pending target and mutate on confirm.
+ */
+
+import { useTranslation } from 'react-i18next'
+import type { CompositeArtifactId } from '@/api/types/artifacts.types'
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+
+export interface DeleteArtifactTarget {
+  id: CompositeArtifactId
+  name: string
+}
+
+export interface ConfirmDeleteArtifactDialogProps {
+  target: DeleteArtifactTarget | null
+  onCancel: () => void
+  onConfirm: (id: CompositeArtifactId) => void
+}
+
+export function ConfirmDeleteArtifactDialog({
+  target,
+  onCancel,
+  onConfirm,
+}: ConfirmDeleteArtifactDialogProps) {
+  const { t } = useTranslation('artifacts')
+
+  return (
+    <AlertDialog
+      open={target !== null}
+      onOpenChange={(open) => {
+        if (!open) onCancel()
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t('confirmDelete.title')}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {t('confirmDelete.description', { name: target?.name ?? '' })}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <Button type="button" variant="outline" onClick={onCancel}>
+            {t('confirmDelete.cancel')}
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={() => {
+              if (target) onConfirm(target.id)
+            }}
+          >
+            {t('confirmDelete.confirm')}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/frontend/src/features/plugins/components/PluginStatusBadge.tsx
+++ b/frontend/src/features/plugins/components/PluginStatusBadge.tsx
@@ -37,11 +37,11 @@ interface PluginStatusBadgeProps {
   status: PluginStatus
   /** Whether an update is available (shown as visual indicator) */
   hasUpdate?: boolean
-  /** Max diagnostic severity; drives the badge directly (a warning is amber
-   *  whether the plugin loaded or errored). */
+  /** Max diagnostic severity; drives the badge directly (error/critical red,
+   *  warning amber — whether the plugin loaded or errored). */
   severity?: PluginErrorSeverity | null
-  /** `plugin_enabled` flag. Explicit `false` → "Disabled" regardless of load
-   *  status. Omit to drive the badge by `status` alone. */
+  /** `settings_data.isEnabled` flag. Explicit `false` → "Disabled" regardless
+   *  of load status. Omit to drive the badge by `status` alone. */
   isEnabled?: boolean
   className?: string
 }

--- a/frontend/src/locales/en/artifacts.json
+++ b/frontend/src/locales/en/artifacts.json
@@ -66,7 +66,12 @@
     "qubeParamCount_other": "{{count}} params",
     "qubeSectionTitle": "{{name}} levels ({{code}})",
     "qubeLevelValue": "{{level}} hPa",
+    "copyConstraint": "Copy value",
+    "constraintCopyFailed": "Could not copy to clipboard",
     "notFound": "Model not found: {{id}}"
+  },
+  "tags": {
+    "overflow": "+{{count}}"
   },
   "compatibility": {
     "compatible": "Compatible",

--- a/frontend/src/routes/_authenticated/admin/artifacts.$artifactId.tsx
+++ b/frontend/src/routes/_authenticated/admin/artifacts.$artifactId.tsx
@@ -14,8 +14,10 @@
  * Shows full details for a single ML model artifact.
  */
 
+import { useState } from 'react'
 import { createFileRoute } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
+import type { DeleteArtifactTarget } from '@/features/artifacts/components/ConfirmDeleteArtifactDialog'
 import { decodeArtifactId } from '@/api/types/artifacts.types'
 import {
   useArtifactDetail,
@@ -24,6 +26,7 @@ import {
 } from '@/api/hooks/useArtifacts'
 import { LoadingSpinner } from '@/components/common/LoadingSpinner'
 import { ArtifactDetailPage } from '@/features/artifacts/components/ArtifactDetailPage'
+import { ConfirmDeleteArtifactDialog } from '@/features/artifacts/components/ConfirmDeleteArtifactDialog'
 
 export const Route = createFileRoute(
   '/_authenticated/admin/artifacts/$artifactId',
@@ -39,6 +42,8 @@ function ArtifactDetailRoute() {
   const { data: detail, isLoading } = useArtifactDetail(compositeId)
   const downloadModel = useDownloadModel()
   const deleteModel = useDeleteModel()
+  const [pendingDelete, setPendingDelete] =
+    useState<DeleteArtifactTarget | null>(null)
 
   if (isLoading) {
     return (
@@ -57,14 +62,24 @@ function ArtifactDetailRoute() {
   }
 
   return (
-    <ArtifactDetailPage
-      detail={detail}
-      onDownload={(id) => downloadModel.mutate(id)}
-      onDelete={(id) => deleteModel.mutate(id)}
-      onCancelDownload={downloadModel.cancel}
-      isDownloading={downloadModel.isDownloading(detail.composite_id)}
-      downloadProgress={downloadModel.getProgress(detail.composite_id)}
-      isDeleting={deleteModel.isPending}
-    />
+    <>
+      <ArtifactDetailPage
+        detail={detail}
+        onDownload={(id) => downloadModel.mutate(id)}
+        onDelete={(id) => setPendingDelete({ id, name: detail.display_name })}
+        onCancelDownload={downloadModel.cancel}
+        isDownloading={downloadModel.isDownloading(detail.composite_id)}
+        downloadProgress={downloadModel.getProgress(detail.composite_id)}
+        isDeleting={deleteModel.isPending}
+      />
+      <ConfirmDeleteArtifactDialog
+        target={pendingDelete}
+        onCancel={() => setPendingDelete(null)}
+        onConfirm={(id) => {
+          setPendingDelete(null)
+          deleteModel.mutate(id)
+        }}
+      />
+    </>
   )
 }

--- a/frontend/src/routes/_authenticated/admin/artifacts.index.tsx
+++ b/frontend/src/routes/_authenticated/admin/artifacts.index.tsx
@@ -21,6 +21,7 @@ import { RefreshCw } from 'lucide-react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 import type { ArtifactInfo } from '@/api/types/artifacts.types'
+import type { DeleteArtifactTarget } from '@/features/artifacts/components/ConfirmDeleteArtifactDialog'
 import { encodeArtifactId } from '@/api/types/artifacts.types'
 import {
   useArtifacts,
@@ -35,6 +36,7 @@ import { PageHeader } from '@/components/common/PageHeader'
 import { ArtifactsFilters } from '@/features/artifacts/components/ArtifactsFilters'
 import { ArtifactsList } from '@/features/artifacts/components/ArtifactsList'
 import { AvailableModelsSection } from '@/features/artifacts/components/AvailableModelsSection'
+import { ConfirmDeleteArtifactDialog } from '@/features/artifacts/components/ConfirmDeleteArtifactDialog'
 import { useUiStore } from '@/stores/uiStore'
 
 export const Route = createFileRoute('/_authenticated/admin/artifacts/')({
@@ -50,6 +52,8 @@ function ArtifactsPage() {
 
   // Filter state
   const [searchQuery, setSearchQuery] = useState('')
+  const [pendingDelete, setPendingDelete] =
+    useState<DeleteArtifactTarget | null>(null)
 
   // Queries & mutations
   const { artifacts, isLoading, refetch } = useArtifacts()
@@ -134,13 +138,29 @@ function ArtifactsPage() {
         <ArtifactsList
           artifacts={downloadedArtifacts}
           viewMode={artifactsViewMode}
-          onDelete={(id) => deleteModel.mutate(id)}
+          onDelete={(id) => {
+            const artifact = downloadedArtifacts.find(
+              (a) =>
+                a.id.artifact_store_id === id.artifact_store_id &&
+                a.id.artifact_local_id === id.artifact_local_id,
+            )
+            setPendingDelete({ id, name: artifact?.displayName ?? '' })
+          }}
           onViewDetails={handleViewDetails}
           deletingId={deleteModel.isPending ? deleteModel.variables : undefined}
           variant={dashboardVariant}
           shadow={panelShadow}
         />
       </div>
+
+      <ConfirmDeleteArtifactDialog
+        target={pendingDelete}
+        onCancel={() => setPendingDelete(null)}
+        onConfirm={(id) => {
+          setPendingDelete(null)
+          deleteModel.mutate(id)
+        }}
+      />
 
       {/* Available Models Section */}
       <AvailableModelsSection

--- a/frontend/tests/e2e/plugin-install.spec.ts
+++ b/frontend/tests/e2e/plugin-install.spec.ts
@@ -103,7 +103,7 @@ test.describe('Plugin Install Flow', () => {
     //  1. POST /plugin/install      → 200
     //  2. GET  /blueprint/catalogue → 503  (plugins reloading)
     //  3. GET  /blueprint/catalogue → 200  (retry succeeds)
-    //  4. GET  /plugin/details      → 200  (updated listing)
+    //  4. GET  /plugin/list         → 200  (updated listing)
 
     // After install completes the plugin should appear in the installed
     // section with a toggle switch. Wait for the full retry + refetch cycle.

--- a/frontend/tests/integration/features/plugins/plugin-updates.test.tsx
+++ b/frontend/tests/integration/features/plugins/plugin-updates.test.tsx
@@ -300,7 +300,7 @@ describe('Plugin Updates Integration', () => {
         .element(screen.getByRole('heading', { name: 'Plugin Store' }))
         .toBeVisible()
 
-      // ECMWF Ensemble has loaded_version '2.1.0' but remote_info version '2.4.0';
+      // ECMWF Ensemble has local_version '2.1.0' but remote_info version '2.4.0';
       // it renders in the updates section AND the installed list
       await expect
         .element(screen.getByText('ECMWF Ensemble').first())
@@ -574,7 +574,7 @@ describe('Plugin Updates Integration', () => {
   // -----------------------------------------------------------------------
   // Mutating tests (trigger update mutation) - placed LAST because the MSW
   // handler uses shared mutable state that persists across tests.
-  // After update, ECMWF Ensemble loaded_version becomes 2.4.0 and
+  // After update, ECMWF Ensemble local_version becomes 2.4.0 and
   // hasUpdate becomes false, removing it from the updates section.
   // -----------------------------------------------------------------------
 
@@ -598,7 +598,7 @@ describe('Plugin Updates Integration', () => {
       const updateButton = screen.getByRole('button', { name: /update now/i })
       await updateButton.click()
 
-      // The MSW handler updates the plugin state (loaded_version becomes 2.4.0)
+      // The MSW handler updates the plugin state (local_version becomes 2.4.0)
       // and invalidates queries. After refetch, the plugin should no longer
       // appear in the updates section since versions will match.
       // MSW update handler has 1000ms delay + refetch (300ms for details)

--- a/frontend/tests/integration/features/plugins/plugins-management.test.tsx
+++ b/frontend/tests/integration/features/plugins/plugins-management.test.tsx
@@ -582,6 +582,37 @@ describe('Plugins Management Integration', () => {
       await expect.element(screen.getByText('Loaded')).not.toBeInTheDocument()
       await expect.element(screen.getByText(/version mismatch/)).toBeVisible()
     })
+
+    it('badges an installed plugin whose module failed to load as red Errored', async () => {
+      // Install succeeded (settings_data present, enabled) but loading the
+      // module failed — the error-severity diagnostic must win over 'loaded'.
+      worker.use(
+        http.get(API_ENDPOINTS.plugin.list, () =>
+          detailsResponse({
+            ...baseDetail,
+            load_errors: [
+              {
+                source: 'load',
+                detail:
+                  "ModuleNotFoundError: no module named 'fiab_plugin_diag'",
+                severity: 'error',
+              },
+            ],
+          }),
+        ),
+      )
+
+      const screen = await renderWithRouter(<TestPluginsPage />)
+      await expect
+        .element(screen.getByRole('heading', { name: 'Plugin Store' }))
+        .toBeVisible()
+
+      await expect.element(screen.getByText('Errored')).toBeVisible()
+      await expect.element(screen.getByText('Loaded')).not.toBeInTheDocument()
+      await expect
+        .element(screen.getByText(/ModuleNotFoundError/))
+        .toBeVisible()
+    })
   })
 
   describe('Error Handling', () => {

--- a/frontend/tests/unit/api/types/artifacts.types.test.ts
+++ b/frontend/tests/unit/api/types/artifacts.types.test.ts
@@ -1,0 +1,61 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { MlModelOverview } from '@/api/types/artifacts.types'
+import {
+  MlModelOverviewSchema,
+  toArtifactInfo,
+} from '@/api/types/artifacts.types'
+
+const baseOverview = {
+  composite_id: { artifact_store_id: 'ecmwf', artifact_local_id: 'aifs-x' },
+  display_name: 'AIFS X',
+  display_author: 'ECMWF',
+  disk_size_bytes: 1024,
+  supported_platforms: ['linux'],
+  tags: {},
+  is_available: true,
+  is_locally_compatible: true,
+  local_compatibility_detail: null,
+}
+
+describe('MlModelOverviewSchema — tags', () => {
+  it('accepts string and null tag values', () => {
+    const parsed = MlModelOverviewSchema.parse({
+      ...baseOverview,
+      tags: { resolution: 'n320', experimental: null },
+    })
+    expect(parsed.tags).toEqual({ resolution: 'n320', experimental: null })
+  })
+
+  it('accepts an empty tags record', () => {
+    expect(MlModelOverviewSchema.parse(baseOverview).tags).toEqual({})
+  })
+
+  it('rejects non-string tag values', () => {
+    expect(() =>
+      MlModelOverviewSchema.parse({
+        ...baseOverview,
+        tags: { count: 3 },
+      }),
+    ).toThrow()
+  })
+})
+
+describe('toArtifactInfo', () => {
+  it('carries tags through to the UI type', () => {
+    const overview: MlModelOverview = {
+      ...baseOverview,
+      tags: { ensemble: null },
+    }
+    expect(toArtifactInfo(overview).tags).toEqual({ ensemble: null })
+  })
+})

--- a/frontend/tests/unit/api/types/plugins.types.test.ts
+++ b/frontend/tests/unit/api/types/plugins.types.test.ts
@@ -267,6 +267,25 @@ describe('pluginBadgeKind — one source of truth for badge + filter', () => {
     )
   })
 
+  it('an error/critical diagnostic reddens even a loaded plugin (load failure)', () => {
+    // Install succeeded (status derives to 'loaded') but the module failed to
+    // load — the severe diagnostic must win over 'loaded' and 'update'.
+    expect(pluginBadgeKind({ status: 'loaded', errorSeverity: 'error' })).toBe(
+      'errored',
+    )
+    expect(
+      pluginBadgeKind({ status: 'loaded', errorSeverity: 'critical' }),
+    ).toBe('errored')
+    expect(
+      pluginBadgeKind({
+        status: 'loaded',
+        isEnabled: true,
+        hasUpdate: true,
+        errorSeverity: 'error',
+      }),
+    ).toBe('errored')
+  })
+
   it('falls through to the plain status when nothing else applies', () => {
     expect(pluginBadgeKind({ status: 'loaded', isEnabled: true })).toBe(
       'loaded',

--- a/frontend/tests/unit/features/artifacts/ArtifactTagChips.test.tsx
+++ b/frontend/tests/unit/features/artifacts/ArtifactTagChips.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { renderWithProviders } from '@tests/utils/render'
+import { ArtifactTagChips } from '@/features/artifacts/components/ArtifactTagChips'
+
+describe('ArtifactTagChips', () => {
+  it('renders nothing for an empty tags record', async () => {
+    const screen = await renderWithProviders(
+      <div data-testid="host">
+        <ArtifactTagChips tags={{}} />
+      </div>,
+    )
+    expect(screen.getByTestId('host').element().childElementCount).toBe(0)
+  })
+
+  it('renders a bare key for a null-valued tag', async () => {
+    const screen = await renderWithProviders(
+      <ArtifactTagChips tags={{ ensemble: null }} />,
+    )
+    await expect.element(screen.getByText('ensemble')).toBeVisible()
+  })
+
+  it('renders key: value inline for short details', async () => {
+    const screen = await renderWithProviders(
+      <ArtifactTagChips tags={{ resolution: 'n320' }} />,
+    )
+    await expect.element(screen.getByText('resolution: n320')).toBeVisible()
+  })
+
+  it('keeps long details in the tooltip, label stays the key', async () => {
+    const long = 'scaled dot-product attention (sdpa) variant'
+    const screen = await renderWithProviders(
+      <ArtifactTagChips tags={{ attention: long }} />,
+    )
+    const chip = screen.getByText('attention', { exact: true })
+    await expect.element(chip).toBeVisible()
+    expect(chip.element().getAttribute('title')).toBe(`attention: ${long}`)
+  })
+
+  it('collapses beyond max into a "+N" chip listing the rest', async () => {
+    const screen = await renderWithProviders(
+      <ArtifactTagChips
+        tags={{ a: null, b: null, c: null, d: 'x', e: null }}
+        max={3}
+      />,
+    )
+    for (const key of ['a', 'b', 'c']) {
+      await expect.element(screen.getByText(key, { exact: true })).toBeVisible()
+    }
+    const overflow = screen.getByText('+2')
+    await expect.element(overflow).toBeVisible()
+    expect(overflow.element().getAttribute('title')).toBe('d: x\ne')
+    expect(screen.getByText('d: x', { exact: true }).elements()).toHaveLength(0)
+  })
+})

--- a/frontend/tests/unit/features/artifacts/ConfirmDeleteArtifactDialog.test.tsx
+++ b/frontend/tests/unit/features/artifacts/ConfirmDeleteArtifactDialog.test.tsx
@@ -1,0 +1,84 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { renderWithProviders } from '@tests/utils/render'
+import { ConfirmDeleteArtifactDialog } from '@/features/artifacts/components/ConfirmDeleteArtifactDialog'
+
+const target = {
+  id: { artifact_store_id: 'ecmwf', artifact_local_id: 'aifs-x' },
+  name: 'AIFS X',
+}
+
+describe('ConfirmDeleteArtifactDialog', () => {
+  // Browser-mode tests render without the app stylesheet, so the dialog loses
+  // its Tailwind `fixed`/`z-50` positioning while Base UI's modal backdrop
+  // keeps its inline `position: fixed`. Restore the dialog's production
+  // stacking so the backdrop can't paint over the popup and swallow clicks.
+  beforeAll(() => {
+    const style = document.createElement('style')
+    style.textContent =
+      '[data-slot="alert-dialog-content"]{position:fixed;z-index:50}'
+    document.head.appendChild(style)
+  })
+
+  it('renders nothing without a target', async () => {
+    const screen = await renderWithProviders(
+      <ConfirmDeleteArtifactDialog
+        target={null}
+        onCancel={() => {}}
+        onConfirm={() => {}}
+      />,
+    )
+    expect(screen.getByText('Delete Model').elements()).toHaveLength(0)
+  })
+
+  it('shows title and the model name in the description', async () => {
+    const screen = await renderWithProviders(
+      <ConfirmDeleteArtifactDialog
+        target={target}
+        onCancel={() => {}}
+        onConfirm={() => {}}
+      />,
+    )
+    await expect.element(screen.getByText('Delete Model')).toBeVisible()
+    await expect
+      .element(screen.getByText(/Are you sure you want to delete AIFS X\?/))
+      .toBeVisible()
+  })
+
+  it('confirm invokes onConfirm with the composite id', async () => {
+    const onConfirm = vi.fn()
+    const screen = await renderWithProviders(
+      <ConfirmDeleteArtifactDialog
+        target={target}
+        onCancel={() => {}}
+        onConfirm={onConfirm}
+      />,
+    )
+    await screen.getByRole('button', { name: 'Delete' }).click()
+    expect(onConfirm).toHaveBeenCalledWith(target.id)
+  })
+
+  it('cancel invokes onCancel without confirming', async () => {
+    const onCancel = vi.fn()
+    const onConfirm = vi.fn()
+    const screen = await renderWithProviders(
+      <ConfirmDeleteArtifactDialog
+        target={target}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+      />,
+    )
+    await screen.getByRole('button', { name: 'Cancel' }).click()
+    expect(onCancel).toHaveBeenCalled()
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Description
Two frontend changes on top of #550 

### Artifacts

- Renders the new catalog tags (key → optional detail) as outline chips on the model detail header, cards , and table rows and bare key for null values, key: value inline when short, tooltip when long, and nothing while catalogs ship empty tags.
- Deleting a downloaded model now asks for confirmation, wiring the previously orphaned confirmDelete i18n strings into a shared dialog.
- The local-incompatibility reason moves out of the badge row into an amber alert line, leaving a compact badge in the row.
- Pip constraints render as uniform truncating mono chips, with tooltip plus copy-to-clipboard for long values such as wheel URLs.

### Plugins

After the #547 migration, a plugin whose install succeeded but whose module failed to load (error-severity load_errors with settings_data present) showed a green "Loaded" badge contradicting its diagnostics panel. Error/critical severity now wins over loaded/update in pluginBadgeKind; warning precedence is unchanged. 

Also cleans up comments left stale.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
