### PR TITLE
[plugin.ecmwf] add dummy input anemoi

### DIFF
--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
@@ -40,6 +40,7 @@ INPUT_SOURCE_EXTRAS: dict[str, list[str]] = {
     "opendata": ["anemoi-plugins-ecmwf-inference[opendata]"],
     "polytope": ["anemoi-plugins-ecmwf-inference[polytope]"],
     "mars": ["earthkit-data[mars]"],
+    "dummy": [],
 }
 
 ENSEMBLE = ConfigurationOptionId("number")
@@ -126,7 +127,7 @@ class AnemoiSource(Source):
         INPUT_SOURCE: BlockConfigurationOption(
             title="Input Source",
             description="Source of the initial conditions",
-            value_type=OpenEnumType(["mars", "opendata", "polytope"]),
+            value_type=OpenEnumType(list(INPUT_SOURCE_EXTRAS.keys())),
             default_value="opendata",
         ),
         LEAD_TIME: BlockConfigurationOption(


### PR DESCRIPTION
Adding anemoi dummy input for case where the user does not have a valid mars key or opendata is timeouting too much