### PR TITLE
[frontend] feat(execute): show the configuration values a run actually used

### DIFF
--- a/frontend/mocks/data/fable.data.ts
+++ b/frontend/mocks/data/fable.data.ts
@@ -312,10 +312,16 @@ export function calculateExpansion(fable: FableBuilderV1): {
   block_errors: Record<string, Array<string>>
   possible_sources: Array<PluginBlockFactoryId>
   possible_expansions: Record<string, Array<BlockExpansion>>
+  resolved_configuration_options: Record<string, Record<string, string>>
   missing_glyphs: Record<string, Record<string, Array<string>>>
 } {
   const block_errors: Record<string, Array<string>> = {}
   const possible_expansions: Record<string, Array<BlockExpansion>> = {}
+  const resolved_configuration_options: Record<
+    string,
+    Record<string, string>
+  > = {}
+  const localGlyphs = fable.local_glyphs ?? {}
 
   // Available blocks by kind (using new PluginCompositeId format)
   // Only ecmwf-base plugin is loaded
@@ -378,6 +384,22 @@ export function calculateExpansion(fable: FableBuilderV1): {
       block_errors[blockId] = errors
     }
 
+    // Substitute `${name}` from local_glyphs like the backend; unresolved stay put.
+    const resolvedForBlock: Record<string, string> = {}
+    for (const [optionId, value] of Object.entries(
+      instance.configuration_values,
+    )) {
+      if (!value.includes('${')) continue
+      const substituted = value.replace(
+        /\$\{\s*(\w+)[^}]*\}/g,
+        (match, name: string) => localGlyphs[name] ?? match,
+      )
+      if (substituted !== value) resolvedForBlock[optionId] = substituted
+    }
+    if (Object.keys(resolvedForBlock).length > 0) {
+      resolved_configuration_options[blockId] = resolvedForBlock
+    }
+
     // Calculate possible expansions based on block kind
     if (factory.kind === 'source' || factory.kind === 'transform') {
       possible_expansions[blockId] = qubedBlocks
@@ -391,6 +413,7 @@ export function calculateExpansion(fable: FableBuilderV1): {
     block_errors,
     possible_sources: sourceBlocks,
     possible_expansions,
+    resolved_configuration_options,
     missing_glyphs: {},
   }
 }

--- a/frontend/mocks/data/job.data.ts
+++ b/frontend/mocks/data/job.data.ts
@@ -213,6 +213,32 @@ export const opaqueMimeExecution: JobExecutionDetail = {
   planned_block_ids: null,
 }
 
+/** Test-only fixture: completed run of the glyphed `template-typed-inputs`
+ * fable with an as-run `resolution` (#640, glyphed options only). Inject via
+ * {@link injectMockExecution}. */
+export const resolvedConfigExecution: JobExecutionDetail = {
+  run_id: 'job-resolved-009',
+  attempt_count: 1,
+  status: 'completed',
+  created_at: oneHourAgo,
+  updated_at: oneHourAgo,
+  blueprint_id: 'template-typed-inputs',
+  blueprint_version: 1,
+  error: null,
+  progress: '100',
+  cascade_job_id: 'cascade-009',
+  lost_task_ids: {},
+  outputs: null,
+  completed_block_ids: null,
+  planned_block_ids: null,
+  resolution: {
+    block_source_1: {
+      forecast: 'grib',
+      base_time: '72 Europe',
+    },
+  },
+}
+
 /** Terminal run with `outputs: null` — drives the backend's "no recorded
  * outputs yet" 500 from /run/outputContent. Inject via injectMockExecution. */
 export const noStoredOutputsExecution: JobExecutionDetail = {

--- a/frontend/src/api/types/job.types.ts
+++ b/frontend/src/api/types/job.types.ts
@@ -68,6 +68,11 @@ export const JobExecutionDetailSchema = z.object({
   outputs: RunOutputsSchema.nullable(),
   completed_block_ids: z.array(z.string()).nullable().optional(),
   planned_block_ids: z.array(z.string()).nullable().optional(),
+  /** As-run values of glyphed options, by block then option; absent pre-#640. */
+  resolution: z
+    .record(z.string(), z.record(z.string(), z.string()))
+    .nullable()
+    .optional(),
 })
 
 /** routes/run.py: CompilationDetailTask */

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -4,12 +4,15 @@ import { cn } from '@/lib/utils'
 
 function TooltipProvider({
   delay = 0,
+  // Tolerates brief pointer slips en route into the hoverable popup.
+  closeDelay = 100,
   ...props
 }: TooltipPrimitive.Provider.Props) {
   return (
     <TooltipPrimitive.Provider
       data-slot="tooltip-provider"
       delay={delay}
+      closeDelay={closeDelay}
       {...props}
     />
   )
@@ -30,13 +33,12 @@ function TooltipContent({
   align = 'center',
   alignOffset = 0,
   children,
-  variant = 'default',
   ...props
 }: TooltipPrimitive.Popup.Props &
   Pick<
     TooltipPrimitive.Positioner.Props,
     'align' | 'alignOffset' | 'side' | 'sideOffset'
-  > & { variant?: 'default' | 'light' }) {
+  >) {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Positioner
@@ -49,17 +51,14 @@ function TooltipContent({
         <TooltipPrimitive.Popup
           data-slot="tooltip-content"
           className={cn(
-            'z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
-            variant === 'light' &&
-              'bg-popover text-popover-foreground shadow-md ring-1 ring-border',
+            // Theme-following popover style; arrowless (an arrow can't cross
+            // the ring); selectable since hoverable popups invite copying.
+            'z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md ring-1 ring-border select-text has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
             className,
           )}
           {...props}
         >
           {children}
-          {variant === 'default' && (
-            <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
-          )}
         </TooltipPrimitive.Popup>
       </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>

--- a/frontend/src/features/executions/components/RunCanvas.tsx
+++ b/frontend/src/features/executions/components/RunCanvas.tsx
@@ -51,6 +51,17 @@ export function useShowConfig() {
   return useContext(ShowConfigContext)
 }
 
+/** As-run values keyed by block, then option; empty until they resolve. */
+const ResolvedConfigContext = createContext<
+  Record<string, Record<string, string>>
+>({})
+
+export function useResolvedConfigFor(
+  blockId: string,
+): Record<string, string> | undefined {
+  return useContext(ResolvedConfigContext)[blockId]
+}
+
 export interface BlockProgressInfo {
   completedSet: ReadonlySet<BlockInstanceId>
   plannedSet: ReadonlySet<BlockInstanceId>
@@ -77,10 +88,15 @@ interface RunCanvasProps {
   /** Optional + nullable: backend emits only on /run/get and clears on terminal status. */
   completedBlockIds?: ReadonlyArray<BlockInstanceId> | null
   plannedBlockIds?: ReadonlyArray<BlockInstanceId> | null
+  /** As-run values by block then option; absent while loading or unrecorded. */
+  resolvedConfig?: Record<string, Record<string, string>>
 }
 
 /** Fit never zooms past 1:1 — a tiny graph stays natural-sized, not blown up. */
 const FIT_MAX_ZOOM = 1
+
+/** Stable identity so an absent map does not remount every consumer. */
+const EMPTY_RESOLVED: Record<string, Record<string, string>> = {}
 
 const nodeTypes: Record<string, typeof RunNode> = {
   sourceBlock: RunNode,
@@ -99,6 +115,7 @@ function RunCanvasInner({
   status,
   completedBlockIds,
   plannedBlockIds,
+  resolvedConfig,
 }: RunCanvasProps) {
   // Primitive selectors (per field) — an object-returning selector would
   // mint a new reference each render and loop Zustand's Object.is check.
@@ -206,94 +223,100 @@ function RunCanvasInner({
 
   return (
     <ShowConfigContext value={showConfig}>
-      <BlockProgressContext value={blockProgress}>
-        <div
-          ref={containerRef}
-          style={maximized ? undefined : { height: `${canvasHeight}px` }}
-          className={cn(
-            'relative overflow-hidden',
-            maximized
-              ? 'fixed inset-0 z-50 bg-background'
-              : [
-                  'rounded-lg',
-                  // Narrow: inline `height` is the authority (React Flow needs a
-                  // definite height, not just `min-height`). Wide: `!h-full`
-                  // overrides it so the canvas fills the bounded column.
-                  'min-[1280px]:!h-full min-[1280px]:min-h-0 min-[1280px]:flex-1',
-                ],
-          )}
-        >
-          <ReactFlow
-            nodes={layoutedNodes}
-            edges={edges}
-            nodeTypes={nodeTypes}
-            edgeTypes={edgeTypes}
-            nodesDraggable={false}
-            nodesConnectable={false}
-            elementsSelectable={false}
-            panOnDrag={true}
-            zoomOnScroll={true}
-            fitView={true}
-            fitViewOptions={{ padding: 0.15, maxZoom: FIT_MAX_ZOOM }}
-            // Default 0.5 floor can't fit a wide pipeline into a phone container.
-            minZoom={0.1}
-            proOptions={{ hideAttribution: true }}
-            onNodeClick={(_event, node) => {
-              // Toggle: click the already-selected block to clear.
-              setSelectedBlockId(selectedBlockId === node.id ? null : node.id)
-            }}
-            onPaneClick={() => {
-              if (selectedBlockId !== null) setSelectedBlockId(null)
-            }}
+      <ResolvedConfigContext value={resolvedConfig ?? EMPTY_RESOLVED}>
+        <BlockProgressContext value={blockProgress}>
+          <div
+            ref={containerRef}
+            style={maximized ? undefined : { height: `${canvasHeight}px` }}
+            className={cn(
+              'relative overflow-hidden',
+              maximized
+                ? 'fixed inset-0 z-50 bg-background'
+                : [
+                    'rounded-lg',
+                    // Narrow: inline `height` is the authority (React Flow needs a
+                    // definite height, not just `min-height`). Wide: `!h-full`
+                    // overrides it so the canvas fills the bounded column.
+                    'min-[1280px]:!h-full min-[1280px]:min-h-0 min-[1280px]:flex-1',
+                  ],
+            )}
           >
-            <Background
-              variant={BackgroundVariant.Dots}
-              gap={24}
-              size={1.5}
-              color="#cbd5e1"
-              className="dark:opacity-30"
-            />
-            <Controls
-              showInteractive={false}
-              position="bottom-left"
-              className="bottom-2! left-2!"
-            />
-            <Panel position="top-left" className="top-2! left-2!">
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 gap-1.5 bg-background/80 text-sm backdrop-blur-sm"
-                onClick={() => setShowConfig((prev) => !prev)}
-              >
-                <Settings2 className="h-3.5 w-3.5" />
-                {showConfig
-                  ? t('detail.hideParameters')
-                  : t('detail.showParameters')}
-              </Button>
-            </Panel>
-            <Panel position="top-right" className="top-2! right-2!">
-              <Button
-                variant="outline"
-                size="icon"
-                className="h-7 w-7 bg-background/80 backdrop-blur-sm"
-                onClick={() => setMaximized((prev) => !prev)}
-                aria-label={t(
-                  maximized ? 'detail.restoreCanvas' : 'detail.maximizeCanvas',
-                )}
-                title={t(
-                  maximized ? 'detail.restoreCanvas' : 'detail.maximizeCanvas',
-                )}
-              >
-                {maximized ? (
-                  <Minimize2 className="h-3.5 w-3.5" />
-                ) : (
-                  <Maximize2 className="h-3.5 w-3.5" />
-                )}
-              </Button>
-            </Panel>
-          </ReactFlow>
-        </div>
-      </BlockProgressContext>
+            <ReactFlow
+              nodes={layoutedNodes}
+              edges={edges}
+              nodeTypes={nodeTypes}
+              edgeTypes={edgeTypes}
+              nodesDraggable={false}
+              nodesConnectable={false}
+              elementsSelectable={false}
+              panOnDrag={true}
+              zoomOnScroll={true}
+              fitView={true}
+              fitViewOptions={{ padding: 0.15, maxZoom: FIT_MAX_ZOOM }}
+              // Default 0.5 floor can't fit a wide pipeline into a phone container.
+              minZoom={0.1}
+              proOptions={{ hideAttribution: true }}
+              onNodeClick={(_event, node) => {
+                // Toggle: click the already-selected block to clear.
+                setSelectedBlockId(selectedBlockId === node.id ? null : node.id)
+              }}
+              onPaneClick={() => {
+                if (selectedBlockId !== null) setSelectedBlockId(null)
+              }}
+            >
+              <Background
+                variant={BackgroundVariant.Dots}
+                gap={24}
+                size={1.5}
+                color="#cbd5e1"
+                className="dark:opacity-30"
+              />
+              <Controls
+                showInteractive={false}
+                position="bottom-left"
+                className="bottom-2! left-2!"
+              />
+              <Panel position="top-left" className="top-2! left-2!">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 gap-1.5 bg-background/80 text-sm backdrop-blur-sm"
+                  onClick={() => setShowConfig((prev) => !prev)}
+                >
+                  <Settings2 className="h-3.5 w-3.5" />
+                  {showConfig
+                    ? t('detail.hideParameters')
+                    : t('detail.showParameters')}
+                </Button>
+              </Panel>
+              <Panel position="top-right" className="top-2! right-2!">
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="h-7 w-7 bg-background/80 backdrop-blur-sm"
+                  onClick={() => setMaximized((prev) => !prev)}
+                  aria-label={t(
+                    maximized
+                      ? 'detail.restoreCanvas'
+                      : 'detail.maximizeCanvas',
+                  )}
+                  title={t(
+                    maximized
+                      ? 'detail.restoreCanvas'
+                      : 'detail.maximizeCanvas',
+                  )}
+                >
+                  {maximized ? (
+                    <Minimize2 className="h-3.5 w-3.5" />
+                  ) : (
+                    <Maximize2 className="h-3.5 w-3.5" />
+                  )}
+                </Button>
+              </Panel>
+            </ReactFlow>
+          </div>
+        </BlockProgressContext>
+      </ResolvedConfigContext>
     </ShowConfigContext>
   )
 }

--- a/frontend/src/features/executions/components/RunDetailPage.tsx
+++ b/frontend/src/features/executions/components/RunDetailPage.tsx
@@ -143,6 +143,8 @@ export function RunDetailPage() {
     [onSplitLayoutChanged],
   )
   const { data: catalogue } = useBlockCatalogue()
+  // As-run values off the run detail (#640); null on older runs.
+  const resolvedConfig = jobData?.resolution ?? undefined
 
   // Sync scroll-to-top before paint — a tall /configure scroll position
   // otherwise clamps into the shorter loading layout and exposes the footer.
@@ -316,6 +318,7 @@ export function RunDetailPage() {
                   status={jobData.status}
                   completedBlockIds={jobData.completed_block_ids}
                   plannedBlockIds={jobData.planned_block_ids}
+                  resolvedConfig={resolvedConfig}
                 />
               ) : (
                 <div className="flex h-full flex-col items-center justify-center gap-2 rounded-lg border border-dashed py-12 text-center">

--- a/frontend/src/features/executions/components/RunNode.tsx
+++ b/frontend/src/features/executions/components/RunNode.tsx
@@ -8,22 +8,83 @@
  * does it submit to any jurisdiction.
  */
 
-import { memo } from 'react'
+import { memo, useEffect, useRef, useState } from 'react'
 import { Handle, Position } from '@xyflow/react'
-import { CheckCircle2, Loader2 } from 'lucide-react'
+import { Check, CheckCircle2, Copy, Loader2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import type { NodeProps } from '@xyflow/react'
 import type { BlockKind } from '@/api/types/fable.types'
 import type { FableNodeData } from '@/features/fable-builder/utils/fable-to-graph'
 import { BLOCK_KIND_METADATA, getBlockKindIcon } from '@/api/types/fable.types'
 import {
   useBlockProgress,
+  useResolvedConfigFor,
   useShowConfig,
 } from '@/features/executions/components/RunCanvas'
 import {
   useIsBlockHovered,
   useIsBlockSelected,
 } from '@/features/executions/stores/executionHoverStore'
-import { cn } from '@/lib/utils'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { showToast } from '@/lib/toast'
+import { cn, copyToClipboard } from '@/lib/utils'
+
+/** Tooltip row: a mono value with its own copy-to-clipboard button. */
+function CopyValueRow({
+  text,
+  label,
+  dimmed = false,
+}: {
+  text: string
+  label: string
+  dimmed?: boolean
+}) {
+  const { t } = useTranslation('executions')
+  const [copied, setCopied] = useState(false)
+  const resetTimer = useRef<number>(undefined)
+  useEffect(() => () => window.clearTimeout(resetTimer.current), [])
+
+  return (
+    <div className="flex items-start gap-2 rounded-sm px-2 py-1.5">
+      <span
+        className={cn(
+          'min-w-0 flex-1 font-mono break-all',
+          dimmed && 'text-muted-foreground',
+        )}
+      >
+        {text}
+      </span>
+      <button
+        type="button"
+        aria-label={label}
+        title={copied ? t('detail.copied') : label}
+        onClick={() => {
+          void copyToClipboard(text).then((ok) => {
+            if (!ok) {
+              showToast.error(t('detail.copyFailed'))
+              return
+            }
+            setCopied(true)
+            window.clearTimeout(resetTimer.current)
+            resetTimer.current = window.setTimeout(() => setCopied(false), 1500)
+          })
+        }}
+        className="shrink-0 rounded-sm p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        {copied ? (
+          <Check className="h-3.5 w-3.5 text-success" />
+        ) : (
+          <Copy className="h-3.5 w-3.5" />
+        )}
+      </button>
+    </div>
+  )
+}
 
 const NODE_TYPE_TO_KIND: Record<string, BlockKind> = {
   sourceBlock: 'source',
@@ -39,6 +100,7 @@ const HANDLE_Y_PX = 32
 const MULTI_HANDLE_GAP_PX = 12
 
 export const RunNode = memo(function ({ data, type }: NodeProps) {
+  const { t } = useTranslation('executions')
   const nodeData = data as FableNodeData
   const showConfig = useShowConfig()
   const { completedSet, runningSet, plannedSet } = useBlockProgress()
@@ -58,6 +120,7 @@ export const RunNode = memo(function ({ data, type }: NodeProps) {
     !isRunning
 
   const inputNames = Object.keys(nodeData.instance.input_ids)
+  const resolved = useResolvedConfigFor(nodeData.instanceId)
   const configEntries = Object.entries(
     nodeData.instance.configuration_values,
   ).filter(([, v]) => v !== '')
@@ -129,21 +192,61 @@ export const RunNode = memo(function ({ data, type }: NodeProps) {
       </div>
 
       {showConfig && configEntries.length > 0 && (
-        <div className="border-t border-border px-2 py-1">
-          {configEntries.map(([key, value]) => (
-            <div
-              key={key}
-              className="flex items-baseline justify-between gap-1 py-px"
-            >
-              <span className="shrink-0 text-xs text-muted-foreground">
-                {configOptions[key].title}
-              </span>
-              <span className="max-w-[100px] truncate text-right font-mono text-xs">
-                {value}
-              </span>
-            </div>
-          ))}
-        </div>
+        // One provider for the whole card: the browser's own title tooltip is
+        // too slow and unstyled for values this often truncated.
+        <TooltipProvider delay={120}>
+          <div className="border-t border-border px-2 py-1">
+            {configEntries.map(([key, value]) => {
+              // Show what the run used; the template stays reachable on hover.
+              const asRun = resolved?.[key]
+              const display = asRun ?? value
+              const fromTemplate = asRun !== undefined && asRun !== value
+              // The column truncates early, so anything longer needs the hover.
+              const needsHover = fromTemplate || display.length > 12
+              const valueClass = cn(
+                'max-w-[100px] truncate text-right font-mono text-xs',
+                // Marks a value that came from a variable; costs no width in a
+                // column that already truncates.
+                fromTemplate &&
+                  'underline decoration-muted-foreground/60 decoration-dotted underline-offset-2',
+              )
+              return (
+                <div
+                  key={key}
+                  className="flex items-baseline justify-between gap-1 py-px"
+                >
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    {configOptions[key].title}
+                  </span>
+                  {needsHover ? (
+                    <Tooltip>
+                      <TooltipTrigger render={<span className={valueClass} />}>
+                        {display}
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-sm p-1">
+                        <div className="flex min-w-0 flex-col">
+                          <CopyValueRow
+                            text={display}
+                            label={t('detail.copyValue')}
+                          />
+                          {fromTemplate && (
+                            <CopyValueRow
+                              text={value}
+                              label={t('detail.copyTemplate')}
+                              dimmed
+                            />
+                          )}
+                        </div>
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : (
+                    <span className={valueClass}>{display}</span>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </TooltipProvider>
       )}
     </div>
   )

--- a/frontend/src/features/fable-builder/components/form-mode/BlockInstanceCard.tsx
+++ b/frontend/src/features/fable-builder/components/form-mode/BlockInstanceCard.tsx
@@ -26,6 +26,7 @@ import type {
   BlockInstanceId,
   PluginBlockFactoryId,
 } from '@/api/types/fable.types'
+import { definableGlyphs } from '@/features/fable-builder/utils/definable-glyphs'
 import { useFieldErrorMessages } from '@/features/fable-builder/hooks/useFieldErrorMessages'
 import { useReservedGlyphReason } from '@/features/glyphs/utils/reserved-names'
 import {
@@ -179,6 +180,8 @@ export function BlockInstanceCard({
   const mappedErrors = validationState
     ? liveMappedErrors
     : lastMappedErrorsRef.current
+  const definableMissingGlyphs =
+    definableGlyphs(missingGlyphs, mappedErrors.invalidGlyphNames) ?? {}
 
   if (!factory) {
     return null
@@ -321,7 +324,7 @@ export function BlockInstanceCard({
                 <BlockValidationProvider
                   resolvedConfig={resolvedConfigForBlock}
                   fieldErrors={mappedErrors.byConfigKey}
-                  missingGlyphs={missingGlyphs}
+                  missingGlyphs={definableMissingGlyphs}
                 >
                   <div className="space-y-4">
                     {Object.entries(factory.configuration_options).map(

--- a/frontend/src/features/fable-builder/components/graph-mode/QubeSpectrum.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/QubeSpectrum.tsx
@@ -116,7 +116,7 @@ export function QubeSpectrum({
                   />
                 }
               />
-              <TooltipContent variant="light" side="top" sideOffset={6}>
+              <TooltipContent side="top" sideOffset={6}>
                 {t('qubeLens.barTooltip', {
                   dimension: dim.key,
                   count: dim.values.length,

--- a/frontend/src/features/fable-builder/components/layout/ConfigPanel.tsx
+++ b/frontend/src/features/fable-builder/components/layout/ConfigPanel.tsx
@@ -12,6 +12,7 @@ import { useCallback, useMemo, useRef } from 'react'
 import { AlertCircle, ChevronRight, Link2, Trash2, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import type { BlockFactoryCatalogue } from '@/api/types/fable.types'
+import { definableGlyphs } from '@/features/fable-builder/utils/definable-glyphs'
 import { useFieldErrorMessages } from '@/features/fable-builder/hooks/useFieldErrorMessages'
 import { useReservedGlyphReason } from '@/features/glyphs/utils/reserved-names'
 import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
@@ -226,6 +227,10 @@ export function ConfigPanel({ catalogue }: ConfigPanelProps): React.ReactNode {
     validationState || !selectedBlockId
       ? liveMappedErrors
       : (lastMappedErrorsRef.current[selectedBlockId] ?? liveMappedErrors)
+  const definableMissingGlyphs = definableGlyphs(
+    missingGlyphs,
+    mappedErrors.invalidGlyphNames,
+  )
   const configOptions = Object.entries(factory.configuration_options)
   const inputs = factory.inputs
 
@@ -307,7 +312,7 @@ export function ConfigPanel({ catalogue }: ConfigPanelProps): React.ReactNode {
           <BlockValidationProvider
             resolvedConfig={resolvedConfigForBlock}
             fieldErrors={mappedErrors.byConfigKey}
-            missingGlyphs={missingGlyphs}
+            missingGlyphs={definableMissingGlyphs}
           >
             <div className="space-y-3">
               <div className="text-sm font-medium">

--- a/frontend/src/features/fable-builder/utils/definable-glyphs.ts
+++ b/frontend/src/features/fable-builder/utils/definable-glyphs.ts
@@ -1,0 +1,27 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/** Drop names the backend rejected outright: offering to define a glyph whose
+ * name it refuses is an action that can never succeed. */
+export function definableGlyphs(
+  missingGlyphs: Record<string, ReadonlyArray<string>> | null,
+  invalidGlyphNames: ReadonlyArray<string>,
+): Record<string, Array<string>> | null {
+  if (!missingGlyphs || invalidGlyphNames.length === 0) {
+    return missingGlyphs as Record<string, Array<string>> | null
+  }
+  const invalid = new Set(invalidGlyphNames)
+  const out: Record<string, Array<string>> = {}
+  for (const [configKey, names] of Object.entries(missingGlyphs)) {
+    const kept = names.filter((name) => !invalid.has(name))
+    if (kept.length > 0) out[configKey] = kept
+  }
+  return out
+}

--- a/frontend/src/features/fable-builder/utils/map-block-errors-to-fields.ts
+++ b/frontend/src/features/fable-builder/utils/map-block-errors-to-fields.ts
@@ -21,6 +21,8 @@ export interface MappedBlockErrors {
   byConfigKey: Record<string, Array<string>>
   /** Errors that could not be attributed to a specific field. */
   unmapped: Array<string>
+  /** Glyph names the backend rejected outright — defining them cannot succeed. */
+  invalidGlyphNames: Array<string>
 }
 
 /** Pre-translated messages — callers resolve via i18next so this util stays pure. */
@@ -79,6 +81,8 @@ function pushError(
  * - "Configuration option 'x' is missing for block factory ..." →
  *   messages.missingRequiredValue
  * - "Invalid value for configuration option 'x': ..." → verbatim, on `x`
+ * - "Invalid glyph name: g (due to r); appears in [a, b]" → verbatim, on the
+ *   keys it names
  * - "Jinja expression error: 'x' is undefined" → attributed to the config
  *   keys whose value references `x` inside a `${...}` expression; when `x`
  *   is jinja-reserved the clearer messages.jinjaReservedReference is shown
@@ -97,6 +101,7 @@ export function mapBlockErrorsToFields(
 ): MappedBlockErrors {
   const byConfigKey: Record<string, Array<string>> = {}
   const unmapped: Array<string> = []
+  const invalidGlyphNames: Array<string> = []
   const keysWithUnknownGlyphs = new Set(
     Object.entries(missingGlyphs)
       .filter(([, names]) => names.length > 0)
@@ -149,6 +154,22 @@ export function mapBlockErrorsToFields(
       continue
     }
 
+    // Backend names the offending options, so no usage lookup is needed.
+    const invalidGlyphName = error.match(
+      /^Invalid glyph name: (\S+) .*appears in \[(.*)\]$/,
+    )
+    if (invalidGlyphName) {
+      invalidGlyphNames.push(invalidGlyphName[1])
+      const keys = invalidGlyphName[2]
+        .split(',')
+        .map((key) => key.trim())
+        .filter(Boolean)
+      if (keys.length > 0) {
+        for (const key of keys) pushError(byConfigKey, key, error)
+        continue
+      }
+    }
+
     const jinjaUndefined = error.match(
       /^Jinja expression error: '([^']+)' is undefined/,
     )
@@ -176,11 +197,14 @@ export function mapBlockErrorsToFields(
     unmapped.push(error)
   }
 
+  const invalid = new Set(invalidGlyphNames)
   for (const [configKey, glyphNames] of Object.entries(missingGlyphs)) {
     for (const name of glyphNames) {
+      // An invalid name is not merely unknown; its own error already says so.
+      if (invalid.has(name)) continue
       pushError(byConfigKey, configKey, messages.unknownGlyph(name))
     }
   }
 
-  return { byConfigKey, unmapped }
+  return { byConfigKey, unmapped, invalidGlyphNames }
 }

--- a/frontend/src/features/plugins/components/PluginDiagnostics.tsx
+++ b/frontend/src/features/plugins/components/PluginDiagnostics.tsx
@@ -64,7 +64,9 @@ export function PluginDiagnostics({
         const severity = normalizePluginErrorSeverity(error.severity)
         const { Icon, className: iconClass } = SEVERITY_ICONS[severity]
         return (
-          <li key={index} className="flex items-start gap-1.5 text-xs">
+          // min-w-0: without it the text cannot shrink and long paths in raw
+          // exception text overflow the tooltip instead of wrapping.
+          <li key={index} className="flex min-w-0 items-start gap-1.5 text-xs">
             <Icon
               className={cn('mt-0.5 h-3.5 w-3.5 shrink-0', iconClass)}
               aria-label={t(
@@ -75,7 +77,7 @@ export function PluginDiagnostics({
                     : 'diagnostics.severity.error',
               )}
             />
-            <span>
+            <span className="min-w-0 break-words">
               <span className="font-medium">
                 {sourceLabels[error.source] ?? error.source}
               </span>

--- a/frontend/src/features/plugins/components/PluginRow.tsx
+++ b/frontend/src/features/plugins/components/PluginRow.tsx
@@ -74,9 +74,11 @@ export function PluginRow({
   const isWarningOnly = plugin.errorSeverity === 'warning'
   const pypiUrl = getPyPIUrl(plugin.pipSource)
 
-  // Roughly when line-clamp-6 will cut the tooltip text (~45 chars/line)
-  const diagnosticsClamped =
-    (plugin.errorDetail?.reduce((n, e) => n + e.detail.length, 0) ?? 0) > 240
+  // Entry count, not a character guess: each entry is separately clamped, so
+  // the tooltip height is bounded without ever cutting the list mid-line.
+  const tooltipDiagnostics = plugin.errorDetail?.slice(0, 3)
+  const hiddenDiagnostics =
+    (plugin.errorDetail?.length ?? 0) - (tooltipDiagnostics?.length ?? 0)
 
   return (
     <div
@@ -106,19 +108,24 @@ export function PluginRow({
                   )}
                 </TooltipTrigger>
                 <TooltipContent>
-                  {plugin.errorDetail ? (
-                    <div className="max-w-xs">
-                      <div className="line-clamp-6">
-                        <PluginDiagnostics errors={plugin.errorDetail} plain />
-                      </div>
-                      {diagnosticsClamped && (
+                  {plugin.errorDetail && tooltipDiagnostics ? (
+                    // No width of its own: TooltipContent already caps the
+                    // width, and a nested max-w-xs overflows its px-3 padding.
+                    <div className="min-w-0">
+                      <PluginDiagnostics errors={tooltipDiagnostics} plain />
+                      {(hiddenDiagnostics > 0 ||
+                        plugin.errorDetail.length > 0) && (
                         <P className="mt-1 text-xs text-inherit opacity-70">
-                          {t('diagnostics.seeDetails')}
+                          {hiddenDiagnostics > 0
+                            ? t('diagnostics.moreAndSeeDetails', {
+                                count: hiddenDiagnostics,
+                              })
+                            : t('diagnostics.seeDetails')}
                         </P>
                       )}
                     </div>
                   ) : (
-                    <P className="max-w-xs text-xs text-inherit">
+                    <P className="min-w-0 text-xs text-inherit">
                       {t('status.errored')}
                     </P>
                   )}

--- a/frontend/src/locales/en/executions.json
+++ b/frontend/src/locales/en/executions.json
@@ -16,6 +16,9 @@
     "specUnavailableDescription": "The original configuration was not stored for this job.",
     "copySpec": "Copy",
     "copied": "Copied",
+    "copyValue": "Copy value",
+    "copyTemplate": "Copy template",
+    "copyFailed": "Couldn't copy to clipboard",
     "specCopyFailed": "Couldn't copy specification",
     "startedAt": "Started {{date}}"
   },

--- a/frontend/src/locales/en/plugins.json
+++ b/frontend/src/locales/en/plugins.json
@@ -69,6 +69,8 @@
   },
   "diagnostics": {
     "seeDetails": "See the details page for the full text",
+    "moreAndSeeDetails_one": "+{{count}} more — see the details page for the full text",
+    "moreAndSeeDetails_other": "+{{count}} more — see the details page for the full text",
     "source": {
       "install": "Installation",
       "load": "Plugin load",

--- a/frontend/tests/integration/features/executions/job-detail.test.tsx
+++ b/frontend/tests/integration/features/executions/job-detail.test.tsx
@@ -34,6 +34,7 @@ import {
   mixedAvailabilityExecution,
   opaqueMimeExecution,
   resetJobsState,
+  resolvedConfigExecution,
 } from '@tests/../mocks/data/job.data'
 import type { AuthContextValue } from '@/features/auth/AuthContext'
 import { AuthContext } from '@/features/auth/AuthContext'
@@ -250,6 +251,33 @@ describe('RunDetailPage Integration', () => {
       const screen = await renderDetailPage('job-running-002')
       await expect.element(screen.getByText(/Pending: 1/)).toBeVisible()
       await expect.element(screen.getByText('Group by')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('as-run configuration (ecmwf#640 resolution)', () => {
+    it('shows resolved values instead of glyph templates on the canvas', async () => {
+      injectMockExecution(resolvedConfigExecution)
+      const screen = await renderDetailPage('job-resolved-009')
+
+      // Params show by default; glyphed options show as-run values.
+      await expect.element(screen.getByText('grib')).toBeVisible()
+      await expect.element(screen.getByText('72 Europe')).toBeVisible()
+      await expect.element(screen.getByText('mars')).toBeVisible()
+      await expect
+        .element(screen.getByText('${format}'))
+        .not.toBeInTheDocument()
+    })
+
+    it('falls back to stored templates on runs without a recorded resolution', async () => {
+      // Same glyphed fable, but a pre-#640 run: no resolution recorded.
+      injectMockExecution({
+        ...resolvedConfigExecution,
+        run_id: 'job-unresolved-010',
+        resolution: null,
+      })
+      const screen = await renderDetailPage('job-unresolved-010')
+
+      await expect.element(screen.getByText('${format}')).toBeVisible()
     })
   })
 })

--- a/frontend/tests/unit/api/job-types.test.ts
+++ b/frontend/tests/unit/api/job-types.test.ts
@@ -69,6 +69,27 @@ describe('JobExecutionDetailSchema', () => {
     expect(result.planned_block_ids).toBeNull()
   })
 
+  it('parses the per-block resolution map recorded since ecmwf#640', () => {
+    const result = JobExecutionDetailSchema.parse({
+      ...baseDetail,
+      status: 'completed',
+      resolution: { block_source_1: { base_time: '2026-05-15T00:00:00' } },
+    })
+    expect(result.resolution).toEqual({
+      block_source_1: { base_time: '2026-05-15T00:00:00' },
+    })
+  })
+
+  it('accepts absent and null resolution (pre-#640 backends and old runs)', () => {
+    expect(
+      JobExecutionDetailSchema.parse(baseDetail).resolution,
+    ).toBeUndefined()
+    expect(
+      JobExecutionDetailSchema.parse({ ...baseDetail, resolution: null })
+        .resolution,
+    ).toBeNull()
+  })
+
   it('rejects non-array values in the block-id fields', () => {
     expect(() =>
       JobExecutionDetailSchema.parse({

--- a/frontend/tests/unit/features/fable-builder/utils/map-block-errors-to-fields.test.ts
+++ b/frontend/tests/unit/features/fable-builder/utils/map-block-errors-to-fields.test.ts
@@ -22,7 +22,11 @@ const messages: FieldErrorMessages = {
 describe('mapBlockErrorsToFields', () => {
   it('returns empty result for empty inputs', () => {
     const result = mapBlockErrorsToFields([], {}, messages)
-    expect(result).toEqual({ byConfigKey: {}, unmapped: [] })
+    expect(result).toEqual({
+      byConfigKey: {},
+      unmapped: [],
+      invalidGlyphNames: [],
+    })
   })
 
   describe('Block contains extra / missing config', () => {
@@ -87,7 +91,11 @@ describe('mapBlockErrorsToFields', () => {
 
     it('treats an empty missingGlyphs map as a no-op', () => {
       const result = mapBlockErrorsToFields([], {}, messages)
-      expect(result).toEqual({ byConfigKey: {}, unmapped: [] })
+      expect(result).toEqual({
+        byConfigKey: {},
+        unmapped: [],
+        invalidGlyphNames: [],
+      })
     })
   })
 
@@ -180,6 +188,48 @@ describe('mapBlockErrorsToFields', () => {
       const result = mapBlockErrorsToFields([error], {}, messages, {})
       expect(result.byConfigKey).toEqual({ format: [error] })
       expect(result.unmapped).toEqual([])
+    })
+  })
+
+  describe('invalid glyph names', () => {
+    // #630 rewrites a filter/intrinsic clash into this, naming its options.
+    const error =
+      "Invalid glyph name: format (due to clashes with jinja keyword 'format'); appears in [format, path]"
+
+    it('attributes the verbatim error to every option it names', () => {
+      const result = mapBlockErrorsToFields([error], {}, messages, {})
+      expect(result.byConfigKey).toEqual({ format: [error], path: [error] })
+      expect(result.unmapped).toEqual([])
+    })
+
+    it('handles a single option', () => {
+      const single =
+        "Invalid glyph name: runId (due to clashes with intrinsic glyph 'runId'); appears in [path]"
+      const result = mapBlockErrorsToFields([single], {}, messages, {})
+      expect(result.byConfigKey).toEqual({ path: [single] })
+    })
+
+    it('reports the rejected name so it cannot be offered for definition', () => {
+      const result = mapBlockErrorsToFields([error], {}, messages, {})
+      expect(result.invalidGlyphNames).toEqual(['format'])
+    })
+
+    it('suppresses the unknown-glyph message for a rejected name', () => {
+      // The backend still lists it as missing (#630 does not strip it yet).
+      const result = mapBlockErrorsToFields(
+        [error],
+        { format: ['format'] },
+        messages,
+        {},
+      )
+      expect(result.byConfigKey.format).toEqual([error])
+    })
+
+    it('stays unmapped when it names no option', () => {
+      const empty = 'Invalid glyph name: x (due to y); appears in []'
+      const result = mapBlockErrorsToFields([empty], {}, messages, {})
+      expect(result.byConfigKey).toEqual({})
+      expect(result.unmapped).toEqual([empty])
     })
   })
 

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -10,7 +10,7 @@
 
 import { defineConfig, mergeConfig } from 'vitest/config'
 import { playwright } from '@vitest/browser-playwright'
-import viteConfig from './vite.config'
+import viteConfig from './vite.config.ts'
 
 export default mergeConfig(
   viteConfig({ mode: 'test', command: 'serve' }),


### PR DESCRIPTION
### Description

Frontend adoption of #640: the run detail canvas now shows the configuration values a run actually used, read from the `resolution` map the backend persists at compile time.

### As-run configuration on the run canvas
- Options whose value came from a `${glyph}` template display their final resolved value with a dotted underline; hovering shows both the resolved value and the stored template
- Each tooltip row has a copy-to-clipboard button (icon flips to a check on success), so e.g. a resolved output path can be grabbed directly from the canvas
- Runs recorded before #640 have no stored `resolution` and gracefully fall back to showing the raw templates
- Covered by schema unit tests and two integration tests on a new injectable mock fixture; verified live against a real backend including a restart (attempt 2 shows its own fresh `startDatetime`/`attemptCount`)

### Tooltip restyle (site-wide)
- Tooltips now use the theme-following popover surface (light in light theme) with a border ring, replacing the inverted dark default; the arrow is gone and the former `variant="light"` opt-in is now the only style
- Tooltip content is selectable and popups tolerate brief pointer slips (`closeDelay`), so hoverable tooltips support copying

### Independent fixes (bundled)
- `fix(configure)`: a glyph name the backend rejects (Jinja keyword / intrinsic clash) now shows its error on each option field that uses it, instead of only as a generic block error; rejected names no longer offer a "Define" button
- `fix(plugins)`: long diagnostic paths in the plugin tooltip were clipped at both edges by a nested max-width box; they now shrink, wrap, and cap at three entries with a remainder count

### Housekeeping
- `vitest.config.ts`: explicit extension on the `vite.config` import (silences the Vite 8.2 config-loader warning)

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
