### PR TITLE
Broaden glyph name validation and apply it more broadly

### DIFF
--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -52,6 +52,7 @@ from forecastbox.domain.glyphs import global_db, resolution
 from forecastbox.domain.glyphs.exceptions import GlyphCircularReferenceError
 from forecastbox.domain.glyphs.intrinsic import get_values_and_examples
 from forecastbox.domain.glyphs.resolution import ExtractedGlyphs, expand_glyph_values, merge_glyph_values, remap_glyph_names
+from forecastbox.domain.glyphs.validation import validate_glyph
 from forecastbox.domain.plugin.manager import PluginManager
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.concurrency.manager import execution_manager
@@ -60,6 +61,10 @@ from forecastbox.utility.pydantic import FiabBaseModel
 from forecastbox.utility.time import value_dt2str
 
 logger = logging.getLogger(__name__)
+
+
+CORE_VERSION_MISMATCH_TAG_KEY = "CoreVersionMismatch"
+"""Reserved tag key used to flag a fiab-core major version mismatch; may not be set by callers."""
 
 
 class Tag(FiabBaseModel):
@@ -71,6 +76,17 @@ class Tag(FiabBaseModel):
 
     key: str
     value: str | None = None
+
+
+def tag_name_errors(tags: list[Tag]) -> list[str]:
+    """Return error messages for any tag using a key reserved for system use.
+
+    Does not raise -- callers combine the returned errors with other validation
+    errors before deciding how to surface them.
+    """
+    if any(t.key == CORE_VERSION_MISMATCH_TAG_KEY for t in tags):
+        return [f"Tag key {CORE_VERSION_MISMATCH_TAG_KEY!r} is reserved and may not be set by callers."]
+    return []
 
 
 class PluginBlockFactoryId(FiabBaseModel):
@@ -232,10 +248,12 @@ def _validate_expand_with_buckets(
     available_glyphs = set(all_glyphs_raw.keys())
 
     global_errors: list[str] = []
-    intrinsic_names = set(intrinsic_values.keys())
-    colliding_keys = set(local_glyphs.keys()) & intrinsic_names
-    for key in sorted(colliding_keys):
-        global_errors.append(f"Local glyph key {key!r} is reserved as an intrinsic glyph and cannot be overridden.")
+    for key in sorted(local_glyphs):
+        glyph_validation = validate_glyph(key)
+        if glyph_validation.e is not None:
+            # Soft path: flag the bad local glyph name but keep using its value as-is
+            # for the rest of validation -- this is not a showstopper.
+            global_errors.append(f"Local glyph key {key!r} {glyph_validation.e}.")
 
     # Build lookup and detect duplicate instance ids.
     block_lookup: dict[BlockInstanceId, RoutableBlock] = {}

--- a/backend/src/forecastbox/domain/glyphs/jinja_interpolation.py
+++ b/backend/src/forecastbox/domain/glyphs/jinja_interpolation.py
@@ -172,6 +172,13 @@ def get_custom_functions() -> list[CustomFunction]:
     return list(CUSTOM_FUNCTIONS)
 
 
+def is_jinja_reserved_name(s: str) -> bool:
+    """Return True if `s` collides with a jinja2 filter or global name registered in
+    the interpolation environment (e.g. ``floor_day``, ``timedelta``), and would
+    therefore shadow a built-in function rather than resolve as a glyph."""
+    return s in _FILTER_NAMES
+
+
 def render_expression(raw: str, variables: dict[str, str]) -> str:
     """Render ``raw`` as a Jinja2 template, substituting ``${...}`` expressions.
 

--- a/backend/src/forecastbox/domain/glyphs/validation.py
+++ b/backend/src/forecastbox/domain/glyphs/validation.py
@@ -1,0 +1,34 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Shared validation of glyph names -- used both when a global glyph is created/updated
+and when a BlueprintBuilder's local glyphs are validated.
+
+A glyph name is rejected if it collides with either an intrinsic glyph name (``runId``,
+etc.) or a name reserved by the jinja2 interpolation environment (filters and globals,
+e.g. ``timedelta``, ``floor_day``).
+"""
+
+from cascade.low.func import Either
+
+from forecastbox.domain.glyphs.intrinsic import get_values_and_examples
+from forecastbox.domain.glyphs.jinja_interpolation import is_jinja_reserved_name
+
+
+def validate_glyph(s: str) -> Either[str, str]:  # type: ignore[invalid-argument]
+    """Validate a glyph name against intrinsic glyph names and jinja2 reserved names.
+
+    Returns ``Either.ok(s)`` when ``s`` is a valid glyph name, or ``Either.error(reason)``
+    when it clashes with an intrinsic glyph or a jinja2 reserved keyword.
+    """
+    if s in get_values_and_examples():
+        return Either.error(f"clashes with intrinsic glyph {s!r}")
+    if is_jinja_reserved_name(s):
+        return Either.error(f"clashes with jinja keyword {s!r}")
+    return Either.ok(s)

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -112,8 +112,10 @@ def _ingest_plugin_templates(plugin_id: PluginCompositeId, plugin: Plugin) -> No
     """
     from forecastbox.domain.blueprint.db import find_plugin_template_id, soft_delete_plugin_template, upsert_blueprint
     from forecastbox.domain.blueprint.service import (
+        Tag,
         remap_builder_glyphs,
         resolve_builder_with_examples,
+        tag_name_errors,
         template_to_builder,
         validate_expand_sync,
     )
@@ -150,7 +152,8 @@ def _ingest_plugin_templates(plugin_id: PluginCompositeId, plugin: Plugin) -> No
                 builder = remap_builder_glyphs(builder, glyph_remapping)
             validation_builder = resolve_builder_with_examples(builder, template.example_values, template.example_glyphs)
             result = validate_expand_sync(validation_builder, auth, validate_only=True)
-            all_errors: list[str] = list(result.global_errors)
+            all_errors: list[str] = tag_name_errors([Tag(key=tag) for tag in template.tags])
+            all_errors.extend(result.global_errors)
             for block_errs in result.block_errors.values():
                 all_errors.extend(block_errs)
             if all_errors:

--- a/backend/src/forecastbox/routes/blueprint.py
+++ b/backend/src/forecastbox/routes/blueprint.py
@@ -48,18 +48,21 @@ from forecastbox.domain.blueprint.exceptions import (
     BlueprintVersionConflict,
 )
 from forecastbox.domain.blueprint.service import (
+    CORE_VERSION_MISMATCH_TAG_KEY,
     BlueprintBuilder,
     BlueprintSaveCommand,
     BlueprintValidationExpansion,
     PluginBlockFactoryId,
     SerializedBlockExpansion,
     Tag,
+    tag_name_errors,
 )
 from forecastbox.domain.blueprint.types import BlueprintId
 from forecastbox.domain.glyphs import global_db
 from forecastbox.domain.glyphs.intrinsic import AvailableIntrinsicGlyphs, get_values_and_examples
 from forecastbox.domain.glyphs.jinja_interpolation import get_custom_functions
 from forecastbox.domain.glyphs.types import GlobalGlyphId
+from forecastbox.domain.glyphs.validation import validate_glyph
 from forecastbox.domain.plugin.compatibility import get_fiabcore_version
 from forecastbox.domain.plugin.manager import catalogue_view, plugins_ready
 from forecastbox.schemata.jobs import BlueprintSource
@@ -78,22 +81,10 @@ router = APIRouter(
 )
 
 
-_CORE_VERSION_MISMATCH_KEY = "CoreVersionMismatch"
-
-
 def _maybe_append_coreversion_mismatch(tags: list[Tag], entity_coreversion: int, current_coreversion: int) -> None:
     """Append a ``CoreVersionMismatch`` tag when the stored and current fiab-core major versions differ."""
     if entity_coreversion != current_coreversion:
-        tags.append(Tag(key=_CORE_VERSION_MISMATCH_KEY, value=f"!{entity_coreversion} != {current_coreversion}"))
-
-
-def _reject_reserved_tags(tags: list[Tag]) -> None:
-    """Raise HTTP 422 if any tag uses a key reserved for system use."""
-    if any(t.key == _CORE_VERSION_MISMATCH_KEY for t in tags):
-        raise HTTPException(
-            status_code=422,
-            detail=f"Tag key {_CORE_VERSION_MISMATCH_KEY!r} is reserved and may not be set by callers.",
-        )
+        tags.append(Tag(key=CORE_VERSION_MISMATCH_TAG_KEY, value=f"!{entity_coreversion} != {current_coreversion}"))
 
 
 # ---------------------------------------------------------------------------
@@ -272,12 +263,13 @@ async def create_blueprint(
     glyphs, config errors, intrinsic glyph key collisions, etc.).
     Returns 422 if any of the supplied tags has a reserved key.
     """
-    _reject_reserved_tags(request.tags)
+    tag_errors = tag_name_errors(request.tags)
     validation = await service.validate_expand(request.builder, auth_context, validate_only=True)
-    if validation.global_errors or validation.block_errors:
+    global_errors = tag_errors + validation.global_errors
+    if global_errors or validation.block_errors:
         raise HTTPException(
             status_code=422,
-            detail={"global_errors": validation.global_errors, "block_errors": validation.block_errors},
+            detail={"global_errors": global_errors, "block_errors": validation.block_errors},
         )
     payload = BlueprintSaveCommand(
         builder=request.builder,
@@ -398,12 +390,13 @@ async def update_blueprint(
     Returns 422 if any of the supplied tags has a reserved key.
     Returns the new version number on success.
     """
-    _reject_reserved_tags(request.tags)
+    tag_errors = tag_name_errors(request.tags)
     validation = await service.validate_expand(request.builder, auth_context, validate_only=True)
-    if validation.global_errors or validation.block_errors:
+    global_errors = tag_errors + validation.global_errors
+    if global_errors or validation.block_errors:
         raise HTTPException(
             status_code=422,
-            detail={"global_errors": validation.global_errors, "block_errors": validation.block_errors},
+            detail={"global_errors": global_errors, "block_errors": validation.block_errors},
         )
     payload = BlueprintSaveCommand(
         builder=request.builder,
@@ -602,11 +595,11 @@ async def post_global_glyph(
     must be absent when public=False).
     Returns 403 if a non-admin tries to create a public glyph.
     """
-    intrinsic_names = set(get_values_and_examples().keys())
-    if request.key in intrinsic_names:
+    glyph_validation = validate_glyph(request.key)
+    if glyph_validation.e is not None:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Key {request.key!r} is reserved as an intrinsic glyph and cannot be overridden.",
+            detail=f"Key {request.key!r} {glyph_validation.e}.",
         )
     if request.public and request.overriddable is None:
         raise HTTPException(

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -37,7 +37,7 @@ import pytest
 from fiab_core.fable import BlockFactoryId, BlockInstance, BlockInstanceId, ConfigurationOptionId, PluginCompositeId
 
 from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
-from forecastbox.domain.blueprint.service import BlueprintBuilder, BlueprintSaveCommand, RoutableBlock, Tag
+from forecastbox.domain.blueprint.service import CORE_VERSION_MISMATCH_TAG_KEY, BlueprintBuilder, BlueprintSaveCommand, RoutableBlock, Tag
 from forecastbox.domain.glyphs.intrinsic import AvailableIntrinsicGlyphs
 from forecastbox.routes.run import CompilationDetailResponse, RunCreateResponse
 
@@ -227,6 +227,23 @@ def test_blueprint_save_and_retrieve(backend_client_user: httpx.Client) -> None:
     assert response.is_success, response.text
     ids = [b["blueprint_id"] for b in response.json()["blueprints"]]
     assert saved["blueprint_id"] not in ids, "Blueprint should not appear when created_by does not match"
+
+
+def test_blueprint_create_combines_reserved_tag_and_local_glyph_errors(backend_client_user: httpx.Client) -> None:
+    """A reserved tag key and a reserved local glyph key are both reported together in a
+    single 422 response -- neither check short-circuits the other."""
+    builder = _make_builder_source_only()
+    builder.local_glyphs = {"runId": "should-not-be-allowed"}
+    payload = BlueprintSaveCommand(
+        builder=builder,
+        display_name="Bad Blueprint",
+        tags=[Tag(key=CORE_VERSION_MISMATCH_TAG_KEY)],
+    )
+    response = backend_client_user.post("/blueprint/create", json=payload.model_dump())
+    assert response.status_code == 422, response.text
+    global_errors = response.json()["detail"]["global_errors"]
+    assert any(CORE_VERSION_MISMATCH_TAG_KEY in err for err in global_errors)
+    assert any("runId" in err for err in global_errors)
 
 
 def test_blueprint_retrieve_nonexistent(backend_client_user: httpx.Client) -> None:

--- a/backend/tests/unit/domain/blueprint/test_blueprint_service.py
+++ b/backend/tests/unit/domain/blueprint/test_blueprint_service.py
@@ -27,10 +27,14 @@ from fiab_core.fable import (
 from forecastbox.domain.blueprint.service import (
     BlueprintBuilder,
     RoutableBlock,
+    _validate_expand_with_buckets,
     remap_builder_glyphs,
     resolve_builder_with_examples,
     template_to_builder,
 )
+from forecastbox.domain.glyphs.global_db import GlyphResolutionBuckets
+from forecastbox.domain.glyphs.intrinsic import get_values_and_examples
+from forecastbox.utility.auth import AuthContext
 
 _REAL_PLUGIN_ID = PluginCompositeId(store=PluginStoreId("myStore"), local=PluginId("myPlugin"))
 _BLOCK_A = BlockInstanceId("blockA")
@@ -203,3 +207,45 @@ def test_resolve_builder_with_examples_does_not_mutate_original() -> None:
     original_config = dict(_get_block(builder, _BLOCK_A).instance.configuration_values)
     resolve_builder_with_examples(builder, {_BLOCK_A: {_OPT: BlueprintTemplateExampleInput(example_value="override")}}, {})
     assert _get_block(builder, _BLOCK_A).instance.configuration_values == original_config
+
+
+# ---------------------------------------------------------------------------
+# _validate_expand_with_buckets -- local glyph name validation
+# ---------------------------------------------------------------------------
+
+_AUTH = AuthContext(user_id="tester", is_admin=True)
+_EMPTY_BUCKETS = GlyphResolutionBuckets(public_overriddable={}, user_own={}, public_nonoverridable={})
+
+
+def test_validate_expand_flags_intrinsic_local_glyph_but_does_not_raise() -> None:
+    """A local glyph colliding with an intrinsic name is flagged in global_errors, but
+    validation carries on rather than raising -- the bad glyph is not a showstopper."""
+    intrinsic_name = next(iter(get_values_and_examples()))
+    builder = BlueprintBuilder(local_glyphs={intrinsic_name: "overridden-value"})
+    result = _validate_expand_with_buckets(builder, _AUTH, _EMPTY_BUCKETS, validate_only=True)
+    assert any(intrinsic_name in err and "intrinsic glyph" in err for err in result.global_errors)
+
+
+def test_validate_expand_flags_jinja_reserved_local_glyph() -> None:
+    """A local glyph colliding with a jinja2 reserved keyword is flagged in global_errors."""
+    builder = BlueprintBuilder(local_glyphs={"timedelta": "some-value"})
+    result = _validate_expand_with_buckets(builder, _AUTH, _EMPTY_BUCKETS, validate_only=True)
+    assert any("timedelta" in err and "jinja keyword" in err for err in result.global_errors)
+
+
+def test_validate_expand_no_errors_for_valid_local_glyph() -> None:
+    """A local glyph with a plain, non-reserved name produces no global_errors."""
+    builder = BlueprintBuilder(local_glyphs={"myGlyph": "some-value"})
+    result = _validate_expand_with_buckets(builder, _AUTH, _EMPTY_BUCKETS, validate_only=True)
+    assert result.global_errors == []
+
+
+def test_validate_expand_multiple_bad_local_glyphs_both_flagged() -> None:
+    """Several bad local glyph keys are each individually reported, and validation
+    still completes (no exception, no early abort)."""
+    intrinsic_name = next(iter(get_values_and_examples()))
+    builder = BlueprintBuilder(local_glyphs={intrinsic_name: "v1", "timedelta": "v2", "goodGlyph": "v3"})
+    result = _validate_expand_with_buckets(builder, _AUTH, _EMPTY_BUCKETS, validate_only=True)
+    assert len(result.global_errors) == 2
+    assert any(intrinsic_name in err for err in result.global_errors)
+    assert any("timedelta" in err for err in result.global_errors)

--- a/backend/tests/unit/domain/glyphs/test_validation.py
+++ b/backend/tests/unit/domain/glyphs/test_validation.py
@@ -1,0 +1,67 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Unit tests for domain/glyphs/validation and the jinja-reserved-name predicate."""
+
+from forecastbox.domain.glyphs.intrinsic import get_values_and_examples
+from forecastbox.domain.glyphs.jinja_interpolation import is_jinja_reserved_name
+from forecastbox.domain.glyphs.validation import validate_glyph
+
+# ---------------------------------------------------------------------------
+# is_jinja_reserved_name
+# ---------------------------------------------------------------------------
+
+
+def test_is_jinja_reserved_name_true_for_filter() -> None:
+    assert is_jinja_reserved_name("floor_day") is True
+
+
+def test_is_jinja_reserved_name_true_for_global() -> None:
+    assert is_jinja_reserved_name("timedelta") is True
+    assert is_jinja_reserved_name("datetime") is True
+
+
+def test_is_jinja_reserved_name_false_for_regular_name() -> None:
+    assert is_jinja_reserved_name("myCustomGlyph") is False
+
+
+# ---------------------------------------------------------------------------
+# validate_glyph
+# ---------------------------------------------------------------------------
+
+
+def test_validate_glyph_ok_for_regular_name() -> None:
+    result = validate_glyph("myCustomGlyph")
+    assert result.e is None
+    assert result.t == "myCustomGlyph"
+
+
+def test_validate_glyph_rejects_intrinsic_name() -> None:
+    intrinsic_name = next(iter(get_values_and_examples()))
+    result = validate_glyph(intrinsic_name)
+    assert result.t is None
+    assert result.e is not None
+    assert "intrinsic glyph" in result.e
+    assert repr(intrinsic_name) in result.e
+
+
+def test_validate_glyph_rejects_jinja_reserved_name() -> None:
+    result = validate_glyph("timedelta")
+    assert result.t is None
+    assert result.e is not None
+    assert "jinja keyword" in result.e
+    assert repr("timedelta") in result.e
+
+
+def test_validate_glyph_intrinsic_check_takes_precedence() -> None:
+    # Sanity check: none of the intrinsic names currently collide with jinja reserved
+    # names, so the two checks are independently exercised. If this ever changes, the
+    # intrinsic check should win (it is checked first in validate_glyph).
+    intrinsic_names = set(get_values_and_examples())
+    assert not any(is_jinja_reserved_name(name) for name in intrinsic_names)

--- a/backend/tests/unit/domain/plugins/test_plugin_template_ingest.py
+++ b/backend/tests/unit/domain/plugins/test_plugin_template_ingest.py
@@ -1,0 +1,105 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Unit tests for _ingest_plugin_templates -- in particular that reserved tag keys are
+flagged and combined with validate_expand_sync errors, rather than raising or being
+checked separately."""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock
+
+import pytest
+from fiab_core.fable import PluginCompositeId, PluginId, PluginStoreId
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import forecastbox.domain.blueprint.service as blueprint_service
+import forecastbox.domain.plugin.db as plugin_db
+import forecastbox.schemata.jobs as _jobs_module
+from forecastbox.domain.blueprint.service import CORE_VERSION_MISMATCH_TAG_KEY, BlueprintBuilder, BlueprintValidationExpansion
+from forecastbox.domain.plugin.db import get_plugin_state, upsert_plugin_state
+from forecastbox.domain.plugin.manager import _ingest_plugin_templates
+from forecastbox.schemata.jobs import Base
+
+_PLUGIN_ID = PluginCompositeId(store=PluginStoreId("myStore"), local=PluginId("myPlugin"))
+_PLUGIN_ID_STR = PluginCompositeId.to_str(_PLUGIN_ID)
+
+
+@pytest.fixture
+def mem_session_maker(monkeypatch: pytest.MonkeyPatch) -> Generator[sessionmaker[Session], None, None]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    maker = sessionmaker(engine, expire_on_commit=False)
+    monkeypatch.setattr(_jobs_module, "sync_session_maker", maker)
+    monkeypatch.setattr(plugin_db._jobs_module, "sync_session_maker", maker)
+    yield maker
+    engine.dispose()
+
+
+def _make_template(tags: list[str]) -> MagicMock:
+    template = MagicMock()
+    template.display_name = "my_template"
+    template.display_description = "desc"
+    template.tags = tags
+    template.example_values = {}
+    template.example_glyphs = {}
+    template.local_glyphs = {}
+    return template
+
+
+def _make_plugin(tags: list[str]) -> MagicMock:
+    plugin = MagicMock()
+    plugin.blueprint_templates = (_make_template(tags),)
+    return plugin
+
+
+def _patch_validation_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bypass real blueprint validation -- irrelevant to this test, and would otherwise
+    require a fully-fledged plugin catalogue."""
+    monkeypatch.setattr(blueprint_service, "template_to_builder", lambda template, plugin_id: BlueprintBuilder())
+    monkeypatch.setattr(blueprint_service, "resolve_builder_with_examples", lambda builder, example_values, example_glyphs: builder)
+    monkeypatch.setattr(
+        blueprint_service,
+        "validate_expand_sync",
+        lambda builder, auth, validate_only: BlueprintValidationExpansion(
+            global_errors=[], block_errors={}, possible_sources=[], possible_expansions={}
+        ),
+    )
+
+
+def test_ingest_plugin_templates_reserved_tag_recorded_as_template_error(
+    mem_session_maker: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    upsert_plugin_state(plugin_id=_PLUGIN_ID_STR, version="1.0")
+    _patch_validation_ok(monkeypatch)
+    plugin = _make_plugin(tags=[CORE_VERSION_MISMATCH_TAG_KEY])
+
+    _ingest_plugin_templates(_PLUGIN_ID, plugin)
+
+    state = get_plugin_state(_PLUGIN_ID_STR)
+    assert state is not None
+    assert "my_template" in state.template_errors
+    assert CORE_VERSION_MISMATCH_TAG_KEY in state.template_errors["my_template"]
+
+
+def test_ingest_plugin_templates_normal_tag_not_flagged(mem_session_maker: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch) -> None:
+    upsert_plugin_state(plugin_id=_PLUGIN_ID_STR, version="1.0")
+    _patch_validation_ok(monkeypatch)
+    plugin = _make_plugin(tags=["normal-tag"])
+
+    _ingest_plugin_templates(_PLUGIN_ID, plugin)
+
+    state = get_plugin_state(_PLUGIN_ID_STR)
+    assert state is not None
+    assert state.template_errors == {}

--- a/backend/tests/unit/routes/test_blueprint.py
+++ b/backend/tests/unit/routes/test_blueprint.py
@@ -9,11 +9,8 @@
 
 """Unit tests for the blueprint route helpers."""
 
-import pytest
-from fastapi.exceptions import HTTPException
-
-from forecastbox.domain.blueprint.service import Tag
-from forecastbox.routes.blueprint import _CORE_VERSION_MISMATCH_KEY, _maybe_append_coreversion_mismatch, _reject_reserved_tags
+from forecastbox.domain.blueprint.service import CORE_VERSION_MISMATCH_TAG_KEY, Tag
+from forecastbox.routes.blueprint import _maybe_append_coreversion_mismatch, tag_name_errors
 
 # ---------------------------------------------------------------------------
 # _maybe_append_coreversion_mismatch
@@ -31,7 +28,7 @@ def test_appends_tag_when_versions_differ() -> None:
     tags: list[Tag] = []
     _maybe_append_coreversion_mismatch(tags, entity_coreversion=0, current_coreversion=1)
     assert len(tags) == 1
-    assert tags[0].key == _CORE_VERSION_MISMATCH_KEY
+    assert tags[0].key == CORE_VERSION_MISMATCH_TAG_KEY
     assert tags[0].value == "!0 != 1"
 
 
@@ -47,7 +44,7 @@ def test_existing_tags_preserved_when_mismatch() -> None:
     assert len(tags) == 3
     assert tags[0].key == "a"
     assert tags[1].key == "b"
-    assert tags[2].key == _CORE_VERSION_MISMATCH_KEY
+    assert tags[2].key == CORE_VERSION_MISMATCH_TAG_KEY
 
 
 def test_no_tag_appended_on_zero_versions_match() -> None:
@@ -86,28 +83,28 @@ def test_tag_roundtrip_via_model_validate() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _reject_reserved_tags
+# tag_name_errors
 # ---------------------------------------------------------------------------
 
 
 def test_reject_reserved_tags_raises_on_reserved_key() -> None:
-    tags = [Tag(key=_CORE_VERSION_MISMATCH_KEY)]
-    with pytest.raises(HTTPException) as exc_info:
-        _reject_reserved_tags(tags)
-    assert exc_info.value.status_code == 422
+    tags = [Tag(key=CORE_VERSION_MISMATCH_TAG_KEY)]
+    errors = tag_name_errors(tags)
+    assert len(errors) == 1
+    assert CORE_VERSION_MISMATCH_TAG_KEY in errors[0]
 
 
 def test_reject_reserved_tags_passes_with_normal_tags() -> None:
     tags = [Tag(key="foo"), Tag(key="bar", value="baz")]
-    _reject_reserved_tags(tags)  # should not raise
+    assert tag_name_errors(tags) == []
 
 
 def test_reject_reserved_tags_passes_for_empty_list() -> None:
-    _reject_reserved_tags([])  # should not raise
+    assert tag_name_errors([]) == []
 
 
 def test_reject_reserved_tags_mixed_raises() -> None:
-    tags = [Tag(key="ok"), Tag(key=_CORE_VERSION_MISMATCH_KEY, value="!0 != 1")]
-    with pytest.raises(HTTPException) as exc_info:
-        _reject_reserved_tags(tags)
-    assert exc_info.value.status_code == 422
+    tags = [Tag(key="ok"), Tag(key=CORE_VERSION_MISMATCH_TAG_KEY, value="!0 != 1")]
+    errors = tag_name_errors(tags)
+    assert len(errors) == 1
+    assert CORE_VERSION_MISMATCH_TAG_KEY in errors[0]


### PR DESCRIPTION
backend now refuses glyphs which share the name with a jinja filter / udf -- in the same fashion like we check intrinsic glyph clash. This applies uniformly at global glyph upsert, blueprint's validate_expand, and template ingestion

similarly, we now apply the same tag validation at the template ingest time as we do during blueprint upsert

cc @liefra (no change should be required at the frontend, just letting you know we are more strict -- you reported some time ago that the conflict in glyph name with jinja keyword kinda misbehaves)

In detail:

- Add is_jinja_reserved_name() to domain/glyphs/jinja_interpolation, exposing the existing _FILTER_NAMES set as a public predicate.
- Add domain/glyphs/validation.validate_glyph(), which checks a glyph name against both intrinsic glyph names and jinja2 reserved keywords, returning an Either[str, str] (ok = glyph name, error = reason).
- Use validate_glyph() in glyphs/global/post (post_global_glyph) instead of the previous intrinsic-only check.
- Use validate_glyph() in BlueprintBuilder validation (_validate_expand_with_buckets) for every local glyph key, collecting errors into global_errors without aborting the rest of validation -- a bad local glyph name is flagged but its value is still used.
- Rename _reject_reserved_tags to tag_name_errors (moved to domain/blueprint/service, alongside the new CORE_VERSION_MISMATCH_TAG_KEY constant) and change its contract from raising to returning a list of error strings, so callers can combine it with other validation errors instead of short-circuiting.
- create_blueprint/update_blueprint now combine tag_name_errors with validate_expand's global_errors into a single 422 response.
- _ingest_plugin_templates now also runs tag_name_errors against each template's tags, combining them with validate_expand_sync errors before deciding whether to skip the template.
- Add unit tests for is_jinja_reserved_name/validate_glyph, the soft-error local-glyph validation path, tag_name_errors, and the combined tag+glyph ingestion error path; add an integration test asserting reserved tag and reserved local glyph errors are combined in a single /blueprint/create response.