### PR TITLE
Feat/glyphs to run detail

### DIFF
--- a/backend/src/forecastbox/domain/run/service.py
+++ b/backend/src/forecastbox/domain/run/service.py
@@ -92,6 +92,7 @@ class RunDetail(FiabBaseModel):
     outputs: dict | None = None
     completed_block_ids: set[BlockInstanceId] | None = None
     planned_block_ids: set[BlockInstanceId] | None = None
+    glyph_values: dict[str, str] | None = None
 
 
 class ExecuteResult(FiabBaseModel):
@@ -313,6 +314,7 @@ async def poll_and_update(execution: RunRecord, detailed_report: bool = False) -
             outputs=raw_outputs,
             completed_block_ids=completed_block_ids,
             planned_block_ids=planned_block_ids,
+            glyph_values=execution.compiler_runtime_context.get("glyphs", None),
         )
 
     if status in ("submitted", "preparing", "running", "unknown") and cascade_job_id:

--- a/backend/src/forecastbox/domain/run/service.py
+++ b/backend/src/forecastbox/domain/run/service.py
@@ -314,7 +314,13 @@ async def poll_and_update(execution: RunRecord, detailed_report: bool = False) -
             outputs=raw_outputs,
             completed_block_ids=completed_block_ids,
             planned_block_ids=planned_block_ids,
-            glyph_values=execution.compiler_runtime_context.get("glyphs", None),
+            # NOTE: we add glyph values for submit date time and attempt count because they are
+            # *never* in the compiler runtime context, yet the client may require them for resolution
+            glyph_values={
+                **(execution.compiler_runtime_context.get("glyphs", None) or {}),
+                "submitDatetime": value_dt2str(execution.created_at),
+                "attemptCount": str(actual_attempt),
+            },
         )
 
     if status in ("submitted", "preparing", "running", "unknown") and cascade_job_id:

--- a/backend/src/forecastbox/routes/blueprint.py
+++ b/backend/src/forecastbox/routes/blueprint.py
@@ -463,13 +463,18 @@ def get_catalogue() -> dict[PluginCompositeId, BlockFactoryCatalogue]:
 async def expand_blueprint(
     blueprint: BlueprintBuilder,
     auth_context: AuthContext = Depends(get_auth_context),
+    validate_only: bool = False,
 ) -> BlueprintValidationExpansionResponse:
     """Validate a partially-constructed BlueprintBuilder and return completion options.
 
     Returns 200 regardless of whether validation errors are present; callers must
     inspect the returned error fields.
+
+    ``validate_only`` skips the (more expensive) expansion computation when the caller
+    only cares about resolved configuration options and validation errors -- e.g. when
+    re-rendering a previously executed Run for display purposes.
     """
-    result = await service.validate_expand(blueprint, auth_context, validate_only=False)
+    result = await service.validate_expand(blueprint, auth_context, validate_only=validate_only)
     return BlueprintValidationExpansionResponse(
         global_errors=result.global_errors,
         block_errors=result.block_errors,

--- a/backend/src/forecastbox/routes/run.py
+++ b/backend/src/forecastbox/routes/run.py
@@ -114,6 +114,7 @@ class RunDetailResponse(FiabBaseModel):
     outputs: RunOutputsResponse | None = None
     completed_block_ids: list[BlockInstanceId] | None = None
     planned_block_ids: list[BlockInstanceId] | None = None
+    glyph_values: dict[str, str] | None = None
 
 
 class RunListResponse(FiabBaseModel):
@@ -195,6 +196,7 @@ def _to_run_detail(domain_detail: service.RunDetail) -> RunDetailResponse:
         outputs=outputs_response,
         completed_block_ids=maybe_list(domain_detail.completed_block_ids),
         planned_block_ids=maybe_list(domain_detail.planned_block_ids),
+        glyph_values=domain_detail.glyph_values,
     )
 
 

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -795,6 +795,9 @@ def test_blueprint_expand_missing_glyph_warnings(tmpdir: Any, backend_client_use
     assert compare_with_tolerance(_time_parts[1], _dt.fromisoformat(created_at_sec))
     assert _time_parts[2] == "initial_value"
     assert _time_parts[3] == "local_glyph_value"
+    glyph_values = status_resp.json()["glyph_values"]
+    assert glyph_values["basicExecuteGlobalGlyph"] == "initial_value"
+    assert glyph_values["blueprintExecuteLocalGlyph"] == "local_glyph_value"
     outputTime.unlink()
 
     list_resp = backend_client_user.get("/run/list")

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -767,6 +767,15 @@ def test_blueprint_expand_missing_glyph_warnings(tmpdir: Any, backend_client_use
     assert post_resp.is_success, post_resp.text
 
     builder = _make_builder_full(tmpdir)
+
+    # Baseline: expand the blueprint before submission, using validate_only=True (the
+    # convenience/perf flag) since we only care about resolved_configuration_options here.
+    expand_before_resp = backend_client_user.put("/blueprint/expand", json=builder.model_dump(), params={"validate_only": True})
+    assert expand_before_resp.is_success, expand_before_resp.text
+    resolved_before = expand_before_resp.json()["resolved_configuration_options"]
+    assert resolved_before["source_time"]["text"].split(";")[2] == "initial_value"
+    assert resolved_before["source_time"]["text"].split(";")[3] == "local_glyph_value"
+
     save_req = BlueprintSaveCommand(builder=builder)
     save_resp = backend_client_user.post("/blueprint/create", json=save_req.model_dump())
     assert save_resp.is_success, save_resp.text
@@ -798,6 +807,34 @@ def test_blueprint_expand_missing_glyph_warnings(tmpdir: Any, backend_client_use
     glyph_values = status_resp.json()["glyph_values"]
     assert glyph_values["basicExecuteGlobalGlyph"] == "initial_value"
     assert glyph_values["blueprintExecuteLocalGlyph"] == "local_glyph_value"
+    # The two glyphs not stored on CompilerRuntimeContext (they're always recomputed on
+    # restart) must nonetheless be surfaced in their original, as-submitted shape.
+    assert glyph_values["submitDatetime"] == created_at
+    assert glyph_values["attemptCount"] == "1"
+    assert glyph_values["runId"] == run_id
+
+    # Re-expand the blueprint using the glyph values retrieved from RunDetail as local
+    # glyphs, to verify the rendering matches what was actually executed. This is expected
+    # to report global_errors (the retrieved glyphs include reserved/intrinsic names like
+    # runId/submitDatetime/attemptCount), but the resolved_configuration_options must still
+    # be computed using the provided values.
+    builder_with_run_glyphs = builder.model_copy(update={"local_glyphs": glyph_values})
+    expand_after_resp = backend_client_user.put(
+        "/blueprint/expand", json=builder_with_run_glyphs.model_dump(), params={"validate_only": True}
+    )
+    assert expand_after_resp.is_success, expand_after_resp.text
+    expand_after_data = expand_after_resp.json()
+    assert expand_after_data["global_errors"], "expected reserved intrinsic glyph names to be flagged"
+    resolved_after = expand_after_data["resolved_configuration_options"]
+    # runId is now the real one (was an example value before submission).
+    assert resolved_after["sink_main"]["fname"] == f"{tmpdir}/output{run_id}.main.txt"
+    # submitDatetime, and the global/local glyphs, now match what was actually used at
+    # execution time (startDatetime is intentionally not reproducible here, since it is
+    # always recomputed fresh on every attempt and never persisted).
+    resolved_time_parts = resolved_after["source_time"]["text"].split(";")
+    assert resolved_time_parts[0] == created_at
+    assert resolved_time_parts[2] == "initial_value"
+    assert resolved_time_parts[3] == "local_glyph_value"
     outputTime.unlink()
 
     list_resp = backend_client_user.get("/run/list")

--- a/backend/tests/unit/domain/run/test_run_detailed_report.py
+++ b/backend/tests/unit/domain/run/test_run_detailed_report.py
@@ -57,6 +57,7 @@ async def test_poll_and_update_requests_detailed_report_and_translates_to_block_
         progress=None,
         cascade_job_id="job-1",
         outputs=None,
+        compiler_runtime_context={},
     )
     response = SimpleNamespace(
         progresses={JobId("job-1"): SimpleNamespace(completed=False, pct="12.50", failure=None)},
@@ -102,6 +103,7 @@ async def test_poll_and_update_disables_detailed_report_when_cache_misses() -> N
         progress=None,
         cascade_job_id="job-1",
         outputs=None,
+        compiler_runtime_context={},
     )
     response = SimpleNamespace(
         progresses={JobId("job-1"): SimpleNamespace(completed=False, pct="12.50", failure=None)},
@@ -144,6 +146,7 @@ async def test_poll_and_update_returns_empty_detailed_fields_for_completed_runs(
         progress="100.00",
         cascade_job_id="job-1",
         outputs={"outputs": {"task-a": {"mime_type": "application/json", "original_block": "block-a"}}},
+        compiler_runtime_context={},
     )
 
     detail = await run_service.poll_and_update(cast(Run, execution), detailed_report=True)
@@ -167,6 +170,7 @@ async def test_get_run_asks_for_detailed_report_while_list_runs_does_not() -> No
         progress=None,
         cascade_job_id="job-1",
         outputs=None,
+        compiler_runtime_context={},
     )
     detailed = _run_detail(
         completed_block_ids={BlockInstanceId("block-a")},

--- a/backend/tests/unit/domain/run/test_service.py
+++ b/backend/tests/unit/domain/run/test_service.py
@@ -77,6 +77,7 @@ def _make_running_execution(outputs: RunOutputs | None) -> SimpleNamespace:
         progress=None,
         cascade_job_id="job-1",
         outputs=outputs.model_dump() if outputs is not None else None,
+        compiler_runtime_context={},
     )
 
 
@@ -257,6 +258,7 @@ async def test_poll_and_update_failed_job_exposes_cached_values_as_available() -
             progress=None,
             cascade_job_id="job-1",
             outputs=outputs.model_dump(),
+            compiler_runtime_context={},
         ),
     )
 


### PR DESCRIPTION
Adding glyph values to RunDetail

Allowing /expand to be run in validateOnly mode

Adding integration tests that check /expand-before-submit ~ /expand-after-submit, and that /expand after submit has the correct implicit glyph values