### PR TITLE
[backend] fix jinja filter handling

### DIFF
--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -391,6 +391,27 @@ def _validate_expand_with_buckets(
                 block_errors[blockId] += [f"References non-existent block(s): {missing}"]
                 invalidable.add(blockId)
 
+    # NOTE it may happen that the user did like ${format} in a configuration option, ie,
+    # used a filter name in place of a glyph. Thats technically jinja valid, but we
+    # forbid using filter names as glyph names for clarity -- hence there is no way this
+    # would ever render. At this stage of the code, if ${format} gets used but is not
+    # declared a local glyph, it is treated as a missing glyph -- which is misleading,
+    # because specifying the glyph would just give a *different* error. Hence we inspect
+    # missing glyphs for invalid glyph values, and convert them to more explicit block
+    # errors
+    for blockId, value in missing_glyphs_result.items():
+        invalid_glyph_names_reason: dict[str, str] = {}
+        invalid_glyph_names_occurrence: dict[str, list[str]] = defaultdict(list)
+        for configurationOptionId, missingGlyphs in value.items():
+            for missingGlyph in missingGlyphs:
+                e = validate_glyph(missingGlyph).e
+                if e is not None:
+                    invalid_glyph_names_reason[missingGlyph] = f"Invalid glyph name: {missingGlyph} (due to {e}); appears in ["
+                    invalid_glyph_names_occurrence[missingGlyph].append(configurationOptionId)
+            missingGlyphs -= invalid_glyph_names_reason.keys()
+        for invalidGlyph, prefix in invalid_glyph_names_reason.items():
+            block_errors[blockId] += [prefix + ", ".join(invalid_glyph_names_occurrence[invalidGlyph]) + "]"]
+
     return BlueprintValidationExpansion(
         possible_sources=possible_sources,
         possible_expansions=possible_expansions,

--- a/backend/src/forecastbox/domain/glyphs/jinja_interpolation.py
+++ b/backend/src/forecastbox/domain/glyphs/jinja_interpolation.py
@@ -16,6 +16,7 @@ work directly. The auto-coercion is bound to fiab-core.types.DatetimeType, as th
 inherently coupled.
 """
 
+import logging
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -29,6 +30,7 @@ from jinja2.sandbox import SandboxedEnvironment
 
 from forecastbox.utility.time import value_dt2str
 
+logger = logging.getLogger(__name__)
 _dt_instance = DatetimeType()
 
 
@@ -164,7 +166,8 @@ def _make_env() -> SandboxedEnvironment:
 _ENV = _make_env()
 
 # Names that are part of the jinja2 environment (filters + globals) rather than user variables.
-_FILTER_NAMES: frozenset[str] = frozenset(_ENV.filters) | frozenset(_ENV.globals)
+_GLOBALS = frozenset(_ENV.globals)
+_FILTER_NAMES: frozenset[str] = frozenset(_ENV.filters) | _GLOBALS
 
 
 def get_custom_functions() -> list[CustomFunction]:
@@ -194,7 +197,7 @@ def render_expression(raw: str, variables: dict[str, str]) -> str:
 
 
 def _collect_glyph_names(node: nodes.Node, glyphs: set[str]) -> None:
-    if isinstance(node, nodes.Name) and node.ctx == "load" and node.name not in _FILTER_NAMES:
+    if isinstance(node, nodes.Name) and node.ctx == "load" and node.name not in _GLOBALS:
         glyphs.add(node.name)
     for child in node.iter_child_nodes():
         _collect_glyph_names(child, glyphs)
@@ -217,4 +220,8 @@ def extract_glyph_names(raw: str) -> Either[set[str], str]:  # type: ignore[inva
 
     glyphs: set[str] = set()
     _collect_glyph_names(ast, glyphs)
-    return Either.ok(glyphs - _FILTER_NAMES)
+    # NOTE we used to subtract _FILTER_NAMES here, but thats actually not necessary:
+    # an expression like ${myGlyph | aFilter(var1, var2)} will not return aFilter
+    # as a node anyway due to jinja ast typing. And in case user malforms by providing
+    # ${aFilter}, which oddly is valid in jinja, we *do* want to return it
+    return Either.ok(glyphs)

--- a/backend/src/forecastbox/domain/glyphs/resolution.py
+++ b/backend/src/forecastbox/domain/glyphs/resolution.py
@@ -16,6 +16,7 @@
 # (resolution, error, missing), etc
 
 import datetime as dt
+import logging
 import re
 from dataclasses import dataclass
 
@@ -24,6 +25,8 @@ from fiab_core.fable import BlockInstance, ConfigurationOptionId
 
 from forecastbox.domain.glyphs.exceptions import GlyphCircularReferenceError
 from forecastbox.domain.glyphs.jinja_interpolation import extract_glyph_names, render_expression
+
+logger = logging.getLogger(__name__)
 
 PINNED_INTRINSIC_KEYS: frozenset[str] = frozenset({"startDatetime", "attemptCount"})
 """Intrinsic glyph keys that are always forced to their fresh intrinsic value in each attempt,


### PR DESCRIPTION
we remove filter names from the set of extracted glyphs, which was a bug -- our parsing of ast does not return _actual_ filters from the expression, only variables

this led to curious bug of eg ${format} considered as having no glyphs at all, which made subsequent validation/reporting odd

after fixing this, we can thus report the glyph as possibly missing, but that runs afoul of the validation where we prevent glyph names to overlap with filter names. We thus add a post-validation transformer, which converts missing glyphs to more descriptive block errors in case the glyph in question is invalid
