### PR TITLE
[backend] move wms lens tz to central util

### DIFF
--- a/backend/src/forecastbox/domain/lens/manager.py
+++ b/backend/src/forecastbox/domain/lens/manager.py
@@ -32,6 +32,7 @@ from forecastbox.utility.concurrency.ports import FreePortsManager, NoFreePortsE
 from forecastbox.utility.concurrency.shutdown import shutdown_popen
 from forecastbox.utility.concurrency.synchronization import timed_acquire
 from forecastbox.utility.pydantic import FiabBaseModel
+from forecastbox.utility.time import default_tz_fallback
 
 logger = logging.getLogger(__name__)
 
@@ -117,8 +118,9 @@ def start_skinny_wms(local_path: str) -> LensInstanceId:
             # SkinnyWMS honours this via flask-cors on all endpoints.
             "SKINNYWMS_CORS_ORIGINS": "*",
             # SkinnyWMS localizes naive UTC GRIB datetimes via astimezone(),
-            # shifting advertised times by the host's UTC offset — pin UTC.
-            "TZ": "UTC",
+            # shifting advertised times by the host's UTC offset — we explicitly
+            # use the backend-wide default tz
+            "TZ": default_tz_fallback(),
         }
         process: subprocess.Popen[bytes] = subprocess.Popen(
             cmd,

--- a/backend/src/forecastbox/utility/time.py
+++ b/backend/src/forecastbox/utility/time.py
@@ -7,7 +7,11 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-"""Time and Date related utilities"""
+"""Time and Date related utilities. Centralizes all default tz and conversion
+logic as well, to have a consistent behaviour wrt naive timestamps and UTC etc"""
+
+# NOTE this file should be kept consistent with fiab-core's types handling of
+# datetimes and dates! It would be however odd to make this coupling explicit
 
 import sys
 from datetime import UTC, datetime, timedelta
@@ -23,6 +27,12 @@ TimeQueryReason = Literal[
     "dbref",  # for db inserts and created_at/updated_at
     "pylock_save",  # for creating the pylock.toml.timestamp file utilized by the installer
 ]
+
+
+def default_tz_fallback() -> str:
+    """In situations like launching external lenses, we prefer to override host TZ because
+    gribs are often produced with a tacit assumption of UTCness"""
+    return "UTC"
 
 
 def current_time(reason: TimeQueryReason) -> datetime:


### PR DESCRIPTION
cc @liefra I'm just moving your fix to a "all-datetime-related" util module, to increase chance of maintaining consistency long term