### PR TITLE
Add lens metadata: CRUD routes & persistence

### DIFF
--- a/backend/src/forecastbox/domain/lens/__init__.py
+++ b/backend/src/forecastbox/domain/lens/__init__.py
@@ -10,7 +10,8 @@
 """
 Manages the Lens domain -- external inspection tools (e.g. skinnyWMS) that clients
 can launch against the outputs of individual Runs for interactive visualisation and
-exploration.
+exploration. Also manages LensMetadata -- generic, frontend-managed metadata attached
+to a lens type (e.g. per-lens display preferences), persisted in `metadata_db.py`.
 
 Does not depend on any other domain, and is not depended on by any other domain.
 The association between a Lens instance and a specific Run output is handled

--- a/backend/src/forecastbox/domain/lens/metadata_db.py
+++ b/backend/src/forecastbox/domain/lens/metadata_db.py
@@ -1,0 +1,209 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Persistence layer for generic per-lens metadata (LensMetadata).
+
+Structurally mirrors ``domain.glyphs.global_db``: each user owns their own row
+per (lens_id, lens_metadata_id) pair, and rows marked ``public`` are visible to
+everyone (an admin-provided default/template), but only mutable by their owner.
+"""
+
+import datetime as dt
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any, cast
+
+from sqlalchemy import Select, delete, func, or_, select, update
+
+import forecastbox.schemata.jobs as _jobs_module
+from forecastbox.schemata.jobs import LensMetadata
+from forecastbox.utility.auth import AuthContext
+from forecastbox.utility.db import dbRetry
+from forecastbox.utility.time import current_time
+
+
+@dataclass(frozen=True, eq=True, slots=True)
+class LensMetadataRecord:
+    lens_id: str
+    lens_metadata_id: str
+    metadata_content: Any
+    public: bool
+    created_by: str
+    created_at: dt.datetime
+    updated_at: dt.datetime
+
+
+def _to_record(row: LensMetadata) -> LensMetadataRecord:
+    return LensMetadataRecord(
+        lens_id=cast(str, row.lens_id),
+        lens_metadata_id=cast(str, row.lens_metadata_id),
+        metadata_content=cast(Any, row.metadata_content),
+        public=cast(bool, row.public),
+        created_by=cast(str, row.created_by),
+        created_at=cast(dt.datetime, row.created_at),
+        updated_at=cast(dt.datetime, row.updated_at),
+    )
+
+
+def _visibility_filter(query: Select, auth_context: AuthContext) -> Select:  # type: ignore[type-arg]
+    """Restrict a query to rows the caller is allowed to see.
+
+    Admins see every row. Non-admins see their own rows plus any row that has
+    ``public=True`` (an admin-provided default/template).
+    """
+    if not auth_context.has_admin():
+        query = query.where(
+            or_(
+                LensMetadata.created_by == auth_context.user_id,
+                LensMetadata.public.is_(True),
+            )
+        )
+    return query
+
+
+def upsert_lens_metadata(
+    lens_id: str,
+    lens_metadata_id: str,
+    metadata_content: Any,
+    public: bool,
+    auth_context: AuthContext,
+) -> LensMetadataRecord:
+    """Insert or update a LensMetadata row by (lens_id, lens_metadata_id, created_by).
+
+    Each user owns their own row per (lens_id, lens_metadata_id); callers can only
+    upsert their own rows -- the caller always becomes (or remains) the owner.
+    """
+    ref_time = current_time("dbref")
+
+    def function(i: int) -> LensMetadataRecord:
+        with _jobs_module.sync_session_maker() as session:
+            result = session.execute(
+                select(LensMetadata).where(
+                    LensMetadata.lens_id == lens_id,
+                    LensMetadata.lens_metadata_id == lens_metadata_id,
+                    LensMetadata.created_by == auth_context.user_id,
+                )
+            )
+            existing: LensMetadata | None = result.scalar_one_or_none()
+            if existing is not None:
+                session.execute(
+                    update(LensMetadata)
+                    .where(
+                        LensMetadata.lens_id == lens_id,
+                        LensMetadata.lens_metadata_id == lens_metadata_id,
+                        LensMetadata.created_by == auth_context.user_id,
+                    )
+                    .values(metadata_content=metadata_content, public=public, updated_at=ref_time)
+                )
+                session.commit()
+                refreshed = session.execute(
+                    select(LensMetadata).where(
+                        LensMetadata.lens_id == lens_id,
+                        LensMetadata.lens_metadata_id == lens_metadata_id,
+                        LensMetadata.created_by == auth_context.user_id,
+                    )
+                ).scalar_one()
+                return _to_record(refreshed)
+            new = LensMetadata(
+                lens_id=lens_id,
+                lens_metadata_id=lens_metadata_id,
+                created_by=auth_context.user_id,
+                metadata_content=metadata_content,
+                public=public,
+                created_at=ref_time,
+                updated_at=ref_time,
+            )
+            session.add(new)
+            session.commit()
+            return _to_record(new)
+
+    return dbRetry(function)
+
+
+def list_lens_metadata(
+    lens_id: str,
+    auth_context: AuthContext,
+    offset: int = 0,
+    limit: int | None = None,
+    lens_metadata_id: str | None = None,
+) -> Iterable[LensMetadataRecord]:
+    """Return LensMetadata rows for ``lens_id`` visible to the caller, with optional paging.
+
+    Admins see all rows for the given lens. Non-admins see their own rows plus
+    all public rows. When ``lens_metadata_id`` is given, only rows with that
+    exact id are returned -- this may still yield more than one row (e.g. the
+    caller's own row plus a public row from another user); the frontend is
+    responsible for merging these as needed.
+    """
+
+    def function(i: int) -> list[LensMetadataRecord]:
+        with _jobs_module.sync_session_maker() as session:
+            query = _visibility_filter(
+                select(LensMetadata)
+                .where(LensMetadata.lens_id == lens_id)
+                .order_by(LensMetadata.lens_metadata_id, LensMetadata.created_by)
+                .offset(offset),
+                auth_context,
+            )
+            if lens_metadata_id is not None:
+                query = query.where(LensMetadata.lens_metadata_id == lens_metadata_id)
+            if limit is not None:
+                query = query.limit(limit)
+            result = session.execute(query)
+            return [_to_record(r[0]) for r in result.all()]
+
+    return dbRetry(function)
+
+
+def count_lens_metadata(lens_id: str, auth_context: AuthContext, lens_metadata_id: str | None = None) -> int:
+    """Return the total number of LensMetadata rows for ``lens_id`` visible to the caller."""
+
+    def function(i: int) -> int:
+        with _jobs_module.sync_session_maker() as session:
+            query = _visibility_filter(select(func.count()).select_from(LensMetadata).where(LensMetadata.lens_id == lens_id), auth_context)
+            if lens_metadata_id is not None:
+                query = query.where(LensMetadata.lens_metadata_id == lens_metadata_id)
+            result = session.execute(query)
+            return result.scalar() or 0
+
+    return dbRetry(function)
+
+
+def delete_lens_metadata(lens_id: str, lens_metadata_id: str, auth_context: AuthContext) -> LensMetadataRecord | None:
+    """Delete the caller's own LensMetadata row for (lens_id, lens_metadata_id).
+
+    Always scoped to the caller's own row (``created_by == auth_context.user_id``),
+    even for admins -- there is no cross-user delete. Returns the deleted row on
+    success, or None if the caller has no such row.
+    """
+
+    def function(i: int) -> LensMetadataRecord | None:
+        with _jobs_module.sync_session_maker() as session:
+            result = session.execute(
+                select(LensMetadata).where(
+                    LensMetadata.lens_id == lens_id,
+                    LensMetadata.lens_metadata_id == lens_metadata_id,
+                    LensMetadata.created_by == auth_context.user_id,
+                )
+            )
+            row: LensMetadata | None = result.scalar_one_or_none()
+            if row is None:
+                return None
+            dto = _to_record(row)
+            session.execute(
+                delete(LensMetadata).where(
+                    LensMetadata.lens_id == lens_id,
+                    LensMetadata.lens_metadata_id == lens_metadata_id,
+                    LensMetadata.created_by == auth_context.user_id,
+                )
+            )
+            session.commit()
+            return dto
+
+    return dbRetry(function)

--- a/backend/src/forecastbox/routes/lens.py
+++ b/backend/src/forecastbox/routes/lens.py
@@ -12,28 +12,42 @@ Lens routes — /lens/*. Corresponds to the `domain.lens` domain.
 
 Lenses are external inspection tools (e.g. skinnyWMS) that clients can launch
 against Run outputs. Routes cover: start, status, stop, list, and supported lenses.
+
+Also covers `/metadata/*` -- generic, frontend-managed metadata storage attached
+to a lens type (e.g. per-lens display preferences). Fully generic and parametrized
+by `lens_id`; only the set of currently supported lensIds is validated at request
+time.
 """
 
 # TODO currently no authentication here. Add auth and propagate into the manager itself
 # TODO currently no log propagation -- consider routing stdout of skinnywms to files, and allow retrieval here via a new route
 
+import json
 import logging
 import pathlib
-from typing import TYPE_CHECKING, Any, Self
+from functools import partial
+from typing import TYPE_CHECKING, Annotated, Any, Self, cast, get_args
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 
+from forecastbox.domain.auth.users import get_auth_context
+from forecastbox.domain.lens import metadata_db
 from forecastbox.domain.lens.manager import (
     LensInstanceDetail,
     LensInstanceId,
+    LensName,
     LensStatus,
     get_status,
     list_instances,
     start_skinny_wms,
     stop_instance,
 )
+from forecastbox.utility.auth import AuthContext
+from forecastbox.utility.concurrency.manager import execution_manager
 from forecastbox.utility.concurrency.ports import NoFreePortsException
+from forecastbox.utility.pagination import PaginationSpec
 from forecastbox.utility.pydantic import FiabBaseModel
+from forecastbox.utility.time import value_dt2str
 
 PREFIX = "/api/v1/lens"
 
@@ -43,6 +57,15 @@ router = APIRouter(
     tags=["lens"],
     responses={404: {"description": "Not found"}},
 )
+
+#: Maximum size, in bytes, of the JSON-serialized ``metadata_content`` accepted by
+#: the lens metadata ``post`` route. Not exposed as a configuration option.
+MAX_LENS_METADATA_CONTENT_BYTES = 1 * 1024 * 1024
+
+#: LensIds currently supported by the metadata routes below. Kept in sync with
+#: ``LensName`` (the set of lens types the lens-instance manager supports) --
+#: the metadata routes are otherwise fully generic and parametrized by lensId.
+SUPPORTED_LENS_IDS = set(get_args(LensName))
 
 try:
     if not TYPE_CHECKING:
@@ -137,3 +160,183 @@ def list_supported_lenses() -> list[SupportedLensDetail]:
             )
         )
     return supported
+
+
+# ---------------------------------------------------------------------------
+# Lens Metadata Endpoints
+# ---------------------------------------------------------------------------
+#
+# Generic, frontend-managed metadata storage keyed by (lensId, lensMetadataId).
+# Fully generic in implementation; only the set of supported lensIds is
+# validated at request time (currently just "skinnyWMS"). `lens_id` is passed
+# as a query param (list) or body field (post, delete) rather than a path
+# param, per the routes module's no-path-params convention.
+#
+# Visibility/write rules (mirrors domain.glyphs global glyphs):
+#  - admins see and may list all rows for a lensId.
+#  - non-admins see their own rows plus any row marked ``public`` (an
+#    admin-provided default/template); no server-side merging is performed --
+#    the frontend is responsible for combining own + public rows as needed.
+#  - post (upsert) always writes the caller's own row.
+#  - delete always targets the caller's own row only, regardless of admin status.
+
+
+def _validate_lens_id(lens_id: str) -> None:
+    if lens_id not in SUPPORTED_LENS_IDS:
+        raise HTTPException(status_code=404, detail=f"Lens {lens_id!r} is not supported.")
+
+
+class LensMetadataResponse(FiabBaseModel):
+    """Detail of a single lens metadata row, returned by list and post endpoints."""
+
+    lens_id: str
+    lens_metadata_id: str
+    metadata_content: Any
+    public: bool
+    created_by: str
+    created_at: str
+    updated_at: str
+
+
+class LensMetadataListResponse(FiabBaseModel):
+    """Paginated list of lens metadata rows."""
+
+    items: list[LensMetadataResponse]
+    total: int
+    page: int
+    page_size: int
+
+
+class LensMetadataListFilters(FiabBaseModel):
+    """Query-parameter filters for the lens metadata list endpoint."""
+
+    lens_id: str
+    lens_metadata_id: str | None = None
+
+
+class LensMetadataPostRequest(FiabBaseModel):
+    """Request body for creating or updating the caller's lens metadata row."""
+
+    lens_id: str
+    lens_metadata_id: str
+    metadata_content: Any
+    public: bool = False
+
+
+class LensMetadataDeleteRequest(FiabBaseModel):
+    """Identifies the caller's own lens metadata row to delete."""
+
+    lens_id: str
+    lens_metadata_id: str
+
+
+def _row_to_metadata_response(row: metadata_db.LensMetadataRecord) -> LensMetadataResponse:
+    return LensMetadataResponse(
+        lens_id=row.lens_id,
+        lens_metadata_id=row.lens_metadata_id,
+        metadata_content=row.metadata_content,
+        public=row.public,
+        created_by=row.created_by,
+        created_at=value_dt2str(row.created_at),
+        updated_at=value_dt2str(row.updated_at),
+    )
+
+
+@router.get("/metadata/list")
+async def list_lens_metadata(
+    filters: Annotated[LensMetadataListFilters, Depends()],
+    pagination: Annotated[PaginationSpec, Depends()] = PaginationSpec(),
+    auth_context: AuthContext = Depends(get_auth_context),
+) -> LensMetadataListResponse:
+    """List lens metadata rows for ``lens_id`` visible to the caller.
+
+    Admins see all rows. Non-admins see their own rows plus any row marked
+    ``public``. When ``lens_metadata_id`` is given, only rows with that exact
+    id are returned -- this may still yield more than one row (e.g. the
+    caller's own row plus a public row from another user); the frontend is
+    responsible for merging these as needed.
+    """
+    _validate_lens_id(filters.lens_id)
+    total = cast(
+        int,
+        await execution_manager.await_jobs_db(
+            "lens_metadata.count",
+            partial(metadata_db.count_lens_metadata, filters.lens_id, auth_context, lens_metadata_id=filters.lens_metadata_id),
+        ),
+    )
+    rows = cast(
+        list[metadata_db.LensMetadataRecord],
+        await execution_manager.await_jobs_db(
+            "lens_metadata.list",
+            partial(
+                metadata_db.list_lens_metadata,
+                filters.lens_id,
+                auth_context,
+                offset=pagination.start(),
+                limit=pagination.page_size,
+                lens_metadata_id=filters.lens_metadata_id,
+            ),
+        ),
+    )
+    return LensMetadataListResponse(
+        items=[_row_to_metadata_response(row) for row in rows],
+        total=total,
+        page=pagination.page,
+        page_size=pagination.page_size,
+    )
+
+
+@router.post("/metadata/post")
+async def post_lens_metadata(
+    request: LensMetadataPostRequest,
+    auth_context: AuthContext = Depends(get_auth_context),
+) -> LensMetadataResponse:
+    """Create or update the caller's lens metadata row for ``lens_metadata_id``.
+
+    Always writes the caller's own row -- there is no way to write another
+    user's row, admin or not. Returns 413 if the serialized ``metadata_content``
+    exceeds ``MAX_LENS_METADATA_CONTENT_BYTES``.
+    """
+    _validate_lens_id(request.lens_id)
+    content_size = len(json.dumps(request.metadata_content).encode("utf-8"))
+    if content_size > MAX_LENS_METADATA_CONTENT_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"metadata_content exceeds the maximum allowed size of {MAX_LENS_METADATA_CONTENT_BYTES} bytes.",
+        )
+    row = cast(
+        metadata_db.LensMetadataRecord,
+        await execution_manager.await_jobs_db(
+            "lens_metadata.upsert",
+            partial(
+                metadata_db.upsert_lens_metadata,
+                request.lens_id,
+                request.lens_metadata_id,
+                request.metadata_content,
+                request.public,
+                auth_context,
+            ),
+        ),
+    )
+    return _row_to_metadata_response(row)
+
+
+@router.delete("/metadata/delete")
+async def delete_lens_metadata(
+    request: LensMetadataDeleteRequest,
+    auth_context: AuthContext = Depends(get_auth_context),
+) -> None:
+    """Delete the caller's own lens metadata row for ``lens_metadata_id``.
+
+    Always scoped to the caller's own row, regardless of admin status. Returns
+    404 if the caller has no such row.
+    """
+    _validate_lens_id(request.lens_id)
+    row = cast(
+        metadata_db.LensMetadataRecord | None,
+        await execution_manager.await_jobs_db(
+            "lens_metadata.delete", partial(metadata_db.delete_lens_metadata, request.lens_id, request.lens_metadata_id, auth_context)
+        ),
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"LensMetadata {request.lens_metadata_id!r} not found for lens {request.lens_id!r}.")

--- a/backend/src/forecastbox/schemata/jobs.py
+++ b/backend/src/forecastbox/schemata/jobs.py
@@ -101,6 +101,28 @@ class GlobalGlyph(Base):
     )
 
 
+class LensMetadata(Base):
+    """Generic, frontend-managed metadata attached to a lens type (e.g. skinnyWMS).
+
+    Each user owns their own row per (lens_id, lens_metadata_id) pair -- mirrors
+    GlobalGlyph's (created_by, key) pattern. ``public`` rows represent an
+    admin-provided default/template and are visible (read-only) to every caller
+    in addition to their own rows; they are never merged server-side -- the
+    frontend is responsible for combining them as needed.
+    """
+
+    __tablename__ = "lens_metadata"
+
+    lens_id = Column(String(255), primary_key=True, nullable=False)
+    lens_metadata_id = Column(String(255), primary_key=True, nullable=False)
+    created_by = Column(String(255), primary_key=True, nullable=False)
+    created_at = Column(UTCDateTime, nullable=False)
+    updated_at = Column(UTCDateTime, nullable=False)
+
+    metadata_content = Column(JSON, nullable=True)
+    public = Column(Boolean, nullable=False, default=False)
+
+
 class ExperimentDefinition(Base):
     """Captures that a Blueprint should execute multiple times.
 

--- a/backend/tests/unit/domain/lens/test_metadata_db.py
+++ b/backend/tests/unit/domain/lens/test_metadata_db.py
@@ -1,0 +1,165 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Unit tests for domain/lens/metadata_db persistence layer."""
+
+from collections.abc import Generator
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import forecastbox.domain.lens.metadata_db as metadata_db
+from forecastbox.schemata.jobs import Base
+from forecastbox.utility.auth import AuthContext
+
+_user1 = AuthContext(user_id="user1", is_admin=False)
+_user2 = AuthContext(user_id="user2", is_admin=False)
+_admin = AuthContext(user_id="admin", is_admin=True)
+
+
+@pytest.fixture
+def mem_session_maker(monkeypatch: pytest.MonkeyPatch) -> Generator[sessionmaker[Session], None, None]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    maker = sessionmaker(engine, expire_on_commit=False)
+    monkeypatch.setattr(metadata_db._jobs_module, "sync_session_maker", maker)
+    yield maker
+    engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# upsert_lens_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_creates_new_row(mem_session_maker: sessionmaker[Session]) -> None:
+    row = metadata_db.upsert_lens_metadata("skinnyWMS", "myId", {"foo": "bar"}, False, _user1)
+    assert row.lens_id == "skinnyWMS"
+    assert row.lens_metadata_id == "myId"
+    assert row.metadata_content == {"foo": "bar"}
+    assert row.public is False
+    assert row.created_by == "user1"
+
+
+def test_upsert_owner_can_update(mem_session_maker: sessionmaker[Session]) -> None:
+    row1 = metadata_db.upsert_lens_metadata("skinnyWMS", "myId", {"v": 1}, False, _user1)
+    row2 = metadata_db.upsert_lens_metadata("skinnyWMS", "myId", {"v": 2}, True, _user1)
+    assert row2.metadata_content == {"v": 2}
+    assert row2.public is True
+    assert row2.created_by == "user1"
+    assert row1.created_at == row2.created_at
+
+
+def test_upsert_different_users_same_id_creates_separate_rows(mem_session_maker: sessionmaker[Session]) -> None:
+    """Two different users can each have a row with the same (lens_id, lens_metadata_id)."""
+    row1 = metadata_db.upsert_lens_metadata("skinnyWMS", "myId", {"owner": "user1"}, False, _user1)
+    row2 = metadata_db.upsert_lens_metadata("skinnyWMS", "myId", {"owner": "user2"}, False, _user2)
+    assert row1.created_by == "user1"
+    assert row2.created_by == "user2"
+    assert row1.metadata_content == {"owner": "user1"}
+    assert row2.metadata_content == {"owner": "user2"}
+
+
+def test_upsert_different_lens_ids_independent(mem_session_maker: sessionmaker[Session]) -> None:
+    metadata_db.upsert_lens_metadata("skinnyWMS", "myId", {"a": 1}, False, _user1)
+    row = metadata_db.upsert_lens_metadata("otherLens", "myId", {"a": 2}, False, _user1)
+    rows = list(metadata_db.list_lens_metadata("otherLens", _user1))
+    assert len(rows) == 1
+    assert rows[0].lens_id == "otherLens"
+    assert row.metadata_content == {"a": 2}
+
+
+# ---------------------------------------------------------------------------
+# list_lens_metadata / count_lens_metadata -- visibility
+# ---------------------------------------------------------------------------
+
+
+def test_non_admin_sees_own_and_public_rows(mem_session_maker: sessionmaker[Session]) -> None:
+    metadata_db.upsert_lens_metadata("skinnyWMS", "own", {}, False, _user1)
+    metadata_db.upsert_lens_metadata("skinnyWMS", "pub", {}, True, _user2)
+    metadata_db.upsert_lens_metadata("skinnyWMS", "private-other", {}, False, _user2)
+
+    rows = list(metadata_db.list_lens_metadata("skinnyWMS", _user1))
+    ids = {r.lens_metadata_id for r in rows}
+    assert ids == {"own", "pub"}
+    assert metadata_db.count_lens_metadata("skinnyWMS", _user1) == 2
+
+
+def test_admin_sees_all_rows(mem_session_maker: sessionmaker[Session]) -> None:
+    metadata_db.upsert_lens_metadata("skinnyWMS", "own", {}, False, _user1)
+    metadata_db.upsert_lens_metadata("skinnyWMS", "pub", {}, True, _user2)
+    metadata_db.upsert_lens_metadata("skinnyWMS", "private-other", {}, False, _user2)
+
+    rows = list(metadata_db.list_lens_metadata("skinnyWMS", _admin))
+    ids = {r.lens_metadata_id for r in rows}
+    assert ids == {"own", "pub", "private-other"}
+    assert metadata_db.count_lens_metadata("skinnyWMS", _admin) == 3
+
+
+def test_list_filters_by_lens_metadata_id(mem_session_maker: sessionmaker[Session]) -> None:
+    metadata_db.upsert_lens_metadata("skinnyWMS", "a", {}, False, _user1)
+    metadata_db.upsert_lens_metadata("skinnyWMS", "b", {}, False, _user1)
+
+    rows = list(metadata_db.list_lens_metadata("skinnyWMS", _user1, lens_metadata_id="a"))
+    assert [r.lens_metadata_id for r in rows] == ["a"]
+    assert metadata_db.count_lens_metadata("skinnyWMS", _user1, lens_metadata_id="a") == 1
+
+
+def test_list_can_return_own_and_public_rows_for_same_id(mem_session_maker: sessionmaker[Session]) -> None:
+    """A caller's own row and another user's public row may share the same id;
+    both are returned -- merging is left to the frontend."""
+    metadata_db.upsert_lens_metadata("skinnyWMS", "shared", {"who": "user1"}, False, _user1)
+    metadata_db.upsert_lens_metadata("skinnyWMS", "shared", {"who": "admin-default"}, True, _admin)
+
+    rows = list(metadata_db.list_lens_metadata("skinnyWMS", _user1, lens_metadata_id="shared"))
+    owners = {r.created_by for r in rows}
+    assert owners == {"user1", "admin"}
+
+
+def test_list_pagination(mem_session_maker: sessionmaker[Session]) -> None:
+    for i in range(5):
+        metadata_db.upsert_lens_metadata("skinnyWMS", f"id{i}", {}, False, _user1)
+    rows = list(metadata_db.list_lens_metadata("skinnyWMS", _user1, offset=2, limit=2))
+    assert len(rows) == 2
+
+
+# ---------------------------------------------------------------------------
+# delete_lens_metadata
+# ---------------------------------------------------------------------------
+
+
+def test_delete_own_row_succeeds(mem_session_maker: sessionmaker[Session]) -> None:
+    metadata_db.upsert_lens_metadata("skinnyWMS", "myId", {}, False, _user1)
+    deleted = metadata_db.delete_lens_metadata("skinnyWMS", "myId", _user1)
+    assert deleted is not None
+    assert deleted.created_by == "user1"
+    assert list(metadata_db.list_lens_metadata("skinnyWMS", _user1)) == []
+
+
+def test_delete_missing_row_returns_none(mem_session_maker: sessionmaker[Session]) -> None:
+    assert metadata_db.delete_lens_metadata("skinnyWMS", "doesNotExist", _user1) is None
+
+
+def test_delete_never_targets_other_users_row(mem_session_maker: sessionmaker[Session]) -> None:
+    """Delete is always scoped to the caller's own row -- even for a public row owned by
+    someone else, and even for admins."""
+    metadata_db.upsert_lens_metadata("skinnyWMS", "myId", {}, True, _user1)
+
+    assert metadata_db.delete_lens_metadata("skinnyWMS", "myId", _user2) is None
+    assert metadata_db.delete_lens_metadata("skinnyWMS", "myId", _admin) is None
+    # row is still there, owned by user1
+    rows = list(metadata_db.list_lens_metadata("skinnyWMS", _user1, lens_metadata_id="myId"))
+    assert len(rows) == 1
+    assert rows[0].created_by == "user1"

--- a/backend/tests/unit/routes/test_lens.py
+++ b/backend/tests/unit/routes/test_lens.py
@@ -1,0 +1,29 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Unit tests for the lens route helpers, focused on the /metadata/* endpoints."""
+
+import pytest
+from fastapi.exceptions import HTTPException
+
+from forecastbox.routes import lens as lens_routes
+
+
+def test_validate_lens_id_accepts_supported() -> None:
+    lens_routes._validate_lens_id("skinnyWMS")  # should not raise
+
+
+def test_validate_lens_id_rejects_unsupported() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        lens_routes._validate_lens_id("notALens")
+    assert exc_info.value.status_code == 404
+
+
+def test_supported_lens_ids_matches_lens_name() -> None:
+    assert lens_routes.SUPPORTED_LENS_IDS == {"skinnyWMS"}


### PR DESCRIPTION
cc @liefra -- this is something we can utilize for persistence of external wms server, and many more things

there are now routes `/lens/metadata/{list, post, delete}` , which you can use to store aribtrary json. All accept LensId (where we put skinnyWMS for now since its the only Lens), and LensMetadataId -- where I imagine you will put like "wmsExternalServers", or anything you need -- meaning we'll have "row-per-feature", not "row-per-single-entity" (though you can use it like that, up to you).

for multi-user systems, it behaves similarly to global glyphs -- there is the "public" flag which admins can set during the post. When  any user calls list with lensMetadataId=wmsExternalServer, they get the row they created with this id as well as any "public" row with this id. You can then merge at the frontend level in some sense (or treat the user's row as override -- up to you again)

in this current design, it is done in a very general fashion. We can eventually move to backend owning the schema and there being more constrained routes (like addExternalWMS, listExternalWMS, etc). But I wanted to start flexibly, to first explore what exact feature set we want at the frontend, and then perhaps stabilize. And the intention is that the stabilization would under the hood use the exact same table, ie, the routes I'll add to the backend would just validate the schema but insert the same entity to the same table, and prevent this lensMetadataId on the general-purpose route. This would allow us to stabilize *without* migrating -- something I find quite enticing

either way open to discussion in any direction :) 


(original agent PR description):

Introduces a generic LensMetadata table (schemata/jobs.py) plus a domain/lens/metadata_db.py persistence layer mirroring the GlobalGlyph visibility model: admins see/manage all rows; non-admins see their own rows plus admin-provided public rows, and may only write/delete their own. Adds GET /metadata/list (with optional lens_metadata_id filter and pagination), POST /metadata/post (upsert), and DELETE /metadata/delete routes to routes/lens.py, parametrized by lens_id and validated against the currently supported LensName set (skinnyWMS). Enforces a 1MiB cap on metadata_content. Includes unit tests for the persistence layer and route helpers.
