### PR TITLE
Feat/extensible types

### DIFF
--- a/backend/development.md
+++ b/backend/development.md
@@ -14,6 +14,7 @@
   * when working with a package with insufficient typing coverage like sqlalchemy, use `ty:ignore` comment
   * when `ty` is not powerful enough, use `ty:ignore `
   * use `typing.cast` when the code logic is implicitly erasing the type information
+  * do not use annotation-as-string unless necessary -- that is, prefer `f: TypeExpression` instead of `f: "TypeExpression"`
 * prioritize using pydantic BaseModel or dataclasses.dataclass object for capturing contracts and interfaces.
   * when using pydantic, use `FiabBaseModel` from `forecastbox.utility.pydantic` (or `FiabCoreBaseModel` from `fiab_core.pydantic_utils` in fiab-core) instead of `pydantic.BaseModel` directly, unless the model requires dynamic field handling (e.g., `extra="allow"` for JSON Schema types). These base models set `extra="forbid"` to catch misconfigured constructors early. If you need the dynamic model handling, mark it clearly with a comment.
   * ideally keep them plain, stateless, frozen, without functions -- we end up serializing those objects often over to other python processes or different languages

--- a/backend/packages/fiab-core/src/fiab_core/fable.py
+++ b/backend/packages/fiab-core/src/fiab_core/fable.py
@@ -12,10 +12,10 @@ Types pertaining to Forecast As BLock Expression (Fable): blocks
 """
 
 import abc
-from typing import Any, Literal, NewType
+from typing import Annotated, Any, Literal, NewType
 
 from earthkit.workflows.fluent import Action
-from pydantic import ConfigDict, Field, PrivateAttr, model_validator
+from pydantic import BeforeValidator, ConfigDict, Field, PlainSerializer, WithJsonSchema, model_validator
 from qubed import Qube
 from typing_extensions import Self
 
@@ -26,35 +26,45 @@ Error = str
 """Compiler/validator error message type alias."""
 
 
+def _parse_fable_type(value: str | FableType) -> FableType:
+    if isinstance(value, FableType):
+        return value
+    if not isinstance(value, str):
+        raise ValueError(f"Expected a Fable type expression string, got {type(value).__name__}")
+    try:
+        parsed, remainder = parse(value)
+        if remainder.strip():
+            raise NotFableType(f"Unexpected trailing content in type expression: {remainder!r}")
+    except NotFableType as exc:
+        raise ValueError(str(exc)) from exc
+    return parsed
+
+
+def _serialize_fable_type(value: FableType) -> str:
+    return value.serialize()
+
+
+FableTypeField = Annotated[
+    FableType,
+    BeforeValidator(_parse_fable_type),
+    PlainSerializer(_serialize_fable_type, return_type=str),
+    WithJsonSchema({"type": "string"}),
+]
+
+
 class BlockConfigurationOption(FiabCoreBaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     title: str
     """Brief string to display in the BlockFactory detail"""
     description: str
     """Extended description, possibly with example values and their effect"""
-    value_type: str
-    """Will be used when deserializing the actual value"""
+    value_type: FableTypeField
+    """Type used when deserializing the actual value; serialized as an expression for clients"""
     default_value: str | None = None
     """Used by the frontend to inject the default value"""
     is_advanced: bool = False
     """Used by the frontend to optionally hide the setting unless advanced. Do not set if no default provided / None not valid"""
-
-    # TODO replace value_type: str with Annotated[fiab_core.FableType, BeforeValidator of fiab_core.types.parse, PlainSerializer of fiab_coreFableType.serialize], and remove this private attr
-    _value_type: FableType = PrivateAttr()
-
-    @model_validator(mode="after")
-    def _validate_and_cache_value_type(self) -> Self:
-        try:
-            parsed, remainder = parse(self.value_type)
-            if remainder.strip():
-                raise NotFableType(f"Unexpected trailing content in type expression: {remainder!r}")
-            self._value_type = parsed
-        except NotFableType as exc:
-            raise ValueError(str(exc)) from exc
-        return self
-
-    @property
-    def parsed_value_type(self) -> FableType:
-        return self._value_type
 
 
 ConfigurationOptionId = NewType("ConfigurationOptionId", str)

--- a/backend/packages/fiab-core/src/fiab_core/fable.py
+++ b/backend/packages/fiab-core/src/fiab_core/fable.py
@@ -33,13 +33,12 @@ class BlockConfigurationOption(FiabCoreBaseModel):
     """Extended description, possibly with example values and their effect"""
     value_type: str
     """Will be used when deserializing the actual value"""
-    # TODO do we want Literal instead of str for values? Probably `str` since this will need to be parsed anyway
-    # TODO do we prefer nesting or flattening for complex config? Ideally we support both, its just about the type system
     default_value: str | None = None
     """Used by the frontend to inject the default value"""
     is_advanced: bool = False
     """Used by the frontend to optionally hide the setting unless advanced. Do not set if no default provided / None not valid"""
 
+    # TODO replace value_type: str with Annotated[fiab_core.FableType, BeforeValidator of fiab_core.types.parse, PlainSerializer of fiab_coreFableType.serialize], and remove this private attr
     _value_type: FableType = PrivateAttr()
 
     @model_validator(mode="after")

--- a/backend/packages/fiab-core/src/fiab_core/fable.py
+++ b/backend/packages/fiab-core/src/fiab_core/fable.py
@@ -37,14 +37,10 @@ def _parse_fable_type(value: str | FableType) -> FableType:
             raise NotFableType(f"Unexpected trailing content in type expression: {remainder!r}")
     except NotFableType as exc:
         raise ValueError(str(exc)) from exc
-    setattr(parsed, "_fable_type_expression", value)
     return parsed
 
 
 def _serialize_fable_type(value: FableType) -> str:
-    original_expression = getattr(value, "_fable_type_expression", None)
-    if isinstance(original_expression, str):
-        return original_expression
     return value.serialize()
 
 

--- a/backend/packages/fiab-core/src/fiab_core/fable.py
+++ b/backend/packages/fiab-core/src/fiab_core/fable.py
@@ -20,34 +20,16 @@ from qubed import Qube
 from typing_extensions import Self
 
 from fiab_core.pydantic_utils import FiabCoreBaseModel
-from fiab_core.types import FableType, NotFableType, parse
+from fiab_core.types import FableType, parse
 
 Error = str
 """Compiler/validator error message type alias."""
 
 
-def _parse_fable_type(value: str | FableType) -> FableType:
-    if isinstance(value, FableType):
-        return value
-    if not isinstance(value, str):
-        raise ValueError(f"Expected a Fable type expression string, got {type(value).__name__}")
-    try:
-        parsed, remainder = parse(value)
-        if remainder.strip():
-            raise NotFableType(f"Unexpected trailing content in type expression: {remainder!r}")
-    except NotFableType as exc:
-        raise ValueError(str(exc)) from exc
-    return parsed
-
-
-def _serialize_fable_type(value: FableType) -> str:
-    return value.serialize()
-
-
 FableTypeField = Annotated[
     FableType,
-    BeforeValidator(_parse_fable_type),
-    PlainSerializer(_serialize_fable_type, return_type=str),
+    BeforeValidator(parse),
+    PlainSerializer(lambda value: value.serialize(), return_type=str),
     WithJsonSchema({"type": "string"}),
 ]
 
@@ -214,12 +196,7 @@ class BlueprintTemplateExampleInput(FiabCoreBaseModel):
     @model_validator(mode="after")
     def _validate_type_hint(self) -> Self:
         if self.type_hint is not None:
-            try:
-                _, remainder = parse(self.type_hint)
-                if remainder.strip():
-                    raise NotFableType(f"Unexpected trailing content in type expression: {remainder!r}")
-            except NotFableType as exc:
-                raise ValueError(str(exc)) from exc
+            parse(self.type_hint)
         return self
 
 

--- a/backend/packages/fiab-core/src/fiab_core/fable.py
+++ b/backend/packages/fiab-core/src/fiab_core/fable.py
@@ -15,7 +15,7 @@ import abc
 from typing import Annotated, Any, Literal, NewType
 
 from earthkit.workflows.fluent import Action
-from pydantic import BeforeValidator, ConfigDict, Field, PlainSerializer, WithJsonSchema, model_validator
+from pydantic import BeforeValidator, ConfigDict, Field, PlainSerializer, WithJsonSchema
 from qubed import Qube
 from typing_extensions import Self
 
@@ -188,16 +188,12 @@ class BlueprintTemplateExampleInput(FiabCoreBaseModel):
     is assumed to take them from the underlying configuration option, or,
     in the glyph case, assume no data."""
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     example_value: str
     display_name: str | None = None
     display_description: str | None = None
-    type_hint: str | None = None
-
-    @model_validator(mode="after")
-    def _validate_type_hint(self) -> Self:
-        if self.type_hint is not None:
-            parse(self.type_hint)
-        return self
+    type_hint: FableTypeField | None = None
 
 
 class BlueprintTemplate(FiabCoreBaseModel):

--- a/backend/packages/fiab-core/src/fiab_core/fable.py
+++ b/backend/packages/fiab-core/src/fiab_core/fable.py
@@ -37,10 +37,14 @@ def _parse_fable_type(value: str | FableType) -> FableType:
             raise NotFableType(f"Unexpected trailing content in type expression: {remainder!r}")
     except NotFableType as exc:
         raise ValueError(str(exc)) from exc
+    setattr(parsed, "_fable_type_expression", value)
     return parsed
 
 
 def _serialize_fable_type(value: FableType) -> str:
+    original_expression = getattr(value, "_fable_type_expression", None)
+    if isinstance(original_expression, str):
+        return original_expression
     return value.serialize()
 
 

--- a/backend/packages/fiab-core/src/fiab_core/tools/blocks.py
+++ b/backend/packages/fiab-core/src/fiab_core/tools/blocks.py
@@ -86,8 +86,8 @@ class BlockInstanceRich:
 
     def config_as_str(self, key: str | ConfigurationOptionId, *, validator: Callable[[str, str], None] | None = None) -> str:
         option_id, option = self._get_configuration_option(key)
-        if not isinstance(option.parsed_value_type, (StringType, ClosedEnumType, OpenEnumType)):
-            raise BlockInstanceConfigurationError(f"Configuration option {option_id!r} has type {option.value_type!r}, not str")
+        if not isinstance(option.value_type, (StringType, ClosedEnumType, OpenEnumType)):
+            raise BlockInstanceConfigurationError(f"Configuration option {option_id!r} has type {option.value_type.serialize()!r}, not str")
         raw_value = self._get_raw_value(option_id)
         if isinstance(raw_value, str):
             if validator is not None:
@@ -97,8 +97,8 @@ class BlockInstanceRich:
 
     def config_as_int(self, key: str | ConfigurationOptionId, *, validator: Callable[[int, str], None] | None = None) -> int:
         option_id, option = self._get_configuration_option(key)
-        if not isinstance(option.parsed_value_type, IntType):
-            raise BlockInstanceConfigurationError(f"Configuration option {option_id!r} has type {option.value_type!r}, not int")
+        if not isinstance(option.value_type, IntType):
+            raise BlockInstanceConfigurationError(f"Configuration option {option_id!r} has type {option.value_type.serialize()!r}, not int")
         raw_value = self._get_raw_value(option_id)
         if type(raw_value) is int:
             if validator is not None:
@@ -108,8 +108,10 @@ class BlockInstanceRich:
 
     def config_as_float(self, key: str | ConfigurationOptionId, *, validator: Callable[[float, str], None] | None = None) -> float:
         option_id, option = self._get_configuration_option(key)
-        if not isinstance(option.parsed_value_type, FloatType):
-            raise BlockInstanceConfigurationError(f"Configuration option {option_id!r} has type {option.value_type!r}, not float")
+        if not isinstance(option.value_type, FloatType):
+            raise BlockInstanceConfigurationError(
+                f"Configuration option {option_id!r} has type {option.value_type.serialize()!r}, not float"
+            )
         raw_value = self._get_raw_value(option_id)
         if type(raw_value) is float:
             if validator is not None:
@@ -119,8 +121,10 @@ class BlockInstanceRich:
 
     def config_as_date(self, key: str | ConfigurationOptionId, *, validator: Callable[[date, str], None] | None = None) -> date:
         option_id, option = self._get_configuration_option(key)
-        if not isinstance(option.parsed_value_type, DateType):
-            raise BlockInstanceConfigurationError(f"Configuration option {option_id!r} has type {option.value_type!r}, not date")
+        if not isinstance(option.value_type, DateType):
+            raise BlockInstanceConfigurationError(
+                f"Configuration option {option_id!r} has type {option.value_type.serialize()!r}, not date"
+            )
         raw_value = self._get_raw_value(option_id)
         if type(raw_value) is date:
             if validator is not None:
@@ -130,8 +134,10 @@ class BlockInstanceRich:
 
     def config_as_datetime(self, key: str | ConfigurationOptionId, *, validator: Callable[[datetime, str], None] | None = None) -> datetime:
         option_id, option = self._get_configuration_option(key)
-        if not isinstance(option.parsed_value_type, DatetimeType):
-            raise BlockInstanceConfigurationError(f"Configuration option {option_id!r} has type {option.value_type!r}, not datetime")
+        if not isinstance(option.value_type, DatetimeType):
+            raise BlockInstanceConfigurationError(
+                f"Configuration option {option_id!r} has type {option.value_type.serialize()!r}, not datetime"
+            )
         raw_value = self._get_raw_value(option_id)
         if type(raw_value) is datetime:
             if validator is not None:
@@ -148,9 +154,9 @@ class BlockInstanceRich:
         validator: Callable[[T, str], None] | None = None,
     ) -> list[T]:
         option_id, option = self._get_configuration_option(key)
-        if not isinstance(option.parsed_value_type, ListType):
+        if not isinstance(option.value_type, ListType):
             raise BlockInstanceConfigurationError(
-                f"Configuration option {option_id!r} has type {option.value_type!r}, not list[{item_type.__name__}]"
+                f"Configuration option {option_id!r} has type {option.value_type.serialize()!r}, not list[{item_type.__name__}]"
             )
         raw_value = self._get_raw_value(option_id)
         if not isinstance(raw_value, list):
@@ -168,9 +174,9 @@ class BlockInstanceRich:
         }.get(item_type)
         if expected_item_types is None:
             raise BlockInstanceConfigurationError(f"Unsupported list item type {item_type!r}")
-        if not isinstance(option.parsed_value_type.item_type, expected_item_types):
+        if not isinstance(option.value_type.item_type, expected_item_types):
             raise BlockInstanceConfigurationError(
-                f"Configuration option {option_id!r} has type {option.value_type!r}, not list[{item_type.__name__}]"
+                f"Configuration option {option_id!r} has type {option.value_type.serialize()!r}, not list[{item_type.__name__}]"
             )
         if any(type(item) is not item_type for item in raw_value):
             raise BlockInstanceConfigurationError(

--- a/backend/packages/fiab-core/src/fiab_core/types.py
+++ b/backend/packages/fiab-core/src/fiab_core/types.py
@@ -193,7 +193,7 @@ class ClosedEnumType(FableType):
         return value
 
     def serialize(self) -> str:
-        items_str = ",".join(self.items)
+        items_str = ",".join(f"'{item}'" for item in self.items)
         return f"enumClosed[{items_str}]"
 
 
@@ -209,7 +209,7 @@ class OpenEnumType(FableType):
         return value
 
     def serialize(self) -> str:
-        items_str = ",".join(self.items)
+        items_str = ",".join(f"'{item}'" for item in self.items)
         return f"enumOpen[{items_str}]"
 
 
@@ -334,9 +334,9 @@ def parse(type_expr: str) -> tuple[FableType, str]:
 
     Supports:
     - Atomic types: 'str', 'int', 'float', 'date', 'datetime', 'country', 'bboxWSEN'
-    - Enumerations: 'enumClosed[item1,item2]', 'enumOpen[item1,item2]'
+    - Enumerations: "enumClosed['item1','item2']", "enumOpen['item1','item2']"
     - Lists: 'list[int]', 'list[enumClosed[...]]', etc.
-    - Union: 'union[int,str]', 'union[enumClosed[a,b],date]', etc.
+    - Union: 'union[int,str]', "union[enumClosed['a','b'],date]", etc.
 
     Raises NotFableType if the expression cannot be parsed.
     """

--- a/backend/packages/fiab-core/src/fiab_core/types.py
+++ b/backend/packages/fiab-core/src/fiab_core/types.py
@@ -20,6 +20,11 @@ Provides parsing, validation, and conversion for a small set of type expressions
 - union[FableType, ...] (union types)
 """
 
+# TODO there is a problem that enums are untyped. Currently, an integer-only enum
+# like closedEnum[1, 2] parses ok but serialized as closedEnum['1', '2'], which is odd.
+# We want to introduce closedEnum<type>[], and parse values with that type. We want to
+# mandate the quotes on the input.
+
 from abc import ABC, abstractmethod
 from datetime import date, datetime
 from typing import Any, Iterable, Literal, get_args

--- a/backend/packages/fiab-core/src/fiab_core/types.py
+++ b/backend/packages/fiab-core/src/fiab_core/types.py
@@ -324,7 +324,7 @@ class GeoDomainType(UnionType):
         return "geodomain"
 
 
-def parse(type_expr: str) -> tuple[FableType, str]:
+def _parse(type_expr: str) -> tuple[FableType, str]:
     """Parse a type expression from the start of type_expr.
 
     Returns ``(parsed_type, remainder)`` where ``remainder`` is the unparsed
@@ -372,7 +372,7 @@ def parse(type_expr: str) -> tuple[FableType, str]:
     # list[...]
     if type_expr.startswith("list["):
         _, inner, remainder = _split_by_brackets(type_expr)
-        inner_type, inner_remainder = parse(inner)
+        inner_type, inner_remainder = _parse(inner)
         if inner_remainder.strip():
             raise NotFableType(f"Unexpected content after inner type in list: {inner_remainder!r}")
         return (ListType(inner_type), remainder)
@@ -389,7 +389,7 @@ def parse(type_expr: str) -> tuple[FableType, str]:
                     raise NotFableType(f"Expected ',' between union member types, got {remaining!r}")
                 remaining = remaining[1:].lstrip()
             first = False
-            t, remaining = parse(remaining)
+            t, remaining = _parse(remaining)
             remaining = remaining.lstrip()
             member_types.append(t)
         if not member_types:
@@ -401,3 +401,18 @@ def parse(type_expr: str) -> tuple[FableType, str]:
         "Expected one of: str, int, float, date, datetime, country, bboxWSEN, geodomain, "
         "enumClosed[...], enumOpen[...], list[...], union[...]"
     )
+
+
+def parse(type_expr: str | FableType) -> FableType:
+    """Parse a complete Fable type expression."""
+    if isinstance(type_expr, FableType):
+        return type_expr
+    if not isinstance(type_expr, str):
+        raise ValueError(f"Expected a Fable type expression string, got {type(type_expr).__name__}")
+    try:
+        parsed, remainder = _parse(type_expr)
+        if remainder.strip():
+            raise NotFableType(f"Unexpected trailing content in type expression: {remainder!r}")
+    except NotFableType as exc:
+        raise ValueError(str(exc)) from exc
+    return parsed

--- a/backend/packages/fiab-core/src/fiab_core/types.py
+++ b/backend/packages/fiab-core/src/fiab_core/types.py
@@ -204,7 +204,7 @@ class ClosedEnumType(FableType):
     string (in which case it is parsed first). Defaults to StringType for backwards compatibility.
     """
 
-    def __init__(self, items: Iterable[Any], subtype: "FableType | str" = StringType()) -> None:
+    def __init__(self, items: Iterable[Any], subtype: FableType | str = StringType()) -> None:
         self.subtype = parse(subtype) if isinstance(subtype, str) else subtype
         self.items = [self.subtype.validate_convert(item) for item in items]
         self._item_set = set(self.items)
@@ -229,7 +229,7 @@ class OpenEnumType(FableType):
     See ClosedEnumType for the meaning of ``items`` and ``subtype``.
     """
 
-    def __init__(self, items: Iterable[Any], subtype: "FableType | str" = StringType()) -> None:
+    def __init__(self, items: Iterable[Any], subtype: FableType | str = StringType()) -> None:
         self.subtype = parse(subtype) if isinstance(subtype, str) else subtype
         self.items = [self.subtype.validate_convert(item) for item in items]
 
@@ -399,9 +399,9 @@ def _parse(type_expr: str) -> tuple[FableType, str]:
             if subtype_remainder.strip():
                 raise NotFableType(f"Unexpected content after enum subtype in {prefix}: {subtype_remainder!r}")
             after_subtype = after_subtype.lstrip()
-            if not after_subtype.startswith("("):
-                raise NotFableType(f"{prefix} must be followed by '(' item, item, ... ')' after the subtype")
-            _, items_str, remainder = _split_by_parens(after_subtype)
+            should_be_empty, items_str, remainder = _split_by_parens(after_subtype)
+            if should_be_empty:
+                raise NotFableType(f"{prefix} must be followed by '(' item, item, ... ')' after the subtype, gotten {should_be_empty}")
             items = [_normalize_enum_item(item) for item in items_str.split(",") if item.strip()]
             if not items:
                 raise NotFableType(f"{prefix} must contain at least one item")

--- a/backend/packages/fiab-core/src/fiab_core/types.py
+++ b/backend/packages/fiab-core/src/fiab_core/types.py
@@ -13,17 +13,12 @@ FableType: Type system for Forecast As BLock Expression (Fable) configuration va
 Provides parsing, validation, and conversion for a small set of type expressions:
 - str, int, float, date, datetime (atomic types)
 - country (string subtype)
-- enumClosed[...], enumOpen[...] (enumeration types)
+- enumClosed[subtype](...), enumOpen[subtype](...) (enumeration types, e.g. enumClosed[int](1,2))
 - list[FableType] (container types)
 - bboxWSEN (bounding box: exactly four integers, west-south-east-north, obeying constraints)
 - geodomain (bounding box or region/country names; the frontend renders a map/region picker)
 - union[FableType, ...] (union types)
 """
-
-# TODO there is a problem that enums are untyped. Currently, an integer-only enum
-# like closedEnum[1, 2] parses ok but serialized as closedEnum['1', '2'], which is odd.
-# We want to introduce closedEnum<type>[], and parse values with that type. We want to
-# mandate the quotes on the input.
 
 from abc import ABC, abstractmethod
 from datetime import date, datetime
@@ -64,26 +59,36 @@ class FableType(ABC):
         """Serialize this type to a string expression that can be parsed back via parse()."""
 
 
-def _split_by_brackets(s: str) -> tuple[str, str, str]:
-    """Split 'prefix[inner]remainder' into (prefix, inner, remainder).
+def _split_by_delim(s: str, open_ch: str, close_ch: str) -> tuple[str, str, str]:
+    """Split 'prefix<open_ch>inner<close_ch>remainder' into (prefix, inner, remainder).
 
     The inner content is stripped of leading/trailing whitespace.
-    Raises NotFableType if no '[' is found or if the brackets are unmatched.
+    Raises NotFableType if open_ch is not found or if the delimiters are unmatched.
     """
-    open_pos = s.find("[")
+    open_pos = s.find(open_ch)
     if open_pos == -1:
-        raise NotFableType(f"Expected '[' in expression: {s!r}")
+        raise NotFableType(f"Expected {open_ch!r} in expression: {s!r}")
     prefix = s[:open_pos]
     depth = 0
     for i in range(open_pos, len(s)):
         ch = s[i]
-        if ch == "[":
+        if ch == open_ch:
             depth += 1
-        elif ch == "]":
+        elif ch == close_ch:
             depth -= 1
             if depth == 0:
                 return (prefix, s[open_pos + 1 : i].strip(), s[i + 1 :])
-    raise NotFableType(f"Unmatched '[' in {prefix!r} expression")
+    raise NotFableType(f"Unmatched {open_ch!r} in {prefix!r} expression")
+
+
+def _split_by_brackets(s: str) -> tuple[str, str, str]:
+    """Split 'prefix[inner]remainder' into (prefix, inner, remainder)."""
+    return _split_by_delim(s, "[", "]")
+
+
+def _split_by_parens(s: str) -> tuple[str, str, str]:
+    """Split 'prefix(inner)remainder' into (prefix, inner, remainder)."""
+    return _split_by_delim(s, "(", ")")
 
 
 def _normalize_enum_item(item: str) -> str:
@@ -183,39 +188,59 @@ class DatetimeType(FableType):
 # GENERIC TYPES
 
 
+def _serialize_enum_item(item: Any) -> str:
+    if isinstance(item, str):
+        return f"'{item}'"
+    if hasattr(item, "isoformat"):
+        return item.isoformat()
+    return str(item)
+
+
 class ClosedEnumType(FableType):
-    """Closed enumeration type. Validates membership in the enum; conversion is a no-op."""
+    """Closed enumeration type. Validates membership in the enum, converting via the given subtype.
 
-    def __init__(self, items: Iterable[str]) -> None:
-        self.items = items
-        self._item_set = set(items)
+    ``items`` are the raw (string) representations of the allowed values, converted eagerly at
+    construction time via ``subtype``. ``subtype`` may be a FableType instance or a type expression
+    string (in which case it is parsed first). Defaults to StringType for backwards compatibility.
+    """
 
-    def validate_convert(self, value: Any) -> str:
+    def __init__(self, items: Iterable[Any], subtype: "FableType | str" = StringType()) -> None:
+        self.subtype = parse(subtype) if isinstance(subtype, str) else subtype
+        self.items = [self.subtype.validate_convert(item) for item in items]
+        self._item_set = set(self.items)
+
+    def validate_convert(self, value: Any) -> Any:
         if not isinstance(value, str):
             raise NotStringInput(f"Expected string, got {type(value).__name__}")
-        if value not in self._item_set:
-            raise WrongType(f"{value!r} is not a valid option. Valid options are: {', '.join(self.items)}")
-        return value
+        converted = self.subtype.validate_convert(value)
+        if converted not in self._item_set:
+            options = ", ".join(str(item) for item in self.items)
+            raise WrongType(f"{value!r} is not a valid option. Valid options are: {options}")
+        return converted
 
     def serialize(self) -> str:
-        items_str = ",".join(f"'{item}'" for item in self.items)
-        return f"enumClosed[{items_str}]"
+        items_str = ",".join(_serialize_enum_item(item) for item in self.items)
+        return f"enumClosed[{self.subtype.serialize()}]({items_str})"
 
 
 class OpenEnumType(FableType):
-    """Open enumeration type. Accepts any string value; conversion is a no-op."""
+    """Open enumeration type. Accepts any value convertible via the subtype; membership is not enforced.
 
-    def __init__(self, items: list[str]) -> None:
-        self.items = items
+    See ClosedEnumType for the meaning of ``items`` and ``subtype``.
+    """
 
-    def validate_convert(self, value: Any) -> str:
+    def __init__(self, items: Iterable[Any], subtype: "FableType | str" = StringType()) -> None:
+        self.subtype = parse(subtype) if isinstance(subtype, str) else subtype
+        self.items = [self.subtype.validate_convert(item) for item in items]
+
+    def validate_convert(self, value: Any) -> Any:
         if not isinstance(value, str):
             raise NotStringInput(f"Expected string, got {type(value).__name__}")
-        return value
+        return self.subtype.validate_convert(value)
 
     def serialize(self) -> str:
-        items_str = ",".join(f"'{item}'" for item in self.items)
-        return f"enumOpen[{items_str}]"
+        items_str = ",".join(_serialize_enum_item(item) for item in self.items)
+        return f"enumOpen[{self.subtype.serialize()}]({items_str})"
 
 
 class ListType(FableType):
@@ -339,9 +364,9 @@ def _parse(type_expr: str) -> tuple[FableType, str]:
 
     Supports:
     - Atomic types: 'str', 'int', 'float', 'date', 'datetime', 'country', 'bboxWSEN'
-    - Enumerations: "enumClosed['item1','item2']", "enumOpen['item1','item2']"
-    - Lists: 'list[int]', 'list[enumClosed[...]]', etc.
-    - Union: 'union[int,str]', "union[enumClosed['a','b'],date]", etc.
+    - Enumerations: "enumClosed[str]('item1','item2')", "enumOpen[int](1,2)"
+    - Lists: 'list[int]', 'list[enumClosed[...](...)]', etc.
+    - Union: 'union[int,str]', "union[enumClosed[str]('a','b'),date]", etc.
 
     Raises NotFableType if the expression cannot be parsed.
     """
@@ -365,14 +390,22 @@ def _parse(type_expr: str) -> tuple[FableType, str]:
             return (factory(), type_expr[n:])
 
     # Enum types (enumClosed and enumOpen share identical logic)
+    # Grammar: enumClosed[subtype](item1,item2,...), e.g. enumClosed[int](1,2) or enumOpen[str]('a','b')
     _ENUMS = {"enumClosed": ClosedEnumType, "enumOpen": OpenEnumType}
     for prefix, factory in _ENUMS.items():
         if type_expr.startswith(prefix):
-            _, inner, remainder = _split_by_brackets(type_expr)
-            items = [_normalize_enum_item(item) for item in inner.split(",") if item.strip()]
+            _, subtype_expr, after_subtype = _split_by_brackets(type_expr)
+            subtype, subtype_remainder = _parse(subtype_expr)
+            if subtype_remainder.strip():
+                raise NotFableType(f"Unexpected content after enum subtype in {prefix}: {subtype_remainder!r}")
+            after_subtype = after_subtype.lstrip()
+            if not after_subtype.startswith("("):
+                raise NotFableType(f"{prefix} must be followed by '(' item, item, ... ')' after the subtype")
+            _, items_str, remainder = _split_by_parens(after_subtype)
+            items = [_normalize_enum_item(item) for item in items_str.split(",") if item.strip()]
             if not items:
                 raise NotFableType(f"{prefix} must contain at least one item")
-            return (factory(items), remainder)
+            return (factory(items, subtype), remainder)
 
     # list[...]
     if type_expr.startswith("list["):
@@ -404,7 +437,7 @@ def _parse(type_expr: str) -> tuple[FableType, str]:
     raise NotFableType(
         f"Invalid type expression: {type_expr!r}. "
         "Expected one of: str, int, float, date, datetime, country, bboxWSEN, geodomain, "
-        "enumClosed[...], enumOpen[...], list[...], union[...]"
+        "enumClosed[subtype](...), enumOpen[subtype](...), list[...], union[...]"
     )
 
 

--- a/backend/packages/fiab-core/tests/test_fable.py
+++ b/backend/packages/fiab-core/tests/test_fable.py
@@ -24,17 +24,16 @@ from fiab_core.fable import (
     PluginId,
     PluginStoreId,
 )
-from fiab_core.types import FableType, StringType
+from fiab_core.types import StringType
 
 
-def test_block_configuration_option_caches_parsed_value_type() -> None:
+def test_block_configuration_option_parses_value_type() -> None:
     option = BlockConfigurationOption(title="Title", description="Description", value_type="str")
 
-    assert isinstance(option.parsed_value_type, StringType)
-    assert isinstance(option._value_type, FableType)
+    assert isinstance(option.value_type, StringType)
 
 
-def test_block_configuration_option_excludes_cached_value_type_from_serialization() -> None:
+def test_block_configuration_option_serializes_value_type() -> None:
     option = BlockConfigurationOption(title="Title", description="Description", value_type="str")
 
     dumped = option.model_dump()

--- a/backend/packages/fiab-core/tests/test_fable.py
+++ b/backend/packages/fiab-core/tests/test_fable.py
@@ -125,7 +125,9 @@ def test_blueprint_template_environment_rejects_unknown_field() -> None:
 
 def test_blueprint_template_example_input_accepts_valid_type_hint() -> None:
     inp = BlueprintTemplateExampleInput(example_value="hello", type_hint="str")
-    assert inp.type_hint == "str"
+    assert isinstance(inp.type_hint, StringType)
+    assert inp.type_hint.serialize() == "str"
+    assert inp.model_dump()["type_hint"] == "str"
 
 
 def test_blueprint_template_example_input_accepts_none_type_hint() -> None:

--- a/backend/packages/fiab-core/tests/test_types.py
+++ b/backend/packages/fiab-core/tests/test_types.py
@@ -32,13 +32,13 @@ from fiab_core.types import (
     WrongType,
     parse,
 )
+from fiab_core.types import (
+    _parse as _parse_raw,
+)
 
 
 def _parse(expr: str) -> FableType:
-    """Parse a complete type expression, asserting there is no non-whitespace remainder."""
-    t, remainder = parse(expr)
-    assert not remainder.strip(), f"Expected empty remainder for {expr!r}, got {remainder!r}"
-    return t
+    return parse(expr)
 
 
 class TestStringType:
@@ -379,16 +379,15 @@ class TestFableTypeParse:
         assert t.validate_convert("1,2,3") == [[1], [2], [3]]
 
     def test_parse_invalid_type_raises_error(self) -> None:
-        with pytest.raises(NotFableType):
+        with pytest.raises(ValueError):
             parse("invalid_type")
-        # "string" parses as str with "ing" as remainder; the outer callsite rejects it
-        _, remainder = parse("string")
-        assert remainder == "ing"
+        with pytest.raises(ValueError, match="Unexpected trailing content"):
+            parse("string")
 
     def test_parse_empty_enum_raises_error(self) -> None:
-        with pytest.raises(NotFableType):
+        with pytest.raises(ValueError):
             parse("enumClosed[]")
-        with pytest.raises(NotFableType):
+        with pytest.raises(ValueError):
             parse("enumOpen[]")
 
     def test_parse_list_with_whitespace(self) -> None:
@@ -571,7 +570,7 @@ class TestUnionType:
         assert t.validate_convert("France") == "France"
 
     def test_parse_empty_union_raises_error(self) -> None:
-        with pytest.raises(NotFableType):
+        with pytest.raises(ValueError):
             parse("union[]")
 
     def test_parse_union_of_unions_now_supported(self) -> None:
@@ -622,48 +621,48 @@ class TestUnionType:
 
 
 class TestFableTypeParseRemainder:
-    """Tests for the remainder returned by parse"""
+    """Tests for the remainder returned by the internal parser."""
 
     def test_atomic_type_returns_remainder(self) -> None:
-        t, remainder = parse("int,str")
+        t, remainder = _parse_raw("int,str")
         assert isinstance(t, IntType)
         assert remainder == ",str"
 
     def test_list_type_returns_remainder(self) -> None:
-        t, remainder = parse("list[int],more")
+        t, remainder = _parse_raw("list[int],more")
         assert isinstance(t, ListType)
         assert remainder == ",more"
 
     def test_enum_type_returns_remainder(self) -> None:
-        t, remainder = parse("enumClosed[a,b],extra")
+        t, remainder = _parse_raw("enumClosed[a,b],extra")
         assert isinstance(t, ClosedEnumType)
         assert remainder == ",extra"
 
     def test_union_type_returns_remainder(self) -> None:
-        t, remainder = parse("union[int,str],extra")
+        t, remainder = _parse_raw("union[int,str],extra")
         assert isinstance(t, UnionType)
         assert remainder == ",extra"
 
     def test_nested_brackets_in_list_parsed_correctly(self) -> None:
-        t, remainder = parse("list[enumClosed[a,b]]suffix")
+        t, remainder = _parse_raw("list[enumClosed[a,b]]suffix")
         assert isinstance(t, ListType)
         assert isinstance(t.item_type, ClosedEnumType)
         assert remainder == "suffix"
 
     def test_unmatched_bracket_in_list_raises_error(self) -> None:
         with pytest.raises(NotFableType):
-            parse("list[int")
+            _parse_raw("list[int")
 
     def test_unmatched_bracket_in_union_raises_error(self) -> None:
         with pytest.raises(NotFableType):
-            parse("union[int,str")
+            _parse_raw("union[int,str")
 
     def test_unmatched_bracket_in_enum_raises_error(self) -> None:
         with pytest.raises(NotFableType):
-            parse("enumClosed[a,b")
+            _parse_raw("enumClosed[a,b")
 
     def test_union_with_enum_member(self) -> None:
-        t, remainder = parse("union[enumClosed[x,y],int]")
+        t, remainder = _parse_raw("union[enumClosed[x,y],int]")
         assert isinstance(t, UnionType)
         assert remainder == ""
         assert isinstance(t.types[0], ClosedEnumType)
@@ -673,4 +672,4 @@ class TestFableTypeParseRemainder:
 
     def test_extra_content_in_list_raises_error(self) -> None:
         with pytest.raises(NotFableType):
-            parse("list[int garbage]")
+            _parse_raw("list[int garbage]")

--- a/backend/packages/fiab-core/tests/test_types.py
+++ b/backend/packages/fiab-core/tests/test_types.py
@@ -170,6 +170,9 @@ class TestDatetimeType:
 class TestClosedEnumType:
     """Tests for ClosedEnumType"""
 
+    def test_serialize_quotes_items(self) -> None:
+        assert ClosedEnumType(["option1", "option2"]).serialize() == "enumClosed['option1','option2']"
+
     def test_convert_valid_enum_value(self) -> None:
         t = ClosedEnumType(["option1", "option2", "option3"])
         assert t.validate_convert("option1") == "option1"
@@ -196,6 +199,9 @@ class TestClosedEnumType:
 
 class TestOpenEnumType:
     """Tests for OpenEnumType"""
+
+    def test_serialize_quotes_items(self) -> None:
+        assert OpenEnumType(["option1", "option2"]).serialize() == "enumOpen['option1','option2']"
 
     def test_convert_any_string(self) -> None:
         t = OpenEnumType(["option1", "option2"])
@@ -337,6 +343,7 @@ class TestFableTypeParse:
     def test_parse_closed_enum(self) -> None:
         t = _parse("enumClosed[option1,option2,option3]")
         assert isinstance(t, ClosedEnumType)
+        assert t.serialize() == "enumClosed['option1','option2','option3']"
         assert t.validate_convert("option1") == "option1"
         with pytest.raises(WrongType):
             t.validate_convert("invalid")
@@ -344,6 +351,7 @@ class TestFableTypeParse:
     def test_parse_open_enum(self) -> None:
         t = _parse("enumOpen[option1,option2]")
         assert isinstance(t, OpenEnumType)
+        assert t.serialize() == "enumOpen['option1','option2']"
         assert t.validate_convert("any_value") == "any_value"
 
     def test_parse_list_of_int(self) -> None:
@@ -361,7 +369,7 @@ class TestFableTypeParse:
         assert isinstance(t, ListType)
         assert isinstance(t.item_type, ClosedEnumType)
         assert t.validate_convert("a,b,a") == ["a", "b", "a"]
-        assert t.serialize() == "list[enumClosed[a,b]]"
+        assert t.serialize() == "list[enumClosed['a','b']]"
 
     def test_parse_nested_list_now_supported(self) -> None:
         t = _parse("list[list[int]]")
@@ -395,6 +403,7 @@ class TestFableTypeParse:
     def test_parse_enum_with_quoted_items(self) -> None:
         t = _parse("enumClosed['a', 'b', 'c']")
         assert isinstance(t, ClosedEnumType)
+        assert t.serialize() == "enumClosed['a','b','c']"
         assert t.validate_convert("b") == "b"
 
 

--- a/backend/packages/fiab-core/tests/test_types.py
+++ b/backend/packages/fiab-core/tests/test_types.py
@@ -30,15 +30,9 @@ from fiab_core.types import (
     StringType,
     UnionType,
     WrongType,
+    _parse,
     parse,
 )
-from fiab_core.types import (
-    _parse as _parse_raw,
-)
-
-
-def _parse(expr: str) -> FableType:
-    return parse(expr)
 
 
 class TestStringType:
@@ -269,13 +263,13 @@ class TestGeoDomainType:
     """GeoDomainType: comma-separated names, or a west,south,east,north integer bbox validated via BoundingBoxWSENType."""
 
     def test_parses_as_a_list_type(self) -> None:
-        t = _parse("geodomain")
+        t = parse("geodomain")
         assert isinstance(t, GeoDomainType)
         assert isinstance(t, UnionType)
 
     def test_serialize(self) -> None:
         assert GeoDomainType().serialize() == "geodomain"
-        assert _parse("geodomain").serialize() == "geodomain"
+        assert parse("geodomain").serialize() == "geodomain"
 
     def test_convert_names(self) -> None:
         assert GeoDomainType().validate_convert("Germany,France,Italy") == ["Germany", "France", "Italy"]
@@ -330,18 +324,18 @@ class TestFableTypeParse:
     """Tests for parse"""
 
     def test_parse_atomic_types(self) -> None:
-        assert isinstance(_parse("str"), StringType)
-        assert isinstance(_parse("int"), IntType)
-        assert isinstance(_parse("float"), FloatType)
-        assert isinstance(_parse("date"), DateType)
-        assert isinstance(_parse("datetime"), DatetimeType)
+        assert isinstance(parse("str"), StringType)
+        assert isinstance(parse("int"), IntType)
+        assert isinstance(parse("float"), FloatType)
+        assert isinstance(parse("date"), DateType)
+        assert isinstance(parse("datetime"), DatetimeType)
 
     def test_parse_whitespace_handling(self) -> None:
-        assert isinstance(_parse("  str  "), StringType)
-        assert isinstance(_parse(" int "), IntType)
+        assert isinstance(parse("  str  "), StringType)
+        assert isinstance(parse(" int "), IntType)
 
     def test_parse_closed_enum(self) -> None:
-        t = _parse("enumClosed[option1,option2,option3]")
+        t = parse("enumClosed[option1,option2,option3]")
         assert isinstance(t, ClosedEnumType)
         assert t.serialize() == "enumClosed['option1','option2','option3']"
         assert t.validate_convert("option1") == "option1"
@@ -349,30 +343,30 @@ class TestFableTypeParse:
             t.validate_convert("invalid")
 
     def test_parse_open_enum(self) -> None:
-        t = _parse("enumOpen[option1,option2]")
+        t = parse("enumOpen[option1,option2]")
         assert isinstance(t, OpenEnumType)
         assert t.serialize() == "enumOpen['option1','option2']"
         assert t.validate_convert("any_value") == "any_value"
 
     def test_parse_list_of_int(self) -> None:
-        t = _parse("list[int]")
+        t = parse("list[int]")
         assert isinstance(t, ListType)
         assert t.validate_convert("1,2,3") == [1, 2, 3]
 
     def test_parse_list_of_string(self) -> None:
-        t = _parse("list[str]")
+        t = parse("list[str]")
         assert isinstance(t, ListType)
         assert t.validate_convert("a,b,c") == ["a", "b", "c"]
 
     def test_parse_list_of_enum(self) -> None:
-        t = _parse("list[enumClosed[a,b]]")
+        t = parse("list[enumClosed[a,b]]")
         assert isinstance(t, ListType)
         assert isinstance(t.item_type, ClosedEnumType)
         assert t.validate_convert("a,b,a") == ["a", "b", "a"]
         assert t.serialize() == "list[enumClosed['a','b']]"
 
     def test_parse_nested_list_now_supported(self) -> None:
-        t = _parse("list[list[int]]")
+        t = parse("list[list[int]]")
         assert isinstance(t, ListType)
         assert isinstance(t.item_type, ListType)
         # outer comma-split means each inner list gets one element
@@ -391,16 +385,16 @@ class TestFableTypeParse:
             parse("enumOpen[]")
 
     def test_parse_list_with_whitespace(self) -> None:
-        t = _parse("list[ int ]")
+        t = parse("list[ int ]")
         assert isinstance(t, ListType)
 
     def test_parse_enum_with_whitespace(self) -> None:
-        t = _parse("enumClosed[ a , b , c ]")
+        t = parse("enumClosed[ a , b , c ]")
         assert isinstance(t, ClosedEnumType)
         assert t.validate_convert("a") == "a"
 
     def test_parse_enum_with_quoted_items(self) -> None:
-        t = _parse("enumClosed['a', 'b', 'c']")
+        t = parse("enumClosed['a', 'b', 'c']")
         assert isinstance(t, ClosedEnumType)
         assert t.serialize() == "enumClosed['a','b','c']"
         assert t.validate_convert("b") == "b"
@@ -423,13 +417,13 @@ class TestValidateConvertIntegration:
         ]
 
         for type_expr, input_val, expected in cases:
-            fable_type = _parse(type_expr)
+            fable_type = parse(type_expr)
             result = fable_type.validate_convert(input_val)
             assert result == expected, f"Failed for {type_expr}"
 
     def test_error_propagation(self) -> None:
         """Test that type errors and value errors propagate correctly"""
-        t = _parse("list[int]")
+        t = parse("list[int]")
         with pytest.raises(WrongType):
             t.validate_convert("1,not_int,3")
 
@@ -462,7 +456,7 @@ class TestGeoDomainSingleType:
         assert GeoDomainSingleType().serialize() == "geodomainSingle"
 
     def test_parse_and_round_trip(self) -> None:
-        t = _parse("geodomainSingle")
+        t = parse("geodomainSingle")
         assert isinstance(t, GeoDomainSingleType)
         assert t.validate_convert("Germany") == "Germany"
         assert t.serialize() == "geodomainSingle"
@@ -503,13 +497,13 @@ class TestBoundingBoxWSENType:
         assert BoundingBoxWSENType().serialize() == "bboxWSEN"
 
     def test_parse_and_round_trip(self) -> None:
-        t = _parse("bboxWSEN")
+        t = parse("bboxWSEN")
         assert isinstance(t, BoundingBoxWSENType)
         assert t.validate_convert("10,20,30,40") == [10, 20, 30, 40]
         assert t.serialize() == "bboxWSEN"
 
     def test_list_of_bbox_now_supported(self) -> None:
-        t = _parse("list[bboxWSEN]")
+        t = parse("list[bboxWSEN]")
         assert isinstance(t, ListType)
         assert isinstance(t.item_type, BoundingBoxWSENType)
         # list[bboxWSEN] always fails at validate_convert: outer comma-split leaves
@@ -551,7 +545,7 @@ class TestUnionType:
         assert t.serialize() == "union[int,float,date]"
 
     def test_parse_and_round_trip(self) -> None:
-        t = _parse("union[int,str]")
+        t = parse("union[int,str]")
         assert isinstance(t, UnionType)
         assert len(t.types) == 2
         assert isinstance(t.types[0], IntType)
@@ -559,12 +553,12 @@ class TestUnionType:
         assert t.serialize() == "union[int,str]"
 
     def test_parse_union_with_date_and_datetime(self) -> None:
-        t = _parse("union[date,datetime]")
+        t = parse("union[date,datetime]")
         assert isinstance(t, UnionType)
         assert t.validate_convert("2026-05-08T10:30:45") == datetime(2026, 5, 8, 10, 30, 45)
 
     def test_parse_union_with_country(self) -> None:
-        t = _parse("union[int,geodomainSingle]")
+        t = parse("union[int,geodomainSingle]")
         assert isinstance(t, UnionType)
         assert t.validate_convert("42") == 42
         assert t.validate_convert("France") == "France"
@@ -574,47 +568,47 @@ class TestUnionType:
             parse("union[]")
 
     def test_parse_union_of_unions_now_supported(self) -> None:
-        t = _parse("union[union[int,str],float]")
+        t = parse("union[union[int,str],float]")
         assert isinstance(t, UnionType)
         assert isinstance(t.types[0], UnionType)
         assert isinstance(t.types[1], FloatType)
         assert t.validate_convert("42") == 42
 
     def test_parse_union_with_list_now_supported(self) -> None:
-        t = _parse("union[list[int],str]")
+        t = parse("union[list[int],str]")
         assert isinstance(t, UnionType)
         assert isinstance(t.types[0], ListType)
         assert t.validate_convert("1,2,3") == [1, 2, 3]
         assert t.validate_convert("hello") == "hello"
 
     def test_parse_union_with_bbox_now_supported(self) -> None:
-        t = _parse("union[bboxWSEN,str]")
+        t = parse("union[bboxWSEN,str]")
         assert isinstance(t, UnionType)
         assert isinstance(t.types[0], BoundingBoxWSENType)
         assert t.validate_convert("1,2,3,4") == [1, 2, 3, 4]
         assert t.validate_convert("hello") == "hello"
 
     def test_parse_list_of_union_now_supported(self) -> None:
-        t = _parse("list[union[int,str]]")
+        t = parse("list[union[int,str]]")
         assert isinstance(t, ListType)
         assert isinstance(t.item_type, UnionType)
         assert t.validate_convert("42,hello,3") == [42, "hello", 3]
 
     def test_parse_union_of_lists(self) -> None:
-        t = _parse("union[list[int],list[float]]")
+        t = parse("union[list[int],list[float]]")
         assert isinstance(t, UnionType)
         assert t.validate_convert("1,2,3") == [1, 2, 3]
         assert t.validate_convert("1.5,2.5") == [1.5, 2.5]
 
     def test_parse_union_with_enum(self) -> None:
-        t = _parse("union[enumClosed[a,b],str]")
+        t = parse("union[enumClosed[a,b],str]")
         assert isinstance(t, UnionType)
         assert isinstance(t.types[0], ClosedEnumType)
         assert t.validate_convert("a") == "a"
         assert t.validate_convert("anything") == "anything"
 
     def test_parse_union_with_whitespace(self) -> None:
-        t = _parse("union[ int , str ]")
+        t = parse("union[ int , str ]")
         assert isinstance(t, UnionType)
         assert isinstance(t.types[0], IntType)
         assert isinstance(t.types[1], StringType)
@@ -624,45 +618,45 @@ class TestFableTypeParseRemainder:
     """Tests for the remainder returned by the internal parser."""
 
     def test_atomic_type_returns_remainder(self) -> None:
-        t, remainder = _parse_raw("int,str")
+        t, remainder = _parse("int,str")
         assert isinstance(t, IntType)
         assert remainder == ",str"
 
     def test_list_type_returns_remainder(self) -> None:
-        t, remainder = _parse_raw("list[int],more")
+        t, remainder = _parse("list[int],more")
         assert isinstance(t, ListType)
         assert remainder == ",more"
 
     def test_enum_type_returns_remainder(self) -> None:
-        t, remainder = _parse_raw("enumClosed[a,b],extra")
+        t, remainder = _parse("enumClosed[a,b],extra")
         assert isinstance(t, ClosedEnumType)
         assert remainder == ",extra"
 
     def test_union_type_returns_remainder(self) -> None:
-        t, remainder = _parse_raw("union[int,str],extra")
+        t, remainder = _parse("union[int,str],extra")
         assert isinstance(t, UnionType)
         assert remainder == ",extra"
 
     def test_nested_brackets_in_list_parsed_correctly(self) -> None:
-        t, remainder = _parse_raw("list[enumClosed[a,b]]suffix")
+        t, remainder = _parse("list[enumClosed[a,b]]suffix")
         assert isinstance(t, ListType)
         assert isinstance(t.item_type, ClosedEnumType)
         assert remainder == "suffix"
 
     def test_unmatched_bracket_in_list_raises_error(self) -> None:
         with pytest.raises(NotFableType):
-            _parse_raw("list[int")
+            _parse("list[int")
 
     def test_unmatched_bracket_in_union_raises_error(self) -> None:
         with pytest.raises(NotFableType):
-            _parse_raw("union[int,str")
+            _parse("union[int,str")
 
     def test_unmatched_bracket_in_enum_raises_error(self) -> None:
         with pytest.raises(NotFableType):
-            _parse_raw("enumClosed[a,b")
+            _parse("enumClosed[a,b")
 
     def test_union_with_enum_member(self) -> None:
-        t, remainder = _parse_raw("union[enumClosed[x,y],int]")
+        t, remainder = _parse("union[enumClosed[x,y],int]")
         assert isinstance(t, UnionType)
         assert remainder == ""
         assert isinstance(t.types[0], ClosedEnumType)
@@ -672,4 +666,4 @@ class TestFableTypeParseRemainder:
 
     def test_extra_content_in_list_raises_error(self) -> None:
         with pytest.raises(NotFableType):
-            _parse_raw("list[int garbage]")
+            _parse("list[int garbage]")

--- a/backend/packages/fiab-core/tests/test_types.py
+++ b/backend/packages/fiab-core/tests/test_types.py
@@ -165,7 +165,7 @@ class TestClosedEnumType:
     """Tests for ClosedEnumType"""
 
     def test_serialize_quotes_items(self) -> None:
-        assert ClosedEnumType(["option1", "option2"]).serialize() == "enumClosed['option1','option2']"
+        assert ClosedEnumType(["option1", "option2"]).serialize() == "enumClosed[str]('option1','option2')"
 
     def test_convert_valid_enum_value(self) -> None:
         t = ClosedEnumType(["option1", "option2", "option3"])
@@ -190,12 +190,28 @@ class TestClosedEnumType:
         with pytest.raises(WrongType):
             t.validate_convert("option1")
 
+    def test_int_subtype_converts_and_validates(self) -> None:
+        t = ClosedEnumType(["1", "2", "3"], subtype=IntType())
+        assert t.items == [1, 2, 3]
+        assert t.validate_convert("2") == 2
+        with pytest.raises(WrongType):
+            t.validate_convert("4")
+
+    def test_subtype_as_string_is_parsed(self) -> None:
+        t = ClosedEnumType(["1", "2"], subtype="int")
+        assert isinstance(t.subtype, IntType)
+        assert t.validate_convert("1") == 1
+
+    def test_serialize_with_int_subtype(self) -> None:
+        t = ClosedEnumType(["1", "2"], subtype=IntType())
+        assert t.serialize() == "enumClosed[int](1,2)"
+
 
 class TestOpenEnumType:
     """Tests for OpenEnumType"""
 
     def test_serialize_quotes_items(self) -> None:
-        assert OpenEnumType(["option1", "option2"]).serialize() == "enumOpen['option1','option2']"
+        assert OpenEnumType(["option1", "option2"]).serialize() == "enumOpen[str]('option1','option2')"
 
     def test_convert_any_string(self) -> None:
         t = OpenEnumType(["option1", "option2"])
@@ -209,6 +225,15 @@ class TestOpenEnumType:
             t.validate_convert(123)
         with pytest.raises(NotStringInput):
             t.validate_convert(None)
+
+    def test_int_subtype_converts(self) -> None:
+        t = OpenEnumType(["1", "2"], subtype=IntType())
+        assert t.items == [1, 2]
+        assert t.validate_convert("99") == 99
+
+    def test_serialize_with_int_subtype(self) -> None:
+        t = OpenEnumType(["1", "2"], subtype=IntType())
+        assert t.serialize() == "enumOpen[int](1,2)"
 
 
 class TestListType:
@@ -335,18 +360,38 @@ class TestFableTypeParse:
         assert isinstance(parse(" int "), IntType)
 
     def test_parse_closed_enum(self) -> None:
-        t = parse("enumClosed[option1,option2,option3]")
+        t = parse("enumClosed[str](option1,option2,option3)")
         assert isinstance(t, ClosedEnumType)
-        assert t.serialize() == "enumClosed['option1','option2','option3']"
+        assert t.serialize() == "enumClosed[str]('option1','option2','option3')"
         assert t.validate_convert("option1") == "option1"
         with pytest.raises(WrongType):
             t.validate_convert("invalid")
 
     def test_parse_open_enum(self) -> None:
-        t = parse("enumOpen[option1,option2]")
+        t = parse("enumOpen[str](option1,option2)")
         assert isinstance(t, OpenEnumType)
-        assert t.serialize() == "enumOpen['option1','option2']"
+        assert t.serialize() == "enumOpen[str]('option1','option2')"
         assert t.validate_convert("any_value") == "any_value"
+
+    def test_parse_closed_enum_with_int_subtype(self) -> None:
+        t = parse("enumClosed[int](1,2,3)")
+        assert isinstance(t, ClosedEnumType)
+        assert isinstance(t.subtype, IntType)
+        assert t.items == [1, 2, 3]
+        assert t.serialize() == "enumClosed[int](1,2,3)"
+        assert t.validate_convert("2") == 2
+        with pytest.raises(WrongType):
+            t.validate_convert("4")
+
+    def test_parse_open_enum_with_int_subtype(self) -> None:
+        t = parse("enumOpen[int](1,2)")
+        assert isinstance(t, OpenEnumType)
+        assert t.items == [1, 2]
+        assert t.validate_convert("99") == 99
+
+    def test_parse_enum_missing_parens_raises_error(self) -> None:
+        with pytest.raises(ValueError):
+            parse("enumClosed[int]")
 
     def test_parse_list_of_int(self) -> None:
         t = parse("list[int]")
@@ -359,11 +404,11 @@ class TestFableTypeParse:
         assert t.validate_convert("a,b,c") == ["a", "b", "c"]
 
     def test_parse_list_of_enum(self) -> None:
-        t = parse("list[enumClosed[a,b]]")
+        t = parse("list[enumClosed[str](a,b)]")
         assert isinstance(t, ListType)
         assert isinstance(t.item_type, ClosedEnumType)
         assert t.validate_convert("a,b,a") == ["a", "b", "a"]
-        assert t.serialize() == "list[enumClosed['a','b']]"
+        assert t.serialize() == "list[enumClosed[str]('a','b')]"
 
     def test_parse_nested_list_now_supported(self) -> None:
         t = parse("list[list[int]]")
@@ -380,23 +425,23 @@ class TestFableTypeParse:
 
     def test_parse_empty_enum_raises_error(self) -> None:
         with pytest.raises(ValueError):
-            parse("enumClosed[]")
+            parse("enumClosed[str]()")
         with pytest.raises(ValueError):
-            parse("enumOpen[]")
+            parse("enumOpen[str]()")
 
     def test_parse_list_with_whitespace(self) -> None:
         t = parse("list[ int ]")
         assert isinstance(t, ListType)
 
     def test_parse_enum_with_whitespace(self) -> None:
-        t = parse("enumClosed[ a , b , c ]")
+        t = parse("enumClosed[str]( a , b , c )")
         assert isinstance(t, ClosedEnumType)
         assert t.validate_convert("a") == "a"
 
     def test_parse_enum_with_quoted_items(self) -> None:
-        t = parse("enumClosed['a', 'b', 'c']")
+        t = parse("enumClosed[str]('a', 'b', 'c')")
         assert isinstance(t, ClosedEnumType)
-        assert t.serialize() == "enumClosed['a','b','c']"
+        assert t.serialize() == "enumClosed[str]('a','b','c')"
         assert t.validate_convert("b") == "b"
 
 
@@ -410,8 +455,8 @@ class TestValidateConvertIntegration:
             ("float", "3.14", 3.14),
             ("date", "2026-05-08", date(2026, 5, 8)),
             ("datetime", "2026-05-08T10:30:45", datetime(2026, 5, 8, 10, 30, 45)),
-            ("enumClosed[a,b,c]", "b", "b"),
-            ("enumOpen[x,y]", "any_value", "any_value"),
+            ("enumClosed[str](a,b,c)", "b", "b"),
+            ("enumOpen[str](x,y)", "any_value", "any_value"),
             ("list[int]", "1,2,3", [1, 2, 3]),
             ("list[str]", "a,b,c", ["a", "b", "c"]),
         ]
@@ -601,7 +646,7 @@ class TestUnionType:
         assert t.validate_convert("1.5,2.5") == [1.5, 2.5]
 
     def test_parse_union_with_enum(self) -> None:
-        t = parse("union[enumClosed[a,b],str]")
+        t = parse("union[enumClosed[str](a,b),str]")
         assert isinstance(t, UnionType)
         assert isinstance(t.types[0], ClosedEnumType)
         assert t.validate_convert("a") == "a"
@@ -628,7 +673,7 @@ class TestFableTypeParseRemainder:
         assert remainder == ",more"
 
     def test_enum_type_returns_remainder(self) -> None:
-        t, remainder = _parse("enumClosed[a,b],extra")
+        t, remainder = _parse("enumClosed[str](a,b),extra")
         assert isinstance(t, ClosedEnumType)
         assert remainder == ",extra"
 
@@ -638,7 +683,7 @@ class TestFableTypeParseRemainder:
         assert remainder == ",extra"
 
     def test_nested_brackets_in_list_parsed_correctly(self) -> None:
-        t, remainder = _parse("list[enumClosed[a,b]]suffix")
+        t, remainder = _parse("list[enumClosed[str](a,b)]suffix")
         assert isinstance(t, ListType)
         assert isinstance(t.item_type, ClosedEnumType)
         assert remainder == "suffix"
@@ -656,7 +701,7 @@ class TestFableTypeParseRemainder:
             _parse("enumClosed[a,b")
 
     def test_union_with_enum_member(self) -> None:
-        t, remainder = _parse("union[enumClosed[x,y],int]")
+        t, remainder = _parse("union[enumClosed[str](x,y),int]")
         assert isinstance(t, UnionType)
         assert remainder == ""
         assert isinstance(t.types[0], ClosedEnumType)

--- a/backend/packages/fiab-plugin-demo/src/fiab_plugin_demo/blocks.py
+++ b/backend/packages/fiab-plugin-demo/src/fiab_plugin_demo/blocks.py
@@ -20,6 +20,7 @@ from fiab_core.fable import (
 )
 from fiab_core.plugin import Error
 from fiab_core.tools.blocks import BlockInstanceRich, Product, Sink, Transform
+from fiab_core.types import ListType, StringType
 
 DIR = ConfigurationOptionId("dir")
 PARAM = ConfigurationOptionId("param")
@@ -100,7 +101,7 @@ class NetCDFOutputSink(_DemoSink):
         DIR: BlockConfigurationOption(
             title="Directory",
             description="Output directory (e.g. '/path/to/output')",
-            value_type="str",
+            value_type=StringType(),
         )
     }
 
@@ -112,7 +113,7 @@ class GRIBOutputSink(_DemoSink):
         DIR: BlockConfigurationOption(
             title="Directory",
             description="Output directory (e.g. '/path/to/output')",
-            value_type="str",
+            value_type=StringType(),
         )
     }
 
@@ -124,7 +125,7 @@ class FilterParam(_DemoTransform):
         PARAM: BlockConfigurationOption(
             title="Parameters",
             description="Parameters to select and plot (e.g. '2t', 'msl')",
-            value_type="list[str]",
+            value_type=ListType(StringType()),
         )
     }
 
@@ -136,7 +137,7 @@ class InterpolationTransform(_DemoTransform):
         PARAM: BlockConfigurationOption(
             title="Grid",
             description="GridSpec to interpolate",
-            value_type="str",
+            value_type=StringType(),
         )
     }
 

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
@@ -26,6 +26,7 @@ from fiab_core.fable import (
 from fiab_core.plugin import Error
 from fiab_core.tools.blocks import BlockInstanceRich, Source, Transform
 from fiab_core.tools.validators import positive
+from fiab_core.types import DatetimeType, IntType, OpenEnumType
 
 from fiab_plugin_ecmwf.qubed_utils import axes, contains, expand
 
@@ -124,23 +125,23 @@ class AnemoiSource(Source):
         INPUT_SOURCE: BlockConfigurationOption(
             title="Input Source",
             description="Source of the initial conditions",
-            value_type="enumOpen['mars', 'opendata', 'polytope']",
+            value_type=OpenEnumType(["mars", "opendata", "polytope"]),
             default_value="opendata",
         ),
         LEAD_TIME: BlockConfigurationOption(
             title="Lead time",
             description="Lead time of the forecast",
-            value_type="int",
+            value_type=IntType(),
         ),
         BASE_TIME: BlockConfigurationOption(
             title="Base time",
             description="Base time of the forecast",
-            value_type="datetime",
+            value_type=DatetimeType(),
         ),
         ENSEMBLE: BlockConfigurationOption(
             title="Ensemble Member",
             description="ID of ensemble member.",
-            value_type="int",
+            value_type=IntType(),
             default_value="1",
         ),
     }
@@ -193,18 +194,18 @@ class AnemoiInputSource(Source):
         INPUT_SOURCE: BlockConfigurationOption(
             title="Input Source",
             description="Source of the initial conditions",
-            value_type="enumOpen['mars', 'opendata', 'polytope']",
+            value_type=OpenEnumType(["mars", "opendata", "polytope"]),
             default_value="opendata",
         ),
         BASE_TIME: BlockConfigurationOption(
             title="Base time",
             description="Base time of the forecast",
-            value_type="datetime",
+            value_type=DatetimeType(),
         ),
         ENSEMBLE: BlockConfigurationOption(
             title="Ensemble Member",
             description="ID of ensemble member.",
-            value_type="int",
+            value_type=IntType(),
             default_value="1",
         ),
     }
@@ -249,7 +250,7 @@ class AnemoiTransform(Transform):
         LEAD_TIME: BlockConfigurationOption(
             title="Lead time",
             description="Lead time of the forecast",
-            value_type="int",
+            value_type=IntType(),
         ),
     }
 

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/utils.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/utils.py
@@ -19,6 +19,7 @@ from earthkit.data.utils.dates import to_timedelta
 from fiab_core.artifacts import AnemoiCheckpoint, ArtifactsProvider, CompositeArtifactId
 from fiab_core.fable import QubedOutput
 from fiab_core.tools.plugins import _detect_editable_install
+from fiab_core.types import ClosedEnumType, FableType, StringType
 from qubed import Qube
 
 from ..qubed_utils import expand
@@ -44,16 +45,16 @@ def get_available_checkpoints() -> dict[CompositeArtifactId, AnemoiCheckpoint]:
     }
 
 
-def get_checkpoint_enum_type() -> str:
+def get_checkpoint_enum_type() -> FableType:
     try:
         available_checkpoints = get_available_checkpoints()
     except Exception as e:
         logger.error(f"Error fetching available checkpoints: {e}")
-        return "str"
+        return StringType()
     if not available_checkpoints:
-        return "str"
-    values = ", ".join(f"'{CompositeArtifactId.to_str(k)}'" for k in available_checkpoints.keys())
-    return f"enumClosed[{values}]"
+        return StringType()
+    values = [CompositeArtifactId.to_str(k) for k in available_checkpoints]
+    return ClosedEnumType(values)
 
 
 class CheckpointArtifact:

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -27,7 +27,7 @@ from fiab_core.fable import (
 )
 from fiab_core.plugin import Error
 from fiab_core.tools.blocks import BlockInstanceConfigurationError, BlockInstanceRich, Product, Sink, Source, Transform
-from fiab_core.types import ClosedEnumType, ListType
+from fiab_core.types import ClosedEnumType, DatetimeType, GeoDomainType, ListType, StringType
 from qubed import Qube
 
 from .datasets import load_datasets
@@ -113,18 +113,18 @@ class OperationalForecastSource(Source):
         SOURCE: BlockConfigurationOption(
             title="Source",
             description="Top level source for earthkit data",
-            value_type="enumClosed['mars', 'ecmwf-open-data']",
+            value_type=ClosedEnumType(["mars", "ecmwf-open-data"]),
         ),
         FORECAST: BlockConfigurationOption(
             title="Forecast model",
             description="Name of forecast",
-            value_type=f"enumClosed[{','.join(FORECAST_DATASETS.keys())}]",
+            value_type=ClosedEnumType(list(FORECAST_DATASETS)),
             default_value=list(FORECAST_DATASETS.keys())[0],
         ),
         BASETIME: BlockConfigurationOption(
             title="Base time",
             description="Base time of the forecast",
-            value_type="datetime",
+            value_type=DatetimeType(),
         ),
     }
     inputs: list[str] = []
@@ -208,11 +208,11 @@ class EnsembleStatistics(Product):
     title: str = "Ensemble Statistics"
     description: str = "Computes ensemble mean or standard deviation"
     configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {
-        PARAM: BlockConfigurationOption(title="Parameter", description="Parameter name like '2t'", value_type="str"),
+        PARAM: BlockConfigurationOption(title="Parameter", description="Parameter name like '2t'", value_type=StringType()),
         STATISTIC: BlockConfigurationOption(
             title="Statistic",
             description="Statistic to compute over the ensemble",
-            value_type="enumClosed['mean', 'std']",
+            value_type=ClosedEnumType(["mean", "std"]),
         ),
     }
     inputs: list[str] = ["dataset"]
@@ -254,11 +254,11 @@ class TemporalStatistics(Product):
     title: str = "Temporal Statistics"
     description: str = "Computes temporal statistics"
     configuration_options: dict[ConfigurationOptionId, BlockConfigurationOption] = {
-        PARAM: BlockConfigurationOption(title=PARAM, description="Param name like '2t'", value_type="str"),
+        PARAM: BlockConfigurationOption(title=PARAM, description="Param name like '2t'", value_type=StringType()),
         STATISTIC: BlockConfigurationOption(
             title="Statistic",
             description="Statistic to compute over steps",
-            value_type="enumClosed['mean', 'std', 'min', 'max']",
+            value_type=ClosedEnumType(["mean", "std", "min", "max"]),
         ),
     }
     inputs: list[str] = ["dataset"]
@@ -306,7 +306,7 @@ class ZarrSink(Sink):
         PATH: BlockConfigurationOption(
             title="Zarr Path",
             description="Filesystem path where the zarr should be written",
-            value_type="str",
+            value_type=StringType(),
         )
     }
     inputs: list[str] = ["dataset"]
@@ -351,12 +351,12 @@ class Select(Transform):
         DIMENSION: BlockConfigurationOption(
             title="Dimension",
             description="Dimension to select from the dataset",
-            value_type="str",
+            value_type=StringType(),
         ),
         VALUES: BlockConfigurationOption(
             title="Values",
             description="Values to select from the chosen dimension",
-            value_type="list[str]",
+            value_type=ListType(StringType()),
         ),
     }
     inputs: list[str] = ["dataset"]
@@ -424,7 +424,7 @@ class GribSink(Sink):
         PATH: BlockConfigurationOption(
             title="GRIB Path",
             description="Filesystem path where the GRIB file should be written. Filename can contain template values from metadata in [] brackets.",
-            value_type="str",
+            value_type=StringType(),
         )
     }
     inputs: list[str] = ["dataset"]
@@ -484,36 +484,36 @@ class MapPlotSink(Sink):
         PARAM: BlockConfigurationOption(
             title="Parameters",
             description="Parameters to select and plot (e.g. '2t', 'msl')",
-            value_type="list[str]",
+            value_type=ListType(StringType()),
         ),
         DOMAIN: BlockConfigurationOption(
             title="Domain",
             description="Area to display: auto (fit the data), global, a named region/country (select several to union), or a drawn bounding box",
-            value_type="geodomain",
+            value_type=GeoDomainType(),
             default_value="global",
         ),
         FORMAT: BlockConfigurationOption(
             title="Format",
             description="Output image format",
-            value_type="enumClosed['png', 'pdf', 'svg']",
+            value_type=ClosedEnumType(["png", "pdf", "svg"]),
             default_value="png",
         ),
         GROUPBY: BlockConfigurationOption(
             title="Group By",
             description="Dimension to create subplots over",
-            value_type="enumClosed['valid_datetime', 'step', 'number', 'none']",
+            value_type=ClosedEnumType(["valid_datetime", "step", "number", "none"]),
             default_value="none",
         ),
         SPLITBY: BlockConfigurationOption(
             title="Split By",
             description="Dimensions to separate plots by",
-            value_type="list[str]",
+            value_type=ListType(StringType()),
             default_value="step",
         ),
         # ConfigurationOptionId("style_schema"): BlockConfigurationOption(
         #     title="Style Schema",
         #     description="earthkit-plots schema identifier",
-        #     value_type="str",
+        #     value_type=StringType(),
         # ),
     }
     inputs: list[str] = ["dataset"]

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/templates/aifs_forecast.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/templates/aifs_forecast.py
@@ -16,6 +16,7 @@ from fiab_core.fable import (
     BlueprintTemplateExampleInput,
     ConfigurationOptionId,
 )
+from fiab_core.types import ClosedEnumType
 
 from fiab_plugin_ecmwf.templates.common import (
     GRIB_OUTPUT_PATH,
@@ -80,7 +81,7 @@ template = BlueprintTemplate(
             example_value="opendata",
             display_name="Initial Conditions",
             display_description="Source of the initial conditions",
-            type_hint="enumOpen['mars', 'opendata', 'polytope']",
+            type_hint=ClosedEnumType(["mars", "opendata", "polytope"]),
         ),
         "area": map_area("europe"),
         "plotFormat": MAP_FORMAT,

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/templates/common.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/templates/common.py
@@ -10,6 +10,7 @@
 """Values shared by this plugin's blueprint templates."""
 
 from fiab_core.fable import BlueprintTemplateExampleInput
+from fiab_core.types import ClosedEnumType, StringType, GeoDomainType
 
 # `[shortName]` is the sink's own metadata templating, not a glyph.
 GRIB_OUTPUT_PATH = "${outputRoot}/${runId}__${attemptCount}/[shortName].grib"
@@ -21,14 +22,14 @@ OUTPUT_ROOT = BlueprintTemplateExampleInput(
     example_value="/tmp/outputRoot",
     display_name="Output Root Location",
     display_description="Each attempt writes to its own folder below this path",
-    type_hint="str",
+    type_hint=StringType(),
 )
 
 FORECAST_SOURCE = BlueprintTemplateExampleInput(
     example_value="ecmwf-open-data",
     display_name="Forecast Source",
     display_description="Where to download the forecast from",
-    type_hint="enumClosed['mars', 'ecmwf-open-data']",
+    type_hint=ClosedEnumType(["mars", "ecmwf-open-data"]),
 )
 
 
@@ -38,7 +39,7 @@ def map_area(example_value: str) -> BlueprintTemplateExampleInput:
         example_value=example_value,
         display_name="Map Area",
         display_description="Area the map plot covers",
-        type_hint="geodomain",
+        type_hint=GeoDomainType(),
     )
 
 
@@ -46,5 +47,5 @@ MAP_FORMAT = BlueprintTemplateExampleInput(
     example_value="png",
     display_name="Output Format",
     display_description="Image format for the map plot",
-    type_hint="enumClosed['png', 'pdf', 'svg']",
+    type_hint=ClosedEnumType(["png", "pdf", "svg"]),
 )

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/templates/common.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/templates/common.py
@@ -10,7 +10,7 @@
 """Values shared by this plugin's blueprint templates."""
 
 from fiab_core.fable import BlueprintTemplateExampleInput
-from fiab_core.types import ClosedEnumType, StringType, GeoDomainType
+from fiab_core.types import ClosedEnumType, GeoDomainType, StringType
 
 # `[shortName]` is the sink's own metadata templating, not a glyph.
 GRIB_OUTPUT_PATH = "${outputRoot}/${runId}__${attemptCount}/[shortName].grib"

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/templates/ifs_ensemble_statistics.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/templates/ifs_ensemble_statistics.py
@@ -16,6 +16,7 @@ from fiab_core.fable import (
     BlueprintTemplateExampleInput,
     ConfigurationOptionId,
 )
+from fiab_core.types import ClosedEnumType
 
 from fiab_plugin_ecmwf.templates.common import (
     FORECAST_SOURCE,
@@ -118,7 +119,7 @@ template = BlueprintTemplate(
             example_value="mean",
             display_name="Ensemble Statistic",
             display_description="Statistic to compute over the ensemble",
-            type_hint="enumClosed['mean', 'std']",
+            type_hint=ClosedEnumType(["mean", "std"]),
         ),
     },
 )

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/templates/prototype.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/templates/prototype.py
@@ -15,6 +15,7 @@ from fiab_core.fable import (
     BlueprintTemplateBlock,
     ConfigurationOptionId,
 )
+from fiab_core.types import ClosedEnumType, StringType
 
 from fiab_plugin_ecmwf.templates.common import (
     FORECAST_SOURCE,

--- a/backend/packages/fiab-plugin-ecmwf/tests/runtime/test_anemoi_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/runtime/test_anemoi_blocks.py
@@ -544,7 +544,7 @@ class TestAnemoiCatalogueIntegration:
     """Verify catalogue / enum types at the plugin registration level."""
 
     def test_checkpoint_enum_type_matches_registered_provider(self, registered_provider: None) -> None:
-        assert get_checkpoint_enum_type() == "enumClosed['dummy_store:dummy_ckpt']"
+        assert get_checkpoint_enum_type().serialize() == "enumClosed['dummy_store:dummy_ckpt']"
 
     def test_plugin_expander_includes_anemoi_transform(self, anemoi_source_output: QubedOutput) -> None:
         """AnemoiTransform should appear in expansions for a QubedOutput that has 'param'."""

--- a/backend/packages/fiab-plugin-ecmwf/tests/runtime/test_anemoi_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/runtime/test_anemoi_blocks.py
@@ -544,7 +544,7 @@ class TestAnemoiCatalogueIntegration:
     """Verify catalogue / enum types at the plugin registration level."""
 
     def test_checkpoint_enum_type_matches_registered_provider(self, registered_provider: None) -> None:
-        assert get_checkpoint_enum_type().serialize() == "enumClosed['dummy_store:dummy_ckpt']"
+        assert get_checkpoint_enum_type().serialize() == "enumClosed[str]('dummy_store:dummy_ckpt')"
 
     def test_plugin_expander_includes_anemoi_transform(self, anemoi_source_output: QubedOutput) -> None:
         """AnemoiTransform should appear in expansions for a QubedOutput that has 'param'."""

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -314,10 +314,10 @@ class TestOperationalForecastSource:
 
     def test_catalogue_value_types_are_canonical(self) -> None:
         assert (
-            OperationalForecastSource.configuration_options[ConfigurationOptionId("source")].value_type.serialize()
-            == "enumClosed[mars,ecmwf-open-data]"
+            OperationalForecastSource.configuration_options[ConfigurationOptionId("source")].model_dump()["value_type"]
+            == "enumClosed['mars', 'ecmwf-open-data']"
         )
-        assert OperationalForecastSource.configuration_options[ConfigurationOptionId("base_time")].value_type.serialize() == "datetime"
+        assert OperationalForecastSource.configuration_options[ConfigurationOptionId("base_time")].model_dump()["value_type"] == "datetime"
         assert PARAM not in OperationalForecastSource.configuration_options
         assert STEP not in OperationalForecastSource.configuration_options
         assert ENSEMBLE not in OperationalForecastSource.configuration_options
@@ -325,7 +325,10 @@ class TestOperationalForecastSource:
 
 class TestEnsembleStatistics:
     def test_catalogue_value_type_is_canonical(self) -> None:
-        assert EnsembleStatistics.configuration_options[ConfigurationOptionId("statistic")].value_type.serialize() == "enumClosed[mean,std]"
+        assert (
+            EnsembleStatistics.configuration_options[ConfigurationOptionId("statistic")].model_dump()["value_type"]
+            == "enumClosed['mean', 'std']"
+        )
 
     def test_from_operational_forecast_source(
         self, ensemble_statistics_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
@@ -381,8 +384,8 @@ class TestEnsembleStatistics:
 class TestTemporalStatistics:
     def test_catalogue_value_type_is_canonical(self) -> None:
         assert (
-            TemporalStatistics.configuration_options[ConfigurationOptionId("statistic")].value_type.serialize()
-            == "enumClosed[mean,std,min,max]"
+            TemporalStatistics.configuration_options[ConfigurationOptionId("statistic")].model_dump()["value_type"]
+            == "enumClosed['mean', 'std', 'min', 'max']"
         )
 
     def test_from_operational_forecast_source(
@@ -511,8 +514,8 @@ class TestZarrSink:
 
 class TestSelect:
     def test_catalogue_value_types_are_canonical(self) -> None:
-        assert _select().configuration_options[DIMENSION].value_type.serialize() == "str"
-        assert _select().configuration_options[VALUES].value_type.serialize() == "list[str]"
+        assert _select().configuration_options[DIMENSION].model_dump()["value_type"] == "str"
+        assert _select().configuration_options[VALUES].model_dump()["value_type"] == "list[str]"
 
     def test_from_operational_forecast_source(
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -314,10 +314,10 @@ class TestOperationalForecastSource:
 
     def test_catalogue_value_types_are_canonical(self) -> None:
         assert (
-            OperationalForecastSource.configuration_options[ConfigurationOptionId("source")].value_type
-            == "enumClosed['mars', 'ecmwf-open-data']"
+            OperationalForecastSource.configuration_options[ConfigurationOptionId("source")].value_type.serialize()
+            == "enumClosed[mars,ecmwf-open-data]"
         )
-        assert OperationalForecastSource.configuration_options[ConfigurationOptionId("base_time")].value_type == "datetime"
+        assert OperationalForecastSource.configuration_options[ConfigurationOptionId("base_time")].value_type.serialize() == "datetime"
         assert PARAM not in OperationalForecastSource.configuration_options
         assert STEP not in OperationalForecastSource.configuration_options
         assert ENSEMBLE not in OperationalForecastSource.configuration_options
@@ -325,7 +325,7 @@ class TestOperationalForecastSource:
 
 class TestEnsembleStatistics:
     def test_catalogue_value_type_is_canonical(self) -> None:
-        assert EnsembleStatistics.configuration_options[ConfigurationOptionId("statistic")].value_type == "enumClosed['mean', 'std']"
+        assert EnsembleStatistics.configuration_options[ConfigurationOptionId("statistic")].value_type.serialize() == "enumClosed[mean,std]"
 
     def test_from_operational_forecast_source(
         self, ensemble_statistics_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
@@ -381,8 +381,8 @@ class TestEnsembleStatistics:
 class TestTemporalStatistics:
     def test_catalogue_value_type_is_canonical(self) -> None:
         assert (
-            TemporalStatistics.configuration_options[ConfigurationOptionId("statistic")].value_type
-            == "enumClosed['mean', 'std', 'min', 'max']"
+            TemporalStatistics.configuration_options[ConfigurationOptionId("statistic")].value_type.serialize()
+            == "enumClosed[mean,std,min,max]"
         )
 
     def test_from_operational_forecast_source(
@@ -511,8 +511,8 @@ class TestZarrSink:
 
 class TestSelect:
     def test_catalogue_value_types_are_canonical(self) -> None:
-        assert _select().configuration_options[DIMENSION].value_type == "str"
-        assert _select().configuration_options[VALUES].value_type == "list[str]"
+        assert _select().configuration_options[DIMENSION].value_type.serialize() == "str"
+        assert _select().configuration_options[VALUES].value_type.serialize() == "list[str]"
 
     def test_from_operational_forecast_source(
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -314,10 +314,10 @@ class TestOperationalForecastSource:
 
     def test_catalogue_value_types_are_canonical(self) -> None:
         assert (
-            OperationalForecastSource.configuration_options[ConfigurationOptionId("source")].model_dump()["value_type"]
-            == "enumClosed['mars', 'ecmwf-open-data']"
+            OperationalForecastSource.configuration_options[ConfigurationOptionId("source")].value_type.serialize()
+            == "enumClosed['mars','ecmwf-open-data']"
         )
-        assert OperationalForecastSource.configuration_options[ConfigurationOptionId("base_time")].model_dump()["value_type"] == "datetime"
+        assert OperationalForecastSource.configuration_options[ConfigurationOptionId("base_time")].value_type.serialize() == "datetime"
         assert PARAM not in OperationalForecastSource.configuration_options
         assert STEP not in OperationalForecastSource.configuration_options
         assert ENSEMBLE not in OperationalForecastSource.configuration_options
@@ -326,8 +326,8 @@ class TestOperationalForecastSource:
 class TestEnsembleStatistics:
     def test_catalogue_value_type_is_canonical(self) -> None:
         assert (
-            EnsembleStatistics.configuration_options[ConfigurationOptionId("statistic")].model_dump()["value_type"]
-            == "enumClosed['mean', 'std']"
+            EnsembleStatistics.configuration_options[ConfigurationOptionId("statistic")].value_type.serialize()
+            == "enumClosed['mean','std']"
         )
 
     def test_from_operational_forecast_source(
@@ -384,8 +384,8 @@ class TestEnsembleStatistics:
 class TestTemporalStatistics:
     def test_catalogue_value_type_is_canonical(self) -> None:
         assert (
-            TemporalStatistics.configuration_options[ConfigurationOptionId("statistic")].model_dump()["value_type"]
-            == "enumClosed['mean', 'std', 'min', 'max']"
+            TemporalStatistics.configuration_options[ConfigurationOptionId("statistic")].value_type.serialize()
+            == "enumClosed['mean','std','min','max']"
         )
 
     def test_from_operational_forecast_source(
@@ -514,8 +514,8 @@ class TestZarrSink:
 
 class TestSelect:
     def test_catalogue_value_types_are_canonical(self) -> None:
-        assert _select().configuration_options[DIMENSION].model_dump()["value_type"] == "str"
-        assert _select().configuration_options[VALUES].model_dump()["value_type"] == "list[str]"
+        assert _select().configuration_options[DIMENSION].value_type.serialize() == "str"
+        assert _select().configuration_options[VALUES].value_type.serialize() == "list[str]"
 
     def test_from_operational_forecast_source(
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
@@ -597,7 +597,7 @@ class TestSelect:
         restrictions = (
             plugin().validator(BlockFactoryId("select"), config.block, {"dataset": operational_forecast_source_output}).restrictions
         )
-        assert restrictions[VALUES].serialize() == "list[enumClosed[0,6,12]]"
+        assert restrictions[VALUES].serialize() == "list[enumClosed['0','6','12']]"
 
     def test_validator_keeps_restrictions_when_configuration_is_missing(
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
@@ -804,7 +804,7 @@ class TestMapPlotSink:
             .validator(BlockFactoryId("mapPlotSink"), map_plot_sink_configuration.block, {"dataset": operational_forecast_source_output})
             .restrictions
         )
-        assert restrictions[PARAM].serialize() == "list[enumClosed[2t,msl,u]]"
+        assert restrictions[PARAM].serialize() == "list[enumClosed['2t','msl','u']]"
 
     def test_expander_has_no_parameters_restrictions(self, operational_forecast_source_output: QubedOutput) -> None:
         expansions = plugin().expander(operational_forecast_source_output)

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -636,7 +636,7 @@ class TestSelect:
 
 
 def test_anemoi_catalogue_value_types_are_canonical(registered_provider: None) -> None:
-    assert get_checkpoint_enum_type() == "enumClosed['dummy_store:dummy_ckpt']"
+    assert get_checkpoint_enum_type().serialize() == "enumClosed['dummy_store:dummy_ckpt']"
 
 
 class TestGribSink:

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -315,7 +315,7 @@ class TestOperationalForecastSource:
     def test_catalogue_value_types_are_canonical(self) -> None:
         assert (
             OperationalForecastSource.configuration_options[ConfigurationOptionId("source")].value_type.serialize()
-            == "enumClosed['mars','ecmwf-open-data']"
+            == "enumClosed[str]('mars','ecmwf-open-data')"
         )
         assert OperationalForecastSource.configuration_options[ConfigurationOptionId("base_time")].value_type.serialize() == "datetime"
         assert PARAM not in OperationalForecastSource.configuration_options
@@ -327,7 +327,7 @@ class TestEnsembleStatistics:
     def test_catalogue_value_type_is_canonical(self) -> None:
         assert (
             EnsembleStatistics.configuration_options[ConfigurationOptionId("statistic")].value_type.serialize()
-            == "enumClosed['mean','std']"
+            == "enumClosed[str]('mean','std')"
         )
 
     def test_from_operational_forecast_source(
@@ -385,7 +385,7 @@ class TestTemporalStatistics:
     def test_catalogue_value_type_is_canonical(self) -> None:
         assert (
             TemporalStatistics.configuration_options[ConfigurationOptionId("statistic")].value_type.serialize()
-            == "enumClosed['mean','std','min','max']"
+            == "enumClosed[str]('mean','std','min','max')"
         )
 
     def test_from_operational_forecast_source(
@@ -597,7 +597,7 @@ class TestSelect:
         restrictions = (
             plugin().validator(BlockFactoryId("select"), config.block, {"dataset": operational_forecast_source_output}).restrictions
         )
-        assert restrictions[VALUES].serialize() == "list[enumClosed['0','6','12']]"
+        assert restrictions[VALUES].serialize() == "list[enumClosed[str]('0','6','12')]"
 
     def test_validator_keeps_restrictions_when_configuration_is_missing(
         self, select_configuration: BlockInstance, operational_forecast_source_output: QubedOutput
@@ -636,7 +636,7 @@ class TestSelect:
 
 
 def test_anemoi_catalogue_value_types_are_canonical(registered_provider: None) -> None:
-    assert get_checkpoint_enum_type().serialize() == "enumClosed['dummy_store:dummy_ckpt']"
+    assert get_checkpoint_enum_type().serialize() == "enumClosed[str]('dummy_store:dummy_ckpt')"
 
 
 class TestGribSink:
@@ -804,7 +804,7 @@ class TestMapPlotSink:
             .validator(BlockFactoryId("mapPlotSink"), map_plot_sink_configuration.block, {"dataset": operational_forecast_source_output})
             .restrictions
         )
-        assert restrictions[PARAM].serialize() == "list[enumClosed['2t','msl','u']]"
+        assert restrictions[PARAM].serialize() == "list[enumClosed[str]('2t','msl','u')]"
 
     def test_expander_has_no_parameters_restrictions(self, operational_forecast_source_output: QubedOutput) -> None:
         expansions = plugin().expander(operational_forecast_source_output)

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_templates.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_templates.py
@@ -109,7 +109,7 @@ def test_option_value_matches_its_type(template: BlueprintTemplate, block_id: Bl
         pytest.skip("intrinsic glyph -- the value only exists at run time")
     resolved = _GLYPH.sub(lambda m: template.example_glyphs[_leading_identifier(m.group(1))].example_value, raw)
 
-    value_type, _ = parse(_factory(template, block_id).configuration_options[option_id].value_type)
+    value_type = parse(_factory(template, block_id).configuration_options[option_id].value_type)
     try:
         value_type.validate_convert(resolved)
     except WrongType as exc:
@@ -145,7 +145,7 @@ def test_example_glyph_values_match_their_own_type_hint(template: BlueprintTempl
             f"{name} must state its own type: templates are self-contained and the client "
             "does not infer types from the catalogue or from validation"
         )
-        value_type, _ = parse(example.type_hint)
+        value_type = parse(example.type_hint)
         try:
             value_type.validate_convert(example.example_value)
         except WrongType as exc:

--- a/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
+++ b/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
@@ -23,7 +23,7 @@ from fiab_core.fable import (
     RawOutput,
 )
 from fiab_core.plugin import BlockValidation, Error, Plugin
-from fiab_core.types import FableType, parse
+from fiab_core.types import ClosedEnumType, FableType, FloatType, IntType, StringType, parse
 
 TEXT = ConfigurationOptionId("text")
 DURATION = ConfigurationOptionId("duration")
@@ -32,10 +32,10 @@ AMOUNT = ConfigurationOptionId("amount")
 FNAME = ConfigurationOptionId("fname")
 
 
-def _get_checkpoint_enum_type() -> str:
+def _get_checkpoint_enum_type() -> FableType:
     available = ArtifactsProvider.get_artifacts_lookup()
-    values = ", ".join(f"'{CompositeArtifactId.to_str(k)}'" for k in available.keys())
-    return f"enumClosed[{values}]"
+    values = [CompositeArtifactId.to_str(k) for k in available]
+    return ClosedEnumType(values)
 
 
 catalogue = lambda: BlockFactoryCatalogue(
@@ -51,7 +51,7 @@ catalogue = lambda: BlockFactoryCatalogue(
             kind="source",
             title="Source Text",
             description="Returns the input text",
-            configuration_options={TEXT: BlockConfigurationOption(title="", description="", value_type="str")},
+            configuration_options={TEXT: BlockConfigurationOption(title="", description="", value_type=StringType())},
             inputs=[],
         ),
         BlockFactoryId("source_sleep"): BlockFactory(
@@ -59,8 +59,8 @@ catalogue = lambda: BlockFactoryCatalogue(
             title="Source Sleep",
             description="Sleeps for a duration, then retuns the input text",
             configuration_options={
-                TEXT: BlockConfigurationOption(title="", description="", value_type="str"),
-                DURATION: BlockConfigurationOption(title="", description="", value_type="float"),
+                TEXT: BlockConfigurationOption(title="", description="", value_type=StringType()),
+                DURATION: BlockConfigurationOption(title="", description="", value_type=FloatType()),
             },
             inputs=[],
         ),
@@ -81,7 +81,7 @@ catalogue = lambda: BlockFactoryCatalogue(
             kind="transform",
             title="Increment",
             description="Adds the amount to the input",
-            configuration_options={AMOUNT: BlockConfigurationOption(title="", description="", value_type="int")},
+            configuration_options={AMOUNT: BlockConfigurationOption(title="", description="", value_type=IntType())},
             inputs=["a"],
         ),
         BlockFactoryId("product_join"): BlockFactory(
@@ -95,7 +95,7 @@ catalogue = lambda: BlockFactoryCatalogue(
             kind="sink",
             title="File",
             description="Saves the input to a file",
-            configuration_options={FNAME: BlockConfigurationOption(title="", description="", value_type="str")},
+            configuration_options={FNAME: BlockConfigurationOption(title="", description="", value_type=StringType())},
             inputs=["data"],
         ),
         BlockFactoryId("sink_image"): BlockFactory(

--- a/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
+++ b/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
@@ -112,7 +112,7 @@ catalogue = lambda: BlockFactoryCatalogue(
 def validator(factory_id: BlockFactoryId, instance: BlockInstance, inputs: dict[str, BlockInstanceOutput]) -> BlockValidation:
     restrictions: ConfigurationOptionRestriction = {}
     if factory_id == BlockFactoryId("transform_increment"):
-        restrictions = {AMOUNT: parse("enumClosed[1,2,3]")[0]}
+        restrictions = {AMOUNT: parse("enumClosed[1,2,3]")}
     if factory_id in ("sink_file",):
         return BlockValidation(Either.ok(RawOutput(type_fqn="bytes", mime_type="text/plain")), restrictions)
     elif factory_id in ("sink_image",):
@@ -131,7 +131,7 @@ def expander(output: BlockInstanceOutput) -> list[BlockExpansion]:
             return [
                 BlockExpansion(
                     factory=BlockFactoryId("transform_increment"),
-                    restrictions={AMOUNT: parse("enumClosed[1,2,3]")[0]},
+                    restrictions={AMOUNT: parse("enumClosed[1,2,3]")},
                 ),
                 BlockExpansion(factory=BlockFactoryId("product_join")),
                 BlockExpansion(factory=BlockFactoryId("sink_file")),

--- a/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
+++ b/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
@@ -112,7 +112,7 @@ catalogue = lambda: BlockFactoryCatalogue(
 def validator(factory_id: BlockFactoryId, instance: BlockInstance, inputs: dict[str, BlockInstanceOutput]) -> BlockValidation:
     restrictions: ConfigurationOptionRestriction = {}
     if factory_id == BlockFactoryId("transform_increment"):
-        restrictions = {AMOUNT: parse("enumClosed[1,2,3]")}
+        restrictions = {AMOUNT: parse("enumClosed[int](1,2,3)")}
     if factory_id in ("sink_file",):
         return BlockValidation(Either.ok(RawOutput(type_fqn="bytes", mime_type="text/plain")), restrictions)
     elif factory_id in ("sink_image",):
@@ -131,7 +131,7 @@ def expander(output: BlockInstanceOutput) -> list[BlockExpansion]:
             return [
                 BlockExpansion(
                     factory=BlockFactoryId("transform_increment"),
-                    restrictions={AMOUNT: parse("enumClosed[1,2,3]")},
+                    restrictions={AMOUNT: parse("enumClosed[int](1,2,3)")},
                 ),
                 BlockExpansion(factory=BlockFactoryId("product_join")),
                 BlockExpansion(factory=BlockFactoryId("sink_file")),

--- a/backend/packages/fiab-plugin-test/tests/test_base.py
+++ b/backend/packages/fiab-plugin-test/tests/test_base.py
@@ -73,10 +73,7 @@ def test_source_filesize_factory_has_checkpoint_option() -> None:
 
 def test_source_filesize_factory_uses_closed_enum_checkpoint_type() -> None:
     factory = catalogue().factories[BlockFactoryId("source_filesize")]
-    assert (
-        factory.configuration_options[ConfigurationOptionId("checkpoint")].model_dump()["value_type"]
-        == "enumClosed['mystore:mycheckpoint']"
-    )
+    assert factory.configuration_options[ConfigurationOptionId("checkpoint")].value_type.serialize() == "enumClosed['mystore:mycheckpoint']"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/packages/fiab-plugin-test/tests/test_base.py
+++ b/backend/packages/fiab-plugin-test/tests/test_base.py
@@ -73,7 +73,10 @@ def test_source_filesize_factory_has_checkpoint_option() -> None:
 
 def test_source_filesize_factory_uses_closed_enum_checkpoint_type() -> None:
     factory = catalogue().factories[BlockFactoryId("source_filesize")]
-    assert factory.configuration_options[ConfigurationOptionId("checkpoint")].value_type.serialize() == "enumClosed[mystore:mycheckpoint]"
+    assert (
+        factory.configuration_options[ConfigurationOptionId("checkpoint")].model_dump()["value_type"]
+        == "enumClosed['mystore:mycheckpoint']"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/packages/fiab-plugin-test/tests/test_base.py
+++ b/backend/packages/fiab-plugin-test/tests/test_base.py
@@ -73,7 +73,7 @@ def test_source_filesize_factory_has_checkpoint_option() -> None:
 
 def test_source_filesize_factory_uses_closed_enum_checkpoint_type() -> None:
     factory = catalogue().factories[BlockFactoryId("source_filesize")]
-    assert factory.configuration_options[ConfigurationOptionId("checkpoint")].value_type == "enumClosed['mystore:mycheckpoint']"
+    assert factory.configuration_options[ConfigurationOptionId("checkpoint")].value_type.serialize() == "enumClosed[mystore:mycheckpoint]"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/packages/fiab-plugin-test/tests/test_base.py
+++ b/backend/packages/fiab-plugin-test/tests/test_base.py
@@ -73,7 +73,10 @@ def test_source_filesize_factory_has_checkpoint_option() -> None:
 
 def test_source_filesize_factory_uses_closed_enum_checkpoint_type() -> None:
     factory = catalogue().factories[BlockFactoryId("source_filesize")]
-    assert factory.configuration_options[ConfigurationOptionId("checkpoint")].value_type.serialize() == "enumClosed['mystore:mycheckpoint']"
+    assert (
+        factory.configuration_options[ConfigurationOptionId("checkpoint")].value_type.serialize()
+        == "enumClosed[str]('mystore:mycheckpoint')"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/src/forecastbox/domain/blueprint/configuration_values.py
+++ b/backend/src/forecastbox/domain/blueprint/configuration_values.py
@@ -25,9 +25,9 @@ def convert_known_configuration_values(
             continue
         raw_value = block_instance.configuration_values[option_id]
         try:
-            converted[option_id] = option.parsed_value_type.validate_convert(raw_value)
+            converted[option_id] = option.value_type.validate_convert(raw_value)
         except (TypeError, WrongType) as exc:
-            errors.append(f"Invalid value for configuration option {option_id!r}: expected {option.value_type}. {exc}")
+            errors.append(f"Invalid value for configuration option {option_id!r}: expected {option.value_type.serialize()}. {exc}")
     if errors:
         return Either.error(errors)
     return Either.ok(converted)

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -95,7 +95,7 @@ class SerializedBlockExpansion(FiabBaseModel):
     plugin: PluginCompositeId
     factory: BlockFactoryId
     restrictions: dict[ConfigurationOptionId, str] = Field(default_factory=dict)
-    """Serialized FableType restrictions (e.g., 'int', 'enumClosed[a,b]')"""
+    """Serialized FableType restrictions (e.g., 'int', "enumClosed['a','b']")"""
 
 
 class RoutableBlock(FiabBaseModel):

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -95,7 +95,7 @@ class SerializedBlockExpansion(FiabBaseModel):
     plugin: PluginCompositeId
     factory: BlockFactoryId
     restrictions: dict[ConfigurationOptionId, str] = Field(default_factory=dict)
-    """Serialized FableType restrictions (e.g., 'int', "enumClosed['a','b']")"""
+    """Serialized FableType restrictions (e.g., 'int', "enumClosed[str]('a','b')")"""
 
 
 class RoutableBlock(FiabBaseModel):

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -470,7 +470,7 @@ def test_blueprint_expand(tmpdir: Any, backend_client_user: httpx.Client) -> Non
             {
                 "plugin": {"store": "localTest", "local": "single"},
                 "factory": "transform_increment",
-                "restrictions": {"amount": "enumClosed['1','2','3']"},
+                "restrictions": {"amount": "enumClosed[int](1,2,3)"},
             },
             {"plugin": {"store": "localTest", "local": "single"}, "factory": "product_join", "restrictions": {}},
             {"plugin": {"store": "localTest", "local": "single"}, "factory": "sink_file", "restrictions": {}},
@@ -494,7 +494,7 @@ def test_blueprint_expand(tmpdir: Any, backend_client_user: httpx.Client) -> Non
         {
             "plugin": {"store": "localTest", "local": "single"},
             "factory": "transform_increment",
-            "restrictions": {"amount": "enumClosed['1','2','3']"},
+            "restrictions": {"amount": "enumClosed[int](1,2,3)"},
         },
         {"plugin": {"store": "localTest", "local": "single"}, "factory": "product_join", "restrictions": {}},
         {"plugin": {"store": "localTest", "local": "single"}, "factory": "sink_file", "restrictions": {}},
@@ -606,7 +606,7 @@ def test_blueprint_expand(tmpdir: Any, backend_client_user: httpx.Client) -> Non
 def test_blueprint_expand_restrictions(backend_client_user: httpx.Client) -> None:
     """The expand endpoint carries non-empty restrictions from test plugin hooks.
 
-    The test plugin returns enumClosed['1','2','3'] as a restriction on the 'amount'
+    The test plugin returns enumClosed[int](1,2,3) as a restriction on the 'amount'
     configuration option when expanding an int-producing block to transform_increment.
     It also returns the same restriction for transform_increment's own configuration.
     This test verifies both restrictions survive the full route round-trip.
@@ -630,8 +630,8 @@ def test_blueprint_expand_restrictions(backend_client_user: httpx.Client) -> Non
 
     expansions = response.json()["possible_expansions"]["source_42"]
     increment_expansion = next(e for e in expansions if e["factory"] == "transform_increment")
-    assert increment_expansion["restrictions"] == {"amount": "enumClosed['1','2','3']"}, (
-        "transform_increment expansion must carry an enumClosed['1','2','3'] restriction on 'amount'"
+    assert increment_expansion["restrictions"] == {"amount": "enumClosed[int](1,2,3)"}, (
+        "transform_increment expansion must carry an enumClosed[int](1,2,3) restriction on 'amount'"
     )
 
     transform_increment = RoutableBlock(
@@ -651,7 +651,7 @@ def test_blueprint_expand_restrictions(backend_client_user: httpx.Client) -> Non
     )
     response = backend_client_user.request(url="/blueprint/expand", method="put", json=builder.model_dump())
     assert response.is_success, response.text
-    assert response.json()["configuration_restrictions"]["transform_increment"] == {"amount": "enumClosed['1','2','3']"}
+    assert response.json()["configuration_restrictions"]["transform_increment"] == {"amount": "enumClosed[int](1,2,3)"}
 
 
 def test_blueprint_expand_missing_glyph_warnings(tmpdir: Any, backend_client_user: httpx.Client) -> None:

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -470,7 +470,7 @@ def test_blueprint_expand(tmpdir: Any, backend_client_user: httpx.Client) -> Non
             {
                 "plugin": {"store": "localTest", "local": "single"},
                 "factory": "transform_increment",
-                "restrictions": {"amount": "enumClosed[1,2,3]"},
+                "restrictions": {"amount": "enumClosed['1','2','3']"},
             },
             {"plugin": {"store": "localTest", "local": "single"}, "factory": "product_join", "restrictions": {}},
             {"plugin": {"store": "localTest", "local": "single"}, "factory": "sink_file", "restrictions": {}},
@@ -494,7 +494,7 @@ def test_blueprint_expand(tmpdir: Any, backend_client_user: httpx.Client) -> Non
         {
             "plugin": {"store": "localTest", "local": "single"},
             "factory": "transform_increment",
-            "restrictions": {"amount": "enumClosed[1,2,3]"},
+            "restrictions": {"amount": "enumClosed['1','2','3']"},
         },
         {"plugin": {"store": "localTest", "local": "single"}, "factory": "product_join", "restrictions": {}},
         {"plugin": {"store": "localTest", "local": "single"}, "factory": "sink_file", "restrictions": {}},
@@ -606,7 +606,7 @@ def test_blueprint_expand(tmpdir: Any, backend_client_user: httpx.Client) -> Non
 def test_blueprint_expand_restrictions(backend_client_user: httpx.Client) -> None:
     """The expand endpoint carries non-empty restrictions from test plugin hooks.
 
-    The test plugin returns enumClosed[1,2,3] as a restriction on the 'amount'
+    The test plugin returns enumClosed['1','2','3'] as a restriction on the 'amount'
     configuration option when expanding an int-producing block to transform_increment.
     It also returns the same restriction for transform_increment's own configuration.
     This test verifies both restrictions survive the full route round-trip.
@@ -630,8 +630,8 @@ def test_blueprint_expand_restrictions(backend_client_user: httpx.Client) -> Non
 
     expansions = response.json()["possible_expansions"]["source_42"]
     increment_expansion = next(e for e in expansions if e["factory"] == "transform_increment")
-    assert increment_expansion["restrictions"] == {"amount": "enumClosed[1,2,3]"}, (
-        "transform_increment expansion must carry an enumClosed[1,2,3] restriction on 'amount'"
+    assert increment_expansion["restrictions"] == {"amount": "enumClosed['1','2','3']"}, (
+        "transform_increment expansion must carry an enumClosed['1','2','3'] restriction on 'amount'"
     )
 
     transform_increment = RoutableBlock(
@@ -651,7 +651,7 @@ def test_blueprint_expand_restrictions(backend_client_user: httpx.Client) -> Non
     )
     response = backend_client_user.request(url="/blueprint/expand", method="put", json=builder.model_dump())
     assert response.is_success, response.text
-    assert response.json()["configuration_restrictions"]["transform_increment"] == {"amount": "enumClosed[1,2,3]"}
+    assert response.json()["configuration_restrictions"]["transform_increment"] == {"amount": "enumClosed['1','2','3']"}
 
 
 def test_blueprint_expand_missing_glyph_warnings(tmpdir: Any, backend_client_user: httpx.Client) -> None:

--- a/frontend/mocks/data/fable.data.ts
+++ b/frontend/mocks/data/fable.data.ts
@@ -55,12 +55,12 @@ export const mockCatalogue: BlockFactoryCatalogue = {
           source: {
             title: 'Source',
             description: 'Top level source for earthkit data',
-            value_type: "enumClosed['mars', 'ecmwf-open-data']",
+            value_type: "enumClosed[str]('mars', 'ecmwf-open-data')",
           },
           forecast: {
             title: 'Forecast model',
             description: 'Name of forecast',
-            value_type: 'enumClosed[aifs-ens,ifs-ens]',
+            value_type: 'enumClosed[str](aifs-ens,ifs-ens)',
             default_value: 'aifs-ens',
           },
           base_time: {
@@ -102,7 +102,7 @@ export const mockCatalogue: BlockFactoryCatalogue = {
           statistic: {
             title: 'Statistic',
             description: 'Statistic to compute over the ensemble',
-            value_type: "enumClosed['mean', 'std']",
+            value_type: "enumClosed[str]('mean', 'std')",
           },
         },
         inputs: ['dataset'],
@@ -120,7 +120,7 @@ export const mockCatalogue: BlockFactoryCatalogue = {
           statistic: {
             title: 'Statistic',
             description: 'Statistic to compute over steps',
-            value_type: "enumClosed['mean', 'std', 'min', 'max']",
+            value_type: "enumClosed[str]('mean', 'std', 'min', 'max')",
           },
         },
         inputs: ['dataset'],

--- a/frontend/mocks/handlers/plugins.handlers.ts
+++ b/frontend/mocks/handlers/plugins.handlers.ts
@@ -311,7 +311,7 @@ export const pluginsHandlers = [
             example_value: 'png',
             display_name: 'Format',
             display_description: 'Output image format.',
-            type_hint: 'enumClosed[png,pdf,svg]',
+            type_hint: 'enumClosed[str](png,pdf,svg)',
           },
           area: {
             example_value: 'Europe',

--- a/frontend/src/components/base/fields/value-type-parser.ts
+++ b/frontend/src/components/base/fields/value-type-parser.ts
@@ -21,15 +21,20 @@
  * - date-iso8601 → date input
  * - list[str] → tag input (badges with add/remove)
  * - list[int] → tag input (badges with add/remove)
- * - enum['a','b','c'] → select dropdown (open: suggestions, accept any string)
- * - enumClosed['a','b','c'] → select dropdown (closed: must be one of the listed)
- * - list[enumClosed[a,b,c]] → multi-select restricted to the listed items
- * - list[enum[a,b,c]] → multi-select with suggestions, accept any string
+ * - enum[str]('a','b','c') → select dropdown (open: suggestions, accept any string)
+ * - enumClosed[str]('a','b','c') → select dropdown (closed: must be one of the listed)
+ * - list[enumClosed[str](a,b,c)] → multi-select restricted to the listed items
+ * - list[enum[str](a,b,c)] → multi-select with suggestions, accept any string
  * - geodomain → geographic-area picker (presets / countries / draw a box)
  * - optional[T] → same widget as T, with optional=true flag
  *
  * `enum`/`enumList` carry `closed: boolean` (closed vs open) for forward
  * compat; no first-party factory emits the open form yet.
+ *
+ * Enum expressions carry an explicit subtype in brackets, e.g.
+ * `enumClosed[str]('a','b')` or `enumOpen[int](1,2)`. Only the `str`
+ * subtype is rendered as a first-class field today; other subtypes fall
+ * back to `unknown`.
  */
 
 import { getAppTimeZone, todayInZone } from '@/lib/datetime'
@@ -126,15 +131,21 @@ export function parseValueType(valueType: string | undefined): ParsedValueType {
     return { type: 'unknown', raw: trimmed }
   }
 
-  // Backend serializes enumClosed/enumOpen; `enum` kept as an alias.
-  const enumMatch = trimmed.match(/^(enum|enumOpen|enumClosed)\[(.+)\]$/i)
+  // Backend serializes enumClosed[subtype](...)/enumOpen[subtype](...); `enum` kept as an alias.
+  // Only the `str` subtype is supported as a first-class field; other subtypes are `unknown`.
+  const enumMatch = trimmed.match(
+    /^(enum|enumOpen|enumClosed)\[(\w+)\]\((.*)\)$/i,
+  )
   if (enumMatch) {
-    const options = parseEnumOptions(enumMatch[2])
-    if (options.length > 0) {
-      return {
-        type: 'enum',
-        options,
-        closed: enumMatch[1].toLowerCase() === 'enumclosed',
+    const subtype = enumMatch[2].toLowerCase()
+    if (subtype === 'str' || subtype === 'string') {
+      const options = parseEnumOptions(enumMatch[3])
+      if (options.length > 0) {
+        return {
+          type: 'enum',
+          options,
+          closed: enumMatch[1].toLowerCase() === 'enumclosed',
+        }
       }
     }
   }

--- a/frontend/tests/integration/components/fields/field-renderer.test.tsx
+++ b/frontend/tests/integration/components/fields/field-renderer.test.tsx
@@ -208,7 +208,7 @@ describe('FieldRenderer Integration', () => {
   describe('Enum field', () => {
     it('renders a select trigger for enum type', async () => {
       const screen = await renderWithProviders(
-        <ControlledFieldRenderer valueType="enum['opt1','opt2','opt3']" />,
+        <ControlledFieldRenderer valueType="enum[str]('opt1','opt2','opt3')" />,
       )
       // SelectTrigger renders a button with role="combobox"
       const trigger = screen.getByRole('combobox')
@@ -217,7 +217,7 @@ describe('FieldRenderer Integration', () => {
 
     it('shows placeholder text', async () => {
       const screen = await renderWithProviders(
-        <ControlledFieldRenderer valueType="enum['opt1','opt2','opt3']" />,
+        <ControlledFieldRenderer valueType="enum[str]('opt1','opt2','opt3')" />,
       )
       await expect
         .element(screen.getByText('Select an option...'))

--- a/frontend/tests/unit/api/endpoints/fable.test.ts
+++ b/frontend/tests/unit/api/endpoints/fable.test.ts
@@ -137,7 +137,7 @@ describe('expandFable', () => {
         ],
       },
       configuration_restrictions: {
-        'block-1': { param1: "enumClosed['value1','value2']" },
+        'block-1': { param1: "enumClosed[str]('value1','value2')" },
       },
       missing_glyphs: {},
     }
@@ -152,7 +152,7 @@ describe('expandFable', () => {
     expect(result.global_errors).toEqual([])
     expect(result.block_errors).toEqual({})
     expect(result.configuration_restrictions).toEqual({
-      'block-1': { param1: "enumClosed['value1','value2']" },
+      'block-1': { param1: "enumClosed[str]('value1','value2')" },
     })
   })
 
@@ -171,7 +171,7 @@ describe('expandFable', () => {
               {
                 plugin: { store: 'ecmwf', local: 'core' },
                 factory: 'model',
-                restrictions: { param1: "enumClosed['value1','value2']" },
+                restrictions: { param1: "enumClosed[str]('value1','value2')" },
               },
             ],
           },

--- a/frontend/tests/unit/api/fable-types.test.ts
+++ b/frontend/tests/unit/api/fable-types.test.ts
@@ -145,7 +145,7 @@ describe('toValidationState', () => {
           {
             plugin: { store: 'ecmwf', local: 'base' },
             factory: 'sink',
-            restrictions: { amount: 'enumClosed[1,2,3]' },
+            restrictions: { amount: 'enumClosed[int](1,2,3)' },
           },
         ],
       },
@@ -164,7 +164,7 @@ describe('toValidationState', () => {
       },
     ])
     expect(result.blockStates.b1.possibleExpansionRestrictions).toEqual({
-      'ecmwf/base:sink': { amount: 'enumClosed[1,2,3]' },
+      'ecmwf/base:sink': { amount: 'enumClosed[int](1,2,3)' },
     })
   })
 
@@ -187,7 +187,7 @@ describe('toValidationState', () => {
       possible_sources: [],
       possible_expansions: {},
       configuration_restrictions: {
-        b1: { param: 'list[enumClosed[2t,msl]]' },
+        b1: { param: 'list[enumClosed[str](2t,msl)]' },
       },
       resolved_configuration_options: {},
       block_output_qubes: {},
@@ -197,11 +197,11 @@ describe('toValidationState', () => {
     const validationState = toValidationState(expansion, fable, mockCatalogue)
 
     expect(validationState.blockStates.b1.configurationRestrictions).toEqual({
-      param: 'list[enumClosed[2t,msl]]',
+      param: 'list[enumClosed[str](2t,msl)]',
     })
     expect(
       getBlockConfigurationRestrictions(fable, validationState, 'b1'),
-    ).toEqual({ param: 'list[enumClosed[2t,msl]]' })
+    ).toEqual({ param: 'list[enumClosed[str](2t,msl)]' })
   })
 })
 

--- a/frontend/tests/unit/components/fields/value-type-parser.test.ts
+++ b/frontend/tests/unit/components/fields/value-type-parser.test.ts
@@ -81,7 +81,7 @@ describe('parseValueType', () => {
     })
 
     it('parses list with closed enum item type', () => {
-      expect(parseValueType('list[enumClosed[2t,msl]]')).toEqual({
+      expect(parseValueType('list[enumClosed[str](2t,msl)]')).toEqual({
         type: 'enumList',
         options: ['2t', 'msl'],
         closed: true,
@@ -89,7 +89,7 @@ describe('parseValueType', () => {
     })
 
     it('parses list with open enum item type', () => {
-      expect(parseValueType("list[enum['a','b']]")).toEqual({
+      expect(parseValueType("list[enum[str]('a','b')]")).toEqual({
         type: 'enumList',
         options: ['a', 'b'],
         closed: false,
@@ -99,7 +99,7 @@ describe('parseValueType', () => {
 
   describe('enum types', () => {
     it('parses single-quoted enum options', () => {
-      expect(parseValueType("enum['a','b','c']")).toEqual({
+      expect(parseValueType("enum[str]('a','b','c')")).toEqual({
         type: 'enum',
         options: ['a', 'b', 'c'],
         closed: false,
@@ -107,7 +107,7 @@ describe('parseValueType', () => {
     })
 
     it('parses double-quoted enum options', () => {
-      expect(parseValueType('enum["x","y","z"]')).toEqual({
+      expect(parseValueType('enum[str]("x","y","z")')).toEqual({
         type: 'enum',
         options: ['x', 'y', 'z'],
         closed: false,
@@ -115,7 +115,7 @@ describe('parseValueType', () => {
     })
 
     it('parses enum with single option', () => {
-      expect(parseValueType("enum['only']")).toEqual({
+      expect(parseValueType("enum[str]('only')")).toEqual({
         type: 'enum',
         options: ['only'],
         closed: false,
@@ -123,7 +123,9 @@ describe('parseValueType', () => {
     })
 
     it('parses enumClosed options', () => {
-      expect(parseValueType("enumClosed['mars','ecmwf-open-data']")).toEqual({
+      expect(
+        parseValueType("enumClosed[str]('mars','ecmwf-open-data')"),
+      ).toEqual({
         type: 'enum',
         options: ['mars', 'ecmwf-open-data'],
         closed: true,
@@ -131,7 +133,7 @@ describe('parseValueType', () => {
     })
 
     it('parses unquoted enumClosed options', () => {
-      expect(parseValueType('enumClosed[2t,msl]')).toEqual({
+      expect(parseValueType('enumClosed[str](2t,msl)')).toEqual({
         type: 'enum',
         options: ['2t', 'msl'],
         closed: true,
@@ -141,7 +143,7 @@ describe('parseValueType', () => {
     // anemoiSource.input_source ships exactly this, spaces and all.
     it('parses enumOpen options as an open enum', () => {
       expect(
-        parseValueType("enumOpen['mars', 'opendata', 'polytope']"),
+        parseValueType("enumOpen[str]('mars', 'opendata', 'polytope')"),
       ).toEqual({
         type: 'enum',
         options: ['mars', 'opendata', 'polytope'],
@@ -222,7 +224,7 @@ describe('parseValueType', () => {
     })
 
     it('preserves enum options when wrapped', () => {
-      expect(parseValueType("optional[enum['a','b']]")).toEqual({
+      expect(parseValueType("optional[enum[str]('a','b')]")).toEqual({
         type: 'enum',
         options: ['a', 'b'],
         closed: false,
@@ -231,12 +233,14 @@ describe('parseValueType', () => {
     })
 
     it('preserves enumClosed options when wrapped', () => {
-      expect(parseValueType("optional[enumClosed['mean','std']]")).toEqual({
-        type: 'enum',
-        options: ['mean', 'std'],
-        closed: true,
-        optional: true,
-      })
+      expect(parseValueType("optional[enumClosed[str]('mean','std')]")).toEqual(
+        {
+          type: 'enum',
+          options: ['mean', 'std'],
+          closed: true,
+          optional: true,
+        },
+      )
     })
 
     it('marks unknown inner as optional unknown', () => {

--- a/frontend/tests/unit/features/fable-builder/components/TemplateParamsDialog.test.tsx
+++ b/frontend/tests/unit/features/fable-builder/components/TemplateParamsDialog.test.tsx
@@ -101,7 +101,7 @@ describe('TemplateParamsDialog — #549 example metadata', () => {
             format: {
               example_value: 'png',
               display_name: 'Format',
-              type_hint: 'enumClosed[png,pdf,svg]',
+              type_hint: 'enumClosed[str](png,pdf,svg)',
             },
             area: {
               example_value: 'Europe',

--- a/frontend/tests/unit/features/fable-builder/stores/fableBuilderStore.test.ts
+++ b/frontend/tests/unit/features/fable-builder/stores/fableBuilderStore.test.ts
@@ -726,7 +726,7 @@ describe('useFableBuilderStore', () => {
               possibleExpansions: [],
               possibleExpansionRestrictions: {
                 'ecmwf/test:transform': {
-                  param: 'list[enumClosed[2t,msl]]',
+                  param: 'list[enumClosed[str](2t,msl)]',
                 },
               },
               configurationRestrictions: {},
@@ -750,7 +750,7 @@ describe('useFableBuilderStore', () => {
       )
       expect(
         useFableBuilderStore.getState().blockConfigurationRestrictions.target,
-      ).toEqual({ param: 'list[enumClosed[2t,msl]]' })
+      ).toEqual({ param: 'list[enumClosed[str](2t,msl)]' })
 
       act(() =>
         useFableBuilderStore.getState().setValidationState(
@@ -869,7 +869,7 @@ describe('useFableBuilderStore', () => {
         useFableBuilderStore
           .getState()
           .setBlockConfigurationRestrictions('block-2', {
-            param: 'list[enumClosed[2t,msl]]',
+            param: 'list[enumClosed[str](2t,msl)]',
           }),
       )
 


### PR DESCRIPTION
1/ Replaces the fable type in BlockConfigurationOption with Annotated, to automatically serde, and get rid of the annoying private attr

2/ Changes enum syntax from eg `enumClosed[a, b]` to `enumClosed[str]('a', 'b')`

#586