### PR TITLE
Feat/artifact notifications

### DIFF
--- a/backend/src/forecastbox/domain/artifact/__init__.py
+++ b/backend/src/forecastbox/domain/artifact/__init__.py
@@ -1,6 +1,10 @@
 """
 Manages the Artifact domain -- downloadable model checkpoints and other large binary data objects utilized by Runs.
 
-Does not depend on any other domain.
+Does not depend on any other domain directly. Loosely coupled with the Notification domain: once an
+artifact download completes, `manager.py` emits an `ArtifactDownloadedEvent` (see `events.py`) through
+the process-local event dispatcher, which the Notification domain picks up and forwards to connected
+websocket clients.
+
 Depended on by Run domain.
 """

--- a/backend/src/forecastbox/domain/artifact/__init__.py
+++ b/backend/src/forecastbox/domain/artifact/__init__.py
@@ -1,10 +1,8 @@
 """
 Manages the Artifact domain -- downloadable model checkpoints and other large binary data objects utilized by Runs.
 
-Does not depend on any other domain directly. Loosely coupled with the Notification domain: once an
-artifact download completes, `manager.py` emits an `ArtifactDownloadedEvent` (see `events.py`) through
-the process-local event dispatcher, which the Notification domain picks up and forwards to connected
-websocket clients.
+Does not depend on any other domain directly. Loosely coupled with the Notification domain eg on Artifact Download
+completion.
 
 Depended on by Run domain.
 """

--- a/backend/src/forecastbox/domain/artifact/events.py
+++ b/backend/src/forecastbox/domain/artifact/events.py
@@ -9,9 +9,9 @@
 
 """Events emitted by the Artifact domain.
 
-Currently only the completion of an artifact download is surfaced to clients, via the
-``ClientNotificationSource`` protocol -- see ``domain.notification``. Progress reports are
-intentionally not surfaced this way, clients are expected to poll for those.
+Currently only the completion of an artifact download is surfaced to clients.
+Progress reports are intentionally not surfaced this way, clients are expected to poll for those.
+Artifact deletion or registry fetch both happen in a blocking manner, thus no need for notification.
 """
 
 from dataclasses import dataclass
@@ -21,19 +21,22 @@ from forecastbox.domain.notification.models import ClientNotification
 
 
 @dataclass(frozen=True, eq=True, slots=True)
-class ArtifactDownloadedEvent:
+class ArtifactDownloadFinishedEvent:
     """Emitted once an artifact download completes and the artifact becomes locally available."""
 
     composite_id: CompositeArtifactId
+    is_success: bool
 
     def as_client_notification(self) -> ClientNotification:
+        result = ("un" if not self.is_success else "") + "successfully"
         return ClientNotification(
-            text=f"Artifact {self.composite_id.artifact_local_id} finished downloading",
+            text=f"Artifact {self.composite_id.artifact_local_id} finished downloading {result}",
             sourceDomainName="artifact",
-            sourceDomainEvent="artifactDownloaded",
+            sourceDomainEvent="artifactDownloadFinished",
             context={
                 "artifact_store_id": self.composite_id.artifact_store_id,
                 "artifact_local_id": self.composite_id.artifact_local_id,
+                "success": self.is_success,
             },
             detailRoute="api/v1/artifacts/model_details",
             refreshRoutes=["api/v1/artifacts/list_models"],

--- a/backend/src/forecastbox/domain/artifact/events.py
+++ b/backend/src/forecastbox/domain/artifact/events.py
@@ -1,0 +1,40 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Events emitted by the Artifact domain.
+
+Currently only the completion of an artifact download is surfaced to clients, via the
+``ClientNotificationSource`` protocol -- see ``domain.notification``. Progress reports are
+intentionally not surfaced this way, clients are expected to poll for those.
+"""
+
+from dataclasses import dataclass
+
+from forecastbox.domain.artifact.base import CompositeArtifactId
+from forecastbox.domain.notification.models import ClientNotification
+
+
+@dataclass(frozen=True, eq=True, slots=True)
+class ArtifactDownloadedEvent:
+    """Emitted once an artifact download completes and the artifact becomes locally available."""
+
+    composite_id: CompositeArtifactId
+
+    def as_client_notification(self) -> ClientNotification:
+        return ClientNotification(
+            text=f"Artifact {self.composite_id.artifact_local_id} finished downloading",
+            sourceDomainName="artifact",
+            sourceDomainEvent="artifactDownloaded",
+            context={
+                "artifact_store_id": self.composite_id.artifact_store_id,
+                "artifact_local_id": self.composite_id.artifact_local_id,
+            },
+            detailRoute="api/v1/artifacts/model_details",
+            refreshRoutes=["api/v1/artifacts/list_models"],
+        )

--- a/backend/src/forecastbox/domain/artifact/manager.py
+++ b/backend/src/forecastbox/domain/artifact/manager.py
@@ -30,7 +30,7 @@ from pyrsistent.typing import PMap, PSet
 
 from forecastbox.domain.artifact.base import ArtifactCatalog, CompositeArtifactId, MlModelDetail, MlModelOverview
 from forecastbox.domain.artifact.catalog import get_artifacts_catalog
-from forecastbox.domain.artifact.events import ArtifactDownloadedEvent
+from forecastbox.domain.artifact.events import ArtifactDownloadFinishedEvent
 from forecastbox.domain.artifact.io import delete_artifact, download_artifact, list_storage
 from forecastbox.utility import tunnel
 from forecastbox.utility.concurrency.synchronization import timed_acquire
@@ -148,13 +148,19 @@ def _download_artifact_task(composite_id: CompositeArtifactId) -> None:
                 else:
                     logger.warning(f"expected {composite_id} to be in ongoing downloads")
         logger.info(f"Successfully downloaded artifact {composite_id}")
+        is_success = True
     except Exception as e:
         logger.exception(f"artifact download failed for {composite_id}: {repr(e)}")
         report_artifact_download_progress(composite_id, failure=repr(e))
-        return
+        is_success = False
 
     try:
-        submit_event(Event(name=EventName("artifact.downloaded"), payload=ArtifactDownloadedEvent(composite_id=composite_id)))
+        submit_event(
+            Event(
+                name=EventName("artifact.downloaded"),
+                payload=ArtifactDownloadFinishedEvent(composite_id=composite_id, is_success=is_success),
+            )
+        )
     except Exception as e:
         logger.exception(f"failed to submit download-completed notification for {composite_id}: {repr(e)}")
 

--- a/backend/src/forecastbox/domain/artifact/manager.py
+++ b/backend/src/forecastbox/domain/artifact/manager.py
@@ -30,10 +30,12 @@ from pyrsistent.typing import PMap, PSet
 
 from forecastbox.domain.artifact.base import ArtifactCatalog, CompositeArtifactId, MlModelDetail, MlModelOverview
 from forecastbox.domain.artifact.catalog import get_artifacts_catalog
+from forecastbox.domain.artifact.events import ArtifactDownloadedEvent
 from forecastbox.domain.artifact.io import delete_artifact, download_artifact, list_storage
 from forecastbox.utility import tunnel
 from forecastbox.utility.concurrency.synchronization import timed_acquire
 from forecastbox.utility.config import config
+from forecastbox.utility.dispatcher import Event, EventName, submit_event
 from forecastbox.utility.tunnel import CommandHandle
 
 logger = logging.getLogger(__name__)
@@ -149,6 +151,12 @@ def _download_artifact_task(composite_id: CompositeArtifactId) -> None:
     except Exception as e:
         logger.exception(f"artifact download failed for {composite_id}: {repr(e)}")
         report_artifact_download_progress(composite_id, failure=repr(e))
+        return
+
+    try:
+        submit_event(Event(name=EventName("artifact.downloaded"), payload=ArtifactDownloadedEvent(composite_id=composite_id)))
+    except Exception as e:
+        logger.exception(f"failed to submit download-completed notification for {composite_id}: {repr(e)}")
 
 
 def submit_artifact_download(composite_id: CompositeArtifactId) -> Either[int, str]:  # ty: ignore[invalid-type-arguments]

--- a/backend/src/forecastbox/domain/artifact/manager.py
+++ b/backend/src/forecastbox/domain/artifact/manager.py
@@ -282,6 +282,8 @@ def delete_model(composite_id: CompositeArtifactId) -> Either[str, str]:  # ty: 
 
     # TODO race condition possibility 1/ pop in one thread 2/ another request triggers a download
     # 3/ unlink happens while download is ongoing -> fix by making the delete two-step
+    # TODO delete is now blocking operation, possibly taking some time -- we may want to switch
+    # to a submit-based one. Do not forget to emit a notification after completion/failure then
     handle = _ssh_handle_if_needed()
     try:
         delete_artifact(composite_id, config.backend.data_path, handle=handle)

--- a/backend/src/forecastbox/domain/notification/models.py
+++ b/backend/src/forecastbox/domain/notification/models.py
@@ -11,7 +11,7 @@
 protocol that other domains' events implement to produce one.
 """
 
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from forecastbox.utility.pydantic import FiabBaseModel
 
@@ -22,7 +22,7 @@ class ClientNotification(FiabBaseModel):
     text: str  # the full text that the frontend will display
     sourceDomainName: str  # domain as understood by backend: artifact, plugin, blueprint, run, ...
     sourceDomainEvent: str  # event name within the domain: artifactDownloaded, pluginUpdated, runFinished, ...
-    context: dict[str, str]  # arbitrary key-value, with schema specific to the sourceDomainEvent
+    context: dict[str, Any]  # arbitrary key-value, with schema specific to the sourceDomainEvent
     detailRoute: str | None  # optionally a direct route that the client could visit for more details
     refreshRoutes: list[str]  # possibly empty list of routes that the client should refresh to update its internal state
 

--- a/backend/tests/integration/test_model.py
+++ b/backend/tests/integration/test_model.py
@@ -43,7 +43,7 @@ def test_download_model(backend_client_admin: httpx.Client, backend_client: http
     expected_checkpoints = {f"{test_model_artifact_id}{e}" for e in range(4)}
 
     # Connect the notification websocket before submitting any downloads, so we cannot miss the
-    # artifactDownloaded notifications emitted once each of them completes.
+    # artifactDownloadFinished notifications emitted once each of them completes.
     with connect_notification_websocket(backend_client) as websocket:
         # Submit download for all 4 models in parallel
         for checkpoint_id in expected_checkpoints:
@@ -69,16 +69,15 @@ def test_download_model(backend_client_admin: httpx.Client, backend_client: http
 
         retry_until(do_action, verify_ok, attempts=128, sleep=0.2, error_msg="Failed to download all artifacts")
 
-        # Collect the artifactDownloaded notifications for the 4 checkpoints we just downloaded.
-        # Unrelated artifactDownloaded notifications (eg from another test's artifacts, running
+        # Collect the artifactDownloadFinished notifications for the 4 checkpoints we just downloaded.
+        # Unrelated artifactDownloadFinished notifications (eg from another test's artifacts, running
         # concurrently) are ignored rather than failing the test.
         remaining_checkpoints = set(expected_checkpoints)
         refresh_routes: set[str] = set()
-        deadline = time.monotonic() + 15
+        timeout = 15
         while remaining_checkpoints:
-            budget = deadline - time.monotonic()
             try:
-                notification = wait_next_notification(websocket, "artifact", "artifactDownloaded", total_timeout=max(budget, 0.1))
+                notification, timeout = wait_next_notification(websocket, "artifact", "artifactDownloadFinished", total_timeout=timeout)
             except NotificationTimeoutError:
                 break
             if notification.context.get("artifact_store_id") != fake_artifact_store_id:
@@ -86,11 +85,13 @@ def test_download_model(backend_client_admin: httpx.Client, backend_client: http
             local_id = notification.context.get("artifact_local_id")
             if local_id not in remaining_checkpoints:
                 continue
+            is_success = notification.context.get("success")
+            assert is_success
             remaining_checkpoints.discard(local_id)
             refresh_routes.update(notification.refreshRoutes)
             assert notification.detailRoute == "api/v1/artifacts/model_details"
 
-        assert not remaining_checkpoints, f"did not receive artifactDownloaded notifications for {remaining_checkpoints}"
+        assert not remaining_checkpoints, f"did not receive artifactDownloadFinished notifications for {remaining_checkpoints}"
         assert len(refresh_routes) == 1, f"expected exactly one distinct refresh route, got {refresh_routes}"
         refresh_route = next(iter(refresh_routes))
         assert refresh_route.startswith("api/v1/")

--- a/backend/tests/integration/test_model.py
+++ b/backend/tests/integration/test_model.py
@@ -1,12 +1,20 @@
+import time
 from typing import Any
 
 import httpx
 
 from .conftest import fake_artifact_registry_port, fake_artifact_store_id, test_model_artifact_id
-from .utils import extract_auth_token_from_response, prepare_cookie_with_auth_token, retry_until
+from .utils import (
+    NotificationTimeoutError,
+    connect_notification_websocket,
+    extract_auth_token_from_response,
+    prepare_cookie_with_auth_token,
+    retry_until,
+    wait_next_notification,
+)
 
 
-def test_download_model(backend_client_admin: httpx.Client) -> None:
+def test_download_model(backend_client_admin: httpx.Client, backend_client: httpx.Client) -> None:
     """Downloads bunch of artifacts in parallel, tests they successfully appear"""
 
     # Verify fake artifact registry is up
@@ -32,30 +40,69 @@ def test_download_model(backend_client_admin: httpx.Client) -> None:
             assert model["local_compatibility_detail"] is None
             assert "tags" in model
 
-    # Submit download for all 4 models in parallel
     expected_checkpoints = {f"{test_model_artifact_id}{e}" for e in range(4)}
-    for checkpoint_id in expected_checkpoints:
-        composite_id = {
-            "artifact_store_id": fake_artifact_store_id,
-            "artifact_local_id": checkpoint_id,
-        }
-        response = backend_client_admin.post("/artifacts/download_model", json=composite_id).raise_for_status()
-        result = response.json()
-        assert result["status"] in ["download submitted", "download in progress"], f"Unexpected status: {result}"
 
-    # Wait until all 4 are available
-    def do_action() -> Any:
-        return backend_client_admin.get("/artifacts/list_models").raise_for_status().json()
+    # Connect the notification websocket before submitting any downloads, so we cannot miss the
+    # artifactDownloaded notifications emitted once each of them completes.
+    with connect_notification_websocket(backend_client) as websocket:
+        # Submit download for all 4 models in parallel
+        for checkpoint_id in expected_checkpoints:
+            composite_id = {
+                "artifact_store_id": fake_artifact_store_id,
+                "artifact_local_id": checkpoint_id,
+            }
+            response = backend_client_admin.post("/artifacts/download_model", json=composite_id).raise_for_status()
+            result = response.json()
+            assert result["status"] in ["download submitted", "download in progress"], f"Unexpected status: {result}"
 
-    def verify_ok(models: Any) -> bool | None:
-        available = {
+        # Wait until all 4 are available
+        def do_action() -> Any:
+            return backend_client_admin.get("/artifacts/list_models").raise_for_status().json()
+
+        def verify_ok(models: Any) -> bool | None:
+            available = {
+                m["composite_id"]["artifact_local_id"]
+                for m in models
+                if m["composite_id"]["artifact_store_id"] == fake_artifact_store_id and m["is_available"]
+            }
+            return True if expected_checkpoints.issubset(available) else None
+
+        retry_until(do_action, verify_ok, attempts=128, sleep=0.2, error_msg="Failed to download all artifacts")
+
+        # Collect the artifactDownloaded notifications for the 4 checkpoints we just downloaded.
+        # Unrelated artifactDownloaded notifications (eg from another test's artifacts, running
+        # concurrently) are ignored rather than failing the test.
+        remaining_checkpoints = set(expected_checkpoints)
+        refresh_routes: set[str] = set()
+        deadline = time.monotonic() + 15
+        while remaining_checkpoints:
+            budget = deadline - time.monotonic()
+            try:
+                notification = wait_next_notification(websocket, "artifact", "artifactDownloaded", total_timeout=max(budget, 0.1))
+            except NotificationTimeoutError:
+                break
+            if notification.context.get("artifact_store_id") != fake_artifact_store_id:
+                continue
+            local_id = notification.context.get("artifact_local_id")
+            if local_id not in remaining_checkpoints:
+                continue
+            remaining_checkpoints.discard(local_id)
+            refresh_routes.update(notification.refreshRoutes)
+            assert notification.detailRoute == "api/v1/artifacts/model_details"
+
+        assert not remaining_checkpoints, f"did not receive artifactDownloaded notifications for {remaining_checkpoints}"
+        assert len(refresh_routes) == 1, f"expected exactly one distinct refresh route, got {refresh_routes}"
+        refresh_route = next(iter(refresh_routes))
+        assert refresh_route.startswith("api/v1/")
+        stripped_route = refresh_route.removeprefix("api/v1/")
+
+        refreshed = backend_client_admin.get(f"/{stripped_route}").raise_for_status().json()
+        refreshed_available = {
             m["composite_id"]["artifact_local_id"]
-            for m in models
+            for m in refreshed
             if m["composite_id"]["artifact_store_id"] == fake_artifact_store_id and m["is_available"]
         }
-        return True if expected_checkpoints.issubset(available) else None
-
-    retry_until(do_action, verify_ok, attempts=128, sleep=0.2, error_msg="Failed to download all artifacts")
+        assert expected_checkpoints.issubset(refreshed_available)
 
     # Test model details endpoint for checkpoint0
     main_composite_id = {

--- a/backend/tests/integration/test_notification.py
+++ b/backend/tests/integration/test_notification.py
@@ -11,40 +11,29 @@
 route, and assert the client receives the corresponding broadcast.
 
 Other integration tests (potentially running concurrently against the same backend) may cause
-their own, unrelated notifications to be emitted -- so the receive loop below ignores any
-notification whose context does not carry our own identifier, and is bounded so it can never hang.
+their own, unrelated notifications to be emitted -- `wait_next_notification` takes care of ignoring
+those.
 """
 
-import json
-import time
 import uuid
 
 import httpx
-import websockets.sync.client
+
+from .utils import connect_notification_websocket, wait_next_notification
 
 
 def test_notification_websocket_receives_test_notification(backend_client: httpx.Client) -> None:
-    ws_url = str(backend_client.base_url).rstrip("/").replace("http://", "ws://", 1) + "/notification/ws"
     identifier = uuid.uuid4().hex
 
-    with websockets.sync.client.connect(ws_url, open_timeout=5) as websocket:
+    with connect_notification_websocket(backend_client) as websocket:
         response = backend_client.post("/notification/testNotification", json={"identifier": identifier})
         assert response.is_success
 
-        notification = None
-        deadline = time.monotonic() + 15
-        while time.monotonic() < deadline:
-            try:
-                raw = websocket.recv(timeout=max(deadline - time.monotonic(), 0.1))
-            except TimeoutError:
-                break
-            candidate = json.loads(raw)
-            if candidate.get("context", {}).get("identifier") == identifier:
-                notification = candidate
-                break
-            # a notification from a different domain/test running concurrently -- ignore it
+        notification = wait_next_notification(websocket, "notification", "testNotification", total_timeout=15)
+        while notification.context.get("identifier") != identifier:
+            # a testNotification from a different, concurrently running test -- ignore it
+            notification = wait_next_notification(websocket, "notification", "testNotification", total_timeout=15)
 
-        assert notification is not None, f"did not receive a matching test notification for identifier {identifier}"
-        assert notification["sourceDomainName"] == "notification"
-        assert notification["sourceDomainEvent"] == "testNotification"
-        assert identifier in notification["text"]
+        assert notification.sourceDomainName == "notification"
+        assert notification.sourceDomainEvent == "testNotification"
+        assert identifier in notification.text

--- a/backend/tests/integration/test_notification.py
+++ b/backend/tests/integration/test_notification.py
@@ -29,10 +29,11 @@ def test_notification_websocket_receives_test_notification(backend_client: httpx
         response = backend_client.post("/notification/testNotification", json={"identifier": identifier})
         assert response.is_success
 
-        notification = wait_next_notification(websocket, "notification", "testNotification", total_timeout=15)
+        timeout = 15
+        notification, timeout = wait_next_notification(websocket, "notification", "testNotification", total_timeout=timeout)
         while notification.context.get("identifier") != identifier:
             # a testNotification from a different, concurrently running test -- ignore it
-            notification = wait_next_notification(websocket, "notification", "testNotification", total_timeout=15)
+            notification, timeout = wait_next_notification(websocket, "notification", "testNotification", total_timeout=timeout)
 
         assert notification.sourceDomainName == "notification"
         assert notification.sourceDomainEvent == "testNotification"

--- a/backend/tests/integration/utils.py
+++ b/backend/tests/integration/utils.py
@@ -1,11 +1,59 @@
+import contextlib
 import datetime
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from typing import Any, TypeVar, cast
 
 import httpx
+import websockets.sync.client
+
+from forecastbox.domain.notification.models import ClientNotification
 
 T = TypeVar("T")
+
+
+class NotificationTimeoutError(TimeoutError):
+    """Raised by `wait_next_notification` when no matching notification arrives within the budget."""
+
+
+@contextlib.contextmanager
+def connect_notification_websocket(backend_client: httpx.Client) -> Generator[websockets.sync.client.ClientConnection, None, None]:
+    """Open a websocket connection to the `/notification/ws` endpoint of the given backend client.
+
+    Usage: `with connect_notification_websocket(backend_client) as websocket: ...`
+    """
+    ws_url = str(backend_client.base_url).rstrip("/").replace("http://", "ws://", 1) + "/notification/ws"
+    with websockets.sync.client.connect(ws_url, open_timeout=5) as websocket:
+        yield websocket
+
+
+def wait_next_notification(
+    websocket: websockets.sync.client.ClientConnection,
+    domain_name: str,
+    domain_event: str,
+    total_timeout: float = 15,
+) -> ClientNotification:
+    """Receive notifications off `websocket` until one matching `domain_name`/`domain_event` arrives.
+
+    Notifications for other domains/events (eg emitted by other tests running concurrently) are
+    silently discarded. Raises `NotificationTimeoutError` if none arrives within `total_timeout`
+    seconds in total.
+    """
+    deadline = time.monotonic() + total_timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise NotificationTimeoutError(f"did not receive a notification for {domain_name}.{domain_event} within {total_timeout}s")
+        try:
+            raw = websocket.recv(timeout=remaining)
+        except TimeoutError:
+            raise NotificationTimeoutError(
+                f"did not receive a notification for {domain_name}.{domain_event} within {total_timeout}s"
+            ) from None
+        notification = ClientNotification.model_validate_json(raw)
+        if notification.sourceDomainName == domain_name and notification.sourceDomainEvent == domain_event:
+            return notification
+        # a notification from a different domain/event, possibly from a concurrently running test -- ignore it
 
 
 def retry_until(

--- a/backend/tests/integration/utils.py
+++ b/backend/tests/integration/utils.py
@@ -32,8 +32,9 @@ def wait_next_notification(
     domain_name: str,
     domain_event: str,
     total_timeout: float = 15,
-) -> ClientNotification:
+) -> tuple[ClientNotification, float]:
     """Receive notifications off `websocket` until one matching `domain_name`/`domain_event` arrives.
+    Returns it as well as the remaining timeout budget.
 
     Notifications for other domains/events (eg emitted by other tests running concurrently) are
     silently discarded. Raises `NotificationTimeoutError` if none arrives within `total_timeout`
@@ -52,7 +53,7 @@ def wait_next_notification(
             ) from None
         notification = ClientNotification.model_validate_json(raw)
         if notification.sourceDomainName == domain_name and notification.sourceDomainEvent == domain_event:
-            return notification
+            return notification, deadline - time.monotonic()
         # a notification from a different domain/event, possibly from a concurrently running test -- ignore it
 
 


### PR DESCRIPTION
artifact: emit ClientNotification when a download completes

Adds domain/artifact/events.py with ArtifactDownloadedEvent, implementing
the ClientNotificationSource protocol, emitted from manager.py once a
downloaded artifact becomes locally available. Progress reports are
intentionally not surfaced this way, clients keep polling for those.

Adds test utilities connect_notification_websocket and
wait_next_notification to tests/integration/utils.py, and refactors
test_notification.py to use them. Extends test_model.py to assert that
matching artifactDownloaded notifications arrive for all downloaded
models, and that their refreshRoutes resolve to a working endpoint.