### PR TITLE
Bug/improve dataset availability

### DIFF
--- a/backend/src/forecastbox/domain/gateway/service.py
+++ b/backend/src/forecastbox/domain/gateway/service.py
@@ -203,6 +203,28 @@ def status_gateway() -> str:
         assert_never(gateway_connection)
 
 
+def get_current_cascade_proc() -> int | str:
+    """Return an id of the currently active and connected gateway process."""
+    gateway_connection = GatewayConnectionManager.gateway_connection
+    if gateway_connection is None:
+        raise GatewayNotStarted("Gateway was not started")
+    if isinstance(gateway_connection, LocalProcess):
+        if gateway_connection.process.exitcode is not None:
+            raise GatewayExited(gateway_connection.process.exitcode)
+        if gateway_connection.process.pid is None:
+            raise GatewayNotStarted("Gateway process has no pid")
+        return gateway_connection.process.pid
+    elif isinstance(gateway_connection, RemoteTunnel):
+        if tunnel.status(gateway_connection.handle):
+            return uuid.uuid5(uuid.NAMESPACE_OID, repr(gateway_connection.handle)).hex[:8]
+        raise GatewayExited(255)
+    elif isinstance(gateway_connection, RemoteUrl):
+        # TODO put something better here
+        return "unmanaged"
+    else:
+        assert_never(gateway_connection)
+
+
 def stop_gateway() -> None:
     with GatewayConnectionManager.lock:
         gateway_connection = GatewayConnectionManager.gateway_connection

--- a/backend/src/forecastbox/domain/run/background.py
+++ b/backend/src/forecastbox/domain/run/background.py
@@ -24,6 +24,7 @@ from cascade.low.core import TaskId
 from fiab_core.fable import BlockInstanceId
 
 from forecastbox.domain.blueprint.service import BlueprintBuilder
+from forecastbox.domain.gateway.service import get_current_cascade_proc
 from forecastbox.domain.glyphs import global_db
 from forecastbox.domain.glyphs.global_db import GlyphResolutionBuckets
 from forecastbox.domain.glyphs.resolution import (
@@ -126,7 +127,15 @@ def execute_background(
                 )
             except TooLargeEntry as e:
                 logger.warning(f"failed to cache compilation detail for {run_id=}, {attempt_count=}: {repr(e)}")
-            (run_async(db.update_run_runtime(run_id, attempt_count, cascade_job_id=response.job_id, outputs=run_outputs.model_dump())),)
+            run_async(
+                db.update_run_runtime(
+                    run_id,
+                    attempt_count,
+                    cascade_job_id=response.job_id,
+                    cascade_proc=get_current_cascade_proc(),
+                    outputs=run_outputs.model_dump(),
+                )
+            )
         else:
             error = (response.error or "no error provided by cascade")[:255]
             run_async(db.update_run_runtime(run_id, attempt_count, status="failed", error=error))

--- a/backend/src/forecastbox/domain/run/service.py
+++ b/backend/src/forecastbox/domain/run/service.py
@@ -33,12 +33,14 @@ from cascade.gateway import api, client
 from cascade.low.core import DatasetId, TaskId
 from cascade.low.func import Either
 from fiab_core.fable import BlockInstanceId, is_textual
+from pydantic import Field
 
 import forecastbox.domain.blueprint.db as blueprint_db
 import forecastbox.domain.run.db as run_db
 from forecastbox.domain.blueprint.types import BlueprintId
 from forecastbox.domain.experiment.types import ExperimentDefinitionId
-from forecastbox.domain.gateway.service import get_gateway_url
+from forecastbox.domain.gateway.exceptions import GatewayExited, GatewayNotStarted
+from forecastbox.domain.gateway.service import get_current_cascade_proc, get_gateway_url
 from forecastbox.domain.run.background import execute_background
 from forecastbox.domain.run.cascade import RunOutputCharacteristic, RunOutputs, stored_output_max_length
 from forecastbox.domain.run.db import CompilerRuntimeContext
@@ -83,6 +85,7 @@ class RunDetail(FiabBaseModel):
     progress: str | None = None
     cascade_job_id: str | None = None
     available_task_ids: list[TaskId] | None = None
+    lost_task_ids: dict[TaskId, str] = Field(default_factory=dict)
     outputs: dict | None = None
     completed_block_ids: set[BlockInstanceId] | None = None
     planned_block_ids: set[BlockInstanceId] | None = None
@@ -210,11 +213,28 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
     status = cast(RunStatus, execution.status)
 
     # Derive available_task_ids from stored outputs without calling cascade for terminal states:
-    # completed → assume all outputs are available; failed → only those with a locally cached value.
+    # completed → assume all outputs are available while the same gateway process is active;
+    # failed → only those with a locally cached value.
     raw_outputs = cast(dict | None, execution.outputs)
+    stored_cascade_proc = cast(int | str | None, getattr(execution, "cascade_proc", None))
     available_task_ids: list[TaskId] | None
+    lost_task_ids: dict[TaskId, str] = {}
     if status == "completed":
-        available_task_ids = [TaskId(k) for k in (raw_outputs or {}).get("outputs", {}).keys()]
+        try:
+            current_cascade_proc = get_current_cascade_proc()
+        except (GatewayExited, GatewayNotStarted):
+            current_cascade_proc = None
+        if current_cascade_proc is not None and stored_cascade_proc == current_cascade_proc:
+            available_task_ids = [TaskId(k) for k in (raw_outputs or {}).get("outputs", {}).keys()]
+        elif raw_outputs:
+            try:
+                cached_outputs = RunOutputs.model_validate(raw_outputs)
+                available_task_ids = [tid for tid, char in cached_outputs.outputs.items() if char.value is not None]
+                lost_task_ids = {tid: "Gateway Proc changed" for tid, char in cached_outputs.outputs.items() if char.value is None}
+            except Exception:
+                available_task_ids = []
+        else:
+            available_task_ids = []
     elif status == "failed":
         if raw_outputs:
             try:
@@ -256,6 +276,7 @@ async def poll_and_update(execution: Run, detailed_report: bool = False) -> RunD
             progress=progress_override if progress_override is not None else cast(str | None, execution.progress),
             cascade_job_id=cascade_job_id,
             available_task_ids=available_task_ids,
+            lost_task_ids=lost_task_ids,
             outputs=raw_outputs,
             completed_block_ids=completed_block_ids,
             planned_block_ids=planned_block_ids,

--- a/backend/src/forecastbox/routes/run.py
+++ b/backend/src/forecastbox/routes/run.py
@@ -30,6 +30,7 @@ from cascade.low.core import DatasetId, TaskId
 from fastapi import APIRouter, Depends, Response
 from fastapi.exceptions import HTTPException
 from fiab_core.fable import BlockInstanceId
+from pydantic import Field
 
 from forecastbox.domain.auth.users import get_auth_context
 from forecastbox.domain.blueprint.types import BlueprintId
@@ -106,6 +107,7 @@ class RunDetailResponse(FiabBaseModel):
     error: str | None = None
     progress: str | None = None
     cascade_job_id: str | None = None
+    lost_task_ids: dict[TaskId, str] = Field(default_factory=dict)
     outputs: RunOutputsResponse | None = None
     completed_block_ids: list[BlockInstanceId] | None = None
     planned_block_ids: list[BlockInstanceId] | None = None
@@ -186,6 +188,7 @@ def _to_run_detail(domain_detail: service.RunDetail) -> RunDetailResponse:
         error=domain_detail.error,
         progress=domain_detail.progress,
         cascade_job_id=domain_detail.cascade_job_id,
+        lost_task_ids=domain_detail.lost_task_ids,
         outputs=outputs_response,
         completed_block_ids=maybe_list(domain_detail.completed_block_ids),
         planned_block_ids=maybe_list(domain_detail.planned_block_ids),

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -1703,29 +1703,12 @@ def _wait_until_running(client: httpx.Client, run_id: str, sleep: float = 1.0, a
 def test_gateway_restart_with_in_progress_job(tmpdir: Any, backend_client_user: httpx.Client) -> None:
     """Kill the gateway while a job is active; verify the expected status transitions.
 
-    A simple text-output job is submitted and completed before the gateway is killed.
-    After the restart, its output must still be fetchable from the locally cached value.
+    A simple two-output job is submitted and completed before the gateway is killed.
+    After the restart, its cached text output remains available while the uncached
+    binary output is reported as lost.
     """
-    # --- Step 1: submit a simple job that completes quickly and has a textual output ---
-    source_text = RoutableBlock(
-        instance_id=BlockInstanceId("source_text"),
-        plugin=testPluginId,
-        factory=BlockFactoryId("source_text"),
-        instance=BlockInstance(
-            configuration_values=_config({"text": "gateway-restart-test-output"}),
-            input_ids={},
-        ),
-    )
-    text_sink = RoutableBlock(
-        instance_id=BlockInstanceId("text_sink"),
-        plugin=testPluginId,
-        factory=BlockFactoryId("sink_file"),
-        instance=BlockInstance(
-            configuration_values=_config({"fname": f"{tmpdir}/gwrestart_${{runId}}.txt"}),
-            input_ids={"data": BlockInstanceId("source_text")},
-        ),
-    )
-    simple_builder = BlueprintBuilder(blocks=[source_text, text_sink])
+    # --- Step 1: submit a simple job that completes quickly and has textual and binary outputs ---
+    simple_builder = _make_builder_source_and_two_sinks(str(tmpdir))
     simple_save_resp = backend_client_user.post("/blueprint/create", json=BlueprintSaveCommand(builder=simple_builder).model_dump())
     assert simple_save_resp.is_success, simple_save_resp.text
     simple_blueprint_id = simple_save_resp.json()["blueprint_id"]
@@ -1743,6 +1726,9 @@ def test_gateway_restart_with_in_progress_job(tmpdir: Any, backend_client_user: 
     simple_available = [tid for tid, char in simple_outputs.items() if char["is_available"] and "sink_file" in tid]
     assert len(simple_available) == 1, f"Expected exactly one available sink_file task, got: {simple_outputs}"
     simple_sink_task_id = simple_available[0]
+    simple_image_tasks = [tid for tid, char in simple_outputs.items() if char["is_available"] and "sink_image" in tid]
+    assert len(simple_image_tasks) == 1, f"Expected exactly one available sink_image task, got: {simple_outputs}"
+    simple_image_task_id = simple_image_tasks[0]
 
     # Sanity check: output is accessible while cascade is still up
     content_resp = backend_client_user.get("/run/outputContent", params={"run_id": simple_run_id, "dataset_id": simple_sink_task_id})
@@ -1812,6 +1798,12 @@ def test_gateway_restart_with_in_progress_job(tmpdir: Any, backend_client_user: 
         return None
 
     retry_until(poll_evicted, verify_evicted, attempts=30, sleep=1.0, error_msg=f"Run {run_id} never reached 'evicted from gateway'")
+
+    # The completed job's cached text output remains available, while its uncached binary output is lost.
+    restarted_simple_detail = backend_client_user.get("/run/get", params={"run_id": simple_run_id}).raise_for_status().json()
+    assert restarted_simple_detail["lost_task_ids"] == {simple_image_task_id: "Gateway Proc changed"}
+    assert restarted_simple_detail["outputs"]["outputs"][simple_sink_task_id]["is_available"] is True
+    assert restarted_simple_detail["outputs"]["outputs"][simple_image_task_id]["is_available"] is False
 
     # --- Step 4: verify the completed simple job's text output is still fetchable ---
     # The gateway no longer holds the result, but it must be served from the local DB cache.

--- a/backend/tests/unit/domain/gateway/test_service.py
+++ b/backend/tests/unit/domain/gateway/test_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -67,3 +67,39 @@ def test_launch_gateway_local_forwards_shared_path_to_process_args(monkeypatch: 
     assert captured["target"] is gateway_service._local_process_entrypoint
     assert captured["args"][3] == "/mnt/shared"
     gateway_service.GatewayConnectionManager.gateway_connection = None
+
+
+def test_get_current_cascade_proc_returns_local_pid(monkeypatch: pytest.MonkeyPatch) -> None:
+    process = type("Process", (), {"pid": 42, "exitcode": None})()
+    connection = gateway_service.LocalProcess(
+        logs_directory=cast(Any, object()),
+        process=process,
+        gateway_url="tcp://localhost:1234",
+    )
+    monkeypatch.setattr(gateway_service.GatewayConnectionManager, "gateway_connection", connection)
+
+    assert gateway_service.get_current_cascade_proc() == 42
+
+
+def test_get_current_cascade_proc_returns_unmanaged_for_remote_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(gateway_service.GatewayConnectionManager, "gateway_connection", gateway_service.RemoteUrl())
+
+    assert gateway_service.get_current_cascade_proc() == "unmanaged"
+
+
+def test_get_current_cascade_proc_identifies_remote_tunnel(monkeypatch: pytest.MonkeyPatch) -> None:
+    handle = gateway_service.tunnel.ConnectionHandle(
+        host="gateway.example",
+        control_path="/tmp/control",
+        local_port=1234,
+        remote_port=5678,
+    )
+    connection = gateway_service.RemoteTunnel(handle=handle)
+    monkeypatch.setattr(gateway_service.GatewayConnectionManager, "gateway_connection", connection)
+    monkeypatch.setattr(gateway_service.tunnel, "status", lambda _: True)
+
+    process_id = gateway_service.get_current_cascade_proc()
+
+    assert isinstance(process_id, str)
+    assert len(process_id) == 8
+    assert process_id == gateway_service.get_current_cascade_proc()

--- a/backend/tests/unit/domain/run/test_service.py
+++ b/backend/tests/unit/domain/run/test_service.py
@@ -265,3 +265,25 @@ async def test_poll_and_update_failed_job_exposes_cached_values_as_available() -
     assert detail.status == "failed"
     # Only the task with a locally cached value is available
     assert detail.available_task_ids == [TaskId("task-text")]
+
+
+@pytest.mark.asyncio
+async def test_poll_and_update_completed_job_with_changed_gateway_exposes_cached_values_and_lost_tasks() -> None:
+    outputs = RunOutputs(
+        outputs={
+            TaskId("task-text"): RunOutputCharacteristic(
+                original_block=BlockInstanceId("sink"), mime_type="text/plain", value="cached output"
+            ),
+            TaskId("task-image"): RunOutputCharacteristic(original_block=BlockInstanceId("sink2"), mime_type="image/png", value=None),
+        }
+    )
+    execution = _make_running_execution(outputs)
+    execution.status = "completed"
+    execution.cascade_proc = 41
+
+    with patch("forecastbox.domain.run.service.get_current_cascade_proc", return_value=42):
+        detail = await service.poll_and_update(cast(Run, execution))
+
+    assert detail.status == "completed"
+    assert detail.available_task_ids == [TaskId("task-text")]
+    assert detail.lost_task_ids == {TaskId("task-image"): "Gateway Proc changed"}

--- a/frontend/mocks/data/job.data.ts
+++ b/frontend/mocks/data/job.data.ts
@@ -48,6 +48,7 @@ const seedExecutions: Array<JobExecutionDetail> = [
     error: null,
     progress: '100',
     cascade_job_id: 'cascade-001',
+    lost_task_ids: {},
     outputs: {
       'task-out-1': {
         mime_type: 'image/png',
@@ -86,6 +87,7 @@ const seedExecutions: Array<JobExecutionDetail> = [
     error: null,
     progress: '45',
     cascade_job_id: 'cascade-002',
+    lost_task_ids: {},
     outputs: {
       'task-out-4': {
         mime_type: 'image/png',
@@ -107,6 +109,7 @@ const seedExecutions: Array<JobExecutionDetail> = [
     error: 'Worker process exited with code 137 (OOM killed)',
     progress: '62',
     cascade_job_id: 'cascade-003',
+    lost_task_ids: {},
     outputs: {},
     completed_block_ids: null,
     planned_block_ids: null,
@@ -122,6 +125,7 @@ const seedExecutions: Array<JobExecutionDetail> = [
     error: null,
     progress: '0',
     cascade_job_id: null,
+    lost_task_ids: {},
     outputs: null,
   },
 ]
@@ -140,6 +144,7 @@ export const mixedAvailabilityExecution: JobExecutionDetail = {
   error: null,
   progress: '70',
   cascade_job_id: 'cascade-005',
+  lost_task_ids: {},
   outputs: {
     'task-out-5a': {
       mime_type: 'image/png',
@@ -169,6 +174,7 @@ export const opaqueMimeExecution: JobExecutionDetail = {
   error: null,
   progress: '100',
   cascade_job_id: 'cascade-006',
+  lost_task_ids: {},
   outputs: {
     'task-out-6': {
       mime_type: 'application/octet-stream',
@@ -193,6 +199,7 @@ export const noStoredOutputsExecution: JobExecutionDetail = {
   error: null,
   progress: '100',
   cascade_job_id: 'cascade-007',
+  lost_task_ids: {},
   outputs: null,
   completed_block_ids: null,
   planned_block_ids: null,
@@ -238,6 +245,7 @@ export function addExecution(request: JobExecuteRequest): JobExecuteResponse {
     error: null,
     progress: '0',
     cascade_job_id: null,
+    lost_task_ids: {},
     outputs: null,
   }
   return { run_id, attempt_count: 1 }

--- a/frontend/src/api/types/job.types.ts
+++ b/frontend/src/api/types/job.types.ts
@@ -51,7 +51,8 @@ export const RunOutputsSchema = z
 
 /** routes/run.py: JobExecutionDetail. `*_block_ids` are only set on
  * /run/get and clear to `null` on terminal status, so both `null` and
- * `undefined` are valid wire shapes. */
+ * `undefined` are valid wire shapes. `lost_task_ids` was added after older
+ * backend versions, so an omitted field is treated as an empty map. */
 export const JobExecutionDetailSchema = z.object({
   run_id: z.string(),
   attempt_count: z.number(),
@@ -63,6 +64,7 @@ export const JobExecutionDetailSchema = z.object({
   error: z.string().nullable(),
   progress: z.string().nullable(),
   cascade_job_id: z.string().nullable(),
+  lost_task_ids: z.record(z.string(), z.string()).default({}),
   outputs: RunOutputsSchema.nullable(),
   completed_block_ids: z.array(z.string()).nullable().optional(),
   planned_block_ids: z.array(z.string()).nullable().optional(),

--- a/frontend/tests/integration/features/dashboard/job-status-popover.test.tsx
+++ b/frontend/tests/integration/features/dashboard/job-status-popover.test.tsx
@@ -33,6 +33,7 @@ const mockJobsResponse: JobExecutionList = {
       error: null,
       progress: '45',
       cascade_job_id: null,
+      lost_task_ids: {},
       outputs: null,
     },
     {
@@ -46,6 +47,7 @@ const mockJobsResponse: JobExecutionList = {
       error: null,
       progress: '100',
       cascade_job_id: null,
+      lost_task_ids: {},
       outputs: null,
     },
     {
@@ -59,6 +61,7 @@ const mockJobsResponse: JobExecutionList = {
       error: null,
       progress: '100',
       cascade_job_id: null,
+      lost_task_ids: {},
       outputs: null,
     },
     {
@@ -72,6 +75,7 @@ const mockJobsResponse: JobExecutionList = {
       error: 'OOM',
       progress: '60',
       cascade_job_id: null,
+      lost_task_ids: {},
       outputs: null,
     },
     {
@@ -85,6 +89,7 @@ const mockJobsResponse: JobExecutionList = {
       error: null,
       progress: '0',
       cascade_job_id: null,
+      lost_task_ids: {},
       outputs: null,
     },
   ],

--- a/frontend/tests/unit/api/hooks/useJobStatusCounts.test.tsx
+++ b/frontend/tests/unit/api/hooks/useJobStatusCounts.test.tsx
@@ -35,6 +35,7 @@ const mockJobsResponse: JobExecutionList = {
       error: null,
       progress: '45',
       cascade_job_id: null,
+      lost_task_ids: {},
       outputs: null,
     },
     {
@@ -48,6 +49,7 @@ const mockJobsResponse: JobExecutionList = {
       error: null,
       progress: '100',
       cascade_job_id: null,
+      lost_task_ids: {},
       outputs: null,
     },
     {
@@ -61,6 +63,7 @@ const mockJobsResponse: JobExecutionList = {
       error: 'OOM',
       progress: '60',
       cascade_job_id: null,
+      lost_task_ids: {},
       outputs: null,
     },
     {
@@ -74,6 +77,7 @@ const mockJobsResponse: JobExecutionList = {
       error: null,
       progress: '0',
       cascade_job_id: null,
+      lost_task_ids: {},
       outputs: null,
     },
   ],

--- a/frontend/tests/unit/api/job-types.test.ts
+++ b/frontend/tests/unit/api/job-types.test.ts
@@ -30,6 +30,18 @@ describe('JobExecutionDetailSchema', () => {
     const result = JobExecutionDetailSchema.parse(baseDetail)
     expect(result.completed_block_ids).toBeUndefined()
     expect(result.planned_block_ids).toBeUndefined()
+    expect(result.lost_task_ids).toEqual({})
+  })
+
+  it('parses lost task reasons from completed runs', () => {
+    const result = JobExecutionDetailSchema.parse({
+      ...baseDetail,
+      status: 'completed',
+      lost_task_ids: { 'task-image': 'Gateway Proc changed' },
+    })
+    expect(result.lost_task_ids).toEqual({
+      'task-image': 'Gateway Proc changed',
+    })
   })
 
   it('parses populated block-id arrays from /run/get during a running job', () => {

--- a/frontend/tests/unit/features/journal/adapters.test.ts
+++ b/frontend/tests/unit/features/journal/adapters.test.ts
@@ -77,6 +77,7 @@ const baseRun: JobExecutionDetail = {
   error: null,
   progress: '42.5',
   cascade_job_id: null,
+  lost_task_ids: {},
   outputs: null,
 }
 


### PR DESCRIPTION
Builds on a previous PR which had backend rely on cached values for outputs of completed jobs

In this one, when a gateway has changed since a job has completed (eg due to a laptop restart), we dont even include the other outputs in the available_task_ids,  we instead put them to a new field called lost_task_ids, which is a dict[TaskId, str], where the value is "reason" -- we include like "Gateway Process has changed". In the future, we plan to add like "Gateway has evicted this dataset due to memory pressure", or "Data are not found on the url anymore" (for when the underlying data would be removed -- though this one is dubious bcs of the data-metadata problem)