### PR TITLE
run: persist resolved configuration options in compiler runtime context

### DIFF
--- a/backend/src/forecastbox/domain/run/background.py
+++ b/backend/src/forecastbox/domain/run/background.py
@@ -95,10 +95,10 @@ def execute_background(
         relevant_glyphs_and_values = expand_glyph_values(all_glyphs_raw, roots=referenced_glyph_names)
         used_glyphs = {k: all_glyphs_raw[k] for k in relevant_glyphs_and_values.keys() if k not in PINNED_INTRINSIC_KEYS}
 
-        exec_spec, run_outputs, compilation_detail, resolved_configuration_options = compile_builder(builder, relevant_glyphs_and_values)
+        compilation_result = compile_builder(builder, relevant_glyphs_and_values)
 
         persisted_context = compiler_runtime_context.model_copy(
-            update={"glyphs": used_glyphs, "resolution": resolved_configuration_options}
+            update={"glyphs": used_glyphs, "resolution": compilation_result.resolved_configuration_options}
         )
         db.update_run_runtime(
             run_id,
@@ -108,12 +108,12 @@ def execute_background(
         )
 
         logger.debug(f"starting background submission of {run_id=}")
-        response = execute_cascade(exec_spec)
+        response = execute_cascade(compilation_result.execution_spec)
         if response.job_id is not None:
             try:
                 store_compilation_detail(
                     run_id,
-                    compilation_detail,
+                    compilation_result.compilation_detail,
                 )
             except TooLargeEntry as e:
                 logger.warning(f"failed to cache compilation detail for {run_id=}, {attempt_count=}: {repr(e)}")
@@ -122,7 +122,7 @@ def execute_background(
                 attempt_count,
                 cascade_job_id=response.job_id,
                 cascade_proc=get_current_cascade_proc(),
-                outputs=run_outputs.model_dump(),
+                outputs=compilation_result.run_outputs.model_dump(),
             )
         else:
             error = (response.error or "no error provided by cascade")[:255]

--- a/backend/src/forecastbox/domain/run/background.py
+++ b/backend/src/forecastbox/domain/run/background.py
@@ -95,9 +95,11 @@ def execute_background(
         relevant_glyphs_and_values = expand_glyph_values(all_glyphs_raw, roots=referenced_glyph_names)
         used_glyphs = {k: all_glyphs_raw[k] for k in relevant_glyphs_and_values.keys() if k not in PINNED_INTRINSIC_KEYS}
 
-        exec_spec, run_outputs, compilation_detail = compile_builder(builder, relevant_glyphs_and_values)
+        exec_spec, run_outputs, compilation_detail, resolved_configuration_options = compile_builder(builder, relevant_glyphs_and_values)
 
-        persisted_context = compiler_runtime_context.model_copy(update={"glyphs": used_glyphs})
+        persisted_context = compiler_runtime_context.model_copy(
+            update={"glyphs": used_glyphs, "resolution": resolved_configuration_options}
+        )
         db.update_run_runtime(
             run_id,
             attempt_count,

--- a/backend/src/forecastbox/domain/run/compile.py
+++ b/backend/src/forecastbox/domain/run/compile.py
@@ -9,6 +9,7 @@
 
 """Compilation of a BlueprintBuilder into an ExecutionSpecification."""
 
+from dataclasses import dataclass
 from datetime import datetime
 from typing import cast
 
@@ -73,24 +74,35 @@ def _get_artifacts_list(graph: Graph) -> list[CompositeArtifactId]:
     return list(artifacts)
 
 
-def compile_builder(
-    blueprint: BlueprintBuilder, glyph_values: dict[str, str]
-) -> tuple[ExecutionSpecification, RunOutputs, CompilationDetail, dict[BlockInstanceId, dict[ConfigurationOptionId, str]]]:
-    """Compile a BlueprintBuilder into an ExecutionSpecification and RunOutputs.
+@dataclass(frozen=True, slots=True)
+class CompilationResult:
+    """Result of compiling a BlueprintBuilder into an ExecutionSpecification.
+
+    ``execution_spec`` and ``run_outputs`` are the compiled cascade job and its declared
+    external outputs, respectively (``execution_spec.job.job_instance.ext_outputs`` is set to
+    the authoritative list of cascade external outputs -- previously a side effect of
+    ``execute_cascade``).
+
+    ``compilation_detail`` carries task-level lookups produced during compilation.
+
+    ``resolved_configuration_options`` maps each block instance id to the subset of its
+    configuration options that referenced at least one glyph, together with their final
+    (post-resolution) string values. This is used to persist the resolution actually used
+    at execution time, for later inspection/reproducibility.
+    """
+
+    execution_spec: ExecutionSpecification
+    run_outputs: RunOutputs
+    compilation_detail: CompilationDetail
+    resolved_configuration_options: dict[BlockInstanceId, dict[ConfigurationOptionId, str]]
+
+
+def compile_builder(blueprint: BlueprintBuilder, glyph_values: dict[str, str]) -> CompilationResult:
+    """Compile a BlueprintBuilder into a CompilationResult.
 
     Raises ``ValueError`` if any block cannot be validated/compiled. When ``glyph_values`` is
     non-empty, ${glyph} patterns in configuration values are resolved before compilation.
-
-    Sets ``job_instance.ext_outputs`` to the authoritative list of cascade external
-    outputs (previously a side effect of ``execute_cascade``).
-
-    The fourth element of the returned tuple maps each block instance id to the subset of
-    its configuration options that referenced at least one glyph, together with their final
-    (post-resolution) string values. This is used to persist the resolution actually used at
-    execution time, for later inspection/reproducibility.
     """
-    # TODO this is a bulky method, returning a tuple of things -- worth simplifying,
-    # like a single dto or perhaps derive the RunOutputs from CompilationDetail
     graph = Graph([])
     plugins = PluginManager.plugins
     action_lookup = {}
@@ -191,9 +203,9 @@ def compile_builder(
     else:
         environment = EnvironmentSpecification(runtime_artifacts=graph_artifacts)
     compilation_detail = CompilationDetail(task_detail=task_detail)
-    return (
-        ExecutionSpecification(job=job, environment=environment),
-        RunOutputs(outputs=run_outputs),
-        compilation_detail,
-        resolved_configuration_options,
+    return CompilationResult(
+        execution_spec=ExecutionSpecification(job=job, environment=environment),
+        run_outputs=RunOutputs(outputs=run_outputs),
+        compilation_detail=compilation_detail,
+        resolved_configuration_options=resolved_configuration_options,
     )

--- a/backend/src/forecastbox/domain/run/compile.py
+++ b/backend/src/forecastbox/domain/run/compile.py
@@ -10,6 +10,7 @@
 """Compilation of a BlueprintBuilder into an ExecutionSpecification."""
 
 from datetime import datetime
+from typing import cast
 
 from cascade.low.core import DatasetId, TaskId
 from cascade.low.func import assert_never
@@ -17,13 +18,13 @@ from earthkit.workflows.compilers import graph2job
 from earthkit.workflows.fluent import PayloadBuildingContext
 from earthkit.workflows.graph import Graph, deduplicate_nodes
 from fiab_core.artifacts import CompositeArtifactId
-from fiab_core.fable import BlockInstanceId, BlockInstanceOutput, NoOutput, RawOutput
+from fiab_core.fable import BlockInstanceId, BlockInstanceOutput, ConfigurationOptionId, NoOutput, RawOutput
 
 from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
 from forecastbox.domain.blueprint.configuration_values import convert_known_configuration_values
 from forecastbox.domain.blueprint.service import BlueprintBuilder
 from forecastbox.domain.glyphs.intrinsic import AvailableIntrinsicGlyphs, get_values_and_examples
-from forecastbox.domain.glyphs.resolution import merge_glyph_values, resolve_configurations
+from forecastbox.domain.glyphs.resolution import ExtractedGlyphs, extract_glyphs, merge_glyph_values, resolve_configurations
 from forecastbox.domain.plugin.manager import PluginManager
 from forecastbox.domain.run.cascade import ExecutionSpecification, RawCascadeJob, RunOutputCharacteristic, RunOutputs
 from forecastbox.domain.run.detail import CompilationDetail, TaskDetail, _fluentName_to_taskId, fluentNode_to_detail
@@ -74,7 +75,7 @@ def _get_artifacts_list(graph: Graph) -> list[CompositeArtifactId]:
 
 def compile_builder(
     blueprint: BlueprintBuilder, glyph_values: dict[str, str]
-) -> tuple[ExecutionSpecification, RunOutputs, CompilationDetail]:
+) -> tuple[ExecutionSpecification, RunOutputs, CompilationDetail, dict[BlockInstanceId, dict[ConfigurationOptionId, str]]]:
     """Compile a BlueprintBuilder into an ExecutionSpecification and RunOutputs.
 
     Raises ``ValueError`` if any block cannot be validated/compiled. When ``glyph_values`` is
@@ -82,6 +83,11 @@ def compile_builder(
 
     Sets ``job_instance.ext_outputs`` to the authoritative list of cascade external
     outputs (previously a side effect of ``execute_cascade``).
+
+    The fourth element of the returned tuple maps each block instance id to the subset of
+    its configuration options that referenced at least one glyph, together with their final
+    (post-resolution) string values. This is used to persist the resolution actually used at
+    execution time, for later inspection/reproducibility.
     """
     # TODO this is a bulky method, returning a tuple of things -- worth simplifying,
     # like a single dto or perhaps derive the RunOutputs from CompilationDetail
@@ -94,6 +100,7 @@ def compile_builder(
     # Maps sink block ids to mime type used in RunOutputs (only relevant for external outputs).
     block_to_mime: dict[BlockInstanceId, str] = {}
     sink_tasks: set[TaskId] = set()
+    resolved_configuration_options: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = {}
 
     block_lookup = {b.instance_id: b for b in blueprint.blocks}
 
@@ -106,7 +113,14 @@ def compile_builder(
         missing_config = sorted(block_factory.configuration_options.keys() - routable.instance.configuration_values.keys())
         if missing_config:
             raise ValueError(f"compile failed at {blockId=} with missing configuration options: {missing_config}")
+        extract_result = extract_glyphs(routable.instance)
+        if extract_result.e is not None:
+            raise ValueError(f"compile failed at {blockId=} with {extract_result.e}")
+        extracted = cast(ExtractedGlyphs, extract_result.t)
         resolve_configurations(routable.instance, glyph_values)
+        resolved_configuration_options[blockId] = {
+            k: routable.instance.configuration_values[k] for k in extracted.glyphed_options if k in routable.instance.configuration_values
+        }
         converted_values = convert_known_configuration_values(routable.instance, block_factory)
         if converted_values.t is None:
             raise ValueError(f"compile failed at {blockId=} with {converted_values.e}")
@@ -177,4 +191,9 @@ def compile_builder(
     else:
         environment = EnvironmentSpecification(runtime_artifacts=graph_artifacts)
     compilation_detail = CompilationDetail(task_detail=task_detail)
-    return ExecutionSpecification(job=job, environment=environment), RunOutputs(outputs=run_outputs), compilation_detail
+    return (
+        ExecutionSpecification(job=job, environment=environment),
+        RunOutputs(outputs=run_outputs),
+        compilation_detail,
+        resolved_configuration_options,
+    )

--- a/backend/src/forecastbox/domain/run/db.py
+++ b/backend/src/forecastbox/domain/run/db.py
@@ -24,6 +24,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any, cast
 
+from fiab_core.fable import BlockInstanceId, ConfigurationOptionId
 from pydantic import Field
 from sqlalchemy import func, select, update
 
@@ -48,6 +49,9 @@ class CompilerRuntimeContext(FiabBaseModel):
     """
 
     glyphs: dict[str, str] = Field(default_factory=dict)
+    resolution: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = Field(default_factory=dict)
+    """Maps each block instance id to the configuration options that were resolved via
+    glyph substitution, together with their final (post-resolution) string values."""
 
 
 @dataclass(frozen=True, eq=True, slots=True)

--- a/backend/src/forecastbox/domain/run/service.py
+++ b/backend/src/forecastbox/domain/run/service.py
@@ -92,7 +92,7 @@ class RunDetail(FiabBaseModel):
     outputs: dict | None = None
     completed_block_ids: set[BlockInstanceId] | None = None
     planned_block_ids: set[BlockInstanceId] | None = None
-    glyph_values: dict[str, str] | None = None
+    resolution: dict[BlockInstanceId, dict[str, str]] | None = None
 
 
 class ExecuteResult(FiabBaseModel):
@@ -314,13 +314,7 @@ async def poll_and_update(execution: RunRecord, detailed_report: bool = False) -
             outputs=raw_outputs,
             completed_block_ids=completed_block_ids,
             planned_block_ids=planned_block_ids,
-            # NOTE: we add glyph values for submit date time and attempt count because they are
-            # *never* in the compiler runtime context, yet the client may require them for resolution
-            glyph_values={
-                **(execution.compiler_runtime_context.get("glyphs", None) or {}),
-                "submitDatetime": value_dt2str(execution.created_at),
-                "attemptCount": str(actual_attempt),
-            },
+            resolution=execution.compiler_runtime_context.get("resolution") or None,
         )
 
     if status in ("submitted", "preparing", "running", "unknown") and cascade_job_id:

--- a/backend/src/forecastbox/routes/run.py
+++ b/backend/src/forecastbox/routes/run.py
@@ -114,7 +114,7 @@ class RunDetailResponse(FiabBaseModel):
     outputs: RunOutputsResponse | None = None
     completed_block_ids: list[BlockInstanceId] | None = None
     planned_block_ids: list[BlockInstanceId] | None = None
-    glyph_values: dict[str, str] | None = None
+    resolution: dict[BlockInstanceId, dict[str, str]] | None = None
 
 
 class RunListResponse(FiabBaseModel):
@@ -196,7 +196,7 @@ def _to_run_detail(domain_detail: service.RunDetail) -> RunDetailResponse:
         outputs=outputs_response,
         completed_block_ids=maybe_list(domain_detail.completed_block_ids),
         planned_block_ids=maybe_list(domain_detail.planned_block_ids),
-        glyph_values=domain_detail.glyph_values,
+        resolution=domain_detail.resolution,
     )
 
 

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -804,34 +804,13 @@ def test_blueprint_expand_missing_glyph_warnings(tmpdir: Any, backend_client_use
     assert compare_with_tolerance(_time_parts[1], _dt.fromisoformat(created_at_sec))
     assert _time_parts[2] == "initial_value"
     assert _time_parts[3] == "local_glyph_value"
-    glyph_values = status_resp.json()["glyph_values"]
-    assert glyph_values["basicExecuteGlobalGlyph"] == "initial_value"
-    assert glyph_values["blueprintExecuteLocalGlyph"] == "local_glyph_value"
-    # The two glyphs not stored on CompilerRuntimeContext (they're always recomputed on
-    # restart) must nonetheless be surfaced in their original, as-submitted shape.
-    assert glyph_values["submitDatetime"] == created_at
-    assert glyph_values["attemptCount"] == "1"
-    assert glyph_values["runId"] == run_id
-
-    # Re-expand the blueprint using the glyph values retrieved from RunDetail as local
-    # glyphs, to verify the rendering matches what was actually executed. This is expected
-    # to report global_errors (the retrieved glyphs include reserved/intrinsic names like
-    # runId/submitDatetime/attemptCount), but the resolved_configuration_options must still
-    # be computed using the provided values.
-    builder_with_run_glyphs = builder.model_copy(update={"local_glyphs": glyph_values})
-    expand_after_resp = backend_client_user.put(
-        "/blueprint/expand", json=builder_with_run_glyphs.model_dump(), params={"validate_only": True}
-    )
-    assert expand_after_resp.is_success, expand_after_resp.text
-    expand_after_data = expand_after_resp.json()
-    assert expand_after_data["global_errors"], "expected reserved intrinsic glyph names to be flagged"
-    resolved_after = expand_after_data["resolved_configuration_options"]
-    # runId is now the real one (was an example value before submission).
-    assert resolved_after["sink_main"]["fname"] == f"{tmpdir}/output{run_id}.main.txt"
-    # submitDatetime, and the global/local glyphs, now match what was actually used at
-    # execution time (startDatetime is intentionally not reproducible here, since it is
-    # always recomputed fresh on every attempt and never persisted).
-    resolved_time_parts = resolved_after["source_time"]["text"].split(";")
+    resolution = status_resp.json()["resolution"]
+    # sink_main's fname was resolved with the real runId (not the example value used at expand time).
+    assert resolution["sink_main"]["fname"] == f"{tmpdir}/output{run_id}.main.txt"
+    # source_time's text was resolved with submitDatetime (as-submitted, matching created_at) and
+    # the global/local glyph values actually used at execution time. startDatetime is intentionally
+    # not asserted here, since it is always recomputed fresh on every attempt and never persisted.
+    resolved_time_parts = resolution["source_time"]["text"].split(";")
     assert resolved_time_parts[0] == created_at
     assert resolved_time_parts[2] == "initial_value"
     assert resolved_time_parts[3] == "local_glyph_value"


### PR DESCRIPTION
Add a resolution field to CompilerRuntimeContext, populated during background compilation with the per-block configuration options that were resolved via glyph substitution. compile_builder now returns this mapping alongside the existing compilation outputs.

Replace RunDetail.glyph_values (and the corresponding route response field) with resolution, sourced directly from the persisted runtime context.

Rework the integration test that inspected glyph_values to instead verify the resolution field.