### PR TITLE
[frontend] unresolved-variables UX incl previews and guided fixes

### DIFF
--- a/frontend/src/components/base/fields/fields/GlyphFieldWrapper.tsx
+++ b/frontend/src/components/base/fields/fields/GlyphFieldWrapper.tsx
@@ -36,6 +36,7 @@ import {
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { useGlyphContext } from '@/features/fable-builder/context/GlyphContext'
@@ -81,21 +82,24 @@ export interface GlyphFieldWrapperProps {
 type FieldMode = 'concrete' | 'glyph'
 
 /** Italic "resolves to …" line with the full value in a tooltip. */
-function ResolvedPreview({ preview }: { preview: string }) {
+export function ResolvedPreview({ preview }: { preview: string }) {
   const { t } = useTranslation('glyphs')
   return (
-    <Tooltip>
-      <TooltipTrigger
-        render={
-          <div className="mt-1 truncate text-sm text-muted-foreground italic" />
-        }
-      >
-        {t('panel.resolvesTo')} <span className="font-mono">{preview}</span>
-      </TooltipTrigger>
-      <TooltipContent side="bottom" className="max-w-96 font-mono break-all">
-        {preview}
-      </TooltipContent>
-    </Tooltip>
+    // fast delay — the tooltip is the only way to read a truncated value
+    <TooltipProvider delay={120}>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <div className="mt-1 truncate text-sm text-muted-foreground italic" />
+          }
+        >
+          {t('panel.resolvesTo')} <span className="font-mono">{preview}</span>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" className="max-w-96 font-mono break-all">
+          {preview}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   )
 }
 
@@ -141,10 +145,8 @@ export function GlyphFieldWrapper({
 
   const valueHasGlyphs = containsGlyphs(value)
 
-  // No glyphs / glyph mode disabled → render children directly, adding an
-  // error ring + inline error text when invalid, and the resolved preview
-  // when a glyph value was injected (e.g. by a template) into a field that
-  // doesn't offer glyph editing itself.
+  // No glyphs / glyph mode disabled → children as-is, plus error text and
+  // the resolved preview when a template injected a glyph value.
   if (!hasGlyphs || !allowGlyphMode) {
     const injectedPreview =
       valueHasGlyphs && !hasFieldError

--- a/frontend/src/components/base/fields/fields/GlyphFieldWrapper.tsx
+++ b/frontend/src/components/base/fields/fields/GlyphFieldWrapper.tsx
@@ -39,9 +39,11 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import { DefineVariableButton } from '@/features/fable-builder/components/shared/DefineVariableButton'
 import { useGlyphContext } from '@/features/fable-builder/context/GlyphContext'
 import {
   useFieldErrors,
+  useMissingGlyphs,
   useResolvedConfig,
 } from '@/features/fable-builder/context/BlockValidationContext'
 import { containsGlyphs } from '@/features/fable-builder/utils/glyph-display'
@@ -143,6 +145,7 @@ export function GlyphFieldWrapper({
       : fieldErrors[0]
     : null
 
+  const missingGlyphNames = useMissingGlyphs()?.[configKey] ?? null
   const valueHasGlyphs = containsGlyphs(value)
 
   // No glyphs / glyph mode disabled → children as-is, plus error text and
@@ -154,7 +157,9 @@ export function GlyphFieldWrapper({
         : null
     const showInjectedPreview =
       injectedPreview !== null && injectedPreview !== value
-    if (!hasFieldError && !showInjectedPreview) return <>{children}</>
+    if (!hasFieldError && !showInjectedPreview && !missingGlyphNames?.length) {
+      return <>{children}</>
+    }
     return (
       <div>
         {hasFieldError ? (
@@ -167,6 +172,9 @@ export function GlyphFieldWrapper({
             {errorMessage}
           </p>
         )}
+        {missingGlyphNames?.map((name) => (
+          <DefineVariableButton key={name} name={name} />
+        ))}
         {showInjectedPreview && <ResolvedPreview preview={injectedPreview} />}
       </div>
     )
@@ -271,6 +279,10 @@ export function GlyphFieldWrapper({
       {errorMessage && (
         <p className="mt-1 truncate text-xs text-destructive">{errorMessage}</p>
       )}
+
+      {missingGlyphNames?.map((name) => (
+        <DefineVariableButton key={name} name={name} />
+      ))}
 
       {/* In-flow so visual order reads Input → Preview → Nudge. Validation
           is debounced 300 ms, so these appear/disappear at pause boundaries,

--- a/frontend/src/components/base/fields/fields/GlyphFieldWrapper.tsx
+++ b/frontend/src/components/base/fields/fields/GlyphFieldWrapper.tsx
@@ -80,6 +80,25 @@ export interface GlyphFieldWrapperProps {
 
 type FieldMode = 'concrete' | 'glyph'
 
+/** Italic "resolves to …" line with the full value in a tooltip. */
+function ResolvedPreview({ preview }: { preview: string }) {
+  const { t } = useTranslation('glyphs')
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <div className="mt-1 truncate text-sm text-muted-foreground italic" />
+        }
+      >
+        {t('panel.resolvesTo')} <span className="font-mono">{preview}</span>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" className="max-w-96 font-mono break-all">
+        {preview}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
 export function GlyphFieldWrapper({
   id,
   configKey,
@@ -120,19 +139,36 @@ export function GlyphFieldWrapper({
       : fieldErrors[0]
     : null
 
-  // No glyphs / glyph mode disabled → render children directly, only adding
-  // an error ring + inline error text when the field is invalid.
+  const valueHasGlyphs = containsGlyphs(value)
+
+  // No glyphs / glyph mode disabled → render children directly, adding an
+  // error ring + inline error text when invalid, and the resolved preview
+  // when a glyph value was injected (e.g. by a template) into a field that
+  // doesn't offer glyph editing itself.
   if (!hasGlyphs || !allowGlyphMode) {
-    if (!hasFieldError) return <>{children}</>
+    const injectedPreview =
+      valueHasGlyphs && !hasFieldError
+        ? (resolvedConfig?.[configKey] ?? null)
+        : null
+    const showInjectedPreview =
+      injectedPreview !== null && injectedPreview !== value
+    if (!hasFieldError && !showInjectedPreview) return <>{children}</>
     return (
       <div>
-        <div className="rounded-md ring-1 ring-destructive">{children}</div>
-        <p className="mt-1 truncate text-xs text-destructive">{errorMessage}</p>
+        {hasFieldError ? (
+          <div className="rounded-md ring-1 ring-destructive">{children}</div>
+        ) : (
+          children
+        )}
+        {errorMessage && (
+          <p className="mt-1 truncate text-xs text-destructive">
+            {errorMessage}
+          </p>
+        )}
+        {showInjectedPreview && <ResolvedPreview preview={injectedPreview} />}
       </div>
     )
   }
-
-  const valueHasGlyphs = containsGlyphs(value)
   const canSwitchToConcrete = mode === 'glyph' && !valueHasGlyphs
 
   function handleToggle() {
@@ -237,24 +273,7 @@ export function GlyphFieldWrapper({
       {/* In-flow so visual order reads Input → Preview → Nudge. Validation
           is debounced 300 ms, so these appear/disappear at pause boundaries,
           not per keystroke — an honest layout reaction, not flicker. */}
-      {showPreview && (
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <div className="mt-1 truncate text-sm text-muted-foreground italic" />
-            }
-          >
-            {t('panel.resolvesTo')}{' '}
-            <span className="font-mono">{resolvedPreview}</span>
-          </TooltipTrigger>
-          <TooltipContent
-            side="bottom"
-            className="max-w-96 font-mono break-all"
-          >
-            {resolvedPreview}
-          </TooltipContent>
-        </Tooltip>
-      )}
+      {showPreview && <ResolvedPreview preview={resolvedPreview} />}
 
       {dateNudgeVisible && (
         <div className="mt-1 flex items-center gap-2 rounded-md border border-amber-500/40 bg-amber-500/5 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400">

--- a/frontend/src/features/fable-builder/components/FableBuilderHeader.tsx
+++ b/frontend/src/features/fable-builder/components/FableBuilderHeader.tsx
@@ -57,11 +57,14 @@ import {
 interface FableBuilderHeaderProps {
   fableId?: string
   catalogue: BlockFactoryCatalogue
+  /** Fired after a config file was parsed and applied to the store */
+  onConfigLoaded?: () => void
 }
 
 export function FableBuilderHeader({
   fableId,
   catalogue,
+  onConfigLoaded,
 }: FableBuilderHeaderProps) {
   const { t } = useTranslation('configure')
   const [shareButtonText, setShareButtonText] = useState(() =>
@@ -195,6 +198,7 @@ export function FableBuilderHeader({
         ) {
           setFable(parsed as FableBuilderV1, null)
           showToast.success(t('header.configLoaded'))
+          onConfigLoaded?.()
         } else {
           showToast.error(
             t('header.invalidConfigTitle'),
@@ -249,7 +253,7 @@ export function FableBuilderHeader({
               </div>
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <span>{t('blockCount', { count: blockCount })}</span>
-                {hasBlocks && <ValidationStatusBadge />}
+                {hasBlocks && <ValidationStatusBadge catalogue={catalogue} />}
                 <DraftStatus className="hidden sm:inline-flex" />
               </div>
             </div>

--- a/frontend/src/features/fable-builder/components/FableBuilderPage.tsx
+++ b/frontend/src/features/fable-builder/components/FableBuilderPage.tsx
@@ -24,6 +24,7 @@ import { TemplateParamsDialog } from './TemplateParamsDialog'
 import type { TFunction } from 'i18next'
 import type { PresetId } from '@/features/fable-builder/presets/presets'
 import type { BlockFactoryCatalogue } from '@/api/types/fable.types'
+import type { TemplateParameters } from '@/features/fable-builder/utils/template-parameters'
 import { SubmitRunDialog } from '@/features/executions/components/SubmitRunDialog'
 import { deriveTemplateParameters } from '@/features/fable-builder/utils/template-parameters'
 import { useAllGlyphs } from '@/features/fable-builder/hooks/useAllGlyphs'
@@ -138,6 +139,11 @@ export function FableBuilderPage({
   const initializedRef = useRef(false)
   const [templateInitialized, setTemplateInitialized] = useState(false)
   const [templateParamsDone, setTemplateParamsDone] = useState(false)
+  // Set after "Load config"; resolved into loadedParams once glyphs are known
+  const [loadedCheckPending, setLoadedCheckPending] = useState(false)
+  const [loadedParams, setLoadedParams] = useState<TemplateParameters | null>(
+    null,
+  )
 
   // Auto-persist drafts to localStorage + beforeunload guard
   useDraftPersistence()
@@ -301,6 +307,24 @@ export function FableBuilderPage({
     )
   }, [templateInitialized, knownGlyphs, knownGlyphsLoading])
 
+  // Loaded-config counterpart: unresolvable references become dialog inputs
+  useEffect(() => {
+    if (!loadedCheckPending || knownGlyphsLoading) return
+    const params = deriveTemplateParameters(
+      useFableBuilderStore.getState().fable,
+      new Set(knownGlyphs.map((glyph) => glyph.name)),
+    )
+    setLoadedParams(params.required.length > 0 ? params : null)
+    setLoadedCheckPending(false)
+  }, [loadedCheckPending, knownGlyphs, knownGlyphsLoading])
+
+  function handleLoadedParamsApply(values: Record<string, string>) {
+    for (const [key, value] of Object.entries(values)) {
+      if (value !== '') setLocalGlyph(key, value)
+    }
+    setLoadedParams(null)
+  }
+
   function applyTemplateExampleValues() {
     if (!templateExamples) return
     const { blocks } = useFableBuilderStore.getState().fable
@@ -455,6 +479,7 @@ export function FableBuilderPage({
         <FableBuilderHeader
           fableId={templateMode ? undefined : fableId}
           catalogue={catalogue}
+          onConfigLoaded={() => setLoadedCheckPending(true)}
         />
 
         {/* Wrapper is relative so the validation banner overlays absolutely —
@@ -498,6 +523,22 @@ export function FableBuilderPage({
           examples={templateExamples}
           onApply={handleTemplateApply}
           onSkip={handleTemplateSkip}
+          catalogue={catalogue}
+        />
+      )}
+
+      {loadedParams && (
+        <TemplateParamsDialog
+          open
+          params={loadedParams}
+          baseFable={fable}
+          examples={undefined}
+          onApply={handleLoadedParamsApply}
+          onSkip={() => setLoadedParams(null)}
+          title={t('template.dialog.missingVarsTitle')}
+          description={t('template.dialog.missingVarsDescription')}
+          catalogue={catalogue}
+          scopeSelectable
         />
       )}
     </GlyphProvider>

--- a/frontend/src/features/fable-builder/components/TemplateParamsDialog.tsx
+++ b/frontend/src/features/fable-builder/components/TemplateParamsDialog.tsx
@@ -48,6 +48,7 @@ import {
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { FieldRenderer } from '@/components/base/fields/FieldRenderer'
+import { ResolvedPreview } from '@/components/base/fields/fields/GlyphFieldWrapper'
 import { useDebounce } from '@/hooks/useDebounce'
 import { cn } from '@/lib/utils'
 
@@ -201,10 +202,9 @@ export function TemplateParamsDialog({
             {t('template.dialog.missingValue')}
           </p>
         ) : (
-          preview !== null && (
-            <p className="truncate text-xs text-muted-foreground">
-              → {preview}
-            </p>
+          preview !== null &&
+          preview !== (values[name] ?? '') && (
+            <ResolvedPreview preview={preview} />
           )
         )}
       </div>
@@ -223,7 +223,8 @@ export function TemplateParamsDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="flex flex-col gap-4">
+        {/* min-w-0: keeps nowrap preview lines from widening the dialog grid */}
+        <div className="flex min-w-0 flex-col gap-4">
           {params.required.length > 0 && (
             <div className="flex flex-col gap-3">
               {params.required.map(renderField)}

--- a/frontend/src/features/fable-builder/components/TemplateParamsDialog.tsx
+++ b/frontend/src/features/fable-builder/components/TemplateParamsDialog.tsx
@@ -26,10 +26,23 @@ import {
   TriangleAlert,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import type { TemplateParameters } from '@/features/fable-builder/utils/template-parameters'
-import type { FableBuilderV1 } from '@/api/types/fable.types'
+import { useQueryClient } from '@tanstack/react-query'
+import type {
+  ParameterUsage,
+  TemplateParameters,
+} from '@/features/fable-builder/utils/template-parameters'
+import type {
+  BlockFactoryCatalogue,
+  FableBuilderV1,
+} from '@/api/types/fable.types'
 import type { TemplateExampleValues } from '@/api/types/plugins.types'
-import { useFableValidation } from '@/api/hooks/useFable'
+import { getFactory } from '@/api/types/fable.types'
+import {
+  fableKeys,
+  useCreateGlobalGlyph,
+  useFableValidation,
+} from '@/api/hooks/useFable'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { hasUnterminatedGlyph } from '@/features/fable-builder/utils/glyph-display'
 import { Button } from '@/components/ui/button'
 import {
@@ -63,6 +76,13 @@ interface TemplateParamsDialogProps {
   onApply: (values: Record<string, string>) => void
   /** Continue with the plugin's examples applied silently */
   onSkip: () => void
+  /** Dialog copy overrides (defaults: template-fork wording) */
+  title?: string
+  description?: string
+  /** Resolves block/option display titles for the usage-context lines */
+  catalogue?: BlockFactoryCatalogue
+  /** Per-parameter local/global scope; global values are created on Apply. */
+  scopeSelectable?: boolean
 }
 
 export function TemplateParamsDialog({
@@ -72,10 +92,19 @@ export function TemplateParamsDialog({
   examples,
   onApply,
   onSkip,
+  title,
+  description,
+  catalogue,
+  scopeSelectable = false,
 }: TemplateParamsDialogProps) {
-  const { t } = useTranslation('configure')
+  const { t } = useTranslation(['configure', 'glyphs'])
   const [values, setValues] = useState<Record<string, string>>({})
+  const [scopes, setScopes] = useState<Record<string, 'local' | 'global'>>({})
   const [showPrefilled, setShowPrefilled] = useState(false)
+  const [applying, setApplying] = useState(false)
+  const [applyError, setApplyError] = useState<string | null>(null)
+  const createGlobal = useCreateGlobalGlyph()
+  const queryClient = useQueryClient()
 
   // Re-seed the form whenever the dialog opens for a template
   useEffect(() => {
@@ -88,6 +117,8 @@ export function TemplateParamsDialog({
       seeded[name] = value
     }
     setValues(seeded)
+    setScopes({})
+    setApplyError(null)
     setShowPrefilled(false)
   }, [open, params, examples])
 
@@ -160,23 +191,127 @@ export function TemplateParamsDialog({
   const setValue = (name: string, value: string) =>
     setValues((current) => ({ ...current, [name]: value }))
 
+  /** Create global-scoped values, then hand the rest to onApply as locals. */
+  async function handleApply() {
+    const globalEntries = Object.entries(values).filter(
+      ([name, value]) => scopes[name] === 'global' && value.trim() !== '',
+    )
+    const localValues = Object.fromEntries(
+      Object.entries(values).filter(([name]) => scopes[name] !== 'global'),
+    )
+    if (globalEntries.length === 0) {
+      onApply(values)
+      return
+    }
+    setApplying(true)
+    setApplyError(null)
+    try {
+      await Promise.all(
+        globalEntries.map(([name, value]) =>
+          createGlobal.mutateAsync({
+            key: name,
+            value: value.trim(),
+            public: false,
+            overriddable: null,
+          }),
+        ),
+      )
+      // Globals don't change the fable, so revalidate explicitly.
+      await queryClient.invalidateQueries({
+        queryKey: [...fableKeys.all, 'validation'],
+      })
+      onApply(localValues)
+    } catch (err) {
+      setApplyError(
+        err instanceof Error
+          ? err.message
+          : t('glyphs:field.defineVariable.globalCreateFailed'),
+      )
+    } finally {
+      setApplying(false)
+    }
+  }
+
+  /** "Block → Option" with display titles when the catalogue knows them */
+  function usageLabel(site: ParameterUsage): string {
+    const block =
+      site.blockId in baseFable.blocks
+        ? baseFable.blocks[site.blockId]
+        : undefined
+    if (!block) return site.optionId
+    const factory = catalogue
+      ? getFactory(catalogue, block.factory_id)
+      : undefined
+    let optionTitle = site.optionId
+    if (factory && site.optionId in factory.configuration_options) {
+      const optionMeta = factory.configuration_options[site.optionId]
+      if (optionMeta.title) optionTitle = optionMeta.title
+    }
+    return t('template.dialog.usedIn', {
+      block: factory?.title ?? block.factory_id.factory,
+      option: optionTitle,
+    })
+  }
+
   const renderField = (name: string) => {
     const preview = resolvedPreview(name)
     const missing = isMissing(name)
     const meta = examples?.example_glyphs[name]
+    const usageSites = name in params.usage ? params.usage[name] : []
+    const scope = scopes[name] === 'global' ? 'global' : 'local'
     return (
       <div key={name} className="flex flex-col gap-1.5">
-        <Label
-          htmlFor={`template-param-${name}`}
-          className={meta?.display_name ? 'text-sm' : 'font-mono text-xs'}
-          // tooltip keeps the raw glyph name reachable
-          title={meta?.display_name ? name : undefined}
-        >
-          {meta?.display_name ?? name}
-        </Label>
+        <div className="flex items-center justify-between gap-2">
+          <Label
+            htmlFor={`template-param-${name}`}
+            className={meta?.display_name ? 'text-sm' : 'font-mono text-xs'}
+            // tooltip keeps the raw glyph name reachable
+            title={meta?.display_name ? name : undefined}
+          >
+            {meta?.display_name ?? name}
+          </Label>
+          {scopeSelectable && params.required.includes(name) && (
+            <ToggleGroup
+              variant="outline"
+              size="sm"
+              value={[scope]}
+              onValueChange={(next) => {
+                const first = next[0]
+                if (first === 'local' || first === 'global') {
+                  setScopes((current) => ({ ...current, [name]: first }))
+                }
+              }}
+            >
+              <ToggleGroupItem
+                value="local"
+                className="h-6 px-2 text-xs"
+                title={t('glyphs:field.defineVariable.scopeLocalHint')}
+              >
+                {t('glyphs:field.defineVariable.scopeLocal')}
+              </ToggleGroupItem>
+              <ToggleGroupItem
+                value="global"
+                className="h-6 px-2 text-xs"
+                title={t('glyphs:field.defineVariable.scopeGlobalHint')}
+              >
+                {t('glyphs:field.defineVariable.scopeGlobal')}
+              </ToggleGroupItem>
+            </ToggleGroup>
+          )}
+        </div>
         {meta?.display_description && (
           <p className="text-xs text-muted-foreground">
             {meta.display_description}
+          </p>
+        )}
+        {usageSites.length > 0 && (
+          <p
+            className="truncate text-xs text-muted-foreground"
+            title={usageSites.map(usageLabel).join('\n')}
+          >
+            {usageLabel(usageSites[0])}
+            {usageSites.length > 1 &&
+              ` ${t('template.dialog.usedInMore', { count: usageSites.length - 1 })}`}
           </p>
         )}
         {meta?.type_hint ? (
@@ -217,9 +352,9 @@ export function TemplateParamsDialog({
     <Dialog open={open} onOpenChange={(next) => !next && onSkip()}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>{t('template.dialog.title')}</DialogTitle>
+          <DialogTitle>{title ?? t('template.dialog.title')}</DialogTitle>
           <DialogDescription>
-            {t('template.dialog.description')}
+            {description ?? t('template.dialog.description')}
           </DialogDescription>
         </DialogHeader>
 
@@ -271,11 +406,17 @@ export function TemplateParamsDialog({
           </div>
         </div>
 
+        {applyError && (
+          <p className="text-xs text-destructive" role="alert">
+            {applyError}
+          </p>
+        )}
+
         <DialogFooter>
-          <Button variant="outline" onClick={onSkip}>
+          <Button variant="outline" onClick={onSkip} disabled={applying}>
             {t('template.dialog.skip')}
           </Button>
-          <Button onClick={() => onApply(values)}>
+          <Button onClick={() => void handleApply()} disabled={applying}>
             {t('template.dialog.apply')}
           </Button>
         </DialogFooter>

--- a/frontend/src/features/fable-builder/components/form-mode/BlockInstanceCard.tsx
+++ b/frontend/src/features/fable-builder/components/form-mode/BlockInstanceCard.tsx
@@ -308,6 +308,7 @@ export function BlockInstanceCard({
                 <BlockValidationProvider
                   resolvedConfig={resolvedConfigForBlock}
                   fieldErrors={mappedErrors.byConfigKey}
+                  missingGlyphs={missingGlyphs}
                 >
                   <div className="space-y-4">
                     {Object.entries(factory.configuration_options).map(

--- a/frontend/src/features/fable-builder/components/layout/ConfigPanel.tsx
+++ b/frontend/src/features/fable-builder/components/layout/ConfigPanel.tsx
@@ -261,6 +261,7 @@ export function ConfigPanel({ catalogue }: ConfigPanelProps): React.ReactNode {
           <BlockValidationProvider
             resolvedConfig={resolvedConfigForBlock}
             fieldErrors={mappedErrors.byConfigKey}
+            missingGlyphs={missingGlyphs}
           >
             <div className="space-y-3">
               <div className="text-sm font-medium">

--- a/frontend/src/features/fable-builder/components/shared/DefineVariableButton.tsx
+++ b/frontend/src/features/fable-builder/components/shared/DefineVariableButton.tsx
@@ -1,0 +1,176 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * DefineVariableButton — quick fix for an unresolvable glyph reference.
+ * Opens a small dialog that creates the name as a local variable (stored in
+ * the configuration, portable) or a global one (stored on this system).
+ */
+
+import { useState } from 'react'
+import { CornerDownRight } from 'lucide-react'
+import { useQueryClient } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { fableKeys, useCreateGlobalGlyph } from '@/api/hooks/useFable'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
+import { showToast } from '@/lib/toast'
+
+type Scope = 'local' | 'global'
+
+export function DefineVariableButton({ name }: { name: string }) {
+  const { t } = useTranslation('glyphs')
+  const setLocalGlyph = useFableBuilderStore((state) => state.setLocalGlyph)
+  const createGlobal = useCreateGlobalGlyph()
+  const queryClient = useQueryClient()
+  const [open, setOpen] = useState(false)
+  const [scope, setScope] = useState<Scope>('local')
+  const [value, setValue] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const glyphRef = `\${${name}}`
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next)
+    if (!next) {
+      setValue('')
+      setScope('local')
+      setError(null)
+    }
+  }
+
+  async function handleCreate() {
+    const trimmed = value.trim()
+    if (!trimmed) return
+    if (scope === 'local') {
+      setLocalGlyph(name, trimmed)
+      handleOpenChange(false)
+      return
+    }
+    try {
+      await createGlobal.mutateAsync({
+        key: name,
+        value: trimmed,
+        public: false,
+        overriddable: null,
+      })
+      // A global doesn't change the fable, so revalidate explicitly.
+      await queryClient.invalidateQueries({
+        queryKey: [...fableKeys.all, 'validation'],
+      })
+      showToast.success(t('actions.createSuccess'), name)
+      handleOpenChange(false)
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : t('field.defineVariable.globalCreateFailed'),
+      )
+    }
+  }
+
+  return (
+    <>
+      {/* ↳ ties the action to the error line above it */}
+      <div className="mt-1 flex items-center gap-1.5">
+        <CornerDownRight
+          aria-hidden
+          className="h-3.5 w-3.5 shrink-0 text-destructive/70"
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-6 px-2 font-mono text-xs"
+          onClick={() => handleOpenChange(true)}
+        >
+          {t('field.defineVariable.action', { name: glyphRef })}
+        </Button>
+      </div>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>{t('field.defineVariable.title')}</DialogTitle>
+            <DialogDescription>
+              {t('field.defineVariable.description', { name: glyphRef })}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex min-w-0 flex-col gap-4">
+            <div className="flex flex-col gap-1.5">
+              <Label>{t('field.defineVariable.scopeLabel')}</Label>
+              <ToggleGroup
+                variant="outline"
+                className="w-full"
+                value={[scope]}
+                onValueChange={(next) => {
+                  const first = next[0]
+                  if (first === 'local' || first === 'global') setScope(first)
+                }}
+              >
+                <ToggleGroupItem value="local" className="flex-1">
+                  {t('field.defineVariable.scopeLocal')}
+                </ToggleGroupItem>
+                <ToggleGroupItem value="global" className="flex-1">
+                  {t('field.defineVariable.scopeGlobal')}
+                </ToggleGroupItem>
+              </ToggleGroup>
+              <p className="text-xs text-muted-foreground">
+                {scope === 'local'
+                  ? t('field.defineVariable.scopeLocalHint')
+                  : t('field.defineVariable.scopeGlobalHint')}
+              </p>
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor={`define-variable-${name}`}>
+                {t('field.defineVariable.valueLabel')}
+              </Label>
+              <Input
+                id={`define-variable-${name}`}
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                autoFocus
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && value.trim()) void handleCreate()
+                }}
+              />
+            </div>
+            {error && (
+              <p className="text-xs text-destructive" role="alert">
+                {error}
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => handleOpenChange(false)}>
+              {t('field.defineVariable.cancel')}
+            </Button>
+            <Button
+              onClick={() => void handleCreate()}
+              disabled={!value.trim() || createGlobal.isPending}
+            >
+              {t('field.defineVariable.create')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/frontend/src/features/fable-builder/components/shared/ValidationStatus.tsx
+++ b/frontend/src/features/fable-builder/components/shared/ValidationStatus.tsx
@@ -8,16 +8,83 @@
  * does it submit to any jurisdiction.
  */
 
+/**
+ * Header validation badge. Issues render as a counted badge whose popover
+ * lists them; clicking an issue selects the offending block.
+ */
+
+import { useMemo, useState } from 'react'
 import { AlertCircle, CheckCircle2, Loader2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import type { BlockFactoryCatalogue } from '@/api/types/fable.types'
+import { getFactory } from '@/api/types/fable.types'
 import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
 import { Badge } from '@/components/ui/badge'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
 import { cn } from '@/lib/utils'
 
-export function ValidationStatusBadge({ className }: { className?: string }) {
+interface Issue {
+  blockId: string | null
+  label: string
+  message: string
+}
+
+export function ValidationStatusBadge({
+  className,
+  catalogue,
+}: {
+  className?: string
+  catalogue?: BlockFactoryCatalogue
+}) {
   const { t } = useTranslation('configure')
   const validationState = useFableBuilderStore((state) => state.validationState)
   const isValidating = useFableBuilderStore((state) => state.isValidating)
+  const fable = useFableBuilderStore((state) => state.fable)
+  const selectBlock = useFableBuilderStore((state) => state.selectBlock)
+  const [open, setOpen] = useState(false)
+
+  const issues = useMemo<Array<Issue>>(() => {
+    if (!validationState) return []
+    const list: Array<Issue> = []
+    for (const message of validationState.globalErrors) {
+      list.push({
+        blockId: null,
+        label: t('validationStatus.globalIssueLabel'),
+        message,
+      })
+    }
+    for (const [blockId, state] of Object.entries(
+      validationState.blockStates,
+    )) {
+      if (!state.hasErrors) continue
+      // `in` guard, not `?.`: index access is typed non-nullable here.
+      const block = blockId in fable.blocks ? fable.blocks[blockId] : undefined
+      let label = blockId
+      if (block) {
+        const factoryTitle = catalogue
+          ? getFactory(catalogue, block.factory_id)?.title
+          : undefined
+        label = factoryTitle ?? block.factory_id.factory
+      }
+      for (const message of state.errors) {
+        list.push({ blockId, label, message })
+      }
+      for (const names of Object.values(state.missingGlyphs)) {
+        for (const name of names) {
+          list.push({
+            blockId,
+            label,
+            message: t('fieldErrors.unknownGlyph', { glyph: `\${${name}}` }),
+          })
+        }
+      }
+    }
+    return list
+  }, [validationState, fable.blocks, catalogue, t])
 
   if (isValidating) {
     return (
@@ -32,12 +99,7 @@ export function ValidationStatusBadge({ className }: { className?: string }) {
     return null
   }
 
-  const hasGlobalErrors = validationState.globalErrors.length > 0
-  const hasBlockErrors = Object.values(validationState.blockStates).some(
-    (state) => state.hasErrors,
-  )
-
-  if (!hasGlobalErrors && !hasBlockErrors) {
+  if (issues.length === 0) {
     return (
       <Badge
         variant="outline"
@@ -50,9 +112,44 @@ export function ValidationStatusBadge({ className }: { className?: string }) {
   }
 
   return (
-    <Badge variant="destructive" className={cn('gap-1', className)}>
-      <AlertCircle className="h-3 w-3" />
-      {t('validationStatus.hasErrors')}
-    </Badge>
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <Badge
+            variant="destructive"
+            render={<button type="button" />}
+            className={cn('cursor-pointer gap-1', className)}
+          />
+        }
+      >
+        <AlertCircle className="h-3 w-3" />
+        {t('validationStatus.issues', { count: issues.length })}
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-80 p-2">
+        <p className="px-2 py-1.5 text-xs font-medium tracking-wide text-muted-foreground uppercase">
+          {t('validationStatus.configurationIssues')}
+        </p>
+        <div className="flex max-h-72 flex-col gap-0.5 overflow-y-auto">
+          {issues.map((issue, index) => (
+            <button
+              key={index}
+              type="button"
+              disabled={issue.blockId === null}
+              onClick={() => {
+                if (issue.blockId === null) return
+                selectBlock(issue.blockId)
+                setOpen(false)
+              }}
+              className="min-w-0 rounded-sm px-2 py-1.5 text-left text-sm hover:bg-muted disabled:cursor-default disabled:hover:bg-transparent"
+            >
+              <span className="block font-medium">{issue.label}</span>
+              <span className="mt-0.5 block truncate text-xs text-muted-foreground">
+                {issue.message}
+              </span>
+            </button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
   )
 }

--- a/frontend/src/features/fable-builder/context/BlockValidationContext.tsx
+++ b/frontend/src/features/fable-builder/context/BlockValidationContext.tsx
@@ -21,21 +21,25 @@ interface BlockValidation {
   fieldErrors: Record<string, Array<string>> | null
   /** Backend-resolved config map (`/blueprint/expand`); null when unresolved. */
   resolvedConfig: Record<string, string> | null
+  /** Unresolvable glyph names per config option key; null when none. */
+  missingGlyphs?: Record<string, ReadonlyArray<string>> | null
 }
 
 const BlockValidationContext = createContext<BlockValidation>({
   fieldErrors: null,
   resolvedConfig: null,
+  missingGlyphs: null,
 })
 
 export function BlockValidationProvider({
   fieldErrors,
   resolvedConfig,
+  missingGlyphs = null,
   children,
 }: BlockValidation & { children: ReactNode }) {
   const value = useMemo(
-    () => ({ fieldErrors, resolvedConfig }),
-    [fieldErrors, resolvedConfig],
+    () => ({ fieldErrors, resolvedConfig, missingGlyphs }),
+    [fieldErrors, resolvedConfig, missingGlyphs],
   )
   return (
     <BlockValidationContext.Provider value={value}>
@@ -50,4 +54,11 @@ export function useFieldErrors(): Record<string, Array<string>> | null {
 
 export function useResolvedConfig(): Record<string, string> | null {
   return useContext(BlockValidationContext).resolvedConfig
+}
+
+export function useMissingGlyphs(): Record<
+  string,
+  ReadonlyArray<string>
+> | null {
+  return useContext(BlockValidationContext).missingGlyphs ?? null
 }

--- a/frontend/src/features/fable-builder/utils/map-block-errors-to-fields.ts
+++ b/frontend/src/features/fable-builder/utils/map-block-errors-to-fields.ts
@@ -68,11 +68,15 @@ function pushError(
  * Map block-level backend errors and structured missing glyphs onto specific
  * configuration keys.
  *
- * Recognised `errors` shapes (Python-set literals):
+ * Recognised `errors` shapes:
  * - "Block contains extra config: {...}" → messages.unknownConfigKey
  * - "Block contains missing config: {...}" → messages.missingRequiredValue
+ * - "Configuration option 'x' is missing for block factory ..." →
+ *   messages.missingRequiredValue
  *
  * `missingGlyphs[configKey] = [name, ...]` → messages.unknownGlyph(name) per name.
+ * Missing-config errors for a key that also has unknown glyphs are dropped —
+ * the unresolvable glyph is the root cause and gets the one message.
  * Anything else in `errors` is returned as `unmapped`.
  */
 export function mapBlockErrorsToFields(
@@ -82,6 +86,11 @@ export function mapBlockErrorsToFields(
 ): MappedBlockErrors {
   const byConfigKey: Record<string, Array<string>> = {}
   const unmapped: Array<string> = []
+  const keysWithUnknownGlyphs = new Set(
+    Object.entries(missingGlyphs)
+      .filter(([, names]) => names.length > 0)
+      .map(([key]) => key),
+  )
 
   for (const error of errors) {
     const extraConfig = error.match(/^Block contains extra config:\s*(.+)$/)
@@ -105,7 +114,18 @@ export function mapBlockErrorsToFields(
         continue
       }
       for (const key of set) {
+        if (keysWithUnknownGlyphs.has(key)) continue
         pushError(byConfigKey, key, messages.missingRequiredValue)
+      }
+      continue
+    }
+
+    const missingOption = error.match(
+      /^Configuration option '([^']+)' is missing for block factory\b/,
+    )
+    if (missingOption) {
+      if (!keysWithUnknownGlyphs.has(missingOption[1])) {
+        pushError(byConfigKey, missingOption[1], messages.missingRequiredValue)
       }
       continue
     }

--- a/frontend/src/locales/en/configure.json
+++ b/frontend/src/locales/en/configure.json
@@ -82,7 +82,9 @@
   "validationStatus": {
     "validating": "Validating",
     "valid": "Valid",
-    "hasErrors": "Has errors",
+    "issues_one": "{{count}} issue",
+    "issues_other": "{{count}} issues",
+    "globalIssueLabel": "Configuration",
     "validatingConfiguration": "Validating configuration...",
     "configurationIssues": "Configuration Issues"
   },
@@ -296,6 +298,10 @@
     "dialog": {
       "title": "Template parameters",
       "description": "Provide values for this template's placeholders — everything can still be changed in the builder.",
+      "missingVarsTitle": "Missing variables",
+      "missingVarsDescription": "This configuration references variables that are not defined on this system. Provide values and choose per variable whether it is stored in the configuration (local) or on this system (global).",
+      "usedIn": "Used in {{block}} → {{option}}",
+      "usedInMore": "+{{count}}",
       "prefilled": "Prefilled by the template ({{count}})",
       "apply": "Apply",
       "skip": "Skip",

--- a/frontend/src/locales/en/glyphs.json
+++ b/frontend/src/locales/en/glyphs.json
@@ -92,6 +92,20 @@
     "switchToConcrete": "Use the value picker",
     "cannotSwitchBack": "Clear the variable expression to switch back",
     "glyphPlaceholder": "e.g. ${variableName}",
+    "defineVariable": {
+      "action": "Define {{name}}",
+      "title": "Define variable",
+      "description": "Provide a value for {{name}} so it can resolve.",
+      "scopeLabel": "Scope",
+      "scopeLocal": "Local",
+      "scopeGlobal": "Global",
+      "scopeLocalHint": "This configuration — travels with it when shared.",
+      "scopeGlobalHint": "This system — available to every configuration here.",
+      "valueLabel": "Value",
+      "create": "Create",
+      "cancel": "Cancel",
+      "globalCreateFailed": "Could not create the global variable"
+    },
     "datePreview": {
       "hasTime": "Date field — the value carries a time component",
       "floorDayAction": "Truncate to date",

--- a/frontend/tests/integration/features/fable-builder/form-mode.test.tsx
+++ b/frontend/tests/integration/features/fable-builder/form-mode.test.tsx
@@ -212,8 +212,8 @@ describe('Fable Builder Form Mode', () => {
       )
       .toBe(true)
 
-    // The "Has errors" badge should be visible on the card
-    // Use .first() since ValidationStatusBadge in the header also shows "Has errors"
+    // The "Has errors" badge should be visible on the card (the header badge
+    // now shows an issue count instead)
     await expect.element(screen.getByText('Has errors').first()).toBeVisible()
   })
 

--- a/frontend/tests/integration/features/fable-builder/load-config-missing-vars.test.tsx
+++ b/frontend/tests/integration/features/fable-builder/load-config-missing-vars.test.tsx
@@ -1,0 +1,146 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Loading a config that references variables unknown on this system
+ * (e.g. globals from another machine) opens the missing-variables dialog
+ * and stores the provided values as local variables.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { userEvent } from 'vitest/browser'
+import { renderWithRouter } from '@tests/utils/render'
+import { FableBuilderPage } from '@/features/fable-builder/components/FableBuilderPage'
+import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
+
+// Same environment mocks as build-flow.test.tsx
+vi.mock('@/hooks/useMedia', () => ({
+  useMedia: () => true,
+}))
+vi.mock('@/features/fable-builder/hooks/useURLStateSync', () => ({
+  useURLStateSync: () => ({ loadedFromURL: false }),
+}))
+vi.mock('@/features/auth/AuthContext', () => ({
+  useAuth: () => ({ authType: 'anonymous', isAuthenticated: true }),
+}))
+vi.mock('@/hooks/useUser', () => ({
+  useUser: () => ({ data: { is_superuser: true } }),
+}))
+
+const loadedConfig = {
+  blocks: {
+    source1: {
+      factory_id: {
+        plugin: { store: 'ecmwf', local: 'ecmwf-base' },
+        factory: 'operationalForecastSource',
+      },
+      configuration_values: {
+        source: '${myDataRoot}',
+        forecast: 'aifs-ens',
+        base_time: '2026-07-14T00:00:00',
+      },
+      input_ids: {},
+    },
+  },
+  environment: null,
+  local_glyphs: {},
+}
+
+describe('Load config — missing variables dialog', () => {
+  // Unstyled browser tests: restore dialog stacking so the backdrop can't
+  // swallow clicks; top/left pin keeps it in the viewport on this tall page.
+  beforeAll(() => {
+    const style = document.createElement('style')
+    style.textContent =
+      '[data-slot="dialog-content"]{position:fixed;top:0;left:0;z-index:50;background:#fff}'
+    document.head.appendChild(style)
+  })
+
+  beforeEach(() => {
+    localStorage.clear()
+    useFableBuilderStore.getState().reset()
+  })
+
+  it('asks for unknown references and stores them as local variables', async () => {
+    const screen = await renderWithRouter(<FableBuilderPage />)
+    await expect.element(screen.getByText('Block Palette')).toBeVisible()
+
+    const input = document.querySelector<HTMLInputElement>('input[type="file"]')
+    expect(input).not.toBeNull()
+    await userEvent.upload(
+      input!,
+      new File([JSON.stringify(loadedConfig)], 'config.json', {
+        type: 'application/json',
+      }),
+    )
+
+    await expect.element(screen.getByText('Missing variables')).toBeVisible()
+    // Usage context: block + option display titles from the catalogue
+    await expect.element(screen.getByText(/Used in .+ → .+/)).toBeVisible()
+
+    await screen.getByLabelText('myDataRoot').fill('/data/root')
+    await screen.getByRole('button', { name: 'Apply' }).click()
+
+    expect(useFableBuilderStore.getState().fable.local_glyphs?.myDataRoot).toBe(
+      '/data/root',
+    )
+    expect(screen.getByText('Missing variables').elements()).toHaveLength(0)
+  })
+
+  it('Global scope creates a global variable instead of a local one', async () => {
+    const screen = await renderWithRouter(<FableBuilderPage />)
+    await expect.element(screen.getByText('Block Palette')).toBeVisible()
+
+    const input = document.querySelector<HTMLInputElement>('input[type="file"]')
+    await userEvent.upload(
+      input!,
+      new File([JSON.stringify(loadedConfig)], 'config.json', {
+        type: 'application/json',
+      }),
+    )
+
+    await expect.element(screen.getByText('Missing variables')).toBeVisible()
+
+    await screen.getByRole('button', { name: 'Global' }).click()
+    await screen.getByLabelText('myDataRoot').fill('/srv/data')
+    await screen.getByRole('button', { name: 'Apply' }).click()
+
+    // Dialog closes on success; the value must NOT land in local_glyphs.
+    await expect
+      .poll(() => screen.getByText('Missing variables').elements().length)
+      .toBe(0)
+    expect(
+      useFableBuilderStore.getState().fable.local_glyphs?.myDataRoot,
+    ).toBeUndefined()
+  })
+
+  it('stays quiet when every reference resolves', async () => {
+    const screen = await renderWithRouter(<FableBuilderPage />)
+    await expect.element(screen.getByText('Block Palette')).toBeVisible()
+
+    const selfContained = {
+      ...loadedConfig,
+      local_glyphs: { myDataRoot: '/tmp/data' },
+    }
+    const input = document.querySelector<HTMLInputElement>('input[type="file"]')
+    await userEvent.upload(
+      input!,
+      new File([JSON.stringify(selfContained)], 'config.json', {
+        type: 'application/json',
+      }),
+    )
+
+    // Load succeeds without the missing-variables dialog.
+    await expect
+      .poll(() => useFableBuilderStore.getState().fable.blocks.source1)
+      .toBeDefined()
+    expect(screen.getByText('Missing variables').elements()).toHaveLength(0)
+  })
+})

--- a/frontend/tests/unit/components/fields/EnumField.test.tsx
+++ b/frontend/tests/unit/components/fields/EnumField.test.tsx
@@ -13,20 +13,24 @@ import { renderWithProviders } from '@tests/utils/render'
 import { Dialog, DialogContent } from '@/components/ui/dialog'
 import { EnumField } from '@/components/base/fields/fields/EnumField'
 import { BlockValidationProvider } from '@/features/fable-builder/context/BlockValidationContext'
+import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
 
 function renderEnum({
   value,
   resolvedConfig = null,
   fieldErrors = null,
+  missingGlyphs = null,
 }: {
   value: string
   resolvedConfig?: Record<string, string> | null
   fieldErrors?: Record<string, Array<string>> | null
+  missingGlyphs?: Record<string, ReadonlyArray<string>> | null
 }) {
   return renderWithProviders(
     <BlockValidationProvider
       fieldErrors={fieldErrors}
       resolvedConfig={resolvedConfig}
+      missingGlyphs={missingGlyphs}
     >
       <EnumField
         id="field-source"
@@ -114,6 +118,45 @@ describe('EnumField — resolved preview for template-injected glyph values', ()
     await expect
       .element(screen.getByText('ecmwf-open-data', { exact: true }).nth(1))
       .toBeInTheDocument()
+  })
+
+  it('offers "Define variable" for an unresolvable glyph and creates a local', async () => {
+    const screen = await renderEnum({
+      value: '${dataRoot}',
+      fieldErrors: { source: ['Unknown glyph: ${dataRoot}'] },
+      missingGlyphs: { source: ['dataRoot'] },
+    })
+
+    await screen.getByRole('button', { name: 'Define ${dataRoot}' }).click()
+    await expect.element(screen.getByText('Define variable')).toBeVisible()
+
+    await screen.getByLabelText('Value').fill('/tmp/data')
+    await screen.getByRole('button', { name: 'Create' }).click()
+
+    expect(useFableBuilderStore.getState().fable.local_glyphs?.dataRoot).toBe(
+      '/tmp/data',
+    )
+  })
+
+  it('define-variable with Global scope creates a global, not a local', async () => {
+    const screen = await renderEnum({
+      value: '${dataRoot}',
+      fieldErrors: { source: ['Unknown glyph: ${dataRoot}'] },
+      missingGlyphs: { source: ['dataRoot'] },
+    })
+
+    await screen.getByRole('button', { name: 'Define ${dataRoot}' }).click()
+    await screen.getByRole('button', { name: 'Global' }).click()
+    await screen.getByLabelText('Value').fill('/srv/data')
+    await screen.getByRole('button', { name: 'Create' }).click()
+
+    // Success (MSW-backed create) closes the dialog; the error path keeps it open.
+    await expect
+      .poll(() => screen.getByText('Define variable').elements().length)
+      .toBe(0)
+    expect(
+      useFableBuilderStore.getState().fable.local_glyphs?.dataRoot,
+    ).toBeUndefined()
   })
 
   it('prefers the field error over the preview', async () => {

--- a/frontend/tests/unit/components/fields/EnumField.test.tsx
+++ b/frontend/tests/unit/components/fields/EnumField.test.tsx
@@ -1,0 +1,79 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { renderWithProviders } from '@tests/utils/render'
+import { EnumField } from '@/components/base/fields/fields/EnumField'
+import { BlockValidationProvider } from '@/features/fable-builder/context/BlockValidationContext'
+
+function renderEnum({
+  value,
+  resolvedConfig = null,
+  fieldErrors = null,
+}: {
+  value: string
+  resolvedConfig?: Record<string, string> | null
+  fieldErrors?: Record<string, Array<string>> | null
+}) {
+  return renderWithProviders(
+    <BlockValidationProvider
+      fieldErrors={fieldErrors}
+      resolvedConfig={resolvedConfig}
+    >
+      <EnumField
+        id="field-source"
+        configKey="source"
+        value={value}
+        onChange={() => {}}
+        options={['mars', 'ecmwf-open-data']}
+      />
+    </BlockValidationProvider>,
+  )
+}
+
+describe('EnumField — resolved preview for template-injected glyph values', () => {
+  it('shows "resolves to" when the value is a glyph with a backend resolution', async () => {
+    const screen = await renderEnum({
+      value: '${forecastSource}',
+      resolvedConfig: { source: 'ecmwf-open-data' },
+    })
+
+    await expect.element(screen.getByText(/resolves to/)).toBeVisible()
+    await expect
+      .element(screen.getByText('ecmwf-open-data', { exact: true }))
+      .toBeVisible()
+  })
+
+  it('shows nothing while the backend has not resolved the value', async () => {
+    const screen = await renderEnum({ value: '${forecastSource}' })
+
+    expect(screen.getByText(/resolves to/).elements()).toHaveLength(0)
+  })
+
+  it('shows nothing for a concrete enum value', async () => {
+    const screen = await renderEnum({
+      value: 'mars',
+      resolvedConfig: { source: 'mars' },
+    })
+
+    expect(screen.getByText(/resolves to/).elements()).toHaveLength(0)
+  })
+
+  it('prefers the field error over the preview', async () => {
+    const screen = await renderEnum({
+      value: '${forecastSource}',
+      resolvedConfig: { source: 'ecmwf-open-data' },
+      fieldErrors: { source: ['not a valid option'] },
+    })
+
+    await expect.element(screen.getByText('not a valid option')).toBeVisible()
+    expect(screen.getByText(/resolves to/).elements()).toHaveLength(0)
+  })
+})

--- a/frontend/tests/unit/components/fields/EnumField.test.tsx
+++ b/frontend/tests/unit/components/fields/EnumField.test.tsx
@@ -8,8 +8,9 @@
  * does it submit to any jurisdiction.
  */
 
-import { describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it } from 'vitest'
 import { renderWithProviders } from '@tests/utils/render'
+import { Dialog, DialogContent } from '@/components/ui/dialog'
 import { EnumField } from '@/components/base/fields/fields/EnumField'
 import { BlockValidationProvider } from '@/features/fable-builder/context/BlockValidationContext'
 
@@ -39,6 +40,16 @@ function renderEnum({
 }
 
 describe('EnumField — resolved preview for template-injected glyph values', () => {
+  // Browser-mode tests render without the app stylesheet; restore the dialog's
+  // production stacking so its backdrop can't paint over the popup and swallow
+  // hover events in the modal test.
+  beforeAll(() => {
+    const style = document.createElement('style')
+    style.textContent =
+      '[data-slot="dialog-content"]{position:fixed;z-index:50}'
+    document.head.appendChild(style)
+  })
+
   it('shows "resolves to" when the value is a glyph with a backend resolution', async () => {
     const screen = await renderEnum({
       value: '${forecastSource}',
@@ -64,6 +75,45 @@ describe('EnumField — resolved preview for template-injected glyph values', ()
     })
 
     expect(screen.getByText(/resolves to/).elements()).toHaveLength(0)
+  })
+
+  it('hovering the preview opens a tooltip with the full value', async () => {
+    const screen = await renderEnum({
+      value: '${forecastSource}',
+      resolvedConfig: { source: 'ecmwf-open-data' },
+    })
+
+    await screen.getByText(/resolves to/).hover()
+    // Tooltip duplicates the value; trigger line + tooltip content = 2.
+    await expect
+      .element(screen.getByText('ecmwf-open-data', { exact: true }).nth(1))
+      .toBeInTheDocument()
+  })
+
+  it('the preview tooltip also opens inside a modal dialog', async () => {
+    const screen = await renderWithProviders(
+      <Dialog open>
+        <DialogContent>
+          <BlockValidationProvider
+            fieldErrors={null}
+            resolvedConfig={{ source: 'ecmwf-open-data' }}
+          >
+            <EnumField
+              id="field-source"
+              configKey="source"
+              value="${forecastSource}"
+              onChange={() => {}}
+              options={['mars', 'ecmwf-open-data']}
+            />
+          </BlockValidationProvider>
+        </DialogContent>
+      </Dialog>,
+    )
+
+    await screen.getByText(/resolves to/).hover()
+    await expect
+      .element(screen.getByText('ecmwf-open-data', { exact: true }).nth(1))
+      .toBeInTheDocument()
   })
 
   it('prefers the field error over the preview', async () => {

--- a/frontend/tests/unit/features/fable-builder/components/ValidationStatus.test.tsx
+++ b/frontend/tests/unit/features/fable-builder/components/ValidationStatus.test.tsx
@@ -1,0 +1,105 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { renderWithProviders } from '@tests/utils/render'
+import type { FableValidationState } from '@/api/types/fable.types'
+import { ValidationStatusBadge } from '@/features/fable-builder/components/shared/ValidationStatus'
+import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
+
+const erroredState: FableValidationState = {
+  isValid: false,
+  globalErrors: [],
+  blockStates: {
+    b1: {
+      errors: ['Some backend error'],
+      hasErrors: true,
+      possibleExpansions: [],
+      possibleExpansionRestrictions: {},
+      configurationRestrictions: {},
+      missingGlyphs: { path: ['dataRoot'] },
+    },
+  },
+  possibleSources: [],
+  resolvedConfigurationOptions: {},
+  blockOutputQubes: {},
+}
+
+function seedStore() {
+  const store = useFableBuilderStore.getState()
+  store.setFable(
+    {
+      blocks: {
+        b1: {
+          factory_id: {
+            plugin: { store: 'ecmwf', local: 'ecmwf-base' },
+            factory: 'gribSink',
+          },
+          configuration_values: {},
+          input_ids: {},
+        },
+      },
+      local_glyphs: {},
+    },
+    null,
+  )
+  store.setValidationState(erroredState)
+}
+
+describe('ValidationStatusBadge — issues popover', () => {
+  // Browser-mode tests render without the app stylesheet; restore popover
+  // stacking/positioning so the popup is clickable in the viewport.
+  beforeAll(() => {
+    const style = document.createElement('style')
+    style.textContent =
+      '[data-slot="popover-content"]{position:fixed;top:0;left:0;z-index:50;background:#fff}'
+    document.head.appendChild(style)
+  })
+
+  beforeEach(() => {
+    localStorage.clear()
+    useFableBuilderStore.getState().reset()
+    seedStore()
+  })
+
+  it('shows the issue count and lists issues in a popover', async () => {
+    const screen = await renderWithProviders(<ValidationStatusBadge />)
+
+    const badge = screen.getByRole('button', { name: /2 issues/ })
+    await expect.element(badge).toBeVisible()
+
+    await badge.click()
+    await expect.element(screen.getByText('Configuration Issues')).toBeVisible()
+    await expect.element(screen.getByText('Some backend error')).toBeVisible()
+    await expect
+      .element(screen.getByText('Unknown glyph: ${dataRoot}'))
+      .toBeVisible()
+  })
+
+  it('clicking an issue selects the offending block', async () => {
+    const screen = await renderWithProviders(<ValidationStatusBadge />)
+
+    await screen.getByRole('button', { name: /2 issues/ }).click()
+    await screen.getByText('Some backend error').click()
+
+    expect(useFableBuilderStore.getState().selectedBlockId).toBe('b1')
+  })
+
+  it('renders the plain Valid badge when there are no issues', async () => {
+    useFableBuilderStore.getState().setValidationState({
+      ...erroredState,
+      isValid: true,
+      blockStates: {},
+    })
+    const screen = await renderWithProviders(<ValidationStatusBadge />)
+
+    await expect.element(screen.getByText('Valid')).toBeVisible()
+  })
+})

--- a/frontend/tests/unit/features/fable-builder/utils/map-block-errors-to-fields.test.ts
+++ b/frontend/tests/unit/features/fable-builder/utils/map-block-errors-to-fields.test.ts
@@ -103,6 +103,44 @@ describe('mapBlockErrorsToFields', () => {
     ])
   })
 
+  describe('root-cause dedup for unresolvable glyphs', () => {
+    it('maps a lone "Configuration option ... is missing" to the field', () => {
+      const result = mapBlockErrorsToFields(
+        ["Configuration option 'path' is missing for block factory 'gribSink'"],
+        {},
+        messages,
+      )
+      expect(result.byConfigKey).toEqual({
+        path: ['Missing required value'],
+      })
+      expect(result.unmapped).toEqual([])
+    })
+
+    it('drops "Configuration option ... is missing" when the key has an unknown glyph', () => {
+      const result = mapBlockErrorsToFields(
+        ["Configuration option 'path' is missing for block factory 'gribSink'"],
+        { path: ['dataRoot'] },
+        messages,
+      )
+      expect(result.byConfigKey).toEqual({
+        path: ['Unknown glyph: ${dataRoot}'],
+      })
+      expect(result.unmapped).toEqual([])
+    })
+
+    it('drops the missing-config set entry when the key has an unknown glyph', () => {
+      const result = mapBlockErrorsToFields(
+        ["Block contains missing config: {'path', 'format'}"],
+        { path: ['dataRoot'] },
+        messages,
+      )
+      expect(result.byConfigKey).toEqual({
+        path: ['Unknown glyph: ${dataRoot}'],
+        format: ['Missing required value'],
+      })
+    })
+  })
+
   it('combines parsed errors, structured missing glyphs, and unmapped errors', () => {
     const result = mapBlockErrorsToFields(
       ["Block contains missing config: {'date'}", 'Plugin not found'],


### PR DESCRIPTION
### Description

Loading a configuration that references variables unknown on the local system (typically globals/locals from another machine, e.g. `${dataRoot}`) used to drop the user onto a red canvas with duplicate, vague errors and no path to a fix. This PR turns that scenario and template parameter handling in general into a guided experience. Motivated by the new #556 Prototype Template and by loading configs exported from other deployments.

## Resolved previews

- Fields that opt out of glyph editing (enum dropdowns) now show the italic *"resolves to …"* line when a template injected a glyph value — previously the Prototype Template's `${forecastSource}` sat in the Source dropdown with no resolution shown.
- The template-params dialog reuses the same preview component instead of its own bare `→ value` line: consistent styling, no redundant echo when the preview equals the value.

## One error, one fix

- The backend reports an unresolvable glyph twice (structured missing-glyph entry + cascaded `Configuration option 'x' is missing` block error). The error mapper now recognises the cascade shape, attributes it to the field, and drops it when the option already carries the unknown-glyph error.
- The unknown-glyph error gains a quick action, tied to it by a corner connector: 'Define `${dataRoot}`' opens a small dialog with a Local/Global scope toggle (wording matches the Variables panel). Local is stored in the configuration and travels with it; Global is created on this system via the existing mutation, with an explicit revalidation since globals don't change the fable.

## Missing-variables dialog on Load Config

- After loading a config, references that resolve nowhere on this system (same derivation as template forking, intrinsics/globals subtracted) open the params dialog retitled 'Missing variables'. Each parameter shows where it is used (*"Used in GRIB Sink → GRIB Path"*, display titles from the catalogue) and its own Local/Global scope toggle. Skipping falls back to the per-field define actions on the canvas.
- The usage-context line also renders in the template-fork flow, complementing #549's `display_name`/`display_description`.

## Issue navigation

- The header's *"Has errors"* badge becomes *"N issues"* and opens a popover listing every issue with its block title; clicking an entry selects the offending block so its panel opens on the errors.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
