### PR TITLE
[frontend] feat(fields): mirror the FableType grammar and surface backend validation

### DIFF
--- a/frontend/mocks/data/fable.data.ts
+++ b/frontend/mocks/data/fable.data.ts
@@ -27,6 +27,10 @@ import type {
 } from '@/api/types/fable.types'
 import type { PluginCompositeId } from '@/api/types/plugins.types'
 import { getFactory } from '@/api/types/fable.types'
+import {
+  closedEnum,
+  serializeValueType,
+} from '@/components/base/fields/fable-type'
 
 /**
  * Helper to create a PluginCompositeId
@@ -55,12 +59,14 @@ export const mockCatalogue: BlockFactoryCatalogue = {
           source: {
             title: 'Source',
             description: 'Top level source for earthkit data',
-            value_type: "enumClosed[str]('mars', 'ecmwf-open-data')",
+            value_type: serializeValueType(
+              closedEnum(['mars', 'ecmwf-open-data']),
+            ),
           },
           forecast: {
             title: 'Forecast model',
             description: 'Name of forecast',
-            value_type: 'enumClosed[str](aifs-ens,ifs-ens)',
+            value_type: serializeValueType(closedEnum(['aifs-ens', 'ifs-ens'])),
             default_value: 'aifs-ens',
           },
           base_time: {
@@ -102,7 +108,7 @@ export const mockCatalogue: BlockFactoryCatalogue = {
           statistic: {
             title: 'Statistic',
             description: 'Statistic to compute over the ensemble',
-            value_type: "enumClosed[str]('mean', 'std')",
+            value_type: serializeValueType(closedEnum(['mean', 'std'])),
           },
         },
         inputs: ['dataset'],
@@ -120,7 +126,9 @@ export const mockCatalogue: BlockFactoryCatalogue = {
           statistic: {
             title: 'Statistic',
             description: 'Statistic to compute over steps',
-            value_type: "enumClosed[str]('mean', 'std', 'min', 'max')",
+            value_type: serializeValueType(
+              closedEnum(['mean', 'std', 'min', 'max']),
+            ),
           },
         },
         inputs: ['dataset'],

--- a/frontend/mocks/handlers/plugins.handlers.ts
+++ b/frontend/mocks/handlers/plugins.handlers.ts
@@ -28,6 +28,10 @@ import type {
   PluginSettingsUpdate,
 } from '@/api/types/plugins.types'
 import { API_ENDPOINTS } from '@/api/endpoints'
+import {
+  closedEnum,
+  serializeValueType,
+} from '@/components/base/fields/fable-type'
 
 // Mutable copy for state changes
 const pluginsState: PluginListing = getMutablePluginListing()
@@ -311,7 +315,7 @@ export const pluginsHandlers = [
             example_value: 'png',
             display_name: 'Format',
             display_description: 'Output image format.',
-            type_hint: 'enumClosed[str](png,pdf,svg)',
+            type_hint: serializeValueType(closedEnum(['png', 'pdf', 'svg'])),
           },
           area: {
             example_value: 'Europe',

--- a/frontend/src/components/base/fields/fable-type.ts
+++ b/frontend/src/components/base/fields/fable-type.ts
@@ -1,0 +1,270 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * FableType — TypeScript mirror of fiab-core's value-type grammar
+ * (backend types.py). The wire string is the source of truth; this module
+ * gives it a typed shape with `serializeValueType`/`parseFableType` as a
+ * round-trip pair. Mocks and fixtures build value_type strings through the
+ * factories so a wire-syntax change is one function edit, not a string
+ * hunt (see the #570 enum migration).
+ *
+ * Parsing is a tolerant superset of the backend `_parse`: keywords are
+ * case-insensitive and legacy aliases (`string`, `integer`, `number`,
+ * `date-iso8601`) normalize to canonical kinds. Serialization is always
+ * canonical. `optional[T]` is NOT part of this grammar anymore — the
+ * legacy widget projection in value-type-parser.ts still peels it.
+ */
+
+export type FableType =
+  | { kind: 'str' }
+  | { kind: 'int' }
+  | { kind: 'float' }
+  | { kind: 'date' }
+  | { kind: 'datetime' }
+  | { kind: 'geodomain' }
+  | { kind: 'geodomainSingle' }
+  | { kind: 'bboxWSEN' }
+  | { kind: 'artifact' }
+  | { kind: 'param' }
+  | {
+      kind: 'enum'
+      closed: boolean
+      subtype: FableType
+      /** Wire items; numbers for numeric subtypes (quoting follows the item type). */
+      items: ReadonlyArray<string | number>
+    }
+  | { kind: 'list'; item: FableType }
+  | { kind: 'union'; types: ReadonlyArray<FableType> }
+
+// -------- Factories (mirror the backend constructors) --------
+
+export const stringType: FableType = { kind: 'str' }
+export const intType: FableType = { kind: 'int' }
+export const floatType: FableType = { kind: 'float' }
+export const dateType: FableType = { kind: 'date' }
+export const datetimeType: FableType = { kind: 'datetime' }
+export const geodomainType: FableType = { kind: 'geodomain' }
+export const artifactType: FableType = { kind: 'artifact' }
+export const paramType: FableType = { kind: 'param' }
+
+function inferSubtype(items: ReadonlyArray<string | number>): FableType {
+  if (items.length > 0 && items.every((i) => typeof i === 'number')) {
+    return items.every((i) => Number.isInteger(i)) ? intType : floatType
+  }
+  return stringType
+}
+
+export function closedEnum(
+  items: ReadonlyArray<string | number>,
+  subtype?: FableType,
+): FableType {
+  return {
+    kind: 'enum',
+    closed: true,
+    subtype: subtype ?? inferSubtype(items),
+    items,
+  }
+}
+
+export function openEnum(
+  items: ReadonlyArray<string | number>,
+  subtype?: FableType,
+): FableType {
+  return {
+    kind: 'enum',
+    closed: false,
+    subtype: subtype ?? inferSubtype(items),
+    items,
+  }
+}
+
+export function listOf(item: FableType): FableType {
+  return { kind: 'list', item }
+}
+
+export function unionOf(types: ReadonlyArray<FableType>): FableType {
+  return { kind: 'union', types }
+}
+
+// -------- Serialization (mirrors FableType.serialize) --------
+
+/** Quote rule mirrors the backend `_serialize_enum_item`: strings quoted, numbers raw. */
+function serializeEnumItem(item: string | number): string {
+  return typeof item === 'string' ? `'${item}'` : String(item)
+}
+
+export function serializeValueType(t: FableType): string {
+  switch (t.kind) {
+    case 'str':
+      return 'str'
+    case 'int':
+      return 'int'
+    case 'float':
+      return 'float'
+    case 'date':
+      return 'date'
+    case 'datetime':
+      return 'datetime'
+    case 'geodomain':
+      return 'geodomain'
+    case 'geodomainSingle':
+      return 'geodomainSingle'
+    case 'bboxWSEN':
+      return 'bboxWSEN'
+    case 'artifact':
+      return 'artifact'
+    case 'param':
+      return 'param'
+    case 'enum': {
+      const keyword = t.closed ? 'enumClosed' : 'enumOpen'
+      const items = t.items.map(serializeEnumItem).join(',')
+      return `${keyword}[${serializeValueType(t.subtype)}](${items})`
+    }
+    case 'list':
+      return `list[${serializeValueType(t.item)}]`
+    case 'union':
+      return `union[${t.types.map(serializeValueType).join(',')}]`
+  }
+}
+
+// -------- Parsing (mirrors the backend `_parse` remainder-threading) --------
+
+/** Longest-first so aliases win over their prefixes (`string` before `str`). */
+const ATOMS: ReadonlyArray<[keyword: string, kind: FableType]> = [
+  ['geodomainsingle', { kind: 'geodomainSingle' }],
+  ['date-iso8601', dateType],
+  ['geodomain', geodomainType],
+  ['datetime', datetimeType],
+  ['bboxwsen', { kind: 'bboxWSEN' }],
+  ['artifact', artifactType],
+  ['integer', intType],
+  ['string', stringType],
+  ['number', floatType],
+  ['param', paramType],
+  ['float', floatType],
+  ['date', dateType],
+  ['int', intType],
+  ['str', stringType],
+]
+
+const ENUM_KEYWORDS: ReadonlyArray<[keyword: string, closed: boolean]> = [
+  ['enumclosed', true],
+  ['enumopen', false],
+  // Legacy alias — the backend never emits bare `enum`.
+  ['enum', false],
+]
+
+/** Split `[inner]remainder` / `(inner)remainder` at the matching delimiter. */
+function splitDelimited(
+  s: string,
+  open: string,
+  close: string,
+): [inner: string, remainder: string] | null {
+  if (!s.startsWith(open)) return null
+  let depth = 0
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === open) depth++
+    else if (s[i] === close && --depth === 0) {
+      return [s.slice(1, i), s.slice(i + 1)]
+    }
+  }
+  return null
+}
+
+function stripQuotes(token: string): string {
+  if (
+    token.length >= 2 &&
+    token[0] === token[token.length - 1] &&
+    (token[0] === "'" || token[0] === '"')
+  ) {
+    return token.slice(1, -1)
+  }
+  return token
+}
+
+const NUMERIC_ITEM = /^-?\d+(\.\d+)?$/
+
+function parseEnumItems(
+  itemsStr: string,
+  subtype: FableType,
+): Array<string | number> {
+  const numeric = subtype.kind === 'int' || subtype.kind === 'float'
+  return itemsStr
+    .split(',')
+    .map((token) => token.trim())
+    .filter(Boolean)
+    .map(stripQuotes)
+    .map((token) =>
+      numeric && NUMERIC_ITEM.test(token) ? Number(token) : token,
+    )
+}
+
+/** Parse a type from the start of `s`; returns the type and the unparsed tail. */
+function parsePrefix(s: string): [FableType, string] | null {
+  const input = s.replace(/^\s+/, '')
+  const lower = input.toLowerCase()
+
+  if (lower.startsWith('list[')) {
+    const split = splitDelimited(input.slice(4), '[', ']')
+    if (!split) return null
+    const inner = parsePrefix(split[0])
+    if (!inner || inner[1].trim()) return null
+    return [{ kind: 'list', item: inner[0] }, split[1]]
+  }
+
+  if (lower.startsWith('union[')) {
+    const split = splitDelimited(input.slice(5), '[', ']')
+    if (!split) return null
+    const types: Array<FableType> = []
+    let remaining = split[0]
+    while (remaining.trim()) {
+      if (types.length > 0) {
+        if (!remaining.startsWith(',')) return null
+        remaining = remaining.slice(1)
+      }
+      const member = parsePrefix(remaining)
+      if (!member) return null
+      types.push(member[0])
+      remaining = member[1].replace(/^\s+/, '')
+    }
+    if (types.length === 0) return null
+    return [{ kind: 'union', types }, split[1]]
+  }
+
+  for (const [keyword, closed] of ENUM_KEYWORDS) {
+    if (!lower.startsWith(`${keyword}[`)) continue
+    const bracket = splitDelimited(input.slice(keyword.length), '[', ']')
+    if (!bracket) return null
+    const subtypeParsed = parsePrefix(bracket[0])
+    if (!subtypeParsed || subtypeParsed[1].trim()) return null
+    const paren = splitDelimited(bracket[1].replace(/^\s+/, ''), '(', ')')
+    if (!paren) return null
+    const items = parseEnumItems(paren[0], subtypeParsed[0])
+    if (items.length === 0) return null
+    return [
+      { kind: 'enum', closed, subtype: subtypeParsed[0], items },
+      paren[1],
+    ]
+  }
+
+  for (const [keyword, kind] of ATOMS) {
+    if (lower.startsWith(keyword)) return [kind, input.slice(keyword.length)]
+  }
+
+  return null
+}
+
+/** Parse a complete value_type expression; null when it is not FableType grammar. */
+export function parseFableType(expr: string): FableType | null {
+  const parsed = parsePrefix(expr)
+  if (!parsed || parsed[1].trim()) return null
+  return parsed[0]
+}

--- a/frontend/src/components/base/fields/fable-type.ts
+++ b/frontend/src/components/base/fields/fable-type.ts
@@ -96,8 +96,11 @@ export function unionOf(types: ReadonlyArray<FableType>): FableType {
 
 // -------- Serialization (mirrors FableType.serialize) --------
 
-/** Quote rule mirrors the backend `_serialize_enum_item`: strings quoted, numbers raw. */
-function serializeEnumItem(item: string | number): string {
+/** Mirrors `_serialize_enum_item`: date/datetime items bare ISO, str-ish quoted. */
+function serializeEnumItem(item: string | number, subtype: FableType): string {
+  if (subtype.kind === 'date' || subtype.kind === 'datetime') {
+    return String(item)
+  }
   return typeof item === 'string' ? `'${item}'` : String(item)
 }
 
@@ -125,7 +128,9 @@ export function serializeValueType(t: FableType): string {
       return 'param'
     case 'enum': {
       const keyword = t.closed ? 'enumClosed' : 'enumOpen'
-      const items = t.items.map(serializeEnumItem).join(',')
+      const items = t.items
+        .map((item) => serializeEnumItem(item, t.subtype))
+        .join(',')
       return `${keyword}[${serializeValueType(t.subtype)}](${items})`
     }
     case 'list':

--- a/frontend/src/components/base/fields/value-type-parser.ts
+++ b/frontend/src/components/base/fields/value-type-parser.ts
@@ -30,8 +30,8 @@
  * - param → string input (param name lookup not yet implemented)
  * - optional[T] → same widget as T, with optional=true flag
  *
- * `enum`/`enumList` carry `closed: boolean` (closed vs open) for forward
- * compat; no first-party factory emits the open form yet.
+ * `enum`/`enumList` carry `closed: boolean` (closed vs open);
+ * anemoiSource's `input_source` ships the open form.
  *
  * Enum expressions carry an explicit subtype in brackets, e.g.
  * `enumClosed[str]('a','b')` or `enumOpen[int](1,2)`. Only the `str`

--- a/frontend/src/components/base/fields/value-type-parser.ts
+++ b/frontend/src/components/base/fields/value-type-parser.ts
@@ -34,12 +34,27 @@
  * anemoiSource's `input_source` ships the open form.
  *
  * Enum expressions carry an explicit subtype in brackets, e.g.
- * `enumClosed[str]('a','b')` or `enumOpen[int](1,2)`. Only the `str`
- * subtype is rendered as a first-class field today; other subtypes fall
- * back to `unknown`.
+ * `enumClosed[str]('a','b')` or `enumClosed[int](1,2)`. str/int/float
+ * subtypes all render as selects over the wire strings; other subtypes
+ * fall back to `unknown`.
  */
 
 import { getAppTimeZone, todayInZone } from '@/lib/datetime'
+
+/** Enum subtypes rendered as selects — values stay wire strings; the
+ *  backend converts on submit. Aliases mirror the simple-type branches.
+ *  `artifact`/`param` members serialize as quoted strings (backend
+ *  `_serialize_enum_item`), so they parse like a `str` subtype. */
+const SELECT_ENUM_SUBTYPES: ReadonlySet<string> = new Set([
+  'str',
+  'string',
+  'int',
+  'integer',
+  'float',
+  'number',
+  'artifact',
+  'param',
+])
 
 export type ParsedValueType =
   | { type: 'string'; optional?: boolean }
@@ -141,21 +156,13 @@ export function parseValueType(valueType: string | undefined): ParsedValueType {
   }
 
   // Backend serializes enumClosed[subtype](...)/enumOpen[subtype](...); `enum` kept as an alias.
-  // Only the `str` subtype is supported as a first-class field; other subtypes are `unknown`.
+  // str/int/float subtypes render as selects; others fall back to `unknown`.
   const enumMatch = trimmed.match(
     /^(enum|enumOpen|enumClosed)\[(\w+)\]\((.*)\)$/i,
   )
   if (enumMatch) {
     const subtype = enumMatch[2].toLowerCase()
-    // `artifact` and `param` enum members are serialized as quoted strings
-    // (see backend's `_serialize_enum_item`), so they parse identically to
-    // a `str` subtype enum.
-    if (
-      subtype === 'str' ||
-      subtype === 'string' ||
-      subtype === 'artifact' ||
-      subtype === 'param'
-    ) {
+    if (SELECT_ENUM_SUBTYPES.has(subtype)) {
       const options = parseEnumOptions(enumMatch[3])
       if (options.length > 0) {
         return {

--- a/frontend/src/components/base/fields/value-type-parser.ts
+++ b/frontend/src/components/base/fields/value-type-parser.ts
@@ -9,52 +9,38 @@
  */
 
 /**
- * Value Type Parser
+ * Value Type Parser — widget projection over the FableType grammar.
  *
- * Parses backend value_type strings into structured types for dynamic field rendering.
+ * fable-type.ts owns the wire grammar (parse/serialize); this module
+ * flattens a parsed type onto the field widgets:
  *
- * Supported value types:
  * - str → string input
  * - int → number input (step=1)
  * - float → number input (step=any)
  * - datetime → datetime-local input
- * - date-iso8601 → date input
- * - list[str] → tag input (badges with add/remove)
- * - list[int] → tag input (badges with add/remove)
+ * - date (legacy alias date-iso8601) → date input
+ * - list[str] / list[int] → tag input (badges with add/remove)
  * - enum[str]('a','b','c') → select dropdown (open: suggestions, accept any string)
  * - enumClosed[str]('a','b','c') → select dropdown (closed: must be one of the listed)
- * - list[enumClosed[str](a,b,c)] → multi-select restricted to the listed items
- * - list[enum[str](a,b,c)] → multi-select with suggestions, accept any string
+ * - list[enumClosed[str]('a','b')] → multi-select restricted to the listed items
+ * - list[enum[str]('a','b')] → multi-select with suggestions, accept any string
  * - geodomain → geographic-area picker (presets / countries / draw a box)
  * - artifact → string input (catalog lookup / richer UI not yet implemented)
  * - param → string input (param name lookup not yet implemented)
- * - optional[T] → same widget as T, with optional=true flag
+ * - optional[T] → same widget as T, with optional=true flag (legacy — the
+ *   current backend grammar has no optional wrapper)
  *
  * `enum`/`enumList` carry `closed: boolean` (closed vs open);
  * anemoiSource's `input_source` ships the open form.
  *
- * Enum expressions carry an explicit subtype in brackets, e.g.
- * `enumClosed[str]('a','b')` or `enumClosed[int](1,2)`. str/int/float
- * subtypes all render as selects over the wire strings; other subtypes
- * fall back to `unknown`.
+ * str/int/float/artifact/param enum subtypes render as selects over the wire strings;
+ * anything else the grammar knows but no widget exists for (other enum
+ * subtypes, union, bboxWSEN, …) falls back to `unknown`.
  */
 
+import { parseFableType } from './fable-type'
+import type { FableType } from './fable-type'
 import { getAppTimeZone, todayInZone } from '@/lib/datetime'
-
-/** Enum subtypes rendered as selects — values stay wire strings; the
- *  backend converts on submit. Aliases mirror the simple-type branches.
- *  `artifact`/`param` members serialize as quoted strings (backend
- *  `_serialize_enum_item`), so they parse like a `str` subtype. */
-const SELECT_ENUM_SUBTYPES: ReadonlySet<string> = new Set([
-  'str',
-  'string',
-  'int',
-  'integer',
-  'float',
-  'number',
-  'artifact',
-  'param',
-])
 
 export type ParsedValueType =
   | { type: 'string'; optional?: boolean }
@@ -91,110 +77,69 @@ export function parseValueType(valueType: string | undefined): ParsedValueType {
 
   const trimmed = valueType.trim()
 
-  // Optional wrapper: unwrap "optional[<inner>]" and mark the result optional.
-  // Recurses so optional[int], optional[list[int]], optional[enum[...]] all work.
+  // Legacy optional wrapper: unwrap "optional[<inner>]" and mark the result
+  // optional. Recurses so optional[int], optional[enum[...]] etc. all work.
   const optionalMatch = trimmed.match(/^optional\[(.+)\]$/i)
   if (optionalMatch) {
     const inner = parseValueType(optionalMatch[1])
     return { ...inner, optional: true }
   }
 
-  const normalized = trimmed.toLowerCase()
-
-  // Simple types
-  if (normalized === 'str' || normalized === 'string') {
-    return { type: 'string' }
-  }
-
-  if (normalized === 'int' || normalized === 'integer') {
-    return { type: 'int' }
-  }
-
-  if (normalized === 'float' || normalized === 'number') {
-    return { type: 'float' }
-  }
-
-  if (normalized === 'datetime') {
-    return { type: 'datetime' }
-  }
-
-  if (normalized === 'date-iso8601' || normalized === 'date') {
-    return { type: 'date' }
-  }
-
-  if (normalized === 'geodomain') {
-    return { type: 'geodomain' }
-  }
-
-  // `artifact` and `param` are treated as plain strings for now; the backend
-  // reserves them for future catalog/param lookups but the frontend does not
-  // yet implement any such lookup, so they behave exactly like `str`.
-  if (normalized === 'artifact' || normalized === 'param') {
-    return { type: 'string' }
-  }
-
-  // List type: list[str], list[int], or list[enumClosed[...]]
-  // Match the trimmed string so leading/trailing whitespace does not fall through.
-  const listMatch = trimmed.match(/^list\[(.+)\]$/i)
-  if (listMatch) {
-    const itemValueType = parseValueType(listMatch[1])
-    if (itemValueType.type === 'string') {
-      return { type: 'list', itemType: 'string' }
-    }
-    if (itemValueType.type === 'int') {
-      return { type: 'list', itemType: 'int' }
-    }
-    if (itemValueType.type === 'enum') {
-      return {
-        type: 'enumList',
-        options: itemValueType.options,
-        closed: itemValueType.closed,
-      }
-    }
-    // Supported: list[str], list[int], list[enum[…]], list[enumClosed[…]].
-    return { type: 'unknown', raw: trimmed }
-  }
-
-  // Backend serializes enumClosed[subtype](...)/enumOpen[subtype](...); `enum` kept as an alias.
-  // str/int/float subtypes render as selects; others fall back to `unknown`.
-  const enumMatch = trimmed.match(
-    /^(enum|enumOpen|enumClosed)\[(\w+)\]\((.*)\)$/i,
-  )
-  if (enumMatch) {
-    const subtype = enumMatch[2].toLowerCase()
-    if (SELECT_ENUM_SUBTYPES.has(subtype)) {
-      const options = parseEnumOptions(enumMatch[3])
-      if (options.length > 0) {
-        return {
-          type: 'enum',
-          options,
-          closed: enumMatch[1].toLowerCase() === 'enumclosed',
-        }
-      }
-    }
-  }
-
-  return { type: 'unknown', raw: trimmed }
+  const parsed = parseFableType(trimmed)
+  return parsed ? flatten(parsed, trimmed) : { type: 'unknown', raw: trimmed }
 }
 
-/**
- * Parse enum options from a string like "'a','b','c'" or '"a","b","c"'
- */
-function parseEnumOptions(optionsStr: string): Array<string> {
-  return optionsStr
-    .split(',')
-    .map((option) => option.trim())
-    .filter(Boolean)
-    .map((option) => {
-      if (
-        option.length >= 2 &&
-        option[0] === option[option.length - 1] &&
-        (option[0] === "'" || option[0] === '"')
-      ) {
-        return option.slice(1, -1)
+/** str/int/float/artifact/param enums render as selects over the wire
+ *  strings — artifact/param members serialize quoted like str items. */
+function isSelectEnum(t: FableType): t is Extract<FableType, { kind: 'enum' }> {
+  return (
+    t.kind === 'enum' &&
+    (t.subtype.kind === 'str' ||
+      t.subtype.kind === 'int' ||
+      t.subtype.kind === 'float' ||
+      t.subtype.kind === 'artifact' ||
+      t.subtype.kind === 'param')
+  )
+}
+
+function flatten(t: FableType, raw: string): ParsedValueType {
+  switch (t.kind) {
+    case 'str':
+      return { type: 'string' }
+    // Reserved for future catalog/param lookups — plain strings until then.
+    case 'artifact':
+    case 'param':
+      return { type: 'string' }
+    case 'int':
+      return { type: 'int' }
+    case 'float':
+      return { type: 'float' }
+    case 'datetime':
+      return { type: 'datetime' }
+    case 'date':
+      return { type: 'date' }
+    case 'geodomain':
+      return { type: 'geodomain' }
+    case 'enum':
+      if (isSelectEnum(t)) {
+        return { type: 'enum', options: t.items.map(String), closed: t.closed }
       }
-      return option
-    })
+      return { type: 'unknown', raw }
+    case 'list':
+      if (t.item.kind === 'str') return { type: 'list', itemType: 'string' }
+      if (t.item.kind === 'int') return { type: 'list', itemType: 'int' }
+      if (isSelectEnum(t.item)) {
+        return {
+          type: 'enumList',
+          options: t.item.items.map(String),
+          closed: t.item.closed,
+        }
+      }
+      return { type: 'unknown', raw }
+    // Grammar-valid but widget-less: geodomainSingle, bboxWSEN, union.
+    default:
+      return { type: 'unknown', raw }
+  }
 }
 
 /**

--- a/frontend/src/features/executions/components/RunCanvas.tsx
+++ b/frontend/src/features/executions/components/RunCanvas.tsx
@@ -220,8 +220,6 @@ function RunCanvasInner({
                   // definite height, not just `min-height`). Wide: `!h-full`
                   // overrides it so the canvas fills the bounded column.
                   'min-[1280px]:!h-full min-[1280px]:min-h-0 min-[1280px]:flex-1',
-                  // Terminal states stay neutral; only live work gets ambient motion.
-                  status === 'running' && 'run-canvas-breathing',
                 ],
           )}
         >

--- a/frontend/src/features/fable-builder/components/form-mode/BlockInstanceCard.tsx
+++ b/frontend/src/features/fable-builder/components/form-mode/BlockInstanceCard.tsx
@@ -8,7 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
-import { useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import {
   AlertCircle,
   Bookmark,
@@ -27,6 +27,7 @@ import type {
   PluginBlockFactoryId,
 } from '@/api/types/fable.types'
 import { useFieldErrorMessages } from '@/features/fable-builder/hooks/useFieldErrorMessages'
+import { useReservedGlyphReason } from '@/features/glyphs/utils/reserved-names'
 import {
   useBlockValidation,
   useFableBuilderStore,
@@ -155,9 +156,21 @@ export function BlockInstanceCard({
   const errors = blockValidation?.errors ?? []
   const missingGlyphs = blockValidation?.missingGlyphs ?? {}
   const fieldErrorMessages = useFieldErrorMessages()
+  const reservedReasonFor = useReservedGlyphReason()
+  const isJinjaReserved = useCallback(
+    (name: string) => reservedReasonFor(name) === 'jinja',
+    [reservedReasonFor],
+  )
   const liveMappedErrors = useMemo(
-    () => mapBlockErrorsToFields(errors, missingGlyphs, fieldErrorMessages),
-    [errors, missingGlyphs, fieldErrorMessages],
+    () =>
+      mapBlockErrorsToFields(
+        errors,
+        missingGlyphs,
+        fieldErrorMessages,
+        instance.configuration_values,
+        isJinjaReserved,
+      ),
+    [errors, missingGlyphs, fieldErrorMessages, instance, isJinjaReserved],
   )
   const lastMappedErrorsRef = useRef(liveMappedErrors)
   if (validationState) {

--- a/frontend/src/features/fable-builder/components/layout/ConfigPanel.tsx
+++ b/frontend/src/features/fable-builder/components/layout/ConfigPanel.tsx
@@ -8,11 +8,12 @@
  * does it submit to any jurisdiction.
  */
 
-import { useMemo, useRef } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 import { AlertCircle, ChevronRight, Link2, Trash2, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import type { BlockFactoryCatalogue } from '@/api/types/fable.types'
 import { useFieldErrorMessages } from '@/features/fable-builder/hooks/useFieldErrorMessages'
+import { useReservedGlyphReason } from '@/features/glyphs/utils/reserved-names'
 import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
 import {
   BLOCK_KIND_METADATA,
@@ -138,6 +139,11 @@ export function ConfigPanel({ catalogue }: ConfigPanelProps): React.ReactNode {
   }
 
   const fieldErrorMessages = useFieldErrorMessages()
+  const reservedReasonFor = useReservedGlyphReason()
+  const isJinjaReserved = useCallback(
+    (name: string) => reservedReasonFor(name) === 'jinja',
+    [reservedReasonFor],
+  )
   // Hook must be called unconditionally — guard inside rather than early-
   // returning above it.
   const liveMappedErrors = useMemo(
@@ -146,8 +152,16 @@ export function ConfigPanel({ catalogue }: ConfigPanelProps): React.ReactNode {
         blockErrors ?? [],
         missingGlyphs ?? {},
         fieldErrorMessages,
+        selectedBlock?.configuration_values ?? {},
+        isJinjaReserved,
       ),
-    [blockErrors, missingGlyphs, fieldErrorMessages],
+    [
+      blockErrors,
+      missingGlyphs,
+      fieldErrorMessages,
+      selectedBlock,
+      isJinjaReserved,
+    ],
   )
 
   // Cache last-known restrictions per block so the field doesn't flash to
@@ -258,6 +272,16 @@ export function ConfigPanel({ catalogue }: ConfigPanelProps): React.ReactNode {
       </div>
 
       <div className="flex-1 space-y-6 overflow-y-auto p-4">
+        {/* Backend block errors that map to no specific field — verbatim. */}
+        {mappedErrors.unmapped.length > 0 && (
+          <div className="space-y-1 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2">
+            {mappedErrors.unmapped.map((message) => (
+              <P key={message} className="text-sm text-destructive">
+                {message}
+              </P>
+            ))}
+          </div>
+        )}
         {inputs.length > 0 && (
           <div className="space-y-3">
             <div className="flex items-center gap-2 text-sm font-medium">

--- a/frontend/src/features/fable-builder/components/shared/GlyphReferencePanel.tsx
+++ b/frontend/src/features/fable-builder/components/shared/GlyphReferencePanel.tsx
@@ -40,6 +40,7 @@ import { useAllGlyphs } from '@/features/fable-builder/hooks/useAllGlyphs'
 import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
 import { GlyphFormDialog } from '@/features/glyphs/components/GlyphFormDialog'
 import { isValidGlyphKey } from '@/features/glyphs/utils/validate-key'
+import { useReservedGlyphReason } from '@/features/glyphs/utils/reserved-names'
 import { showToast } from '@/lib/toast'
 import { P } from '@/components/base/typography'
 import {
@@ -427,6 +428,7 @@ function LocalGlyphSection({
   exampleLabel: string
 }) {
   const { t } = useTranslation('glyphs')
+  const reservedReasonFor = useReservedGlyphReason()
   const setLocalGlyph = useFableBuilderStore((state) => state.setLocalGlyph)
   const removeLocalGlyph = useFableBuilderStore(
     (state) => state.removeLocalGlyph,
@@ -458,7 +460,13 @@ function LocalGlyphSection({
   const trimmedNewKey = newKey.trim()
   // Only flag the user once they've started typing — empty input shouldn't
   // light up red the moment the row appears.
-  const newKeyInvalid = trimmedNewKey !== '' && !isValidGlyphKey(trimmedNewKey)
+  const newKeyReserved =
+    trimmedNewKey !== '' && isValidGlyphKey(trimmedNewKey)
+      ? reservedReasonFor(trimmedNewKey)
+      : null
+  const newKeyInvalid =
+    (trimmedNewKey !== '' && !isValidGlyphKey(trimmedNewKey)) ||
+    newKeyReserved !== null
 
   function handleAdd() {
     const key = newKey.trim()
@@ -466,6 +474,15 @@ function LocalGlyphSection({
     if (!key || !value) return
     if (!isValidGlyphKey(key)) {
       showToast.error(t('panel.localKeyInvalid'))
+      return
+    }
+    const reserved = reservedReasonFor(key)
+    if (reserved) {
+      showToast.error(
+        reserved === 'intrinsic'
+          ? t('form.keyReservedIntrinsic')
+          : t('form.keyReservedJinja'),
+      )
       return
     }
     setLocalGlyph(key, value)

--- a/frontend/src/features/fable-builder/hooks/useFieldErrorMessages.ts
+++ b/frontend/src/features/fable-builder/hooks/useFieldErrorMessages.ts
@@ -20,6 +20,8 @@ export function useFieldErrorMessages(): FieldErrorMessages {
       missingRequiredValue: t('fieldErrors.missingRequiredValue'),
       unknownGlyph: (name) =>
         t('fieldErrors.unknownGlyph', { glyph: `\${${name}}` }),
+      jinjaReservedReference: (name) =>
+        t('fieldErrors.jinjaReservedReference', { name }),
     }),
     [t],
   )

--- a/frontend/src/features/fable-builder/utils/map-block-errors-to-fields.ts
+++ b/frontend/src/features/fable-builder/utils/map-block-errors-to-fields.ts
@@ -28,6 +28,7 @@ export interface FieldErrorMessages {
   unknownConfigKey: string
   missingRequiredValue: string
   unknownGlyph: (name: string) => string
+  jinjaReservedReference: (name: string) => string
 }
 
 /**
@@ -49,6 +50,10 @@ function parsePythonStringSet(input: string): Set<string> | null {
     names.add(match[1])
   }
   return names.size > 0 ? names : null
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 function pushError(
@@ -73,6 +78,10 @@ function pushError(
  * - "Block contains missing config: {...}" → messages.missingRequiredValue
  * - "Configuration option 'x' is missing for block factory ..." →
  *   messages.missingRequiredValue
+ * - "Invalid value for configuration option 'x': ..." → verbatim, on `x`
+ * - "Jinja expression error: 'x' is undefined" → attributed to the config
+ *   keys whose value references `x` inside a `${...}` expression; when `x`
+ *   is jinja-reserved the clearer messages.jinjaReservedReference is shown
  *
  * `missingGlyphs[configKey] = [name, ...]` → messages.unknownGlyph(name) per name.
  * Missing-config errors for a key that also has unknown glyphs are dropped —
@@ -83,6 +92,8 @@ export function mapBlockErrorsToFields(
   errors: ReadonlyArray<string>,
   missingGlyphs: Record<string, ReadonlyArray<string>>,
   messages: FieldErrorMessages,
+  configurationValues: Record<string, string> = {},
+  isJinjaReserved?: (name: string) => boolean,
 ): MappedBlockErrors {
   const byConfigKey: Record<string, Array<string>> = {}
   const unmapped: Array<string> = []
@@ -128,6 +139,38 @@ export function mapBlockErrorsToFields(
         pushError(byConfigKey, missingOption[1], messages.missingRequiredValue)
       }
       continue
+    }
+
+    const invalidValue = error.match(
+      /^Invalid value for configuration option '([^']+)':/,
+    )
+    if (invalidValue) {
+      pushError(byConfigKey, invalidValue[1], error)
+      continue
+    }
+
+    const jinjaUndefined = error.match(
+      /^Jinja expression error: '([^']+)' is undefined/,
+    )
+    if (jinjaUndefined) {
+      const name = jinjaUndefined[1]
+      // "undefined" is misleading when the name is unusable by construction.
+      const message = isJinjaReserved?.(name)
+        ? messages.jinjaReservedReference(name)
+        : error
+      // Attribute by usage: the message names the glyph but not the field.
+      const usage = new RegExp(`\\$\\{[^}]*\\b${escapeRegExp(name)}\\b[^}]*\\}`)
+      const keys = Object.entries(configurationValues)
+        .filter(([, value]) => usage.test(value))
+        .map(([key]) => key)
+      if (keys.length > 0) {
+        for (const key of keys) pushError(byConfigKey, key, message)
+        continue
+      }
+      if (isJinjaReserved?.(name)) {
+        unmapped.push(message)
+        continue
+      }
     }
 
     unmapped.push(error)

--- a/frontend/src/features/glyphs/components/GlyphFormDialog.tsx
+++ b/frontend/src/features/glyphs/components/GlyphFormDialog.tsx
@@ -21,6 +21,7 @@ import type { GlobalGlyphItem } from '@/api/types/fable.types'
 import { useCreateGlobalGlyph } from '@/api/hooks/useFable'
 import { useAuth } from '@/features/auth/AuthContext'
 import { isValidGlyphKey } from '@/features/glyphs/utils/validate-key'
+import { useReservedGlyphReason } from '@/features/glyphs/utils/reserved-names'
 import { useUser } from '@/hooks/useUser'
 import { showToast } from '@/lib/toast'
 import {
@@ -56,6 +57,7 @@ export function GlyphFormDialog({
   editGlyph,
 }: GlyphFormDialogProps) {
   const { t } = useTranslation('glyphs')
+  const reservedReasonFor = useReservedGlyphReason()
   const { authType } = useAuth()
   const { data: user } = useUser()
   // Passthrough mode treats every caller as admin (matches backend AuthContext).
@@ -114,6 +116,16 @@ export function GlyphFormDialog({
     !isEditing &&
     trimmedKeyForValidation !== '' &&
     !isValidGlyphKey(trimmedKeyForValidation)
+  const keyReserved =
+    !isEditing && trimmedKeyForValidation !== '' && !keyFormatInvalid
+      ? reservedReasonFor(trimmedKeyForValidation)
+      : null
+  const reservedMessage =
+    keyReserved === 'intrinsic'
+      ? t('form.keyReservedIntrinsic')
+      : keyReserved === 'jinja'
+        ? t('form.keyReservedJinja')
+        : null
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -125,6 +137,15 @@ export function GlyphFormDialog({
     if (!trimmedKey || !trimmedValue) return
     if (!isEditing && !isValidGlyphKey(trimmedKey)) {
       setError(t('form.keyInvalid'))
+      return
+    }
+    const reserved = !isEditing ? reservedReasonFor(trimmedKey) : null
+    if (reserved) {
+      setError(
+        reserved === 'intrinsic'
+          ? t('form.keyReservedIntrinsic')
+          : t('form.keyReservedJinja'),
+      )
       return
     }
 
@@ -173,10 +194,14 @@ export function GlyphFormDialog({
               onChange={(e) => setKey(e.target.value)}
               placeholder={t('form.keyPlaceholder')}
               disabled={isEditing}
-              aria-invalid={keyFormatInvalid || undefined}
+              aria-invalid={
+                keyFormatInvalid || keyReserved !== null || undefined
+              }
             />
             {keyFormatInvalid ? (
               <P className="text-sm text-destructive">{t('form.keyInvalid')}</P>
+            ) : reservedMessage ? (
+              <P className="text-sm text-destructive">{reservedMessage}</P>
             ) : (
               <P className="text-sm text-muted-foreground">
                 {t('form.keyHelp')}
@@ -262,6 +287,7 @@ export function GlyphFormDialog({
                 !key.trim() ||
                 !value.trim() ||
                 keyFormatInvalid ||
+                keyReserved !== null ||
                 createGlyph.isPending
               }
             >

--- a/frontend/src/features/glyphs/utils/reserved-names.ts
+++ b/frontend/src/features/glyphs/utils/reserved-names.ts
@@ -1,0 +1,42 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/** Client-side mirror of the backend's validate_glyph() (#622): a glyph name
+ * must not shadow an intrinsic glyph or a jinja filter/global. Name sets come
+ * live from the API; while they load, checks pass and the server enforces. */
+
+import { useMemo } from 'react'
+import { useAvailableGlyphs, useGlyphFunctions } from '@/api/hooks/useFable'
+
+export type ReservedGlyphReason = 'intrinsic' | 'jinja'
+
+/** Intrinsic wins over jinja, matching the backend's check order. */
+export function reservedGlyphReason(
+  name: string,
+  intrinsicNames: ReadonlySet<string>,
+  jinjaNames: ReadonlySet<string>,
+): ReservedGlyphReason | null {
+  if (intrinsicNames.has(name)) return 'intrinsic'
+  if (jinjaNames.has(name)) return 'jinja'
+  return null
+}
+
+export function useReservedGlyphReason(): (
+  name: string,
+) => ReservedGlyphReason | null {
+  const { data: intrinsics } = useAvailableGlyphs()
+  const { data: functions } = useGlyphFunctions()
+  return useMemo(() => {
+    const intrinsicNames = new Set((intrinsics ?? []).map((g) => g.name))
+    const jinjaNames = new Set((functions?.functions ?? []).map((f) => f.name))
+    return (name: string) =>
+      reservedGlyphReason(name, intrinsicNames, jinjaNames)
+  }, [intrinsics, functions])
+}

--- a/frontend/src/locales/en/configure.json
+++ b/frontend/src/locales/en/configure.json
@@ -26,7 +26,8 @@
   "fieldErrors": {
     "unknownConfigKey": "Unknown configuration key",
     "missingRequiredValue": "Missing required value",
-    "unknownGlyph": "Unknown glyph: {{glyph}}"
+    "unknownGlyph": "Unknown glyph: {{glyph}}",
+    "jinjaReservedReference": "'{{name}}' clashes with a Jinja filter or function and cannot be used as a variable — choose a different name."
   },
   "page": {
     "notFoundTitle": "The requested configuration was not found.",

--- a/frontend/src/locales/en/glyphs.json
+++ b/frontend/src/locales/en/glyphs.json
@@ -39,6 +39,8 @@
     "keyPlaceholder": "e.g. myVariable",
     "keyHelp": "Used as ${key} in fable configurations",
     "keyInvalid": "Key must start with a letter or underscore and contain only letters, digits and underscores. Hyphens, spaces and other characters are not allowed.",
+    "keyReservedIntrinsic": "This name is a built-in intrinsic glyph and cannot be used.",
+    "keyReservedJinja": "This name is a Jinja filter or function and cannot be used.",
     "value": "Value",
     "valuePlaceholder": "The value to interpolate",
     "public": "Public",

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -298,20 +298,6 @@
   animation: run-node-ring 2s ease-in-out infinite;
 }
 
-/* Run canvas: breathing halo while a job executes — motion means "working". */
-@keyframes run-canvas-breathe {
-  0%,
-  100% {
-    box-shadow: 0 0 8px rgba(251, 191, 36, 0.15);
-  }
-  50% {
-    box-shadow: 0 0 18px rgba(251, 191, 36, 0.4);
-  }
-}
-.run-canvas-breathing {
-  animation: run-canvas-breathe 2.5s ease-in-out infinite;
-}
-
 /*
  * Fable-builder palette drag-and-drop: compatible handles pulse
  * (`.dnd-droppable`), the hovered one locks on (`.dnd-active`). box-shadow

--- a/frontend/tests/integration/features/visualise/visualise-page.test.tsx
+++ b/frontend/tests/integration/features/visualise/visualise-page.test.tsx
@@ -174,25 +174,33 @@ describe('VisualisePage', () => {
       .toBeVisible()
   })
 
-  it('activates two sources as A/B and auto-starts one lens per directory', async () => {
-    useComparisonStore.getState().addEntry(RUN_A)
-    useComparisonStore.getState().addEntry(RUN_B)
-    const screen = await renderVisualisePage()
+  // Double-spawn tests: two staggered lens boots overrun the default test
+  // budget on slow CI runners.
+  it(
+    'activates two sources as A/B and auto-starts one lens per directory',
+    { timeout: 30000 },
+    async () => {
+      useComparisonStore.getState().addEntry(RUN_A)
+      useComparisonStore.getState().addEntry(RUN_B)
+      const screen = await renderVisualisePage()
 
-    // Chips carry the slot badges (name also appears in panel headers).
-    await expect.element(screen.getByText('Run A').first()).toBeVisible()
-    await expect.element(screen.getByText('Run B').first()).toBeVisible()
+      // Chips carry the slot badges (name also appears in panel headers).
+      await expect.element(screen.getByText('Run A').first()).toBeVisible()
+      await expect.element(screen.getByText('Run B').first()).toBeVisible()
 
-    // Each panel resolves its dir and starts its own lens.
-    await expect.poll(() => listMockLenses(), { timeout: 8000 }).toHaveLength(2)
-    const paths = listMockLenses()
-      .map((l) => l.lens_params.local_path)
-      .sort()
-    expect(paths).toEqual([
-      '/data/output/job-completed-001_1',
-      '/data/output/job-grib-b-008_1',
-    ])
-  })
+      // Each panel resolves its dir and starts its own lens.
+      await expect
+        .poll(() => listMockLenses(), { timeout: 15000 })
+        .toHaveLength(2)
+      const paths = listMockLenses()
+        .map((l) => l.lens_params.local_path)
+        .sort()
+      expect(paths).toEqual([
+        '/data/output/job-completed-001_1',
+        '/data/output/job-grib-b-008_1',
+      ])
+    },
+  )
 
   it('starts exactly one lens when both sources resolve to the same directory', async () => {
     useComparisonStore.getState().addEntry(RUN_A)
@@ -407,34 +415,40 @@ describe('VisualisePage', () => {
     ).toEqual(['/data/output/job-completed-001_1'])
   })
 
-  it('removing a source stops its now-orphaned lens', async () => {
-    useComparisonStore.getState().addEntry(RUN_A)
-    useComparisonStore.getState().addEntry(RUN_B)
-    const screen = await renderVisualisePage()
-    await expect.poll(() => listMockLenses(), { timeout: 8000 }).toHaveLength(2)
+  it(
+    'removing a source stops its now-orphaned lens',
+    { timeout: 30000 },
+    async () => {
+      useComparisonStore.getState().addEntry(RUN_A)
+      useComparisonStore.getState().addEntry(RUN_B)
+      const screen = await renderVisualisePage()
+      await expect
+        .poll(() => listMockLenses(), { timeout: 15000 })
+        .toHaveLength(2)
 
-    // Take B out of the view, then out of the basket (collected chip).
-    await screen
-      .getByRole('button', { name: 'Remove B from view — continue with A' })
-      .click()
-    await screen.getByRole('button', { name: 'Manage sources' }).click()
-    // Native click: the unstyled dialog's inert backdrop confuses
-    // Playwright hit-testing (see the stop-row test above).
-    const removeB = screen.getByRole('button', { name: /Remove Run B/ })
-    await expect.element(removeB).toBeVisible()
-    ;(removeB.element() as HTMLElement).click()
+      // Take B out of the view, then out of the basket (collected chip).
+      await screen
+        .getByRole('button', { name: 'Remove B from view — continue with A' })
+        .click()
+      await screen.getByRole('button', { name: 'Manage sources' }).click()
+      // Native click: the unstyled dialog's inert backdrop confuses
+      // Playwright hit-testing (see the stop-row test above).
+      const removeB = screen.getByRole('button', { name: /Remove Run B/ })
+      await expect.element(removeB).toBeVisible()
+      ;(removeB.element() as HTMLElement).click()
 
-    await expect
-      .poll(() => listMockLenses().filter((l) => l.status === 'running'), {
-        timeout: 5000,
-      })
-      .toHaveLength(1)
-    expect(
-      listMockLenses()
-        .filter((l) => l.status === 'running')
-        .map((l) => l.lens_params.local_path),
-    ).toEqual(['/data/output/job-completed-001_1'])
-  })
+      await expect
+        .poll(() => listMockLenses().filter((l) => l.status === 'running'), {
+          timeout: 5000,
+        })
+        .toHaveLength(1)
+      expect(
+        listMockLenses()
+          .filter((l) => l.status === 'running')
+          .map((l) => l.lens_params.local_path),
+      ).toEqual(['/data/output/job-completed-001_1'])
+    },
+  )
 
   it("the slot bar's X on A promotes B to solo view", async () => {
     useComparisonStore.getState().addEntry(RUN_A)

--- a/frontend/tests/unit/components/fields/fable-type.test.ts
+++ b/frontend/tests/unit/components/fields/fable-type.test.ts
@@ -1,0 +1,129 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  artifactType,
+  closedEnum,
+  dateType,
+  datetimeType,
+  floatType,
+  geodomainType,
+  intType,
+  listOf,
+  openEnum,
+  paramType,
+  parseFableType,
+  serializeValueType,
+  stringType,
+  unionOf,
+} from '@/components/base/fields/fable-type'
+
+describe('serializeValueType', () => {
+  // Pinned to the exact strings fiab-core's FableType.serialize() emits —
+  // if one of these fails, the backend grammar moved and the whole module
+  // needs re-alignment, not just the test.
+  it('serializes atoms to the backend wire strings', () => {
+    expect(serializeValueType(stringType)).toBe('str')
+    expect(serializeValueType(intType)).toBe('int')
+    expect(serializeValueType(floatType)).toBe('float')
+    expect(serializeValueType(dateType)).toBe('date')
+    expect(serializeValueType(datetimeType)).toBe('datetime')
+    expect(serializeValueType(geodomainType)).toBe('geodomain')
+    expect(serializeValueType(artifactType)).toBe('artifact')
+    expect(serializeValueType(paramType)).toBe('param')
+  })
+
+  // Real emitters from fiab-plugin-ecmwf blocks.py / anemoi blocks.py.
+  it('serializes enums exactly like the backend emitters', () => {
+    expect(serializeValueType(closedEnum(['mars', 'ecmwf-open-data']))).toBe(
+      "enumClosed[str]('mars','ecmwf-open-data')",
+    )
+    expect(serializeValueType(closedEnum(['png', 'pdf', 'svg']))).toBe(
+      "enumClosed[str]('png','pdf','svg')",
+    )
+    expect(serializeValueType(openEnum(['mars', 'opendata', 'polytope']))).toBe(
+      "enumOpen[str]('mars','opendata','polytope')",
+    )
+  })
+
+  it('serializes numeric enums with inferred subtype and unquoted items', () => {
+    expect(serializeValueType(closedEnum([1, 2, 3]))).toBe(
+      'enumClosed[int](1,2,3)',
+    )
+    expect(serializeValueType(openEnum([0.5, 1.5]))).toBe(
+      'enumOpen[float](0.5,1.5)',
+    )
+  })
+
+  it('serializes lists and unions recursively', () => {
+    expect(serializeValueType(listOf(stringType))).toBe('list[str]')
+    expect(serializeValueType(listOf(closedEnum(['2t', 'msl'])))).toBe(
+      "list[enumClosed[str]('2t','msl')]",
+    )
+    expect(serializeValueType(unionOf([intType, stringType]))).toBe(
+      'union[int,str]',
+    )
+  })
+})
+
+describe('parseFableType', () => {
+  it('round-trips every representative type', () => {
+    const representatives = [
+      stringType,
+      intType,
+      floatType,
+      dateType,
+      datetimeType,
+      geodomainType,
+      artifactType,
+      paramType,
+      closedEnum(['mars', 'ecmwf-open-data']),
+      closedEnum(['fc:t:step0', 'fc:t:step6'], artifactType),
+      openEnum(['mars', 'opendata', 'polytope']),
+      closedEnum([1, 2, 3]),
+      openEnum([0.5, 1.5]),
+      listOf(stringType),
+      listOf(intType),
+      listOf(closedEnum(['2t', 'msl'])),
+      unionOf([intType, stringType]),
+      unionOf([listOf(intType), closedEnum(['a', 'b'])]),
+    ]
+    for (const t of representatives) {
+      expect(parseFableType(serializeValueType(t))).toEqual(t)
+    }
+  })
+
+  it('tolerates legacy aliases, casing, spaces, and unquoted items', () => {
+    expect(parseFableType('date-iso8601')).toEqual(dateType)
+    expect(parseFableType('Integer')).toEqual(intType)
+    expect(parseFableType('number')).toEqual(floatType)
+    expect(parseFableType('List[String]')).toEqual(listOf(stringType))
+    expect(parseFableType("enumOpen[str]('mars', 'opendata')")).toEqual(
+      openEnum(['mars', 'opendata']),
+    )
+    expect(parseFableType('enumClosed[str](2t,msl)')).toEqual(
+      closedEnum(['2t', 'msl']),
+    )
+    // Legacy bare `enum` reads as the open form.
+    expect(parseFableType("enum[str]('a')")).toEqual(openEnum(['a']))
+  })
+
+  it('rejects strings outside the grammar', () => {
+    expect(parseFableType('foobar')).toBeNull()
+    expect(parseFableType('enumClosed[str]()')).toBeNull()
+    expect(parseFableType('list[foobar]')).toBeNull()
+    expect(parseFableType('str trailing')).toBeNull()
+    expect(parseFableType('union[]')).toBeNull()
+    // optional[] left the canonical grammar in #570 — the widget
+    // projection peels it, the grammar itself does not.
+    expect(parseFableType('optional[int]')).toBeNull()
+  })
+})

--- a/frontend/tests/unit/components/fields/fable-type.test.ts
+++ b/frontend/tests/unit/components/fields/fable-type.test.ts
@@ -41,6 +41,20 @@ describe('serializeValueType', () => {
     expect(serializeValueType(paramType)).toBe('param')
   })
 
+  // fiab-core `_serialize_enum_item` dispatches on the declared subtype.
+  it('leaves date and datetime enum items unquoted', () => {
+    expect(serializeValueType(closedEnum(['2026-01-01'], dateType))).toBe(
+      'enumClosed[date](2026-01-01)',
+    )
+    expect(
+      serializeValueType(openEnum(['2026-01-01T00:00:00'], datetimeType)),
+    ).toBe('enumOpen[datetime](2026-01-01T00:00:00)')
+    // str-ish subtypes stay quoted, including artifact and param.
+    expect(serializeValueType(closedEnum(['fc:t:step0'], artifactType))).toBe(
+      "enumClosed[artifact]('fc:t:step0')",
+    )
+  })
+
   // Real emitters from fiab-plugin-ecmwf blocks.py / anemoi blocks.py.
   it('serializes enums exactly like the backend emitters', () => {
     expect(serializeValueType(closedEnum(['mars', 'ecmwf-open-data']))).toBe(
@@ -87,6 +101,9 @@ describe('parseFableType', () => {
       paramType,
       closedEnum(['mars', 'ecmwf-open-data']),
       closedEnum(['fc:t:step0', 'fc:t:step6'], artifactType),
+      closedEnum(['2026-01-01', '2026-01-02'], dateType),
+      openEnum(['2026-01-01T00:00:00'], datetimeType),
+      listOf(closedEnum(['2026-01-01'], dateType)),
       openEnum(['mars', 'opendata', 'polytope']),
       closedEnum([1, 2, 3]),
       openEnum([0.5, 1.5]),

--- a/frontend/tests/unit/components/fields/value-type-parser.test.ts
+++ b/frontend/tests/unit/components/fields/value-type-parser.test.ts
@@ -152,6 +152,38 @@ describe('parseValueType', () => {
       })
     })
 
+    it('parses int-subtype enums as selects over the wire strings', () => {
+      expect(parseValueType('enumClosed[int](1,2,3)')).toEqual({
+        type: 'enum',
+        options: ['1', '2', '3'],
+        closed: true,
+      })
+    })
+
+    it('parses float-subtype enums', () => {
+      expect(parseValueType('enumOpen[float](0.5,1.5)')).toEqual({
+        type: 'enum',
+        options: ['0.5', '1.5'],
+        closed: false,
+      })
+    })
+
+    it('parses a list of int-subtype enums as a closed multi-select', () => {
+      expect(parseValueType('list[enumClosed[int](1,2)]')).toEqual({
+        type: 'enumList',
+        options: ['1', '2'],
+        closed: true,
+      })
+    })
+
+    it('falls back to unknown for unsupported enum subtypes', () => {
+      expect(
+        parseValueType('enumClosed[datetime](2026-01-01T00:00:00)'),
+      ).toEqual({
+        type: 'unknown',
+        raw: 'enumClosed[datetime](2026-01-01T00:00:00)',
+      })
+    })
   })
 
   describe('whitespace and case handling', () => {

--- a/frontend/tests/unit/components/fields/value-type-parser.test.ts
+++ b/frontend/tests/unit/components/fields/value-type-parser.test.ts
@@ -140,7 +140,8 @@ describe('parseValueType', () => {
       })
     })
 
-    // anemoiSource.input_source ships exactly this, spaces and all.
+    // anemoiSource.input_source ships this (the serializer emits no
+    // spaces after commas; tolerate both).
     it('parses enumOpen options as an open enum', () => {
       expect(
         parseValueType("enumOpen[str]('mars', 'opendata', 'polytope')"),
@@ -150,6 +151,7 @@ describe('parseValueType', () => {
         closed: false,
       })
     })
+
   })
 
   describe('whitespace and case handling', () => {

--- a/frontend/tests/unit/features/fable-builder/utils/map-block-errors-to-fields.test.ts
+++ b/frontend/tests/unit/features/fable-builder/utils/map-block-errors-to-fields.test.ts
@@ -16,6 +16,7 @@ const messages: FieldErrorMessages = {
   unknownConfigKey: 'Unknown configuration key',
   missingRequiredValue: 'Missing required value',
   unknownGlyph: (name) => `Unknown glyph: \${${name}}`,
+  jinjaReservedReference: (name) => `Reserved jinja name: ${name}`,
 }
 
 describe('mapBlockErrorsToFields', () => {
@@ -159,6 +160,7 @@ describe('mapBlockErrorsToFields', () => {
       unknownConfigKey: 'Schlüssel unbekannt',
       missingRequiredValue: 'Wert fehlt',
       unknownGlyph: (name) => `Unbekannter Glyph: ${name}`,
+      jinjaReservedReference: (name) => `Reservierter Name: ${name}`,
     }
     const result = mapBlockErrorsToFields(
       ["Block contains missing config: {'date'}"],
@@ -168,6 +170,79 @@ describe('mapBlockErrorsToFields', () => {
     expect(result.byConfigKey).toEqual({
       date: ['Wert fehlt'],
       expver: ['Unbekannter Glyph: runtd'],
+    })
+  })
+
+  describe('invalid configuration values', () => {
+    it('attributes the verbatim error to the named key', () => {
+      const error =
+        "Invalid value for configuration option 'format': expected enumClosed[str]('png','pdf','svg'). 'x' is not a valid option. Valid options are: png, pdf, svg"
+      const result = mapBlockErrorsToFields([error], {}, messages, {})
+      expect(result.byConfigKey).toEqual({ format: [error] })
+      expect(result.unmapped).toEqual([])
+    })
+  })
+
+  describe('jinja expression errors', () => {
+    const error = "Jinja expression error: 'format' is undefined"
+
+    it('attributes the verbatim error to keys whose value uses the glyph', () => {
+      const result = mapBlockErrorsToFields([error], {}, messages, {
+        format: '${format}',
+        domain: 'global',
+      })
+      expect(result.byConfigKey).toEqual({ format: [error] })
+      expect(result.unmapped).toEqual([])
+    })
+
+    it('attributes to every key referencing the glyph inside an expression', () => {
+      const result = mapBlockErrorsToFields([error], {}, messages, {
+        path: '${outputRoot}/x.${format}',
+        format: '${format | upper}',
+      })
+      expect(result.byConfigKey).toEqual({
+        path: [error],
+        format: [error],
+      })
+    })
+
+    it('stays unmapped when no configuration value uses the glyph', () => {
+      const result = mapBlockErrorsToFields([error], {}, messages, {
+        domain: 'global',
+      })
+      expect(result.byConfigKey).toEqual({})
+      expect(result.unmapped).toEqual([error])
+    })
+
+    it('does not match the bare name outside a ${...} expression', () => {
+      const result = mapBlockErrorsToFields([error], {}, messages, {
+        note: 'output format is png',
+      })
+      expect(result.unmapped).toEqual([error])
+    })
+
+    it('swaps in the reserved-name message when the name is jinja-reserved', () => {
+      const result = mapBlockErrorsToFields(
+        [error],
+        {},
+        messages,
+        { format: '${format}' },
+        (name) => name === 'format',
+      )
+      expect(result.byConfigKey).toEqual({
+        format: ['Reserved jinja name: format'],
+      })
+    })
+
+    it('uses the reserved-name message even when unattributed', () => {
+      const result = mapBlockErrorsToFields(
+        [error],
+        {},
+        messages,
+        {},
+        (name) => name === 'format',
+      )
+      expect(result.unmapped).toEqual(['Reserved jinja name: format'])
     })
   })
 })

--- a/frontend/tests/unit/features/glyphs/reserved-names.test.ts
+++ b/frontend/tests/unit/features/glyphs/reserved-names.test.ts
@@ -1,0 +1,43 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { reservedGlyphReason } from '@/features/glyphs/utils/reserved-names'
+
+const INTRINSICS = new Set(['runId', 'submitDatetime', 'attemptCount'])
+const JINJA = new Set(['timedelta', 'floor_day', 'add_days'])
+
+describe('reservedGlyphReason', () => {
+  it('flags intrinsic glyph names', () => {
+    expect(reservedGlyphReason('runId', INTRINSICS, JINJA)).toBe('intrinsic')
+  })
+
+  it('flags jinja filter/global names', () => {
+    expect(reservedGlyphReason('timedelta', INTRINSICS, JINJA)).toBe('jinja')
+  })
+
+  it('intrinsic wins when a name is in both sets (backend check order)', () => {
+    const both = new Set(['clash'])
+    expect(reservedGlyphReason('clash', both, both)).toBe('intrinsic')
+  })
+
+  it('passes ordinary names', () => {
+    expect(reservedGlyphReason('myVariable', INTRINSICS, JINJA)).toBeNull()
+  })
+
+  it('is case-sensitive like the backend sets', () => {
+    expect(reservedGlyphReason('runid', INTRINSICS, JINJA)).toBeNull()
+  })
+
+  it('passes everything while the sets are still empty (loading)', () => {
+    const empty = new Set<string>()
+    expect(reservedGlyphReason('runId', empty, empty)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Follow-ups to #570's extensible types, plus two validation-visibility fixes found while working in the same area. The value-type parser is split into a grammar module that mirrors fiab-core and a thin widget projection over it, and backend validation errors now reach the user at the field they concern instead of only on the canvas node.

## Grammar mirror

`value-type-parser.ts` previously recognised the wire syntax and chose widgets in one pass of regexes, so a grammar change meant editing patterns scattered through widget logic, and mock fixtures hand-wrote wire strings as literals.

- **`fable-type.ts` (new)** owns the grammar: a `FableType` union mirroring fiab-core's `types.py`, factories mirroring its constructors, `serializeValueType` mirroring `FableType.serialize()`, and `parseFableType` mirroring `_parse` (remainder threading, depth-matched brackets, longest-first atoms so `string` wins over `str`). Parsing is a deliberate tolerant superset -- case-insensitive, legacy aliases (`string`, `integer`, `number`, `date-iso8601`) -- while serialization is always canonical.
- **`value-type-parser.ts`** is now just the widget projection: parse, then flatten onto a field. Grammar-valid but widget-less types (`union`, `bboxWSEN`, `geodomainSingle`) degrade to a text input rather than crashing.
- **Mocks build wire strings through the factories**, so fixtures cannot drift from real syntax; a round-trip test pins every representative type.
- `artifact` and `param` from #618 are first-class kinds; int/float enum subtypes render as selects.


## Validation visibility

- **Reserved glyph names are flagged while typing**, mirroring #622's `validate_glyph()`: a new name that shadows an intrinsic glyph or a jinja filter is rejected inline in both the global-variable dialog and the builder's local-variable row. The name sets come live from `/glyphs/list` and `/glyphs/functions` -- nothing is hardcoded, and while they load the check passes so the server stays the authority.
- **Block errors now appear on the field they belong to.** The config sidebar rendered only per-field errors, so any block-level message the mapper could not attribute was invisible there and appeared solely on the canvas node. Invalid-value errors (which name their key) map onto that field; jinja undefined-name errors map onto the fields whose value references the name inside a `${...}` expression; and when the name is a known jinja filter the message says it clashes rather than repeating jinja's misleading "is undefined". Anything still unattributed renders at the top of the sidebar, so no backend error can be silent.

## Also

- The run canvas no longer breathes while a job executes: flush against the split divider the glow read as a vertical amber stripe, and running state is already carried by the header chip, the per-block spinner and the beam edges.
- Two visualise tests that wait for a second lens spawn got 15s polls and 30s budgets; the fixed 8s poll was overrunning on CI runners around 40% slower than local. `expect.poll` resolves early, so fast runs pay nothing.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
