### PR TITLE
Feat/store outputs

### DIFF
--- a/backend/packages/fiab-core/src/fiab_core/fable.py
+++ b/backend/packages/fiab-core/src/fiab_core/fable.py
@@ -152,9 +152,9 @@ class RawOutput(FiabCoreBaseModel):
     mime_type: str = "application/octet-stream"
 
 
-def is_textual(output: RawOutput) -> bool:
+def is_textual(mime_type: str) -> bool:
     # we check the starts with because of encoding, extension, etc
-    return output.mime_type.startswith("text/plain")
+    return mime_type.startswith("text/plain")
 
 
 class NoOutput(FiabCoreBaseModel):

--- a/backend/packages/fiab-core/src/fiab_core/fable.py
+++ b/backend/packages/fiab-core/src/fiab_core/fable.py
@@ -152,6 +152,11 @@ class RawOutput(FiabCoreBaseModel):
     mime_type: str = "application/octet-stream"
 
 
+def is_textual(output: RawOutput) -> bool:
+    # we check the starts with because of encoding, extension, etc
+    return output.mime_type.startswith("text/plain")
+
+
 class NoOutput(FiabCoreBaseModel):
     # use this when there is no output whatsoever -- this stops *any* expansion of the block
     pass

--- a/backend/src/forecastbox/domain/run/cascade.py
+++ b/backend/src/forecastbox/domain/run/cascade.py
@@ -78,9 +78,16 @@ class ExecutionSpecification(FiabBaseModel):
     shared: bool = Field(default=False)
 
 
+stored_output_max_length = 10 * 1024**2
+
+
 class RunOutputCharacteristic(FiabBaseModel):
     mime_type: str = "application/octet-stream"
     original_block: BlockInstanceId
+    value: str | None = Field(
+        default=None,
+        description=f"If the actual output value is textual (text/plain) and has already been computed, we will store it here, trimmed to {stored_output_max_length} characters",
+    )
 
 
 class RunOutputs(FiabBaseModel):

--- a/backend/src/forecastbox/domain/run/service.py
+++ b/backend/src/forecastbox/domain/run/service.py
@@ -26,7 +26,6 @@ based on the supplied ``AuthContext``.
 
 import asyncio
 import logging
-import re
 from typing import cast
 
 from cascade.controller.report import JobId
@@ -48,13 +47,12 @@ from forecastbox.domain.run.exceptions import CompilationDetailCorrupted, Compil
 from forecastbox.domain.run.types import RunId
 from forecastbox.schemata.jobs import Blueprint, Run
 from forecastbox.utility.auth import AuthContext
+from forecastbox.utility.httpx import get_encoding
 from forecastbox.utility.memcache import pop as pop_memcache
 from forecastbox.utility.pydantic import FiabBaseModel
 from forecastbox.utility.time import value_dt2str
 
 logger = logging.getLogger(__name__)
-
-_CHARSET_RE = re.compile(r"charset=([^\s;]+)", re.IGNORECASE)
 
 
 def _decode_textual_output(raw: bytes, mime_type: str) -> str:
@@ -63,8 +61,7 @@ def _decode_textual_output(raw: bytes, mime_type: str) -> str:
     Falls back to utf-8 when no charset is specified. On decode error, stores a
     diagnostic message instead of raising.
     """
-    m = _CHARSET_RE.search(mime_type)
-    encoding = m.group(1) if m else "utf-8"
+    encoding = get_encoding(mime_type)
     try:
         return raw.decode(encoding)[:stored_output_max_length]
     except Exception as e:

--- a/backend/src/forecastbox/domain/run/service.py
+++ b/backend/src/forecastbox/domain/run/service.py
@@ -26,13 +26,14 @@ based on the supplied ``AuthContext``.
 
 import asyncio
 import logging
+import re
 from typing import cast
 
 from cascade.controller.report import JobId
 from cascade.gateway import api, client
 from cascade.low.core import DatasetId, TaskId
 from cascade.low.func import Either
-from fiab_core.fable import BlockInstanceId
+from fiab_core.fable import BlockInstanceId, is_textual
 
 import forecastbox.domain.blueprint.db as blueprint_db
 import forecastbox.domain.run.db as run_db
@@ -40,7 +41,7 @@ from forecastbox.domain.blueprint.types import BlueprintId
 from forecastbox.domain.experiment.types import ExperimentDefinitionId
 from forecastbox.domain.gateway.service import get_gateway_url
 from forecastbox.domain.run.background import execute_background
-from forecastbox.domain.run.cascade import RunOutputs
+from forecastbox.domain.run.cascade import RunOutputCharacteristic, RunOutputs, stored_output_max_length
 from forecastbox.domain.run.db import CompilerRuntimeContext
 from forecastbox.domain.run.detail import retrieve_compilation_detail
 from forecastbox.domain.run.exceptions import CompilationDetailCorrupted, CompilationDetailNotFound, RunNotFound
@@ -52,6 +53,22 @@ from forecastbox.utility.pydantic import FiabBaseModel
 from forecastbox.utility.time import value_dt2str
 
 logger = logging.getLogger(__name__)
+
+_CHARSET_RE = re.compile(r"charset=([^\s;]+)", re.IGNORECASE)
+
+
+def _decode_textual_output(raw: bytes, mime_type: str) -> str:
+    """Decode raw bytes to string using the charset declared in the mime_type.
+
+    Falls back to utf-8 when no charset is specified. On decode error, stores a
+    diagnostic message instead of raising.
+    """
+    m = _CHARSET_RE.search(mime_type)
+    encoding = m.group(1) if m else "utf-8"
+    try:
+        return raw.decode(encoding)[:stored_output_max_length]
+    except Exception as e:
+        return f"Decoding Error: {repr(e)}"[:stored_output_max_length]
 
 
 class RunDetail(FiabBaseModel):
@@ -195,13 +212,20 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
     status = cast(str, execution.status)
 
     # Derive available_task_ids from stored outputs without calling cascade for terminal states:
-    # completed → assume all outputs are available; failed → assume none are.
+    # completed → assume all outputs are available; failed → only those with a locally cached value.
     raw_outputs = cast(dict | None, execution.outputs)
     available_task_ids: list[TaskId] | None
     if status == "completed":
         available_task_ids = [TaskId(k) for k in (raw_outputs or {}).get("outputs", {}).keys()]
     elif status == "failed":
-        available_task_ids = []
+        if raw_outputs:
+            try:
+                _cached = RunOutputs.model_validate(raw_outputs)
+                available_task_ids = [tid for tid, char in _cached.outputs.items() if char.value is not None]
+            except Exception:
+                available_task_ids = []
+        else:
+            available_task_ids = []
     else:
         available_task_ids = None
 
@@ -267,6 +291,39 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
         if response.error:
             return _build(status_override="unknown", error_override=response.error)
 
+        # Fetch and store values for newly available textual outputs.
+        # We compare what cascade reports as available against what is already stored locally,
+        # and fetch any textual (text/plain) outputs that have not been fetched yet.
+        updated_outputs: RunOutputs | None = None
+        if raw_outputs is not None and job_id in response.datasets:
+            try:
+                outputs_model = RunOutputs.model_validate(raw_outputs)
+                already_fetched = {tid for tid, char in outputs_model.outputs.items() if char.value is not None}
+                cascade_available = {d.task for d in response.datasets[job_id]}
+                for task_id in cascade_available - already_fetched:
+                    char = outputs_model.outputs.get(task_id)
+                    if char is None or not is_textual(char.mime_type):
+                        continue
+                    try:
+                        fetch_resp = client.request_response(
+                            api.ResultRetrievalRequest(job_id=job_id, dataset_id=DatasetId(task=task_id, output="0")),
+                            get_gateway_url(),
+                        )
+                        fetch_resp = cast(api.ResultRetrievalResponse, fetch_resp)  # type: ignore[attr-defined]
+                        if fetch_resp.error:
+                            logger.warning("Failed to fetch value for task %r: %s", task_id, fetch_resp.error)
+                            continue
+                        decoded = api.decoded_result(fetch_resp, job=None)  # type: ignore[attr-defined]
+                        if isinstance(decoded, bytes):
+                            char.value = _decode_textual_output(decoded, char.mime_type)
+                            updated_outputs = outputs_model
+                    except Exception as e:
+                        logger.warning("Failed to fetch value for task %r: %r", task_id, e)
+            except Exception as e:
+                logger.warning("Failed to process textual outputs for run %r: %r", run_id, e)
+        if updated_outputs is not None:
+            raw_outputs = updated_outputs.model_dump()
+
         # NOTE we should check more carefuly in the None branch -- the job_id may not be part of the response
         # if the job has not started yet -- but we should verify that in the status, etc
         if task_to_block is not None and response.planned_task_ids is not None and job_id in response.planned_task_ids:
@@ -281,21 +338,22 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
         else:
             completed_block_ids = None
         jobprogress = response.progresses.get(job_id)
+        outputs_kwargs = {"outputs": raw_outputs} if updated_outputs is not None else {}
         if jobprogress is None:
-            await run_db.update_run_runtime(run_id, actual_attempt, status="failed", error="evicted from gateway")
-            available_task_ids = []
+            await run_db.update_run_runtime(run_id, actual_attempt, status="failed", error="evicted from gateway", **outputs_kwargs)
+            available_task_ids = [tid for tid, char in updated_outputs.outputs.items() if char.value is not None] if updated_outputs else []
             pop_memcache(run_id)
             return _build(status_override="failed", error_override="evicted from gateway")
         elif jobprogress.failure:
-            await run_db.update_run_runtime(run_id, actual_attempt, status="failed", error=jobprogress.failure)
-            available_task_ids = []
+            await run_db.update_run_runtime(run_id, actual_attempt, status="failed", error=jobprogress.failure, **outputs_kwargs)
+            available_task_ids = [tid for tid, char in updated_outputs.outputs.items() if char.value is not None] if updated_outputs else []
             pop_memcache(run_id)
             return _build(status_override="failed", error_override=jobprogress.failure)
         elif jobprogress.completed or jobprogress.pct == "100.00":
-            await run_db.update_run_runtime(run_id, actual_attempt, status="completed", progress="100.00")
+            await run_db.update_run_runtime(run_id, actual_attempt, status="completed", progress="100.00", **outputs_kwargs)
             return _build(status_override="completed", progress_override="100.00")
         else:
-            await run_db.update_run_runtime(run_id, actual_attempt, status="running", progress=jobprogress.pct)
+            await run_db.update_run_runtime(run_id, actual_attempt, status="running", progress=jobprogress.pct, **outputs_kwargs)
             return _build(
                 status_override="running",
                 error_override=warning_error,

--- a/backend/src/forecastbox/routes/run.py
+++ b/backend/src/forecastbox/routes/run.py
@@ -426,6 +426,18 @@ async def get_run_output_content(
     """Retrieve the result of a specific output task, encoded as bytes."""
     execution, cascade_job_id = await _resolve_run_with_cascade(spec, auth_context)
     dataset = DatasetId(task=TaskId(dataset_id), output="0")
+
+    # Serve from locally cached value when available, without contacting cascade.
+    raw_outputs = cast(dict | None, execution.outputs)
+    if raw_outputs is not None:
+        try:
+            outputs_model = RunOutputs.model_validate(raw_outputs)
+            char = outputs_model.outputs.get(TaskId(dataset_id))
+            if char is not None and char.value is not None:
+                return Response(char.value.encode("utf-8"), media_type=char.mime_type)
+        except Exception:
+            pass  # fall through to cascade
+
     mime_result = service.get_mime_of_output(execution, dataset)
     if mime_result.t is None:
         raise HTTPException(500, f"Result mime lookup failed: {mime_result.e}")

--- a/backend/src/forecastbox/routes/run.py
+++ b/backend/src/forecastbox/routes/run.py
@@ -40,6 +40,7 @@ from forecastbox.domain.run.detail import retrieve_compilation_detail
 from forecastbox.domain.run.exceptions import CompilationDetailCorrupted, CompilationDetailNotFound, RunAccessDenied, RunNotFound
 from forecastbox.domain.run.types import RunId
 from forecastbox.utility.auth import AuthContext
+from forecastbox.utility.httpx import get_encoding
 from forecastbox.utility.pagination import PaginationSpec
 from forecastbox.utility.pydantic import FiabBaseModel
 
@@ -434,7 +435,8 @@ async def get_run_output_content(
             outputs_model = RunOutputs.model_validate(raw_outputs)
             char = outputs_model.outputs.get(TaskId(dataset_id))
             if char is not None and char.value is not None:
-                return Response(char.value.encode("utf-8"), media_type=char.mime_type)
+                encoding = get_encoding(char.mime_type)
+                return Response(char.value.encode(encoding), media_type=char.mime_type)
         except Exception:
             pass  # fall through to cascade
 

--- a/backend/src/forecastbox/utility/httpx.py
+++ b/backend/src/forecastbox/utility/httpx.py
@@ -7,6 +7,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
+import re
 from pathlib import Path
 
 import httpx
@@ -28,3 +29,11 @@ def fetch_content(url: str, client: httpx.Client) -> bytes:
 
     else:
         raise ValueError("Unsupported protocol. Use http://, https://, or file://")
+
+
+_CHARSET_RE = re.compile(r"charset=([^\s;]+)", re.IGNORECASE)
+
+
+def get_encoding(mime_type: str) -> str:
+    m = _CHARSET_RE.search(mime_type)
+    return m.group(1) if m else "utf-8"

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -1793,7 +1793,7 @@ def test_gateway_restart_with_in_progress_job(tmpdir: Any, backend_client_user: 
     status_resp = backend_client_user.get("/run/get", params={"run_id": run_id}, timeout=30)
     assert status_resp.is_success, status_resp.text
     assert status_resp.json()["status"] == "unknown"
-    assert "failed to communicate with gateway" in status_resp.json()["error"]
+    assert "internal cascade failure: GatewayNotRunning('Gateway is not running')" in status_resp.json()["error"]
 
     start_resp = backend_client_user.post("/gateway/start")
     assert start_resp.is_success, start_resp.text

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -1700,8 +1700,56 @@ def _wait_until_running(client: httpx.Client, run_id: str, sleep: float = 1.0, a
 
 
 @pytest.mark.skip("leaves hanging process behind")
-def test_gateway_restart_with_in_progress_job(backend_client_user: httpx.Client) -> None:
-    """Kill the gateway while a job is active; verify the expected status transitions."""
+def test_gateway_restart_with_in_progress_job(tmpdir: Any, backend_client_user: httpx.Client) -> None:
+    """Kill the gateway while a job is active; verify the expected status transitions.
+
+    A simple text-output job is submitted and completed before the gateway is killed.
+    After the restart, its output must still be fetchable from the locally cached value.
+    """
+    # --- Step 1: submit a simple job that completes quickly and has a textual output ---
+    source_text = RoutableBlock(
+        instance_id=BlockInstanceId("source_text"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("source_text"),
+        instance=BlockInstance(
+            configuration_values=_config({"text": "gateway-restart-test-output"}),
+            input_ids={},
+        ),
+    )
+    text_sink = RoutableBlock(
+        instance_id=BlockInstanceId("text_sink"),
+        plugin=testPluginId,
+        factory=BlockFactoryId("sink_file"),
+        instance=BlockInstance(
+            configuration_values=_config({"fname": f"{tmpdir}/gwrestart_${{runId}}.txt"}),
+            input_ids={"data": BlockInstanceId("source_text")},
+        ),
+    )
+    simple_builder = BlueprintBuilder(blocks=[source_text, text_sink])
+    simple_save_resp = backend_client_user.post("/blueprint/create", json=BlueprintSaveCommand(builder=simple_builder).model_dump())
+    assert simple_save_resp.is_success, simple_save_resp.text
+    simple_blueprint_id = simple_save_resp.json()["blueprint_id"]
+
+    simple_run_resp = backend_client_user.post("/run/create", json={"blueprint_id": simple_blueprint_id})
+    assert simple_run_resp.is_success, simple_run_resp.text
+    simple_run_id = simple_run_resp.json()["run_id"]
+
+    # Wait until the simple job completes (and its textual value is cached in the DB)
+    ensure_completed_v2(backend_client_user, simple_run_id, sleep=1, attempts=120)
+
+    # Identify the sink_file output task id
+    simple_detail = backend_client_user.get("/run/get", params={"run_id": simple_run_id}).raise_for_status().json()
+    simple_outputs = simple_detail["outputs"]["outputs"]
+    simple_available = [tid for tid, char in simple_outputs.items() if char["is_available"] and "sink_file" in tid]
+    assert len(simple_available) == 1, f"Expected exactly one available sink_file task, got: {simple_outputs}"
+    simple_sink_task_id = simple_available[0]
+
+    # Sanity check: output is accessible while cascade is still up
+    content_resp = backend_client_user.get("/run/outputContent", params={"run_id": simple_run_id, "dataset_id": simple_sink_task_id})
+    assert content_resp.is_success, content_resp.text
+    assert content_resp.content.decode("utf-8").startswith("file://")
+
+    # --- Step 2: submit a long-running sleeper job ---
     sleeper = RoutableBlock(
         instance_id=BlockInstanceId("sleeper"),
         plugin=testPluginId,
@@ -1736,6 +1784,7 @@ def test_gateway_restart_with_in_progress_job(backend_client_user: httpx.Client)
 
     _wait_until_running(backend_client_user, run_id)
 
+    # --- Step 3: kill the gateway ---
     # TODO this leaves the workers hanging. We need some solution to collect them properly
     kill_resp = backend_client_user.post("/gateway/kill")
     assert kill_resp.is_success, kill_resp.text
@@ -1749,7 +1798,7 @@ def test_gateway_restart_with_in_progress_job(backend_client_user: httpx.Client)
     start_resp = backend_client_user.post("/gateway/start")
     assert start_resp.is_success, start_resp.text
 
-    # After the gateway restarts (fresh, empty), the job is unknown to it → "evicted from gateway"
+    # After the gateway restarts (fresh, empty), the sleeper job is unknown to it → "evicted from gateway"
     def poll_evicted() -> Any:
         resp = backend_client_user.get("/run/get", params={"run_id": run_id}, timeout=10)
         assert resp.is_success, resp.text
@@ -1763,6 +1812,12 @@ def test_gateway_restart_with_in_progress_job(backend_client_user: httpx.Client)
         return None
 
     retry_until(poll_evicted, verify_evicted, attempts=30, sleep=1.0, error_msg=f"Run {run_id} never reached 'evicted from gateway'")
+
+    # --- Step 4: verify the completed simple job's text output is still fetchable ---
+    # The gateway no longer holds the result, but it must be served from the local DB cache.
+    cached_content_resp = backend_client_user.get("/run/outputContent", params={"run_id": simple_run_id, "dataset_id": simple_sink_task_id})
+    assert cached_content_resp.is_success, cached_content_resp.text
+    assert cached_content_resp.content.decode("utf-8").startswith("file://")
 
 
 def test_blueprint_artifact_execute(tmpdir: Any, backend_client_user: httpx.Client) -> None:

--- a/backend/tests/unit/domain/run/test_service.py
+++ b/backend/tests/unit/domain/run/test_service.py
@@ -1,6 +1,10 @@
+import datetime as dt
 from types import SimpleNamespace
 from typing import cast
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
+import pytest
+from cascade.controller.report import JobId
 from cascade.low.core import DatasetId, TaskId
 from fiab_core.fable import BlockInstanceId
 
@@ -52,3 +56,210 @@ def test_get_mime_of_output_rejects_unknown_task() -> None:
     assert result.t is None
     assert result.e is not None
     assert "not found" in result.e
+
+
+# ---------------------------------------------------------------------------
+# poll_and_update — textual output value fetching
+# ---------------------------------------------------------------------------
+
+
+def _make_running_execution(outputs: RunOutputs | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        run_id="run-1",
+        attempt_count=1,
+        status="running",
+        created_at=dt.datetime(2026, 5, 12),
+        updated_at=dt.datetime(2026, 5, 12),
+        blueprint_id="bp-1",
+        blueprint_version=1,
+        error=None,
+        progress=None,
+        cascade_job_id="job-1",
+        outputs=outputs.model_dump() if outputs is not None else None,
+    )
+
+
+def _make_cascade_response(
+    available_task_ids: list[TaskId],
+    completed: bool = False,
+    pct: str = "50.00",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        progresses={JobId("job-1"): SimpleNamespace(completed=completed, pct=pct, failure=None)},
+        datasets={JobId("job-1"): [DatasetId(task=tid, output="0") for tid in available_task_ids]},
+        error=None,
+        completed_task_ids=None,
+        planned_task_ids=None,
+    )
+
+
+def _make_fetch_response(content: bytes) -> SimpleNamespace:
+    resp = SimpleNamespace(error=None)
+    resp._content = content
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_poll_and_update_fetches_textual_value_for_newly_available_task() -> None:
+    outputs = RunOutputs(
+        outputs={TaskId("task-text"): RunOutputCharacteristic(original_block=BlockInstanceId("sink"), mime_type="text/plain", value=None)}
+    )
+    execution = _make_running_execution(outputs)
+    cascade_response = _make_cascade_response([TaskId("task-text")], pct="100.00", completed=True)
+    text_bytes = b"hello world"
+
+    call_count = 0
+
+    def _fake_request_response(request: object, url: str) -> object:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # First call: JobProgressRequest
+            return cascade_response
+        # Second call: ResultRetrievalRequest
+        return SimpleNamespace(error=None)
+
+    update_mock = AsyncMock()
+
+    with (
+        patch("forecastbox.domain.run.service.client.request_response", side_effect=_fake_request_response),
+        patch("forecastbox.domain.run.service.get_gateway_url", return_value="tcp://gw"),
+        patch("forecastbox.domain.run.service.run_db.update_run_runtime", new=update_mock),
+        patch("forecastbox.domain.run.service.api.decoded_result", return_value=text_bytes),
+    ):
+        detail = await service.poll_and_update(cast(Run, execution))
+
+    assert detail.status == "completed"
+    # The outputs kwarg passed to update_run_runtime must include the fetched value
+    update_kwargs = update_mock.call_args.kwargs
+    stored = RunOutputs.model_validate(update_kwargs["outputs"])
+    assert stored.outputs[TaskId("task-text")].value == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_poll_and_update_skips_non_textual_output() -> None:
+    outputs = RunOutputs(
+        outputs={TaskId("task-bin"): RunOutputCharacteristic(original_block=BlockInstanceId("sink"), mime_type="image/png", value=None)}
+    )
+    execution = _make_running_execution(outputs)
+    cascade_response = _make_cascade_response([TaskId("task-bin")], pct="50.00")
+
+    call_count = 0
+
+    def _fake_request_response(request: object, url: str) -> object:
+        nonlocal call_count
+        call_count += 1
+        return cascade_response  # only the progress request should be made
+
+    update_mock = AsyncMock()
+
+    with (
+        patch("forecastbox.domain.run.service.client.request_response", side_effect=_fake_request_response),
+        patch("forecastbox.domain.run.service.get_gateway_url", return_value="tcp://gw"),
+        patch("forecastbox.domain.run.service.run_db.update_run_runtime", new=update_mock),
+    ):
+        await service.poll_and_update(cast(Run, execution))
+
+    # Only the JobProgressRequest was made — no ResultRetrievalRequest
+    assert call_count == 1
+    # outputs kwarg not passed since nothing was fetched
+    assert "outputs" not in update_mock.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_poll_and_update_does_not_refetch_already_cached_value() -> None:
+    outputs = RunOutputs(
+        outputs={
+            TaskId("task-text"): RunOutputCharacteristic(
+                original_block=BlockInstanceId("sink"), mime_type="text/plain", value="already cached"
+            )
+        }
+    )
+    execution = _make_running_execution(outputs)
+    cascade_response = _make_cascade_response([TaskId("task-text")], pct="50.00")
+
+    call_count = 0
+
+    def _fake_request_response(request: object, url: str) -> object:
+        nonlocal call_count
+        call_count += 1
+        return cascade_response
+
+    update_mock = AsyncMock()
+
+    with (
+        patch("forecastbox.domain.run.service.client.request_response", side_effect=_fake_request_response),
+        patch("forecastbox.domain.run.service.get_gateway_url", return_value="tcp://gw"),
+        patch("forecastbox.domain.run.service.run_db.update_run_runtime", new=update_mock),
+    ):
+        await service.poll_and_update(cast(Run, execution))
+
+    # Only the JobProgressRequest, no ResultRetrievalRequest
+    assert call_count == 1
+    assert "outputs" not in update_mock.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_poll_and_update_handles_fetch_failure_gracefully() -> None:
+    outputs = RunOutputs(
+        outputs={TaskId("task-text"): RunOutputCharacteristic(original_block=BlockInstanceId("sink"), mime_type="text/plain", value=None)}
+    )
+    execution = _make_running_execution(outputs)
+    cascade_response = _make_cascade_response([TaskId("task-text")], pct="50.00")
+
+    call_count = 0
+
+    def _fake_request_response(request: object, url: str) -> object:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return cascade_response
+        raise TimeoutError("cascade unreachable")
+
+    update_mock = AsyncMock()
+
+    with (
+        patch("forecastbox.domain.run.service.client.request_response", side_effect=_fake_request_response),
+        patch("forecastbox.domain.run.service.get_gateway_url", return_value="tcp://gw"),
+        patch("forecastbox.domain.run.service.run_db.update_run_runtime", new=update_mock),
+    ):
+        detail = await service.poll_and_update(cast(Run, execution))
+
+    # Polling itself must succeed — the fetch failure is non-fatal
+    assert detail.status == "running"
+    # No outputs update since nothing was successfully fetched
+    assert "outputs" not in update_mock.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_poll_and_update_failed_job_exposes_cached_values_as_available() -> None:
+    outputs = RunOutputs(
+        outputs={
+            TaskId("task-text"): RunOutputCharacteristic(
+                original_block=BlockInstanceId("sink"), mime_type="text/plain", value="cached output"
+            ),
+            TaskId("task-bin"): RunOutputCharacteristic(original_block=BlockInstanceId("sink2"), mime_type="image/png", value=None),
+        }
+    )
+    execution = cast(
+        Run,
+        SimpleNamespace(
+            run_id="run-1",
+            attempt_count=1,
+            status="failed",
+            created_at=dt.datetime(2026, 5, 12),
+            updated_at=dt.datetime(2026, 5, 12),
+            blueprint_id="bp-1",
+            blueprint_version=1,
+            error="evicted from gateway",
+            progress=None,
+            cascade_job_id="job-1",
+            outputs=outputs.model_dump(),
+        ),
+    )
+
+    detail = await service.poll_and_update(execution)
+
+    assert detail.status == "failed"
+    # Only the task with a locally cached value is available
+    assert detail.available_task_ids == [TaskId("task-text")]


### PR DESCRIPTION
When the output of a job is text/plain (plus possible extensions), we store it in the local db (up to 1MB of data).

This has two advantages:
1/ faster retrieval of these outputs
2/ persistence of these outputs even after the job has been evicted / gateway restarted

Tested by temporarily enabling the skipped test which kills gateway in the middle, as well as manually in the UI with source 42 & sink file and fetch after a manual restart of the whole backend
