### PR TITLE
Bug/plugin uninstall

### DIFF
--- a/backend/src/forecastbox/domain/plugin/compatibility.py
+++ b/backend/src/forecastbox/domain/plugin/compatibility.py
@@ -85,7 +85,7 @@ def install_plugin_compatibly(pip_source: str, version: Version | None) -> Eithe
     package names to their version strings, or ``Either.error(msg)`` on failure.
     Never raises.
     """
-    if pip_source.startswith("-e"):
+    if pip_source.startswith("-e") or pip_source.startswith("file://"):
         pkgs = pip_source.split(" ", 1)
     else:
         if version is not None:

--- a/backend/src/forecastbox/domain/plugin/compatibility.py
+++ b/backend/src/forecastbox/domain/plugin/compatibility.py
@@ -46,7 +46,7 @@ def get_fiabcore_version() -> Version:
         # basically $(git describe --tags --abbrev=0 --match="c*")
         r = git.Repo("..")
         tags = (t.name for t in r.tags if t.name.startswith("c"))
-        mostRecent = max(tags, key=lambda x: int(r.git.rev_list(f"tags/{x}", "--count")))
+        mostRecent = max(tags, key=lambda x: int(r.git.rev_list(f"tags/{x}", "--count")), default="c0.0.0.0")
         noPrefix = mostRecent[1:]
         dropLast = noPrefix.rsplit(".", 1)[0]
         return Version(dropLast)

--- a/backend/src/forecastbox/domain/plugin/compatibility.py
+++ b/backend/src/forecastbox/domain/plugin/compatibility.py
@@ -28,6 +28,7 @@ import importlib
 import logging
 from collections.abc import Iterator
 
+import git
 from cascade.low.func import Either
 from packaging.specifiers import SpecifierSet
 from packaging.version import InvalidVersion, Version
@@ -41,7 +42,16 @@ logger = logging.getLogger(__name__)
 def get_fiabcore_version() -> Version:
     """Return the currently installed version of ``fiab-core`` as a ``Version`` object."""
     raw = importlib.metadata.version("fiab-core")
-    return Version(raw)
+    if raw == "0.0.0":
+        # basically $(git describe --tags --abbrev=0 --match="c*")
+        r = git.Repo("..")
+        tags = (t.name for t in r.tags if t.name.startswith("c"))
+        mostRecent = max(tags, key=lambda x: int(r.git.rev_list(f"tags/{x}", "--count")))
+        noPrefix = mostRecent[1:]
+        dropLast = noPrefix.rsplit(".", 1)[0]
+        return Version(dropLast)
+    else:
+        return Version(raw)
 
 
 def plugin_default_specifier() -> SpecifierSet:

--- a/backend/src/forecastbox/domain/plugin/db.py
+++ b/backend/src/forecastbox/domain/plugin/db.py
@@ -24,10 +24,11 @@ update that leaves unspecified fields (``None`` arguments) unchanged.
 """
 
 import datetime as dt
+import logging
 from dataclasses import dataclass
 from typing import Any, cast
 
-from sqlalchemy import select, update
+from sqlalchemy import delete, select, update
 
 import forecastbox.schemata.jobs as _jobs_module
 from forecastbox.domain.plugin.errors import PluginErrors
@@ -35,6 +36,8 @@ from forecastbox.domain.plugin.exceptions import PluginNotFound
 from forecastbox.schemata.plugin import PluginState
 from forecastbox.utility.db import dbRetry, querySingle
 from forecastbox.utility.time import current_time
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, eq=True, slots=True)
@@ -197,6 +200,20 @@ def clear_asset_ingest_needed(*, plugin_id: str) -> None:
     def function(i: int) -> None:
         with _jobs_module.sync_session_maker() as session:
             session.execute(update(PluginState).where(PluginState.plugin_id == plugin_id).values(asset_ingest_needed=False))
+            session.commit()
+
+    dbRetry(function)
+
+
+def delete_plugin_state(*, plugin_id: str) -> None:
+    """Removes the state row from the database (if any)"""
+
+    def function(i: int) -> None:
+        with _jobs_module.sync_session_maker() as session:
+            result = session.execute(delete(PluginState).where(PluginState.plugin_id == plugin_id))
+            deleted: int = result.rowcount  # ty:ignore
+            if deleted != 1:
+                raise ValueError(f"expected to delete exactly one row, found {deleted} instead")
             session.commit()
 
     dbRetry(function)

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -32,6 +32,7 @@ import re
 import threading
 import time
 from concurrent.futures import Future
+from functools import partial
 
 from cascade.low.func import Either
 from fiab_core.fable import BlockFactoryCatalogue, PluginCompositeId
@@ -41,8 +42,15 @@ from pyrsistent import pmap
 from pyrsistent.typing import PMap
 
 from forecastbox.domain.plugin.compatibility import install_plugin_compatibly
-from forecastbox.domain.plugin.db import clear_asset_ingest_needed, get_plugin_state, update_template_errors, upsert_plugin_state
+from forecastbox.domain.plugin.db import (
+    clear_asset_ingest_needed,
+    delete_plugin_state,
+    get_plugin_state,
+    update_template_errors,
+    upsert_plugin_state,
+)
 from forecastbox.domain.plugin.errors import PluginError, PluginErrors
+from forecastbox.utility.concurrency.manager import execution_manager
 from forecastbox.utility.concurrency.synchronization import delayed_thread, timed_acquire
 from forecastbox.utility.config import PluginSettings, PluginsSettings, config, config_edit_lock
 from forecastbox.utility.packages import try_import, try_version
@@ -411,9 +419,18 @@ def submit_update_single(pluginId: PluginCompositeId, install: bool, version: Ve
     return ""
 
 
-def uninstall_plugin(pluginId: PluginCompositeId) -> None:
+async def uninstall_plugin(pluginId: PluginCompositeId) -> None:
+    logger.debug(f"about to uninstall {pluginId=}")
     if pluginId not in config.external.plugins:
         raise ValueError(f"plugin {pluginId} not installed")
+    # db remove
+    logger.debug(f"about to db remove {pluginId=}")
+    await execution_manager.await_jobs_db(
+        "plugin.state.delete",
+        partial(delete_plugin_state, plugin_id=PluginCompositeId.to_str(pluginId)),
+    )
+    # config entry remove
+    logger.debug(f"about to config remove {pluginId=}")
     with timed_acquire(config_edit_lock, 5) as result:
         if not result:
             raise ValueError("failed to acquire the shared lock")

--- a/backend/src/forecastbox/routes/plugins.py
+++ b/backend/src/forecastbox/routes/plugins.py
@@ -154,7 +154,7 @@ def install_plugin(request: Request, pluginCompositeId: PluginCompositeId, admin
 async def uninstall_plugin_endpoint(
     request: Request, pluginCompositeId: PluginCompositeId, admin: UserRead | None = Depends(get_admin_user)
 ) -> Response:
-    uninstall_plugin(pluginCompositeId)
+    await uninstall_plugin(pluginCompositeId)
     return get_catalogue_redirect(request)
 
 

--- a/backend/src/forecastbox/utility/packages.py
+++ b/backend/src/forecastbox/utility/packages.py
@@ -80,6 +80,12 @@ def try_version(pip_source: str, module_name: str) -> str:
                 version = module._version
                 if isinstance(version, str):
                     return version
+        version_module = try_import(module_name + "._version")
+        if version_module is not None:
+            if hasattr(version_module, "version"):
+                version = version_module.version
+                if isinstance(version, str):
+                    return version
         return "unknown"
 
 
@@ -112,15 +118,17 @@ def _parse_pip_install(pip_output: str) -> dict[str, str]:
 
     Lines starting with `` + `` are newly-installed entries, e.g.:
     ``  + fiab-plugin-test==0.1.0 (from file:///path/to/package)``
+    We also include lines starting with `` ~ ``, which may have been cached from the `uv`'s PoV
+    but for us are at this stage nevertheless new (presumably).
 
     Returns a dict mapping package name to version string.
     """
     rv: dict[str, str] = {}
     for line in pip_output.splitlines():
         clean = line.strip()
-        if not clean.startswith("+"):
+        if not (clean.startswith("+") or clean.startswith("~")):
             continue
-        parts = clean.lstrip("+ ").split("==")
+        parts = clean.lstrip("+ ").lstrip("~ ").split("==")
         if len(parts) != 2:
             logger.warning(f"Suspicious pip output line: {clean!r} -- ignoring")
             continue


### PR DESCRIPTION
    1/ delete db row on plugin uninstall -- not doing so caused
    uninstall leaving the backend in an irrecoverably broken state wrt
    this plugin

    2/ make detection of version of installed plugin more robust by
    considering _version as a submodule

    3/ updating the detection of pip install to also include ~-lines
    along with +-lines, as repeated install/uninstall is served from
    cache

     4/ fix get_fiabcore_version for editable: detect from git tag