### PR TITLE
[plugin] Expand `OperationalForecastSource` by step

### DIFF
--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -155,7 +155,7 @@ class OperationalForecastSource(Source):
         fc_qube = fc_preset.as_qube(ens_dim=ENSEMBLE)
 
         basetime = block.config_as_datetime(BASETIME)
-        date = basetime.date().isoformat()
+        date = basetime.strftime("%Y%m%d")
         time = self._convert_time(basetime.time().hour)
 
         subqube = fc_qube.select({"time": time}).compress()
@@ -166,36 +166,47 @@ class OperationalForecastSource(Source):
             ens_branches = set()
             for index, datacube in enumerate(subqube.select({LEVTYPE: levtype}).datacubes()):
                 ens_branch = f"{path}/{datacube[PARAM]}"
+                datacube.update({"date": [date], "time": [time]})
                 datacube_path = f"{ens_branch}/{index}"
-                expansion_datacube = datacube.copy()
-                coords = {PARAM: datacube[PARAM]}
-                if fc_preset.is_member_zero(datacube):
-                    coords[ENSEMBLE] = 0
                 ens_branches.add(ens_branch)
 
-                levtype_actions[datacube_path] = from_source(
+                new_action = from_source(
                     np.asarray(
                         [
-                            Payload(
-                                "fiab_plugin_ecmwf.runtime.source.earthkit_source",
-                                [block.config_as_str(SOURCE)],
-                                {
-                                    "requests": [
-                                        dict(
-                                            {k: (v if len(v) > 1 else v[0]) for k, v in datacube.items()},
-                                            date=date,
-                                            time=time,
-                                            param=p,
-                                        )
-                                    ],
-                                },
-                            )
-                            for p in datacube[PARAM]
+                            [
+                                Payload(
+                                    "fiab_plugin_ecmwf.runtime.source.earthkit_source",
+                                    [block.config_as_str(SOURCE)],
+                                    {
+                                        "requests": [
+                                            dict(
+                                                {k: (v if len(v) > 1 else v[0]) for k, v in datacube.items()},
+                                                param=p,
+                                                step=step,
+                                            )
+                                        ],
+                                    },
+                                )
+                                for p in datacube[PARAM]
+                            ]
+                            for step in datacube[STEP]
                         ]
                     ),
-                    dims=[PARAM],
-                    coords=coords,
-                ).expand_as_qube(Qube.from_datacube(expansion_datacube), dims=[STEP, ENSEMBLE, LEVTYPE, LEVEL])
+                    dims=[STEP, PARAM],
+                    coords={STEP: datacube[STEP], PARAM: datacube[PARAM]},
+                )
+                expand_dims = [dim for dim, values in datacube.items() if (len(values) > 1 and dim not in [STEP, PARAM])]
+                if len(expand_dims) > 0:
+                    new_action = new_action.expand_as_qube(
+                        Qube.from_datacube(datacube),
+                        dims=expand_dims,
+                    )
+                new_action.set_scalar_coords(
+                    {dim: values[0] for dim, values in datacube.items() if (len(values) == 1 and dim not in [STEP, PARAM])}
+                )
+                if fc_preset.is_member_zero(datacube):
+                    new_action.set_scalar_coords({ENSEMBLE: 0}, override=True, make_dim=True)
+                levtype_actions[datacube_path] = new_action
             merged = merge(**levtype_actions)
             for branch in ens_branches:
                 merged = merged.combine_branches(dim=ENSEMBLE, path=branch)

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -48,6 +48,7 @@ from fiab_plugin_ecmwf.blocks import (
     TemporalStatistics,
     ZarrSink,
 )
+from fiab_plugin_ecmwf.datasets import ForecastDataset
 from fiab_plugin_ecmwf.qubed_utils import axes, collapse, contains
 
 
@@ -234,37 +235,33 @@ def map_plot_sink_configuration() -> BlockInstance:
     )
 
 
+class MockedForecastDataset(ForecastDataset):
+    def as_qube(self, ens_dim: str = "number", include_member_zero: bool = False) -> Qube:
+        full_qube = super().as_qube(ens_dim, include_member_zero=include_member_zero)
+        return full_qube.select(
+            {
+                PARAM: ["2t", "msl", "tp", "mwp", "swh", "u", "v"],
+                STEP: ["0", "6", "12"],
+                ENSEMBLE: ["0", "1", "2", "3", "4"],
+            }
+        )
+
+
+@pytest.fixture
+def mock_forecast_preset(monkeypatch: pytest.MonkeyPatch) -> None:
+    mocked_datasets = {
+        name: MockedForecastDataset(FORECAST_DATASETS[name].datacubes, FORECAST_DATASETS[name].member_zero)
+        for name in FORECAST_DATASETS.keys()
+    }
+    for name, dataset in mocked_datasets.items():
+        monkeypatch.setitem(FORECAST_DATASETS, name, dataset)
+
+
 class TestOperationalForecastSource:
     @pytest.mark.parametrize("forecast", FORECAST_DATASETS.keys())
     def test_creation(self, dummy_blockinstance_output: QubedOutput, forecast: str) -> None:
         block = OperationalForecastSource()
 
-        assert not block.intersect(other=dummy_blockinstance_output)  # type: ignore[arg-type]
-        block_instance = BlockInstance.from_block(
-            BlockFactoryId("operationalForecastSource"),
-            BlockInstanceBase(
-                input_ids={},
-                configuration_values=_config(
-                    dict(
-                        {
-                            "source": "ecmwf-open-data",
-                            "base_time": datetime(2024, 1, 1),
-                            "forecast": forecast,
-                        },
-                    )
-                ),
-            ),
-            OperationalForecastSource.configuration_options,
-        )
-        output = block.validate(block=block_instance, inputs={}, restrictions={})  # type: ignore[assignment]
-        assert isinstance(output, QubedOutput)
-        assert output.dataqube is not None
-        assert contains(output, "param")
-        assert contains(output, "step")
-        assert contains(output, "number")
-
-    def test_compile_builds_action_from_catalogue(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        block = OperationalForecastSource()
         block_instance = BlockInstance.from_block(
             BlockFactoryId("operationalForecastSource"),
             _block_instance(
@@ -272,16 +269,40 @@ class TestOperationalForecastSource:
                 {
                     "source": "ecmwf-open-data",
                     "base_time": datetime(2024, 1, 1),
-                    "forecast": "aifs-ens",
+                    "forecast": forecast,
+                },
+            ),
+            OperationalForecastSource.configuration_options,
+        )
+        assert not block.intersect(other=dummy_blockinstance_output)  # type: ignore[arg-type]
+        output = block.validate(block=block_instance, inputs={}, restrictions={})  # type: ignore[assignment]
+        assert isinstance(output, QubedOutput)
+        assert output.dataqube is not None
+        assert contains(output, "param")
+        assert contains(output, "step")
+        assert contains(output, "number")
+
+    @pytest.mark.parametrize("forecast", ["aifs-ens", "ifs-ens"])
+    @pytest.mark.parametrize("time", [0, 6])
+    def test_compile_builds_action_from_catalogue(self, mock_forecast_preset: pytest.FixtureRequest, forecast: str, time: int) -> None:
+        block = OperationalForecastSource()
+        block_instance = BlockInstance.from_block(
+            BlockFactoryId("operationalForecastSource"),
+            _block_instance(
+                "operationalForecastSource",
+                {
+                    "source": "ecmwf-open-data",
+                    "base_time": datetime(2024, 1, 1, time),
+                    "forecast": forecast,
                 },
             ),
             OperationalForecastSource.configuration_options,
         )
         action = block.compile({}, block_instance).get_or_raise()
-        action = action.select({PARAM: ["2t", "u"], STEP: [0, 6], ENSEMBLE: [1]}, expand=True)
         for _, array in nodetree_arrays(action.nodes):
-            assert array.sizes[STEP] == 2
-            assert array.sizes[ENSEMBLE] > 0
+            assert set(array.coords[PARAM].data.tolist()).issubset({"2t", "msl", "tp", "mwp", "swh", "u", "v"})
+            assert array.sizes[STEP] == 3
+            assert array.sizes[ENSEMBLE] == 5
         assert "levelist" in nodetree_dimensions(action.nodes)
 
     @pytest.mark.parametrize(

--- a/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/tests/unit/test_blocks.py
@@ -262,19 +262,23 @@ class TestOperationalForecastSource:
     def test_creation(self, dummy_blockinstance_output: QubedOutput, forecast: str) -> None:
         block = OperationalForecastSource()
 
+        assert not block.intersect(other=dummy_blockinstance_output)  # type: ignore[arg-type]
         block_instance = BlockInstance.from_block(
             BlockFactoryId("operationalForecastSource"),
-            _block_instance(
-                "operationalForecastSource",
-                {
-                    "source": "ecmwf-open-data",
-                    "base_time": datetime(2024, 1, 1),
-                    "forecast": forecast,
-                },
+            BlockInstanceBase(
+                input_ids={},
+                configuration_values=_config(
+                    dict(
+                        {
+                            "source": "ecmwf-open-data",
+                            "base_time": datetime(2024, 1, 1),
+                            "forecast": forecast,
+                        },
+                    )
+                ),
             ),
             OperationalForecastSource.configuration_options,
         )
-        assert not block.intersect(other=dummy_blockinstance_output)  # type: ignore[arg-type]
         output = block.validate(block=block_instance, inputs={}, restrictions={})  # type: ignore[assignment]
         assert isinstance(output, QubedOutput)
         assert output.dataqube is not None


### PR DESCRIPTION
### Description
Expand `OperationForecastSource` by step, so subsequent selects by `step` reduces the retrieved steps instead of retrieving the whole forecast and then performing the selection. Also, improve runtime of testing compilation by mocking the parameters, steps and ensemble members in forecast presets.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
