### PR TITLE
[fix] Rename the map-plot format glyph, which shadowed a Jinja filter

### DIFF
--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/templates/aifs_forecast.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/templates/aifs_forecast.py
@@ -50,7 +50,7 @@ template = BlueprintTemplate(
                 configuration_values={
                     ConfigurationOptionId("param"): "2t,msl",
                     ConfigurationOptionId("domain"): "${area}",
-                    ConfigurationOptionId("format"): "${format}",
+                    ConfigurationOptionId("format"): "${plotFormat}",
                     ConfigurationOptionId("groupby"): "none",
                     # Splitting by param is valid only because two are selected.
                     ConfigurationOptionId("splitby"): "step,param",
@@ -83,6 +83,6 @@ template = BlueprintTemplate(
             type_hint="enumOpen['mars', 'opendata', 'polytope']",
         ),
         "area": map_area("europe"),
-        "format": MAP_FORMAT,
+        "plotFormat": MAP_FORMAT,
     },
 )

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/templates/ifs_ensemble_statistics.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/templates/ifs_ensemble_statistics.py
@@ -85,7 +85,7 @@ template = BlueprintTemplate(
                 configuration_values={
                     ConfigurationOptionId("param"): "2t",
                     ConfigurationOptionId("domain"): "${area}",
-                    ConfigurationOptionId("format"): "${format}",
+                    ConfigurationOptionId("format"): "${plotFormat}",
                     ConfigurationOptionId("groupby"): "none",
                     # A single field at a single step leaves nothing to split on.
                     ConfigurationOptionId("splitby"): "none",
@@ -113,7 +113,7 @@ template = BlueprintTemplate(
         "outputRoot": OUTPUT_ROOT,
         "forecastSource": FORECAST_SOURCE,
         "area": map_area("global"),
-        "format": MAP_FORMAT,
+        "plotFormat": MAP_FORMAT,
         "statistic": BlueprintTemplateExampleInput(
             example_value="mean",
             display_name="Ensemble Statistic",

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/templates/prototype.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/templates/prototype.py
@@ -83,7 +83,7 @@ template = BlueprintTemplate(
                 configuration_values={
                     ConfigurationOptionId("param"): "2t,msl",
                     ConfigurationOptionId("domain"): "${area}",
-                    ConfigurationOptionId("format"): "${format}",
+                    ConfigurationOptionId("format"): "${plotFormat}",
                     ConfigurationOptionId("groupby"): "none",
                     # A single step leaves nothing else to split on.
                     ConfigurationOptionId("splitby"): "param",
@@ -111,6 +111,6 @@ template = BlueprintTemplate(
         "outputRoot": OUTPUT_ROOT,
         "forecastSource": FORECAST_SOURCE,
         "area": map_area("global"),
-        "format": MAP_FORMAT,
+        "plotFormat": MAP_FORMAT,
     },
 )


### PR DESCRIPTION
## Fix 
`${format}` in the ECMWF starter templates resolved during validation but failed on submit with `UndefinedError("'format' is undefined")`, even with a value in `local_glyphs`. 

Renamed to `plotFormat` in all three templates.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
