### PR TITLE
[frontend] feat: render blueprint-template example metadata in the params dialog

### DIFF
--- a/frontend/mocks/handlers/fable.handlers.ts
+++ b/frontend/mocks/handlers/fable.handlers.ts
@@ -66,6 +66,30 @@ function seedSavedFables(): Record<string, SavedFableEntry | undefined> {
     source: 'plugin_template',
   }
 
+  // Required glyphs with type hints; examples served by plugins.handlers.ts
+  const [baseBlockId, baseBlock] = Object.entries(templateBase.fable.blocks)[0]
+  seeded['template-typed-inputs'] = {
+    ...templateBase,
+    fable: {
+      blocks: {
+        [baseBlockId]: {
+          ...baseBlock,
+          configuration_values: {
+            ...baseBlock.configuration_values,
+            forecast: '${format}',
+            base_time: '${count} ${area}',
+          },
+        },
+      },
+      local_glyphs: {},
+    },
+    display_name: 'testTyped',
+    display_description: 'Template with typed example glyphs',
+    tags: [],
+    user_id: 'local:plugin-test',
+    source: 'plugin_template',
+  }
+
   return seeded
 }
 
@@ -73,6 +97,7 @@ function seedFableVersions(): Record<string, number> {
   return {
     ...Object.fromEntries(Object.keys(mockSavedFables).map((id) => [id, 1])),
     'template-basic-map': 1,
+    'template-typed-inputs': 1,
   }
 }
 

--- a/frontend/mocks/handlers/plugins.handlers.ts
+++ b/frontend/mocks/handlers/plugins.handlers.ts
@@ -277,18 +277,55 @@ export const pluginsHandlers = [
     const displayName = url.searchParams.get('displayName')
 
     // Matches the 'template-basic-map' blueprint fixture in fable.handlers.ts
-    if (displayName !== 'testBasic') {
-      return new HttpResponse(
-        JSON.stringify({ detail: `Template ${displayName} not found` }),
-        { status: 404 },
-      )
+    if (displayName === 'testBasic') {
+      return HttpResponse.json({
+        example_values: {
+          block_source_1: {
+            base_time: { example_value: '2026-07-01T00:00:00' },
+          },
+        },
+        example_glyphs: {
+          // with UI metadata (#549): renders as a labeled typed field
+          leadtime: {
+            example_value: '48',
+            display_name: 'Lead time',
+            display_description: 'Forecast horizon in hours',
+            type_hint: 'int',
+          },
+        },
+      })
     }
 
-    return HttpResponse.json({
-      example_values: {
-        block_source_1: { base_time: { example_value: '2026-07-01T00:00:00' } },
-      },
-      example_glyphs: { leadtime: { example_value: '48' } },
-    })
+    // Matches the 'template-typed-inputs' fixture: one glyph per field kind
+    if (displayName === 'testTyped') {
+      return HttpResponse.json({
+        example_values: {},
+        example_glyphs: {
+          count: {
+            example_value: '4',
+            display_name: 'Count',
+            display_description: 'How many members to request.',
+            type_hint: 'int',
+          },
+          format: {
+            example_value: 'png',
+            display_name: 'Format',
+            display_description: 'Output image format.',
+            type_hint: 'enumClosed[png,pdf,svg]',
+          },
+          area: {
+            example_value: 'Europe',
+            display_name: 'Area',
+            display_description: 'Geographic area to cover.',
+            type_hint: 'geodomain',
+          },
+        },
+      })
+    }
+
+    return new HttpResponse(
+      JSON.stringify({ detail: `Template ${displayName} not found` }),
+      { status: 404 },
+    )
   }),
 ]

--- a/frontend/src/features/fable-builder/components/TemplateParamsDialog.tsx
+++ b/frontend/src/features/fable-builder/components/TemplateParamsDialog.tsx
@@ -13,8 +13,9 @@
  *
  * Collects a template's parameters when forking: required glyphs (seeded
  * from plugin examples) plus the template's own defaults, collapsed.
- * Values validate live against /blueprint/expand on a candidate builder;
- * plain text inputs until the backend ships per-parameter metadata.
+ * Values validate live against /blueprint/expand on a candidate builder.
+ * Parameters with example metadata render as labeled typed fields;
+ * the rest stay plain text.
  */
 
 import { useEffect, useMemo, useState } from 'react'
@@ -46,6 +47,7 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { FieldRenderer } from '@/components/base/fields/FieldRenderer'
 import { useDebounce } from '@/hooks/useDebounce'
 import { cn } from '@/lib/utils'
 
@@ -160,18 +162,40 @@ export function TemplateParamsDialog({
   const renderField = (name: string) => {
     const preview = resolvedPreview(name)
     const missing = isMissing(name)
+    const meta = examples?.example_glyphs[name]
     return (
       <div key={name} className="flex flex-col gap-1.5">
-        <Label htmlFor={`template-param-${name}`} className="font-mono text-xs">
-          {name}
+        <Label
+          htmlFor={`template-param-${name}`}
+          className={meta?.display_name ? 'text-sm' : 'font-mono text-xs'}
+          // tooltip keeps the raw glyph name reachable
+          title={meta?.display_name ? name : undefined}
+        >
+          {meta?.display_name ?? name}
         </Label>
-        <Input
-          id={`template-param-${name}`}
-          value={values[name] ?? ''}
-          onChange={(e) => setValue(name, e.target.value)}
-          aria-invalid={missing || undefined}
-          className={cn(missing && 'border-amber-400')}
-        />
+        {meta?.display_description && (
+          <p className="text-xs text-muted-foreground">
+            {meta.display_description}
+          </p>
+        )}
+        {meta?.type_hint ? (
+          <FieldRenderer
+            id={`template-param-${name}`}
+            configKey={name}
+            valueType={meta.type_hint}
+            value={values[name] ?? ''}
+            onChange={(value) => setValue(name, value)}
+            inputClassName={cn(missing && 'border-amber-400')}
+          />
+        ) : (
+          <Input
+            id={`template-param-${name}`}
+            value={values[name] ?? ''}
+            onChange={(e) => setValue(name, e.target.value)}
+            aria-invalid={missing || undefined}
+            className={cn(missing && 'border-amber-400')}
+          />
+        )}
         {missing ? (
           <p className="text-xs text-amber-600 dark:text-amber-400">
             {t('template.dialog.missingValue')}

--- a/frontend/tests/unit/features/fable-builder/components/TemplateParamsDialog.test.tsx
+++ b/frontend/tests/unit/features/fable-builder/components/TemplateParamsDialog.test.tsx
@@ -1,0 +1,132 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { renderWithProviders } from '@tests/utils/render'
+import type { FableBuilderV1 } from '@/api/types/fable.types'
+import type { TemplateExampleValues } from '@/api/types/plugins.types'
+import type { TemplateParameters } from '@/features/fable-builder/utils/template-parameters'
+import { TemplateParamsDialog } from '@/features/fable-builder/components/TemplateParamsDialog'
+
+const params: TemplateParameters = {
+  required: ['leadtime', 'region'],
+  prefilled: {},
+  usage: {},
+}
+
+const baseFable: FableBuilderV1 = { blocks: {}, local_glyphs: {} }
+
+/** leadtime carries full #549 metadata; region has example_value only. */
+const examples: TemplateExampleValues = {
+  example_values: {},
+  example_glyphs: {
+    leadtime: {
+      example_value: '48',
+      display_name: 'Lead time',
+      display_description: 'Forecast horizon in hours',
+      type_hint: 'int',
+    },
+    region: { example_value: 'Europe' },
+  },
+}
+
+function renderDialog() {
+  return renderWithProviders(
+    <TemplateParamsDialog
+      open={true}
+      params={params}
+      baseFable={baseFable}
+      examples={examples}
+      onApply={() => {}}
+      onSkip={() => {}}
+    />,
+  )
+}
+
+describe('TemplateParamsDialog — #549 example metadata', () => {
+  it('labels a parameter with its display_name and shows the description', async () => {
+    const screen = await renderDialog()
+
+    await expect.element(screen.getByText('Lead time')).toBeVisible()
+    await expect
+      .element(screen.getByText('Forecast horizon in hours'))
+      .toBeVisible()
+  })
+
+  it('keeps the raw glyph name reachable via the label tooltip', async () => {
+    const screen = await renderDialog()
+
+    const label = screen.getByText('Lead time')
+    expect(label.element().getAttribute('title')).toBe('leadtime')
+  })
+
+  it('renders a typed field from type_hint, seeded with the example value', async () => {
+    const screen = await renderDialog()
+
+    // type_hint 'int' → numeric field instead of a plain text input
+    const field = screen.getByLabelText('Lead time')
+    await expect.element(field).toBeVisible()
+    expect(field.element().getAttribute('value')).toBe('48')
+    expect(field.element().getAttribute('inputmode')).toBe('numeric')
+  })
+
+  it('falls back to the mono glyph-name label and plain input without metadata', async () => {
+    const screen = await renderDialog()
+
+    const label = screen.getByText('region', { exact: true })
+    await expect.element(label).toBeVisible()
+    expect(label.element().className).toContain('font-mono')
+
+    const field = screen.getByLabelText('region')
+    expect(field.element().getAttribute('value')).toBe('Europe')
+    expect(field.element().getAttribute('inputmode')).toBeNull()
+  })
+
+  it('renders enum and geodomain type hints as their picker fields', async () => {
+    const screen = await renderWithProviders(
+      <TemplateParamsDialog
+        open={true}
+        params={{ required: ['format', 'area'], prefilled: {}, usage: {} }}
+        baseFable={baseFable}
+        examples={{
+          example_values: {},
+          example_glyphs: {
+            format: {
+              example_value: 'png',
+              display_name: 'Format',
+              type_hint: 'enumClosed[png,pdf,svg]',
+            },
+            area: {
+              example_value: 'Europe',
+              display_name: 'Area',
+              type_hint: 'geodomain',
+            },
+          },
+        }}
+        onApply={() => {}}
+        onSkip={() => {}}
+      />,
+    )
+
+    // enumClosed → select-style trigger seeded with the example value
+    const format = screen.getByLabelText('Format')
+    await expect.element(format).toBeVisible()
+    expect(format.element().tagName).not.toBe('INPUT')
+    await expect.element(screen.getByText('png', { exact: true })).toBeVisible()
+
+    // geodomain → picker trigger showing the selected region
+    const area = screen.getByLabelText('Area')
+    await expect.element(area).toBeVisible()
+    expect(area.element().tagName).toBe('BUTTON')
+    await expect
+      .element(screen.getByText('Europe', { exact: true }))
+      .toBeVisible()
+  })
+})


### PR DESCRIPTION
### Description

Consumes the #549 template example metadata for a create-from-a-template dialog.

- Parameters whose example inputs carry metadata now render with display_name as the label (raw glyph name kept reachable via the label tooltip) and display_description as a help line.
- A type_hint dispatches the input through the builder's existing FieldRenderer, so templates get the full field vocabulary: numeric fields for int, dropdowns for enumClosed[…], date-time pickers, the geodomain map picker, etc., seeded with the example_value and keeping the live /blueprint/expand validation and missing-value states.
- Parameters without metadata keep the previous rendering unchanged, per the contract ("assume no data").
- Mocks gain a testTyped template fixture (one glyph each of int/enum/geodomain) so the mocked app exercises every field kind; 5 new browser-mode tests cover the metadata, typed-field, and fallback paths.

No backend changes. The backend has served this metadata since #549, today no plugin template sets type_hint yet, so this renders identically to before for all existing templates, and typed fields activate automatically once template content starts using the field.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
