### PR TITLE
Feat/plugin concurrency rework

### DIFF
--- a/backend/development.md
+++ b/backend/development.md
@@ -15,7 +15,8 @@
   * when `ty` is not powerful enough, use `ty:ignore `
   * use `typing.cast` when the code logic is implicitly erasing the type information
   * do not use annotation-as-string unless necessary -- that is, prefer `f: TypeExpression` instead of `f: "TypeExpression"`
-* prioritize using pydantic BaseModel or dataclasses.dataclass object for capturing contracts and interfaces.
+* prioritize using pydantic BaseModel or dataclasses.dataclass object for capturing contracts and interfaces
+  * if an object would cross language/host boundaries go with pydantic to have json serde, otherwise dataclass. Do not use NamedTuples
   * when using pydantic, use `FiabBaseModel` from `forecastbox.utility.pydantic` (or `FiabCoreBaseModel` from `fiab_core.pydantic_utils` in fiab-core) instead of `pydantic.BaseModel` directly, unless the model requires dynamic field handling (e.g., `extra="allow"` for JSON Schema types). These base models set `extra="forbid"` to catch misconfigured constructors early. If you need the dynamic model handling, mark it clearly with a comment.
   * ideally keep them plain, stateless, frozen, without functions -- we end up serializing those objects often over to other python processes or different languages
     * having a few methods that provide convenience views, ser/de, validation, conversion does not necessarilly hurt -- its primarily about keeping the codebase generally functional and data-oriented rather than object-oriented.
@@ -23,7 +24,8 @@
   * a convenience decorator `frozendc` exists in `forecastbox.utility.structural` but direct decorator syntax is preferred for type safety
   * when using a primitive type in a semantically restricted context, utilize typing.NewType -- for example, dont do `user_id: str` but `UserId = typing.NewType("UserId", str); user_id: UserId`, because not every string is a valid UserId. This prevents a mixture of ids and gives a stronger type validity
 * use comments sparingly, for non-obvious code only. Add docstrings to functions called from other modules only. When adding docstring, use compact style -- dont separate out Args and Returns, describe everything in one or two paragraphs. Do not make two spaces after a dot.
-* all imports belong to top level of the file, dont import inside function definitions unless necessiated by runtime
+  * when making a code change, do not refer to the previous state in the docstring or the comment. In other words, do not put to docstring texts like "this function replaces the original function". This belongs to commit message, not to the code!
+* all imports belong to top level of the file, dont import inside function definitions unless necessiated by runtime (and in that case, always add explanatory comment at the site)
 * dont alias in imports unless there is a name collision, or unless its a standard shortcut: `datetime as dt`, `multiprocessing as mp`, `numpy as np`, `xarray as xr`, `earthkit.data as ekd`
 * never use python keywords and builtins as variable names -- for example, don't use `id` variable, prefer `id_<something>` or `id_`
 

--- a/backend/src/forecastbox/domain/artifact/manager.py
+++ b/backend/src/forecastbox/domain/artifact/manager.py
@@ -111,6 +111,7 @@ def _refresh_catalog_task() -> None:
         logger.exception(f"catalog refresh failed with {repr(e)}")
         with timed_acquire(ArtifactManager.lock, timeout_acquire_error) as _:
             ArtifactManager.refresh_error = repr(e)
+        raise
 
 
 def submit_refresh_catalog() -> Future[None]:  # ty: ignore[invalid-return-type]

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -53,7 +53,7 @@ from forecastbox.domain.glyphs.exceptions import GlyphCircularReferenceError
 from forecastbox.domain.glyphs.intrinsic import get_values_and_examples
 from forecastbox.domain.glyphs.resolution import ExtractedGlyphs, expand_glyph_values, merge_glyph_values, remap_glyph_names
 from forecastbox.domain.glyphs.validation import validate_glyph
-from forecastbox.domain.plugin.manager import PluginManager
+from forecastbox.domain.plugin.state import PluginManager
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.concurrency.manager import execution_manager
 from forecastbox.utility.graph import topological_order

--- a/backend/src/forecastbox/domain/plugin/compatibility.py
+++ b/backend/src/forecastbox/domain/plugin/compatibility.py
@@ -26,8 +26,8 @@ environments and a handover.
 ``install_plugin_compatibly`` assumes the environment already satisfies ``uv pip check`` --
 it performs no baseline check of its own. Callers that want to guard against attributing
 pre-existing, unrelated environment breakage to the plugin being installed/updated must call
-``check_environment_baseline()`` themselves first; see ``domain.plugin.manager`` for how the
-plugin manager uses it (once per initial batch load, and once per single-plugin update, before
+``check_environment_baseline()`` themselves first; see ``domain.plugin.loading`` for how the
+plugin loader uses it (once per initial batch load, and once per single-plugin update, before
 any install is attempted).
 
 Algorithm for ``install_plugin_compatibly``
@@ -55,7 +55,7 @@ Known limitations (read before touching this module)
    and preserves every other currently-installed distribution. A different install order, or
    resolving several plugins together in a fresh environment, could produce a valid combined
    state that an incremental, one-plugin-at-a-time install like this one rejects.
-2. Plugin uninstall (see ``domain.plugin.manager.uninstall_plugin``) only removes the configured/
+2. Plugin uninstall (see ``domain.plugin.loading.uninstall_plugin_sync``) only removes the configured/
    loaded plugin entry; it does not uninstall the plugin's distribution or its dependencies.
    Packages a plugin introduced become part of later environment snapshots and are consequently
    protected by this same mechanism. We cannot reliably infer which packages are now unused,

--- a/backend/src/forecastbox/domain/plugin/detail.py
+++ b/backend/src/forecastbox/domain/plugin/detail.py
@@ -13,12 +13,12 @@ These classes are both frontend-exposed (serialised as JSON in HTTP responses) a
 consumed internally by the service layer.  Changes to field names or structure affect
 the frontend contract; coordinate with frontend consumers before making breaking changes.
 
-The public entry-point is ``build_plugin_listing()``.  It acquires the PluginManager
-lock for the duration of the in-memory snapshot capture *and* the database reads, so
-that both are taken from the same logical point in time.  This is not a fully
-transactional read (the SQLite reads are not inside a DB transaction), but it is
-sufficient for a consistent UI snapshot.  The lock is held only for the duration of
-these fast operations; long-running work must not be done under it.
+The public entry-point is ``build_plugin_listing()``.  It captures the PluginManager's
+in-memory plugin/error snapshot under the short state lock, releases the lock, and only
+then awaits the jobs-DB pool for database state.  This is a best-effort composed snapshot
+(the in-memory and DB reads are not from exactly the same instant, and the SQLite reads
+are not inside a single DB transaction), but it is sufficient for a consistent-enough UI
+listing while keeping the state lock short.
 """
 
 import logging
@@ -31,7 +31,7 @@ from pydantic import Field
 from forecastbox.domain.plugin.db import PluginStateRecord, get_all_plugin_states
 from forecastbox.domain.plugin.errors import PluginError, PluginErrors
 from forecastbox.domain.plugin.exceptions import PluginManagerBusy
-from forecastbox.domain.plugin.manager import PluginManager
+from forecastbox.domain.plugin.state import PluginManager
 from forecastbox.domain.plugin.store import PluginRemoteInfo, PluginStoreEntry, get_plugins_detail
 from forecastbox.utility.concurrency.manager import execution_manager
 from forecastbox.utility.concurrency.synchronization import timed_acquire
@@ -171,17 +171,19 @@ def _build_detail(
 async def build_plugin_listing() -> PluginListing:
     """Build and return the full plugin listing.
 
-    Acquires the PluginManager lock, captures in-memory plugin and error snapshots,
-    then performs all DB reads while still holding the lock to ensure a consistent
-    view.  Raises ``PluginManagerBusy`` if the lock cannot be acquired within the
-    timeout, which the route layer translates to a 503 response.
+    Captures the in-memory plugin and error snapshots under the short PluginManager state
+    lock, releases the lock, then awaits the jobs-DB pool for database state -- a jobs-DB
+    wait must never happen while the state lock is held.  Raises ``PluginManagerBusy`` if
+    the state lock cannot be acquired within the timeout, which the route layer translates
+    to a 503 response.
     """
     with timed_acquire(PluginManager.lock, 0.5) as acquired:
         if not acquired:
             raise PluginManagerBusy("plugin manager lock could not be acquired; retry later")
         plugins_snapshot: dict[PluginCompositeId, Plugin] = dict(PluginManager.plugins)
         errors_snapshot: dict[PluginCompositeId, PluginErrors] = dict(PluginManager.errors)
-        db_states = await execution_manager.await_jobs_db("plugin.state.list", partial(get_all_plugin_states))
+
+    db_states = await execution_manager.await_jobs_db("plugin.state.list", partial(get_all_plugin_states))
 
     store_detail = get_plugins_detail()
 

--- a/backend/src/forecastbox/domain/plugin/errors.py
+++ b/backend/src/forecastbox/domain/plugin/errors.py
@@ -11,7 +11,10 @@
 
 A ``PluginError`` captures one diagnostic item produced during the plugin
 lifecycle. A plugin may accumulate multiple errors and/or warnings across
-different lifecycle phases.
+different lifecycle phases. Unlike Exceptions, which are emphemeral runtime
+constructs, this is a persisted entity reflecting the state of the virtual
+environment.
+
 
 Lifecycle sources:
 - ``install`` -- pip install phase; failure here means the package could not be

--- a/backend/src/forecastbox/domain/plugin/events.py
+++ b/backend/src/forecastbox/domain/plugin/events.py
@@ -16,7 +16,8 @@ from forecastbox.domain.notification.models import ClientNotification
 
 @dataclass(frozen=True, eq=True, slots=True)
 class PluginGlobalErrorEvent:
-    """Emitted whenever the plugin updater thread fails, mirroring ``PluginManager.updater_error``."""
+    """Emitted whenever a managed plugin-management task fails unexpectedly, mirroring the
+    domain-facing ``updater_error`` field in ``forecastbox.domain.plugin.state.PluginManager``."""
 
     trigger: str
     """What operation was running when the failure occurred, e.g. ``"Initial plugin load"`` or

--- a/backend/src/forecastbox/domain/plugin/loading.py
+++ b/backend/src/forecastbox/domain/plugin/loading.py
@@ -1,0 +1,269 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Synchronous plugin load/update/reload/unload worker orchestration.
+
+Every function here is meant to run on the single-worker
+``ConcurrentPools.PluginManagement`` pool (or, for tests, be called directly).
+None of them import routes, the entrypoint, or hold a reference to an event
+loop. Unexpected exceptions are left to propagate to the caller (see
+``domain.plugin.manager``'s managed-operation wrapper), while per-plugin
+install/load outcomes are represented as ``PluginErrors`` and are normal,
+non-raising completions.
+
+``compatibility.check_environment_baseline()`` and
+``compatibility.install_plugin_compatibly()`` are called at the points below
+and must not be duplicated or moved elsewhere; see
+``domain.plugin.compatibility`` for the policy they implement.
+"""
+
+import importlib
+import logging
+import re
+
+from cascade.low.func import Either
+from fiab_core.fable import PluginCompositeId
+from fiab_core.plugin import Plugin
+from packaging.version import Version
+from pydantic import ValidationError
+
+from forecastbox.domain.plugin.compatibility import check_environment_baseline, install_plugin_compatibly
+from forecastbox.domain.plugin.db import delete_plugin_state, get_plugin_state, upsert_plugin_state
+from forecastbox.domain.plugin.errors import PluginError, PluginErrors
+from forecastbox.domain.plugin.state import publish_bulk_snapshot, publish_single_snapshot, publish_unloaded
+from forecastbox.domain.plugin.template_ingest import ingest_plugin_templates
+from forecastbox.utility.concurrency.synchronization import timed_acquire
+from forecastbox.utility.config import PluginSettings, PluginsSettings, config, config_edit_lock
+from forecastbox.utility.packages import try_import, try_version
+
+logger = logging.getLogger(__name__)
+
+
+def load_single(plugin: PluginSettings) -> Either[Plugin, str]:  # type: ignore[invalid-argument]
+    errors = []
+    try:
+        plugin_impl = try_import(plugin.module_name)
+    except ValidationError as e:
+        # NOTE this should not typically happen -- it suggests a mismatch in core contract
+        msg = f"plugin {plugin.module_name} failed to validate with {e!r}"
+        logger.error(msg)
+        errors.append(msg)
+        return Either.error("\n".join(errors))
+
+    if plugin_impl is None:
+        errors.append(f"failed to import plugin {plugin.module_name}")
+    elif not hasattr(plugin_impl, "plugin"):
+        errors.append(f"plugin {plugin.module_name} does not have a `plugin` attribute")
+    else:
+        try:
+            maybe_plugin = getattr(plugin_impl, "plugin")()
+            if not isinstance(maybe_plugin, Plugin):
+                errors.append(f"plugin {plugin.module_name}'s `plugin()` does not give a Plugin")
+            else:
+                return Either.ok(maybe_plugin)
+        except Exception as e:
+            errors.append(f"failed to invoke plugin(): {repr(e)}")
+    return Either.error("\n".join(errors))
+
+
+def _version_from_install(installed: dict[str, str], module_name: str) -> str | None:
+    """Look up a plugin's newly-installed version from the pip install output dict.
+
+    Normalises names per PEP 503 (``[-_.]+`` -> ``-``, lowercase) before comparing,
+    so ``fiab_plugin_test`` matches ``fiab-plugin-test`` in the pip output.
+    """
+    target = re.sub(r"[-_.]+", "-", module_name).lower()
+    for name, ver in installed.items():
+        if re.sub(r"[-_.]+", "-", name).lower() == target:
+            return ver
+    return None
+
+
+def load_plugins(plugins: PluginsSettings) -> None:
+    """Initial bulk load: install/import every configured, enabled plugin, publish the
+    complete catalogue in one atomic snapshot, then run template ingestion for each
+    successfully loaded plugin.
+    """
+    logger.info("starting initial plugin load")
+    check_environment_baseline()
+    lookup: dict[PluginCompositeId, Plugin] = {}
+    errors: dict[PluginCompositeId, PluginErrors] = {}
+    for pluginKey, pluginSettings in plugins.items():
+        plugin_id_str = PluginCompositeId.to_str(pluginKey)
+        db_state = get_plugin_state(plugin_id_str)
+        if db_state is not None and not db_state.enabled:
+            logger.info(f"skipping disabled plugin {pluginKey}")
+            continue
+        installed_versions: dict[str, str] = {}
+        install_error: str | None = None
+        # NOTE consider running all pip invocations at once -- worse error reporting but better perf
+        if pluginSettings.update_strategy == "auto":
+            logger.info(f"auto-updating {pluginSettings.module_name}")
+            result = install_plugin_compatibly(pluginSettings.pip_source, None, pluginSettings.module_name)
+            if result.e:
+                install_error = result.e
+            else:
+                installed_versions = result.t or {}
+        else:
+            try:
+                is_found = try_import(pluginSettings.module_name) is None
+            except Exception:
+                # NOTE we just want to check whether we should run pip. This error will be resurfaced later during load_single
+                is_found = True
+            if is_found:
+                logger.info(f"installing {pluginSettings.module_name} for the first time")
+                result = install_plugin_compatibly(pluginSettings.pip_source, None, pluginSettings.module_name)
+                if result.e:
+                    install_error = result.e
+                else:
+                    installed_versions = result.t or {}
+
+        if install_error is not None:
+            logger.error(f"install failed for {pluginKey}: {install_error}")
+            upsert_plugin_state(
+                plugin_id=plugin_id_str,
+                version="install failed",
+                enabled=True,
+                plugin_errors=PluginErrors([PluginError(source="install", severity="error", detail=install_error)]),
+            )
+            continue
+        if installed_versions:
+            version_str = _version_from_install(installed_versions, pluginSettings.module_name)
+            if version_str is not None:
+                upsert_plugin_state(plugin_id=plugin_id_str, version=version_str, plugin_errors=PluginErrors([]))
+            else:
+                # pip does not report the version if it isn't changed -> this branch is not necessarily a bug
+                logger.warning(f"pip install of plugin {plugin_id_str} did not produce a version, assuming no change")
+
+        if pluginKey in lookup:
+            errors[pluginKey] = PluginErrors(
+                [
+                    PluginError(
+                        source="load",
+                        severity="error",
+                        detail=f"plugin {pluginKey} is provided by more than just {pluginSettings.pip_source}",
+                    )
+                ]
+            )
+            continue
+        plugin_result = load_single(pluginSettings)
+        if plugin_result.t is not None:
+            lookup[pluginKey] = plugin_result.t
+            version_imported = try_version(pluginSettings.pip_source, pluginSettings.module_name)
+            logger.debug(f"plugin {pluginKey} loaded with success: True and version {version_imported}")
+            fresh_state = get_plugin_state(plugin_id_str)
+            if fresh_state is None:
+                # NOTE this is unexpected state -- it is either developer editable install, or db wipe. We prefer to report,
+                # but dont prevent template ingest
+                err_msg = f"plugin {pluginKey} state not found -- install originally failed?"
+                logger.error(err_msg)
+                errors[pluginKey] = PluginErrors([PluginError(source="load", severity="error", detail=err_msg)])
+                upsert_plugin_state(plugin_id=plugin_id_str, version=version_imported, enabled=True, plugin_errors=PluginErrors([]))
+            else:
+                db_ver = fresh_state.plugin_version
+                if db_ver != version_imported:
+                    mismatch_msg = f"version mismatch: DB has {db_ver!r} but {version_imported!r} is imported"
+                    logger.warning(f"plugin {pluginKey}: {mismatch_msg}")
+                    errors[pluginKey] = PluginErrors([PluginError(source="load", severity="warning", detail=mismatch_msg)])
+        else:
+            logger.debug(f"plugin {pluginKey} loaded with success: False")
+            errors[pluginKey] = PluginErrors([PluginError(source="load", severity="error", detail=plugin_result.e)])  # type: ignore[arg-type]
+
+    # Publish all loaded plugins before running template ingestion so that
+    # validate_expand_sync can resolve factory references during validation.
+    if not publish_bulk_snapshot(lookup, errors):
+        raise ValueError("failed to acquire the shared lock")
+
+    for pluginKey, plugin_result in lookup.items():
+        ingest_plugin_templates(pluginKey, plugin_result)
+
+    logger.debug("global plugin loading finished")
+
+
+def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, install: bool, version: Version | None) -> None:
+    """Install (if requested), import/reload, and publish one plugin."""
+    plugin_id_str = PluginCompositeId.to_str(pluginId)
+    db_state = get_plugin_state(plugin_id_str)
+    if db_state is not None and not db_state.enabled:
+        logger.info(f"skipping disabled plugin {pluginId} in update_single")
+        return
+    installed_versions: dict[str, str] = {}
+    if install:
+        check_environment_baseline()
+        install_result = install_plugin_compatibly(pluginSettings.pip_source, version, pluginSettings.module_name)
+        if install_result.e:
+            upsert_plugin_state(
+                plugin_id=plugin_id_str,
+                version="install failed",
+                plugin_errors=PluginErrors([PluginError(source="install", severity="error", detail=install_result.e)]),
+            )
+            raise RuntimeError(f"install failed for {pluginId}: {install_result.e}")
+        installed_versions = install_result.t or {}
+    # NOTE we need to recommend in the docs to re-launch app after this change, this wont cover all cases:
+    # reloading the top-level module does not reload already-imported submodules/dependencies,
+    # replace previously-imported symbols, update existing instances, or reinitialize extension
+    # modules/registries. See domain.plugin.compatibility's module docstring for the full caveat.
+    importlib.invalidate_caches()
+    importlib.reload(importlib.import_module(pluginSettings.module_name))
+    result = load_single(pluginSettings)
+    logger.debug(f"plugin {pluginId} loaded with success: {result.t is not None}")
+    version_install = _version_from_install(installed_versions, pluginSettings.module_name)
+    version_imported = try_version(pluginSettings.pip_source, pluginSettings.module_name)
+    version_mismatch_err: PluginError | None = None
+    if version_install is not None and version_install != version_imported:
+        mismatch_msg = f"version mismatch: pip installed {version_install!r} but {version_imported!r} is imported"
+        logger.warning(f"plugin {pluginId}: {mismatch_msg}")
+        version_mismatch_err = PluginError(source="load", severity="warning", detail=mismatch_msg)
+    if result.t is not None:
+        new_errs: PluginErrors = PluginErrors([version_mismatch_err]) if version_mismatch_err is not None else PluginErrors([])
+    else:
+        load_err = PluginError(source="load", severity="error", detail=result.e)  # type: ignore[arg-type]
+        new_errs = PluginErrors([load_err, version_mismatch_err] if version_mismatch_err is not None else [load_err])
+    if not publish_single_snapshot(pluginId, result.t, new_errs):
+        raise ValueError("failed to acquire the shared lock")
+    if version_install is not None:
+        upsert_plugin_state(plugin_id=plugin_id_str, version=version_install, plugin_errors=PluginErrors([]))
+    else:
+        upsert_plugin_state(plugin_id=plugin_id_str, plugin_errors=PluginErrors([]))
+    if result.t is not None:
+        ingest_plugin_templates(pluginId, result.t)
+    logger.debug(f"single plugin loading finished: {pluginId}")
+
+
+def unload_single(plugin_id: PluginCompositeId) -> None:
+    """Remove a plugin's in-memory catalogue/error entries and soft-delete its templates.
+
+    Synchronous primitive shared by the plugin-settings disable path and uninstall.
+    """
+    plugin_id_str = PluginCompositeId.to_str(plugin_id)
+    if not publish_unloaded(plugin_id):
+        logger.warning("failed to acquire lock for unload_single")
+        return
+    # DB write outside the lock: remove blueprint templates.
+    # Note: this import is a breach of the dependency hierarchy (plugin domain depending
+    # on blueprint domain), and is temporary -- see domain.plugin.template_ingest's module docstring.
+    from forecastbox.domain.blueprint.db import soft_delete_all_plugin_templates
+
+    soft_delete_all_plugin_templates(created_by=plugin_id_str)
+
+
+def uninstall_plugin_sync(plugin_id: PluginCompositeId) -> None:
+    """Delete a plugin's DB state, remove its config entry, and unload its in-memory
+    catalogue/templates. Runs synchronously on a ``PluginManagement`` worker, so direct
+    (not pool-bridged) DB and config access is correct here.
+    """
+    if plugin_id not in config.external.plugins:
+        raise ValueError(f"plugin {plugin_id} not installed")
+    delete_plugin_state(plugin_id=PluginCompositeId.to_str(plugin_id))
+    with timed_acquire(config_edit_lock, 5) as result:
+        if not result:
+            raise ValueError("failed to acquire the shared lock")
+        config.external.plugins.pop(plugin_id)
+        config.save_to_file()
+    unload_single(plugin_id)

--- a/backend/src/forecastbox/domain/plugin/loading.py
+++ b/backend/src/forecastbox/domain/plugin/loading.py
@@ -9,18 +9,12 @@
 
 """Synchronous plugin load/update/reload/unload worker orchestration.
 
-Every function here is meant to run on the single-worker
+Every function here is meant to run in the single-worker
 ``ConcurrentPools.PluginManagement`` pool (or, for tests, be called directly).
-None of them import routes, the entrypoint, or hold a reference to an event
-loop. Unexpected exceptions are left to propagate to the caller (see
-``domain.plugin.manager``'s managed-operation wrapper), while per-plugin
+Unexpected exceptions are left to propagate to the caller (see
+``domain.plugin.submit``'s managed-operation wrapper), while per-plugin
 install/load outcomes are represented as ``PluginErrors`` and are normal,
-non-raising completions.
-
-``compatibility.check_environment_baseline()`` and
-``compatibility.install_plugin_compatibly()`` are called at the points below
-and must not be duplicated or moved elsewhere; see
-``domain.plugin.compatibility`` for the policy they implement.
+non-raising completions, to be persisted in a structured form.
 """
 
 import importlib
@@ -37,7 +31,7 @@ from forecastbox.domain.plugin.compatibility import check_environment_baseline, 
 from forecastbox.domain.plugin.db import delete_plugin_state, get_plugin_state, upsert_plugin_state
 from forecastbox.domain.plugin.errors import PluginError, PluginErrors
 from forecastbox.domain.plugin.state import publish_bulk_snapshot, publish_single_snapshot, publish_unloaded
-from forecastbox.domain.plugin.template_ingest import ingest_plugin_templates
+from forecastbox.domain.plugin.template_ingest import ingest_plugin_templates, unload_plugin_templates
 from forecastbox.utility.concurrency.synchronization import timed_acquire
 from forecastbox.utility.config import PluginSettings, PluginsSettings, config, config_edit_lock
 from forecastbox.utility.packages import try_import, try_version
@@ -45,7 +39,12 @@ from forecastbox.utility.packages import try_import, try_version
 logger = logging.getLogger(__name__)
 
 
-def load_single(plugin: PluginSettings) -> Either[Plugin, str]:  # type: ignore[invalid-argument]
+def _load_single(plugin: PluginSettings) -> Either[Plugin, str]:  # type: ignore[invalid-argument]
+    """Attempts to import the module and retrieve the `plugin` attribute, oversee the pydantic
+    validation, and return the valid object
+
+    Not expected to raise -- import errors and pydantic validation errors are propagated as Either.e
+    """
     errors = []
     try:
         plugin_impl = try_import(plugin.module_name)
@@ -78,6 +77,8 @@ def _version_from_install(installed: dict[str, str], module_name: str) -> str | 
     Normalises names per PEP 503 (``[-_.]+`` -> ``-``, lowercase) before comparing,
     so ``fiab_plugin_test`` matches ``fiab-plugin-test`` in the pip output.
     """
+    # TODO this should live in utility in some form. Possibly normalize by default
+    # to keep it simple
     target = re.sub(r"[-_.]+", "-", module_name).lower()
     for name, ver in installed.items():
         if re.sub(r"[-_.]+", "-", name).lower() == target:
@@ -114,7 +115,7 @@ def load_plugins(plugins: PluginsSettings) -> None:
             try:
                 is_found = try_import(pluginSettings.module_name) is None
             except Exception:
-                # NOTE we just want to check whether we should run pip. This error will be resurfaced later during load_single
+                # NOTE we just want to check whether we should run pip. This error will be resurfaced later during _load_single
                 is_found = True
             if is_found:
                 logger.info(f"installing {pluginSettings.module_name} for the first time")
@@ -152,7 +153,7 @@ def load_plugins(plugins: PluginsSettings) -> None:
                 ]
             )
             continue
-        plugin_result = load_single(pluginSettings)
+        plugin_result = _load_single(pluginSettings)
         if plugin_result.t is not None:
             lookup[pluginKey] = plugin_result.t
             version_imported = try_version(pluginSettings.pip_source, pluginSettings.module_name)
@@ -183,7 +184,7 @@ def load_plugins(plugins: PluginsSettings) -> None:
     for pluginKey, plugin_result in lookup.items():
         ingest_plugin_templates(pluginKey, plugin_result)
 
-    logger.debug("global plugin loading finished")
+    logger.info("global plugin loading finished")
 
 
 def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, install: bool, version: Version | None) -> None:
@@ -211,7 +212,7 @@ def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, i
     # modules/registries. See domain.plugin.compatibility's module docstring for the full caveat.
     importlib.invalidate_caches()
     importlib.reload(importlib.import_module(pluginSettings.module_name))
-    result = load_single(pluginSettings)
+    result = _load_single(pluginSettings)
     logger.debug(f"plugin {pluginId} loaded with success: {result.t is not None}")
     version_install = _version_from_install(installed_versions, pluginSettings.module_name)
     version_imported = try_version(pluginSettings.pip_source, pluginSettings.module_name)
@@ -241,16 +242,12 @@ def unload_single(plugin_id: PluginCompositeId) -> None:
 
     Synchronous primitive shared by the plugin-settings disable path and uninstall.
     """
-    plugin_id_str = PluginCompositeId.to_str(plugin_id)
     if not publish_unloaded(plugin_id):
-        logger.warning("failed to acquire lock for unload_single")
-        return
-    # DB write outside the lock: remove blueprint templates.
-    # Note: this import is a breach of the dependency hierarchy (plugin domain depending
-    # on blueprint domain), and is temporary -- see domain.plugin.template_ingest's module docstring.
-    from forecastbox.domain.blueprint.db import soft_delete_all_plugin_templates
-
-    soft_delete_all_plugin_templates(created_by=plugin_id_str)
+        logger.error("failed to mark plugin as unloaded! Will still be available")
+        # we raise to mark this future as failed
+        raise TimeoutError("failed to mark plugin as unloaded due to lock acquisition")
+    # DB write outside the lock: remove blueprint templates
+    unload_plugin_templates(plugin_id)
 
 
 def uninstall_plugin_sync(plugin_id: PluginCompositeId) -> None:

--- a/backend/src/forecastbox/domain/plugin/manager.py
+++ b/backend/src/forecastbox/domain/plugin/manager.py
@@ -7,83 +7,56 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-"""API for internal plugin management -- importing configured plugins, invoking
-pip install.
+"""API for internal plugin management -- submitting install/import/reload/unload work
+to the bounded ``ConcurrentPools.PluginManagement`` pool, and readiness/status/catalogue
+queries.
 
-Assumed to be invoked from the plugins router in API, and during application
-startup.
+Assumed to be invoked from the plugins router in API, and during application startup.
 
-The synchronization logic is handled by a PluginManager with a single lock.
-Pyrsistent immutable structures are used for shared state (plugins, errors),
-making reads safe without locks. The lock is only acquired when swapping the
-top-level structure pointers on writes. Plugin versions and timestamps are
-persisted in the DB and read back via domain.plugin.detail; they are not held in memory.
+``ConcurrentPools.PluginManagement`` is registered with exactly one worker. This is a
+correctness boundary, not merely an I/O pool: pip installation, module reload/import,
+and plugin catalogue publication all mutate process-global state, so at most one such
+operation may run at a time. ``domain.plugin.state.reserve_operation`` enforces this at
+the domain level (rejecting a second concurrent operation) in addition to the pool's own
+single worker, since a rejected/queued submission is not enough on its own to prevent two
+operations from being simultaneously "in flight" from the domain's point of view.
 
-There is at most one thread at any time doing any pip/importlib operations,
-thus inside these updater threads we don't need any other critical sections.
-We pay attention not to block forever on acquiring when inquiring for status
-or when running the initial plugin load -- but inside the updater threads,
-we lock for longer.
+Every managed operation is wrapped by ``_run_managed`` so that an unexpected exception
+is recorded both in the domain-facing error/notification surface (``updater_error`` and
+``PluginGlobalErrorEvent``) and in the execution manager's own bounded monitored-failure
+history (by re-raising after recording). Per-plugin install/load outcomes represented as
+``PluginErrors`` are not managed-operation failures; they are normal completions handled
+entirely inside ``domain.plugin.loading``.
 """
 
-import importlib
 import logging
-import re
-import threading
-import time
-from collections.abc import Iterator
+from collections.abc import Callable
 from concurrent.futures import Future
-from contextlib import contextmanager
 from functools import partial
 
-from cascade.low.func import Either
 from fiab_core.fable import BlockFactoryCatalogue, PluginCompositeId
-from fiab_core.plugin import Plugin
 from packaging.version import Version
-from pydantic import ValidationError
-from pyrsistent import pmap
-from pyrsistent.typing import PMap
 
-from forecastbox.domain.plugin.compatibility import check_environment_baseline, install_plugin_compatibly
-from forecastbox.domain.plugin.db import (
-    clear_asset_ingest_needed,
-    delete_plugin_state,
-    get_plugin_state,
-    update_template_errors,
-    upsert_plugin_state,
-)
-from forecastbox.domain.plugin.errors import PluginError, PluginErrors
 from forecastbox.domain.plugin.events import PluginGlobalErrorEvent
 from forecastbox.domain.plugin.exceptions import PluginEnvironmentAlreadyBroken
-from forecastbox.utility.concurrency.manager import execution_manager
-from forecastbox.utility.concurrency.synchronization import delayed_thread, timed_acquire
-from forecastbox.utility.config import PluginSettings, PluginsSettings, config, config_edit_lock
+from forecastbox.domain.plugin.loading import load_plugins as _load_plugins
+from forecastbox.domain.plugin.loading import uninstall_plugin_sync, unload_single, update_single
+from forecastbox.domain.plugin.state import (
+    PluginManager,
+    finish_ok,
+    finish_with_error,
+    release_reservation,
+    reserve_operation,
+)
+from forecastbox.utility.concurrency.manager import ConcurrentPools, SubmissionRejected, TaskName, execution_manager
+from forecastbox.utility.concurrency.synchronization import timed_acquire
+from forecastbox.utility.config import PluginsSettings, config
 from forecastbox.utility.dispatcher import Event, EventName, submit_event
-from forecastbox.utility.packages import try_import, try_version
 
 logger = logging.getLogger(__name__)
 
 
-class PluginManager:
-    lock: threading.Lock = threading.Lock()
-    plugins: PMap[PluginCompositeId, Plugin] = pmap()
-    errors: PMap[PluginCompositeId, PluginErrors] = pmap()
-    updater: threading.Thread | None = None
-    updater_error: str | None = None
-
-
-def _set_updater_error(trigger: str, message: str) -> None:
-    """Best-effort set ``PluginManager.updater_error`` under the lock, prefering corruption over
-    dropping the message outright. Then unconditionally emit a client notification carrying
-    the same error text.
-    """
-    with timed_acquire(PluginManager.lock, 5) as result:
-        if result:
-            PluginManager.updater_error = message
-        else:
-            logger.error("failed to acquire lock to record updater_error")
-            # NOTE we set the field regardless of the lock -- we rather corrupt than drop in this case
-            PluginManager.updater_error = message
+def _notify_failure(trigger: str, message: str) -> None:
     try:
         submit_event(
             Event(
@@ -95,351 +68,68 @@ def _set_updater_error(trigger: str, message: str) -> None:
         logger.exception(f"failed to submit plugin global-error notification for {trigger!r}: {repr(e)}")
 
 
-@contextmanager
-def _updater_failure_notifier(trigger: str) -> Iterator[None]:
-    """Wrap a load/install operation run from the updater thread. On any exception, records
-    ``PluginManager.updater_error`` and notifies clients of the failure via ``_set_updater_error``.
+def _run_managed(trigger: str, worker: Callable[[], None]) -> None:
+    """Run one managed plugin operation assuming its reservation has already been made.
+
+    On normal completion, marks the operation idle. On an unexpected exception, records
+    ``updater_error``, emits the existing ``PluginGlobalErrorEvent`` notification, and
+    re-raises so the execution manager records the failure in its own monitored history.
     """
     try:
-        yield
+        worker()
     except PluginEnvironmentAlreadyBroken as e:
         # NOTE this exception is handled separately for cleaner logging -- no need for the full trace
         logger.error(f"{trigger} refused: {e}")
-        _set_updater_error(trigger, str(e))
+        finish_with_error(str(e))
+        _notify_failure(trigger, str(e))
+        raise
     except Exception as e:
         logger.exception(f"{trigger} failed with {repr(e)}")
-        _set_updater_error(trigger, repr(e))
-
-
-def load_single(plugin: PluginSettings) -> Either[Plugin, str]:  # type: ignore[invalid-argument]
-    errors = []
-    try:
-        plugin_impl = try_import(plugin.module_name)
-    except ValidationError as e:
-        # NOTE this should not typically happen -- it suggests a mismatch in core contract
-        msg = f"plugin {plugin.module_name} failed to validate with {e!r}"
-        logger.error(msg)
-        errors.append(msg)
-        return Either.error("\n".join(errors))
-
-    if plugin_impl is None:
-        errors.append(f"failed to import plugin {plugin.module_name}")
-    elif not hasattr(plugin_impl, "plugin"):
-        errors.append(f"plugin {plugin.module_name} does not have a `plugin` attribute")
+        finish_with_error(repr(e))
+        _notify_failure(trigger, repr(e))
+        raise
     else:
-        try:
-            maybe_plugin = getattr(plugin_impl, "plugin")()
-            if not isinstance(maybe_plugin, Plugin):
-                errors.append(f"plugin {plugin.module_name}'s `plugin()` does not give a Plugin")
-            else:
-                return Either.ok(maybe_plugin)
-        except Exception as e:
-            errors.append(f"failed to invoke plugin(): {repr(e)}")
-    return Either.error("\n".join(errors))
+        finish_ok()
 
 
-def _version_from_install(installed: dict[str, str], module_name: str) -> str | None:
-    """Look up a plugin's newly-installed version from the pip install output dict.
-
-    Normalises names per PEP 503 (``[-_.]+`` -> ``-``, lowercase) before comparing,
-    so ``fiab_plugin_test`` matches ``fiab-plugin-test`` in the pip output.
-    """
-    target = re.sub(r"[-_.]+", "-", module_name).lower()
-    for name, ver in installed.items():
-        if re.sub(r"[-_.]+", "-", name).lower() == target:
-            return ver
-    return None
-
-
-def _ingest_plugin_templates(plugin_id: PluginCompositeId, plugin: Plugin) -> None:
-    """Upsert each blueprint template exposed by the plugin into the DB.
-
-    Skips ingestion entirely if ``asset_ingest_needed`` is not set on the plugin's
-    DB state row. When ingestion does run, the flag is cleared *before* ingesting so
-    that a partial failure does not trigger a spurious re-ingest; per-template errors
-    are persisted via ``update_template_errors`` regardless.
-
-    Excluded templates (per ``PluginState.excluded_templates``) are skipped and
-    any existing plugin-owned blueprint row with that ``display_name`` is
-    soft-deleted. Non-excluded templates have their glyph names rewritten by
-    ``remap_builder_glyphs`` when a non-empty ``glyph_remapping`` is stored for
-    the plugin, then are upserted as normal.
-
-    Uses lazy imports to avoid circular dependencies between the plugin and
-    blueprint domains. A failure on any single template is logged and skipped
-    so the remaining templates are still ingested.
-    Note: these imports are a breach of the dependency hierarchy (plugin domain
-    depending on blueprint domain), and will be fixed later by refactoring into events.
-    """
-    from forecastbox.domain.blueprint.db import find_plugin_template_id, soft_delete_plugin_template, upsert_blueprint
-    from forecastbox.domain.blueprint.service import (
-        Tag,
-        remap_builder_glyphs,
-        resolve_builder_with_examples,
-        tag_name_errors,
-        template_to_builder,
-        validate_expand_sync,
-    )
-    from forecastbox.utility.auth import AuthContext
-
-    plugin_id_str = PluginCompositeId.to_str(plugin_id)
-
-    state = get_plugin_state(plugin_id_str)
-    if state is None:
-        raise RuntimeError(
-            f"_ingest_plugin_templates called for {plugin_id_str!r} but no PluginState row exists; "
-            "this is a programming error -- upsert_plugin_state must be called before ingestion"
-        )
-    if not state.asset_ingest_needed:
-        logger.debug(f"skipping template ingestion for {plugin_id_str!r}: asset_ingest_needed is False")
-        return
-
-    clear_asset_ingest_needed(plugin_id=plugin_id_str)
-
-    auth = AuthContext(user_id=plugin_id_str, is_admin=True)
-    excluded_set = set(state.excluded_templates)
-    glyph_remapping = state.glyph_remapping
-    template_errors: dict[str, str] = {}
-
-    for template in plugin.blueprint_templates:
-        try:
-            if template.display_name in excluded_set:
-                soft_delete_plugin_template(created_by=plugin_id_str, display_name=template.display_name)
-                logger.debug(f"soft-deleted excluded template {template.display_name!r} from plugin {plugin_id_str!r}")
-                continue
-            existing_id = find_plugin_template_id(created_by=plugin_id_str, display_name=template.display_name)
-            builder = template_to_builder(template, plugin_id)
-            if glyph_remapping:
-                builder = remap_builder_glyphs(builder, glyph_remapping)
-            validation_builder = resolve_builder_with_examples(builder, template.example_values, template.example_glyphs)
-            result = validate_expand_sync(validation_builder, auth, validate_only=True)
-            all_errors: list[str] = tag_name_errors([Tag(key=tag) for tag in template.tags])
-            all_errors.extend(result.global_errors)
-            for block_errs in result.block_errors.values():
-                all_errors.extend(block_errs)
-            if all_errors:
-                template_errors[template.display_name] = "; ".join(all_errors)
-                logger.warning(
-                    f"template {template.display_name!r} from plugin {plugin_id_str!r} failed validation, skipping upsert: {all_errors}"
-                )
-                continue
-            upsert_blueprint(
-                auth_context=auth,
-                blueprint_id=existing_id,
-                source="plugin_template",
-                created_by=plugin_id_str,
-                builder=builder.model_dump(mode="json"),
-                display_name=template.display_name,
-                display_description=template.display_description,
-                tags=[{"key": tag} for tag in template.tags] or None,
-            )
-            logger.debug(f"ingested template {template.display_name!r} from plugin {plugin_id_str!r}")
-        except Exception as e:
-            template_errors[template.display_name] = repr(e)
-            logger.error(f"failed to ingest template {template.display_name!r} from plugin {plugin_id_str!r}: {repr(e)}")
-
-    update_template_errors(plugin_id=plugin_id_str, template_errors=template_errors)
-
-
-def load_plugins(plugins: PluginsSettings) -> None:
-    logger.info("starting initial plugin load")
-    trigger = "Initial plugin load"
-    with _updater_failure_notifier(trigger):
-        check_environment_baseline()
-        lookup: dict[PluginCompositeId, Plugin] = {}
-        errors: dict[PluginCompositeId, PluginErrors] = {}
-        for pluginKey, pluginSettings in plugins.items():
-            plugin_id_str = PluginCompositeId.to_str(pluginKey)
-            db_state = get_plugin_state(plugin_id_str)
-            if db_state is not None and not db_state.enabled:
-                logger.info(f"skipping disabled plugin {pluginKey}")
-                continue
-            installed_versions: dict[str, str] = {}
-            install_error: str | None = None
-            # NOTE consider running all pip invocations at once -- worse error reporting but better perf
-            if pluginSettings.update_strategy == "auto":
-                logger.info(f"auto-updating {pluginSettings.module_name}")
-                result = install_plugin_compatibly(pluginSettings.pip_source, None, pluginSettings.module_name)
-                if result.e:
-                    install_error = result.e
-                else:
-                    installed_versions = result.t or {}
-            else:
-                try:
-                    is_found = try_import(pluginSettings.module_name) is None
-                except Exception:
-                    # NOTE we just want to check whether we should run pip. This error will be resurfaced later during load_plugin
-                    is_found = True
-                if is_found:
-                    logger.info(f"installing {pluginSettings.module_name} for the first time")
-                    result = install_plugin_compatibly(pluginSettings.pip_source, None, pluginSettings.module_name)
-                    if result.e:
-                        install_error = result.e
-                    else:
-                        installed_versions = result.t or {}
-
-            if install_error is not None:
-                logger.error(f"install failed for {pluginKey}: {install_error}")
-                upsert_plugin_state(
-                    plugin_id=plugin_id_str,
-                    version="install failed",
-                    enabled=True,
-                    plugin_errors=PluginErrors([PluginError(source="install", severity="error", detail=install_error)]),
-                )
-                continue
-            if installed_versions:
-                version_str = _version_from_install(installed_versions, pluginSettings.module_name)
-                if version_str is not None:
-                    upsert_plugin_state(plugin_id=plugin_id_str, version=version_str, plugin_errors=PluginErrors([]))
-                else:
-                    # pip does not report the version if it isn't changed -> this branch is not necessarily a bug
-                    logger.warning(f"pip install of plugin {plugin_id_str} did not produce a version, assuming no change")
-
-            if pluginKey in lookup:
-                errors[pluginKey] = PluginErrors(
-                    [
-                        PluginError(
-                            source="load",
-                            severity="error",
-                            detail=f"plugin {pluginKey} is provided by more than just {pluginSettings.pip_source}",
-                        )
-                    ]
-                )
-                continue
-            plugin_result = load_single(pluginSettings)
-            if plugin_result.t is not None:
-                lookup[pluginKey] = plugin_result.t
-                version_imported = try_version(pluginSettings.pip_source, pluginSettings.module_name)
-                logger.debug(f"plugin {pluginKey} loaded with success: True and version {version_imported}")
-                fresh_state = get_plugin_state(plugin_id_str)
-                if fresh_state is None:
-                    # NOTE this is unexpected state -- it is either developer editable install, or db wipe. We prefer to report,
-                    # but dont prevent template ingest
-                    err_msg = f"plugin {pluginKey} state not found -- install originally failed?"
-                    logger.error(err_msg)
-                    errors[pluginKey] = PluginErrors([PluginError(source="load", severity="error", detail=err_msg)])
-                    upsert_plugin_state(plugin_id=plugin_id_str, version=version_imported, enabled=True, plugin_errors=PluginErrors([]))
-                else:
-                    db_ver = fresh_state.plugin_version
-                    if db_ver != version_imported:
-                        mismatch_msg = f"version mismatch: DB has {db_ver!r} but {version_imported!r} is imported"
-                        logger.warning(f"plugin {pluginKey}: {mismatch_msg}")
-                        errors[pluginKey] = PluginErrors([PluginError(source="load", severity="warning", detail=mismatch_msg)])
-            else:
-                logger.debug(f"plugin {pluginKey} loaded with success: False")
-                errors[pluginKey] = PluginErrors([PluginError(source="load", severity="error", detail=plugin_result.e)])  # type: ignore[arg-type]
-
-        # Publish all loaded plugins before running template ingestion so that
-        # validate_expand_sync can resolve factory references during validation.
-        with timed_acquire(PluginManager.lock, 60) as lock_result:
-            if not lock_result:
-                raise ValueError("failed to acquire the shared lock")
-            PluginManager.plugins = pmap(lookup)
-            PluginManager.errors = pmap(errors)
-
-        for pluginKey, plugin_result in lookup.items():
-            _ingest_plugin_templates(pluginKey, plugin_result)
-
-        logger.debug("global plugin loading finished")
-
-
-def update_single(pluginId: PluginCompositeId, pluginSettings: PluginSettings, install: bool, version: Version | None) -> None:
-    plugin_id_str = PluginCompositeId.to_str(pluginId)
-    with _updater_failure_notifier(f"Update of plugin {pluginId}"):
-        db_state = get_plugin_state(plugin_id_str)
-        if db_state is not None and not db_state.enabled:
-            logger.info(f"skipping disabled plugin {pluginId} in update_single")
-            return
-        installed_versions: dict[str, str] = {}
-        if install:
-            check_environment_baseline()
-            install_result = install_plugin_compatibly(pluginSettings.pip_source, version, pluginSettings.module_name)
-            if install_result.e:
-                upsert_plugin_state(
-                    plugin_id=plugin_id_str,
-                    version="install failed",
-                    plugin_errors=PluginErrors([PluginError(source="install", severity="error", detail=install_result.e)]),
-                )
-                raise RuntimeError(f"install failed for {pluginId}: {install_result.e}")
-            installed_versions = install_result.t or {}
-        # NOTE we need to recommend in the docs to re-launch app after this change, this wont cover all cases:
-        # reloading the top-level module does not reload already-imported submodules/dependencies,
-        # replace previously-imported symbols, update existing instances, or reinitialize extension
-        # modules/registries. See domain.plugin.compatibility's module docstring for the full caveat.
-        importlib.invalidate_caches()
-        importlib.reload(importlib.import_module(pluginSettings.module_name))
-        result = load_single(pluginSettings)
-        logger.debug(f"plugin {pluginId} loaded with success: {result.t is not None}")
-        version_install = _version_from_install(installed_versions, pluginSettings.module_name)
-        version_imported = try_version(pluginSettings.pip_source, pluginSettings.module_name)
-        version_mismatch_err: PluginError | None = None
-        if version_install is not None and version_install != version_imported:
-            mismatch_msg = f"version mismatch: pip installed {version_install!r} but {version_imported!r} is imported"
-            logger.warning(f"plugin {pluginId}: {mismatch_msg}")
-            version_mismatch_err = PluginError(source="load", severity="warning", detail=mismatch_msg)
-        with timed_acquire(PluginManager.lock, 60) as acquire_result:
-            if not acquire_result:
-                raise ValueError("failed to acquire the shared lock")
-            if result.t is not None:
-                PluginManager.plugins = PluginManager.plugins.set(pluginId, result.t)
-                new_errs: PluginErrors = PluginErrors([version_mismatch_err]) if version_mismatch_err is not None else PluginErrors([])
-            else:
-                load_err = PluginError(source="load", severity="error", detail=result.e)  # type: ignore[arg-type]
-                new_errs = PluginErrors([load_err, version_mismatch_err] if version_mismatch_err is not None else [load_err])
-            if new_errs:
-                PluginManager.errors = PluginManager.errors.set(pluginId, new_errs)
-            elif pluginId in PluginManager.errors:
-                PluginManager.errors = PluginManager.errors.remove(pluginId)
-        if version_install is not None:
-            upsert_plugin_state(plugin_id=plugin_id_str, version=version_install, plugin_errors=PluginErrors([]))
-        else:
-            upsert_plugin_state(plugin_id=plugin_id_str, plugin_errors=PluginErrors([]))
-        if result.t is not None:
-            _ingest_plugin_templates(pluginId, result.t)
-        logger.debug(f"single plugin loading finished: {pluginId}")
-
-
-def unload_single(pluginId: PluginCompositeId) -> None:
-    plugin_id_str = PluginCompositeId.to_str(pluginId)
-    with timed_acquire(PluginManager.lock, 5) as result:
-        if not result:
-            logger.warning("failed to acquire lock for unload_single")
-            return
-        if pluginId in PluginManager.plugins:
-            PluginManager.plugins = PluginManager.plugins.remove(pluginId)
-        if pluginId in PluginManager.errors:
-            PluginManager.errors = PluginManager.errors.remove(pluginId)
-    # DB write outside the lock: remove blueprint templates.
-    # Note: these imports are a breach of the dependency hierarchy (plugin domain depending
-    # on blueprint domain), and will be fixed later by refactoring into events.
-    from forecastbox.domain.blueprint.db import soft_delete_all_plugin_templates
-
-    soft_delete_all_plugin_templates(created_by=plugin_id_str)
+def run_initial_load(plugins: PluginsSettings) -> None:
+    _run_managed("Initial plugin load", partial(_load_plugins, plugins))
 
 
 def submit_load_plugins(start_after: Future[None]) -> None:
-    with timed_acquire(PluginManager.lock, 0.2) as result:
-        if not result:
-            logger.error("failed to submit load_plugins")
-            # NOTE we set updater_error directly here (skipping _set_updater_error) and
-            # deliberately do not emit a client notification: this runs during application
-            # startup, before the app is serving requests, so no client could possibly have
-            # registered yet to receive it. Notifications are not persisted/replayed -- unlike
-            # updater_error, which is polled via the status route -- so a notification here
-            # would simply be dropped. Revisit this if notifications ever become persisted.
-            PluginManager.updater_error = "failed to submit load_plugins"
-        elif PluginManager.updater is not None:
-            raise TypeError("attempted to submit load_plugins but updater is already in progress")
-        else:
-            PluginManager.updater = delayed_thread(start_after, load_plugins, (config.external.plugins,))
-            PluginManager.updater.start()
+    """Reserve the initial-load operation and submit it as a continuation of the artifact
+    catalog refresh future. Replaces the previous ``delayed_thread``-based startup thread.
+    """
+    result = reserve_operation()
+    if not result.accepted:
+        logger.error(f"failed to submit load_plugins: {result.reason}")
+        finish_with_error(f"failed to submit load_plugins: {result.reason}")
+        return
+
+    def _record_dependency_failure(done: Future[None]) -> None:
+        # NOTE this callback only updates the short domain state; it must not acquire the
+        # jobs lock, publish plugins, or submit work while holding the state lock. The
+        # execution manager's own `submit_after` already records the dependency failure in
+        # its monitored failure history; this only keeps `plugins_ready()`/`status_brief()`
+        # consistent and avoids invoking the load worker at all.
+        try:
+            done.result()
+        except BaseException as error:
+            finish_with_error(f"catalog refresh dependency failed: {repr(error)}")
+
+    start_after.add_done_callback(_record_dependency_failure)
+    execution_manager.submit_after(
+        start_after,
+        ConcurrentPools.PluginManagement,
+        TaskName("plugin.initial-load"),
+        partial(run_initial_load, config.external.plugins),
+    )
 
 
 def status_brief() -> str:
-    # NOTE this may be called without locking, we don't risk collection mutation during iteration
     if PluginManager.updater_error is not None:
         return f"failure: {PluginManager.updater_error}"
-    elif PluginManager.updater.is_alive():
+    elif PluginManager.operation_in_progress:
         return "running"
     else:
         return "ok"
@@ -461,53 +151,55 @@ def submit_update_single(pluginId: PluginCompositeId, install: bool, version: Ve
     pluginSettings = config.external.plugins.get(pluginId, None)
     if pluginSettings is None:
         return f"plugin {pluginId} not configured"
-    else:
-        with timed_acquire(PluginManager.lock, 0.5) as result:
-            if not result:
-                return "plugin updater is not idle"
-            if PluginManager.updater_error is not None:
-                logger.warning(f"refusing to update_single because of {PluginManager.updater_error}")
-                return "plugin updater has failed"
-            if PluginManager.updater is not None:
-                if PluginManager.updater.is_alive():
-                    return "plugin updater is not idle"
-                else:
-                    PluginManager.updater.join(0)
-                    # we join despite thread not being alive to ensure resource collection
-            PluginManager.updater = threading.Thread(target=update_single, args=(pluginId, pluginSettings, install, version))
-            PluginManager.updater.start()
+    result = reserve_operation()
+    if not result.accepted:
+        return result.reason
+    trigger = f"Update of plugin {pluginId}"
+    try:
+        execution_manager.submit_monitored(
+            ConcurrentPools.PluginManagement,
+            TaskName("plugin.update"),
+            partial(_run_managed, trigger, partial(update_single, pluginId, pluginSettings, install, version)),
+        )
+    except SubmissionRejected:
+        release_reservation()
+        raise
     return ""
+
+
+async def submit_unload_single(pluginId: PluginCompositeId) -> None:
+    """Reserve and await an unload operation. The caller (route) owns success/failure
+    reporting; a recorded global ``updater_error`` does not block this cleanup path.
+    """
+    result = reserve_operation(block_on_error=False)
+    if not result.accepted:
+        raise SubmissionRejected(result.reason)
+    trigger = f"Unload of plugin {pluginId}"
+    try:
+        await execution_manager.awaitable_submit(
+            ConcurrentPools.PluginManagement,
+            TaskName("plugin.unload"),
+            partial(_run_managed, trigger, partial(unload_single, pluginId)),
+        )
+    except SubmissionRejected:
+        release_reservation()
+        raise
 
 
 async def uninstall_plugin(pluginId: PluginCompositeId) -> None:
     logger.debug(f"about to uninstall {pluginId=}")
     if pluginId not in config.external.plugins:
         raise ValueError(f"plugin {pluginId} not installed")
-    # db remove
-    logger.debug(f"about to db remove {pluginId=}")
-    await execution_manager.await_jobs_db(
-        "plugin.state.delete",
-        partial(delete_plugin_state, plugin_id=PluginCompositeId.to_str(pluginId)),
-    )
-    # config entry remove
-    logger.debug(f"about to config remove {pluginId=}")
-    with timed_acquire(config_edit_lock, 5) as result:
-        if not result:
-            raise ValueError("failed to acquire the shared lock")
-        config.external.plugins.pop(pluginId)
-        config.save_to_file()
-    unload_single(pluginId)
-
-
-def join_updater_thread(timeout_sec: int) -> None:
-    # TODO candidate for ecpyutil, duplicated in plugin.store
-    barrier = (time.perf_counter_ns() / 1e9) + timeout_sec
-    with timed_acquire(PluginManager.lock, timeout_sec) as result:
-        if not result:
-            logger.error("failed to lock for joining updater thread")
-        else:
-            if PluginManager.updater is not None:
-                budget = barrier - (time.perf_counter_ns() / 1e9)
-                PluginManager.updater.join(budget)
-                if PluginManager.updater.is_alive():
-                    logger.error("failed to join PluginManager updater thread")
+    result = reserve_operation(block_on_error=False)
+    if not result.accepted:
+        raise SubmissionRejected(result.reason)
+    trigger = f"Uninstall of plugin {pluginId}"
+    try:
+        await execution_manager.awaitable_submit(
+            ConcurrentPools.PluginManagement,
+            TaskName("plugin.uninstall"),
+            partial(_run_managed, trigger, partial(uninstall_plugin_sync, pluginId)),
+        )
+    except SubmissionRejected:
+        release_reservation()
+        raise

--- a/backend/src/forecastbox/domain/plugin/state.py
+++ b/backend/src/forecastbox/domain/plugin/state.py
@@ -18,9 +18,11 @@ be held across pip, import/reload, template ingestion, database access, or a wai
 a future; those all run on the ``ConcurrentPools.PluginManagement`` worker without
 this lock, see ``domain.plugin.loading`` and ``domain.plugin.manager``.
 
-``operation_in_progress`` replaces the previous thread-object bookkeeping: it is
-``True`` from the moment a startup/update/unload/uninstall operation is accepted
+``operation_in_progress`` is to guarantee we don't have concurrently running/submitted
+operations -- it exists to increase the PluginManagement single-worker guarantee.
+It is ``True`` from the moment a startup/update/unload/uninstall operation is accepted
 until its managed wrapper completes (successfully or not), and ``False`` otherwise.
+
 ``updater_error`` preserves the existing global failure surface: once set, it blocks
 any further update/initial-load operation until the process restarts (there is no
 implicit retry or reset), but it does not block unload/uninstall, which remain
@@ -31,9 +33,17 @@ blocking work outside of them and only call in to publish a snapshot or transiti
 the reservation.
 """
 
+# TODO the updater_error not being None preventing selected operations is odd, we
+# should probably persist the error in structured/accessible/granular form, and
+# do a smarter decision making / cleaning
+
+# TODO the operation_in_progress feels unrequired and complicating -- maybe we just
+# set pending on the pool to 0? The deadlock/corruption scenario during release is
+# undesired!
+
 import logging
 import threading
-from typing import NamedTuple
+from dataclasses import dataclass
 
 from fiab_core.fable import PluginCompositeId
 from fiab_core.plugin import Plugin
@@ -45,13 +55,15 @@ from forecastbox.utility.concurrency.synchronization import timed_acquire
 
 logger = logging.getLogger(__name__)
 
-_LOCK_TIMEOUT_SHORT = 5.0
-_LOCK_TIMEOUT_PUBLISH = 60.0
+_LOCK_TIMEOUT_SHORT = 5.0  # for ops where failure does not render backend useless
+_LOCK_TIMEOUT_RELEASE = 20.0  # failing to release operation_in_progress renders backend useless
+_LOCK_TIMEOUT_INITIAL = 60.0  # without initial load the backend is useless, we rather have a long one
 
 
 class PluginManager:
     """Namespace holding the process-wide plugin catalogue and operation state."""
 
+    # this lock guards only field access in this manager, *not* any venv/pip/io ops
     lock: threading.Lock = threading.Lock()
     plugins: PMap[PluginCompositeId, Plugin] = pmap()
     errors: PMap[PluginCompositeId, PluginErrors] = pmap()
@@ -59,18 +71,19 @@ class PluginManager:
     updater_error: str | None = None
 
 
-class ReservationResult(NamedTuple):
+@dataclass(frozen=True, eq=True, slots=True)
+class ReservationResult:
     accepted: bool
     reason: str
 
 
-def reserve_operation(*, block_on_error: bool = True) -> ReservationResult:
+def reserve_operation(*, refuse_on_error: bool = True) -> ReservationResult:
     """Attempt to reserve the single plugin-management operation slot.
 
-    Fails if a prior operation is still in progress. If ``block_on_error`` is
+    Fails if a prior operation is still in progress. If ``refuse_on_error`` is
     True (the default, used by initial-load/update), a previously recorded
     global ``updater_error`` also blocks the reservation. Unload/uninstall pass
-    ``block_on_error=False`` so they remain available to clean up after a
+    ``refuse_on_error=False`` so they remain available to clean up after a
     failed plugin.
     """
     with timed_acquire(PluginManager.lock, _LOCK_TIMEOUT_SHORT) as acquired:
@@ -78,7 +91,7 @@ def reserve_operation(*, block_on_error: bool = True) -> ReservationResult:
             return ReservationResult(False, "plugin manager state lock could not be acquired")
         if PluginManager.operation_in_progress:
             return ReservationResult(False, "plugin operation is not idle")
-        if block_on_error and PluginManager.updater_error is not None:
+        if refuse_on_error and PluginManager.updater_error is not None:
             return ReservationResult(False, f"plugin updater has failed: {PluginManager.updater_error}")
         PluginManager.operation_in_progress = True
         return ReservationResult(True, "")
@@ -91,20 +104,24 @@ def release_reservation() -> None:
     synchronously after the reservation was already made, e.g. by a saturated
     pool, so that the domain is not left permanently ``running``.
     """
-    with timed_acquire(PluginManager.lock, _LOCK_TIMEOUT_SHORT) as acquired:
+    with timed_acquire(PluginManager.lock, _LOCK_TIMEOUT_RELEASE) as acquired:
         if acquired:
             PluginManager.operation_in_progress = False
         else:
             logger.error("failed to acquire lock to release a plugin operation reservation")
+            # NOTE we release unconditionally -- we rather corrupt than deadlock
+            PluginManager.operation_in_progress = False
 
 
 def finish_ok() -> None:
     """Mark the current operation as finished successfully."""
-    with timed_acquire(PluginManager.lock, _LOCK_TIMEOUT_SHORT) as acquired:
+    with timed_acquire(PluginManager.lock, _LOCK_TIMEOUT_RELEASE) as acquired:
         if acquired:
             PluginManager.operation_in_progress = False
         else:
             logger.error("failed to acquire lock to mark a plugin operation as finished")
+            # NOTE we release unconditionally -- we rather corrupt than deadlock
+            PluginManager.operation_in_progress = False
 
 
 def finish_with_error(message: str) -> None:
@@ -113,18 +130,17 @@ def finish_with_error(message: str) -> None:
     Best-effort: prefers corrupting the shared field over silently dropping the
     message if the lock cannot be acquired within the short timeout.
     """
-    with timed_acquire(PluginManager.lock, _LOCK_TIMEOUT_SHORT) as acquired:
+    with timed_acquire(PluginManager.lock, _LOCK_TIMEOUT_RELEASE) as acquired:
         if not acquired:
             logger.error("failed to acquire lock to record updater_error")
-        # NOTE we set the fields regardless of the lock result -- we prefer to corrupt
-        # rather than drop the failure outright.
+        # NOTE we release unconditionally -- we rather corrupt than deadlock
         PluginManager.updater_error = message
         PluginManager.operation_in_progress = False
 
 
 def publish_bulk_snapshot(plugins: dict[PluginCompositeId, Plugin], errors: dict[PluginCompositeId, PluginErrors]) -> bool:
     """Atomically replace the full plugin/errors maps (initial/bulk load)."""
-    with timed_acquire(PluginManager.lock, _LOCK_TIMEOUT_PUBLISH) as acquired:
+    with timed_acquire(PluginManager.lock, _LOCK_TIMEOUT_INITIAL) as acquired:
         if not acquired:
             return False
         PluginManager.plugins = pmap(plugins)
@@ -134,7 +150,7 @@ def publish_bulk_snapshot(plugins: dict[PluginCompositeId, Plugin], errors: dict
 
 def publish_single_snapshot(plugin_id: PluginCompositeId, plugin: Plugin | None, errors: PluginErrors) -> bool:
     """Atomically publish one plugin's load result (single update)."""
-    with timed_acquire(PluginManager.lock, _LOCK_TIMEOUT_PUBLISH) as acquired:
+    with timed_acquire(PluginManager.lock, _LOCK_TIMEOUT_INITIAL) as acquired:
         if not acquired:
             return False
         if plugin is not None:

--- a/backend/src/forecastbox/domain/plugin/state.py
+++ b/backend/src/forecastbox/domain/plugin/state.py
@@ -1,0 +1,158 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Shared immutable plugin state and short synchronized state transitions.
+
+``PluginManager`` is the single namespace holding the process-wide plugin catalogue
+(``plugins``) and its accumulated in-memory errors (``errors``), both published as
+``pyrsistent`` immutable maps so that reads never need to lock. ``PluginManager.lock``
+protects only the short field transitions in this module -- reserving/releasing the
+single plugin-management operation slot and swapping the map pointers. It must never
+be held across pip, import/reload, template ingestion, database access, or a wait on
+a future; those all run on the ``ConcurrentPools.PluginManagement`` worker without
+this lock, see ``domain.plugin.loading`` and ``domain.plugin.manager``.
+
+``operation_in_progress`` replaces the previous thread-object bookkeeping: it is
+``True`` from the moment a startup/update/unload/uninstall operation is accepted
+until its managed wrapper completes (successfully or not), and ``False`` otherwise.
+``updater_error`` preserves the existing global failure surface: once set, it blocks
+any further update/initial-load operation until the process restarts (there is no
+implicit retry or reset), but it does not block unload/uninstall, which remain
+available to clean up after a failed plugin.
+
+The helpers below are intentionally small and perform no I/O; callers run any
+blocking work outside of them and only call in to publish a snapshot or transition
+the reservation.
+"""
+
+import logging
+import threading
+from typing import NamedTuple
+
+from fiab_core.fable import PluginCompositeId
+from fiab_core.plugin import Plugin
+from pyrsistent import pmap
+from pyrsistent.typing import PMap
+
+from forecastbox.domain.plugin.errors import PluginErrors
+from forecastbox.utility.concurrency.synchronization import timed_acquire
+
+logger = logging.getLogger(__name__)
+
+_LOCK_TIMEOUT_SHORT = 5.0
+_LOCK_TIMEOUT_PUBLISH = 60.0
+
+
+class PluginManager:
+    """Namespace holding the process-wide plugin catalogue and operation state."""
+
+    lock: threading.Lock = threading.Lock()
+    plugins: PMap[PluginCompositeId, Plugin] = pmap()
+    errors: PMap[PluginCompositeId, PluginErrors] = pmap()
+    operation_in_progress: bool = False
+    updater_error: str | None = None
+
+
+class ReservationResult(NamedTuple):
+    accepted: bool
+    reason: str
+
+
+def reserve_operation(*, block_on_error: bool = True) -> ReservationResult:
+    """Attempt to reserve the single plugin-management operation slot.
+
+    Fails if a prior operation is still in progress. If ``block_on_error`` is
+    True (the default, used by initial-load/update), a previously recorded
+    global ``updater_error`` also blocks the reservation. Unload/uninstall pass
+    ``block_on_error=False`` so they remain available to clean up after a
+    failed plugin.
+    """
+    with timed_acquire(PluginManager.lock, _LOCK_TIMEOUT_SHORT) as acquired:
+        if not acquired:
+            return ReservationResult(False, "plugin manager state lock could not be acquired")
+        if PluginManager.operation_in_progress:
+            return ReservationResult(False, "plugin operation is not idle")
+        if block_on_error and PluginManager.updater_error is not None:
+            return ReservationResult(False, f"plugin updater has failed: {PluginManager.updater_error}")
+        PluginManager.operation_in_progress = True
+        return ReservationResult(True, "")
+
+
+def release_reservation() -> None:
+    """Roll back a reservation without recording completion or an error.
+
+    Used when a normal (non-``updater_error``) submission is rejected
+    synchronously after the reservation was already made, e.g. by a saturated
+    pool, so that the domain is not left permanently ``running``.
+    """
+    with timed_acquire(PluginManager.lock, _LOCK_TIMEOUT_SHORT) as acquired:
+        if acquired:
+            PluginManager.operation_in_progress = False
+        else:
+            logger.error("failed to acquire lock to release a plugin operation reservation")
+
+
+def finish_ok() -> None:
+    """Mark the current operation as finished successfully."""
+    with timed_acquire(PluginManager.lock, _LOCK_TIMEOUT_SHORT) as acquired:
+        if acquired:
+            PluginManager.operation_in_progress = False
+        else:
+            logger.error("failed to acquire lock to mark a plugin operation as finished")
+
+
+def finish_with_error(message: str) -> None:
+    """Record an unexpected operation failure and mark the operation as finished.
+
+    Best-effort: prefers corrupting the shared field over silently dropping the
+    message if the lock cannot be acquired within the short timeout.
+    """
+    with timed_acquire(PluginManager.lock, _LOCK_TIMEOUT_SHORT) as acquired:
+        if not acquired:
+            logger.error("failed to acquire lock to record updater_error")
+        # NOTE we set the fields regardless of the lock result -- we prefer to corrupt
+        # rather than drop the failure outright.
+        PluginManager.updater_error = message
+        PluginManager.operation_in_progress = False
+
+
+def publish_bulk_snapshot(plugins: dict[PluginCompositeId, Plugin], errors: dict[PluginCompositeId, PluginErrors]) -> bool:
+    """Atomically replace the full plugin/errors maps (initial/bulk load)."""
+    with timed_acquire(PluginManager.lock, _LOCK_TIMEOUT_PUBLISH) as acquired:
+        if not acquired:
+            return False
+        PluginManager.plugins = pmap(plugins)
+        PluginManager.errors = pmap(errors)
+        return True
+
+
+def publish_single_snapshot(plugin_id: PluginCompositeId, plugin: Plugin | None, errors: PluginErrors) -> bool:
+    """Atomically publish one plugin's load result (single update)."""
+    with timed_acquire(PluginManager.lock, _LOCK_TIMEOUT_PUBLISH) as acquired:
+        if not acquired:
+            return False
+        if plugin is not None:
+            PluginManager.plugins = PluginManager.plugins.set(plugin_id, plugin)
+        if errors:
+            PluginManager.errors = PluginManager.errors.set(plugin_id, errors)
+        elif plugin_id in PluginManager.errors:
+            PluginManager.errors = PluginManager.errors.remove(plugin_id)
+        return True
+
+
+def publish_unloaded(plugin_id: PluginCompositeId) -> bool:
+    """Remove a plugin's immutable catalogue/error entries (unload/uninstall)."""
+    with timed_acquire(PluginManager.lock, _LOCK_TIMEOUT_SHORT) as acquired:
+        if not acquired:
+            return False
+        if plugin_id in PluginManager.plugins:
+            PluginManager.plugins = PluginManager.plugins.remove(plugin_id)
+        if plugin_id in PluginManager.errors:
+            PluginManager.errors = PluginManager.errors.remove(plugin_id)
+        return True

--- a/backend/src/forecastbox/domain/plugin/status.py
+++ b/backend/src/forecastbox/domain/plugin/status.py
@@ -1,0 +1,37 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Status and view helpers for the routes"""
+
+from fiab_core.fable import BlockFactoryCatalogue, PluginCompositeId
+
+from forecastbox.domain.plugin.state import PluginManager
+from forecastbox.utility.concurrency.synchronization import timed_acquire
+
+
+def status_brief() -> str:
+    if PluginManager.updater_error is not None:
+        return f"failure: {PluginManager.updater_error}"
+    elif PluginManager.operation_in_progress:
+        return "running"
+    else:
+        return "ok"
+
+
+def plugins_ready() -> bool:
+    return status_brief() == "ok"
+
+
+def catalogue_view() -> dict[PluginCompositeId, BlockFactoryCatalogue] | bool:
+    with timed_acquire(PluginManager.lock, 1.0) as result:
+        if not result:
+            return False
+        else:
+            plugins = PluginManager.plugins
+    return {plugin_id: plugin.catalogue for plugin_id, plugin in PluginManager.plugins.items()}

--- a/backend/src/forecastbox/domain/plugin/status.py
+++ b/backend/src/forecastbox/domain/plugin/status.py
@@ -34,4 +34,4 @@ def catalogue_view() -> dict[PluginCompositeId, BlockFactoryCatalogue] | bool:
             return False
         else:
             plugins = PluginManager.plugins
-    return {plugin_id: plugin.catalogue for plugin_id, plugin in PluginManager.plugins.items()}
+    return {plugin_id: plugin.catalogue for plugin_id, plugin in plugins.items()}

--- a/backend/src/forecastbox/domain/plugin/store.py
+++ b/backend/src/forecastbox/domain/plugin/store.py
@@ -11,7 +11,7 @@
 
 import logging
 import threading
-import time
+from functools import partial
 
 import httpx
 import orjson
@@ -23,6 +23,7 @@ from pyrsistent.typing import PMap
 from typing_extensions import Self
 
 from forecastbox.domain.plugin.manager import submit_update_single
+from forecastbox.utility.concurrency.manager import ConcurrentPools, TaskName, execution_manager
 from forecastbox.utility.concurrency.synchronization import timed_acquire
 from forecastbox.utility.config import PluginSettings, PluginStoreConfig, PluginStoreId, PluginStoresConfig, config, config_edit_lock
 from forecastbox.utility.httpx import fetch_content
@@ -107,11 +108,10 @@ def populate_store(store: PluginStore, client: httpx.Client) -> None:
 class StoresManager:
     stores: PMap[PluginStoreId, PluginStore] = pmap()
     stores_lock: threading.Lock = threading.Lock()
-    stores_updater: threading.Thread | None = None
 
 
 def initialize_stores(plugin_stores_config: PluginStoresConfig) -> None:
-    # assumed to be submitted from a thread
+    # assumed to be submitted through ConcurrentPools.Io
     with httpx.Client() as client:
         # a thread pool / async could work here but we dont expect many stores here
         stores = {key: fetch_store(client, value) for key, value in plugin_stores_config.items()}
@@ -136,12 +136,18 @@ def get_plugins_detail() -> dict[PluginCompositeId, tuple[PluginStoreEntry, Plug
 
 
 def submit_initialize_stores() -> None:
-    with timed_acquire(StoresManager.stores_lock, 10) as result:
-        if not result:
-            logger.error("failed to initialize stores")
-            return
-        StoresManager.stores_updater = threading.Thread(target=initialize_stores, args=(config.external.plugin_stores,))
-        StoresManager.stores_updater.start()
+    """Submit store initialization as a monitored task on the shared ``Io`` pool.
+
+    Fire-and-forget: an unexpected exception is recorded by the execution manager's
+    monitored-failure history. Callers continue to see an empty store map (via
+    ``get_plugins_detail``/``StoresManager.stores``) until a successful publication
+    replaces it -- a partial store map is never published.
+    """
+    execution_manager.submit_monitored(
+        ConcurrentPools.Io,
+        TaskName("plugin.stores.initialize"),
+        partial(initialize_stores, config.external.plugin_stores),
+    )
 
 
 def submit_install_plugin(plugin_composite_key: PluginCompositeId) -> None:
@@ -168,17 +174,3 @@ def submit_install_plugin(plugin_composite_key: PluginCompositeId) -> None:
             config.save_to_file()
 
     submit_update_single(plugin_composite_key, install=True, version=None)
-
-
-def join_stores_thread(timeout_sec: int) -> None:
-    # TODO candidate for ecpyutil, duplicated in plugin.manager
-    barrier = (time.perf_counter_ns() / 1e9) + timeout_sec
-    with timed_acquire(StoresManager.stores_lock, timeout_sec) as result:
-        if not result:
-            logger.error("failed to lock for joining updater thread")
-        else:
-            if StoresManager.stores_updater is not None:
-                budget = barrier - (time.perf_counter_ns() / 1e9)
-                StoresManager.stores_updater.join(budget)
-                if StoresManager.stores_updater.is_alive():
-                    logger.error("failed to join StoresManager updater thread")

--- a/backend/src/forecastbox/domain/plugin/store.py
+++ b/backend/src/forecastbox/domain/plugin/store.py
@@ -7,7 +7,14 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-"""API for Plugin Stores -- data parsing and extractions"""
+"""API for Plugin Stores -- data retrieval and extractions.
+
+Owns a lock-protected state StoresManager which reflects what the configured
+stores actually offer as plugins.
+
+Owns operations that modify the config file."""
+# TODO ideally we transition all the individual plugin info into the database.
+# But we need to solve the default plugin selection/installation first then
 
 import logging
 import threading
@@ -22,7 +29,7 @@ from pyrsistent import pmap
 from pyrsistent.typing import PMap
 from typing_extensions import Self
 
-from forecastbox.domain.plugin.manager import submit_update_single
+from forecastbox.domain.plugin.submit import submit_update_single
 from forecastbox.utility.concurrency.manager import ConcurrentPools, TaskName, execution_manager
 from forecastbox.utility.concurrency.synchronization import timed_acquire
 from forecastbox.utility.config import PluginSettings, PluginStoreConfig, PluginStoreId, PluginStoresConfig, config, config_edit_lock
@@ -143,6 +150,10 @@ def submit_initialize_stores() -> None:
     ``get_plugins_detail``/``StoresManager.stores``) until a successful publication
     replaces it -- a partial store map is never published.
     """
+
+    # NOTE No need to protect from concurrent runs -- http fetches are safe, and
+    # the last operation which mutates the global state is lock protected, and we
+    # are ok with last one winning.
     execution_manager.submit_monitored(
         ConcurrentPools.Io,
         TaskName("plugin.stores.initialize"),
@@ -150,7 +161,9 @@ def submit_initialize_stores() -> None:
     )
 
 
-def submit_install_plugin(plugin_composite_key: PluginCompositeId) -> None:
+async def submit_install_single(plugin_composite_key: PluginCompositeId) -> None:
+    """Retrieves the information from the store, inserts the record of plugin being presents
+    into the config file, then submits the actual pip operation via `plugins.submit`"""
     # No lock needed for reads with pyrsistent immutable structures
     if not StoresManager.stores:
         raise ValueError("stores not initialized")
@@ -173,4 +186,4 @@ def submit_install_plugin(plugin_composite_key: PluginCompositeId) -> None:
             )
             config.save_to_file()
 
-    submit_update_single(plugin_composite_key, install=True, version=None)
+    await submit_update_single(plugin_composite_key, install=True, version=None)

--- a/backend/src/forecastbox/domain/plugin/submit.py
+++ b/backend/src/forecastbox/domain/plugin/submit.py
@@ -7,9 +7,8 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-"""API for internal plugin management -- submitting install/import/reload/unload work
-to the bounded ``ConcurrentPools.PluginManagement`` pool, and readiness/status/catalogue
-queries.
+"""API for submitting venv-mutating operations in a safe manner  to the bounded
+``ConcurrentPools.PluginManagement.
 
 Assumed to be invoked from the plugins router in API, and during application startup.
 
@@ -92,14 +91,12 @@ def _run_managed(trigger: str, worker: Callable[[], None]) -> None:
         finish_ok()
 
 
-def run_initial_load(plugins: PluginsSettings) -> None:
+def _run_load_all(plugins: PluginsSettings) -> None:
     _run_managed("Initial plugin load", partial(_load_plugins, plugins))
 
 
-def submit_load_plugins(start_after: Future[None]) -> None:
-    """Reserve the initial-load operation and submit it as a continuation of the artifact
-    catalog refresh future. Replaces the previous ``delayed_thread``-based startup thread.
-    """
+def submit_load_all(start_after: Future[None]) -> None:
+    """Reserve and submit the initial load-all-plugins operation"""
     result = reserve_operation()
     if not result.accepted:
         logger.error(f"failed to submit load_plugins: {result.reason}")
@@ -107,11 +104,9 @@ def submit_load_plugins(start_after: Future[None]) -> None:
         return
 
     def _record_dependency_failure(done: Future[None]) -> None:
-        # NOTE this callback only updates the short domain state; it must not acquire the
-        # jobs lock, publish plugins, or submit work while holding the state lock. The
-        # execution manager's own `submit_after` already records the dependency failure in
-        # its monitored failure history; this only keeps `plugins_ready()`/`status_brief()`
-        # consistent and avoids invoking the load worker at all.
+        # NOTE this is just a rollback -- we reserve prior to submit, but the callable
+        # would *not* be executed if the prerequisite has failed, hence would not rollback
+        # on its own.
         try:
             done.result()
         except BaseException as error:
@@ -122,32 +117,11 @@ def submit_load_plugins(start_after: Future[None]) -> None:
         start_after,
         ConcurrentPools.PluginManagement,
         TaskName("plugin.initial-load"),
-        partial(run_initial_load, config.external.plugins),
+        partial(_run_load_all, config.external.plugins),
     )
 
 
-def status_brief() -> str:
-    if PluginManager.updater_error is not None:
-        return f"failure: {PluginManager.updater_error}"
-    elif PluginManager.operation_in_progress:
-        return "running"
-    else:
-        return "ok"
-
-
-def plugins_ready() -> bool:
-    return status_brief() == "ok"
-
-
-def catalogue_view() -> dict[PluginCompositeId, BlockFactoryCatalogue] | bool:
-    with timed_acquire(PluginManager.lock, 1.0) as result:
-        if not result:
-            return False
-        else:
-            return {plugin_id: plugin.catalogue for plugin_id, plugin in PluginManager.plugins.items()}
-
-
-def submit_update_single(pluginId: PluginCompositeId, install: bool, version: Version | None) -> str:
+async def submit_update_single(pluginId: PluginCompositeId, install: bool, version: Version | None) -> str:
     pluginSettings = config.external.plugins.get(pluginId, None)
     if pluginSettings is None:
         return f"plugin {pluginId} not configured"
@@ -156,7 +130,7 @@ def submit_update_single(pluginId: PluginCompositeId, install: bool, version: Ve
         return result.reason
     trigger = f"Update of plugin {pluginId}"
     try:
-        execution_manager.submit_monitored(
+        await execution_manager.awaitable_submit(
             ConcurrentPools.PluginManagement,
             TaskName("plugin.update"),
             partial(_run_managed, trigger, partial(update_single, pluginId, pluginSettings, install, version)),
@@ -171,7 +145,7 @@ async def submit_unload_single(pluginId: PluginCompositeId) -> None:
     """Reserve and await an unload operation. The caller (route) owns success/failure
     reporting; a recorded global ``updater_error`` does not block this cleanup path.
     """
-    result = reserve_operation(block_on_error=False)
+    result = reserve_operation(refuse_on_error=False)
     if not result.accepted:
         raise SubmissionRejected(result.reason)
     trigger = f"Unload of plugin {pluginId}"
@@ -186,11 +160,11 @@ async def submit_unload_single(pluginId: PluginCompositeId) -> None:
         raise
 
 
-async def uninstall_plugin(pluginId: PluginCompositeId) -> None:
+async def submit_uninstall_single(pluginId: PluginCompositeId) -> None:
     logger.debug(f"about to uninstall {pluginId=}")
     if pluginId not in config.external.plugins:
         raise ValueError(f"plugin {pluginId} not installed")
-    result = reserve_operation(block_on_error=False)
+    result = reserve_operation(refuse_on_error=False)
     if not result.accepted:
         raise SubmissionRejected(result.reason)
     trigger = f"Uninstall of plugin {pluginId}"

--- a/backend/src/forecastbox/domain/plugin/submit.py
+++ b/backend/src/forecastbox/domain/plugin/submit.py
@@ -7,8 +7,8 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-"""API for submitting venv-mutating operations in a safe manner  to the bounded
-``ConcurrentPools.PluginManagement.
+"""API for submitting venv-mutating operations in a safe manner to the bounded
+``ConcurrentPools.PluginManagement``.
 
 Assumed to be invoked from the plugins router in API, and during application startup.
 
@@ -33,22 +33,15 @@ from collections.abc import Callable
 from concurrent.futures import Future
 from functools import partial
 
-from fiab_core.fable import BlockFactoryCatalogue, PluginCompositeId
+from fiab_core.fable import PluginCompositeId
 from packaging.version import Version
 
 from forecastbox.domain.plugin.events import PluginGlobalErrorEvent
 from forecastbox.domain.plugin.exceptions import PluginEnvironmentAlreadyBroken
 from forecastbox.domain.plugin.loading import load_plugins as _load_plugins
 from forecastbox.domain.plugin.loading import uninstall_plugin_sync, unload_single, update_single
-from forecastbox.domain.plugin.state import (
-    PluginManager,
-    finish_ok,
-    finish_with_error,
-    release_reservation,
-    reserve_operation,
-)
+from forecastbox.domain.plugin.state import finish_ok, finish_with_error, release_reservation, reserve_operation
 from forecastbox.utility.concurrency.manager import ConcurrentPools, SubmissionRejected, TaskName, execution_manager
-from forecastbox.utility.concurrency.synchronization import timed_acquire
 from forecastbox.utility.config import PluginsSettings, config
 from forecastbox.utility.dispatcher import Event, EventName, submit_event
 

--- a/backend/src/forecastbox/domain/plugin/template_ingest.py
+++ b/backend/src/forecastbox/domain/plugin/template_ingest.py
@@ -1,0 +1,118 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Temporary plugin-to-blueprint template ingestion.
+
+This module reaches directly into the blueprint domain (via lazy imports, see
+below) instead of going through an event. That dependency is temporary and is
+expected to be replaced by blueprint-owned dispatcher handlers in Phase 5 of
+the concurrency rework; see
+``docs/developer/changeSpecs/backend-concurrencyRework-migration.md``. Until
+then, this module is called synchronously from ``domain.plugin.loading`` on
+the single-worker ``ConcurrentPools.PluginManagement`` pool.
+"""
+
+import logging
+
+from fiab_core.fable import PluginCompositeId
+from fiab_core.plugin import Plugin
+
+from forecastbox.domain.plugin.db import clear_asset_ingest_needed, get_plugin_state, update_template_errors
+
+logger = logging.getLogger(__name__)
+
+
+def ingest_plugin_templates(plugin_id: PluginCompositeId, plugin: Plugin) -> None:
+    """Upsert each blueprint template exposed by the plugin into the DB.
+
+    Skips ingestion entirely if ``asset_ingest_needed`` is not set on the plugin's
+    DB state row. When ingestion does run, the flag is cleared *before* ingesting so
+    that a partial failure does not trigger a spurious re-ingest; per-template errors
+    are persisted via ``update_template_errors`` regardless.
+
+    Excluded templates (per ``PluginState.excluded_templates``) are skipped and
+    any existing plugin-owned blueprint row with that ``display_name`` is
+    soft-deleted. Non-excluded templates have their glyph names rewritten by
+    ``remap_builder_glyphs`` when a non-empty ``glyph_remapping`` is stored for
+    the plugin, then are upserted as normal.
+
+    Uses lazy imports to avoid circular dependencies between the plugin and
+    blueprint domains. A failure on any single template is logged and skipped
+    so the remaining templates are still ingested.
+    Note: these imports are a breach of the dependency hierarchy (plugin domain
+    depending on blueprint domain), and are temporary -- see the module docstring.
+    """
+    from forecastbox.domain.blueprint.db import find_plugin_template_id, soft_delete_plugin_template, upsert_blueprint
+    from forecastbox.domain.blueprint.service import (
+        Tag,
+        remap_builder_glyphs,
+        resolve_builder_with_examples,
+        tag_name_errors,
+        template_to_builder,
+        validate_expand_sync,
+    )
+    from forecastbox.utility.auth import AuthContext
+
+    plugin_id_str = PluginCompositeId.to_str(plugin_id)
+
+    state = get_plugin_state(plugin_id_str)
+    if state is None:
+        raise RuntimeError(
+            f"ingest_plugin_templates called for {plugin_id_str!r} but no PluginState row exists; "
+            "this is a programming error -- upsert_plugin_state must be called before ingestion"
+        )
+    if not state.asset_ingest_needed:
+        logger.debug(f"skipping template ingestion for {plugin_id_str!r}: asset_ingest_needed is False")
+        return
+
+    clear_asset_ingest_needed(plugin_id=plugin_id_str)
+
+    auth = AuthContext(user_id=plugin_id_str, is_admin=True)
+    excluded_set = set(state.excluded_templates)
+    glyph_remapping = state.glyph_remapping
+    template_errors: dict[str, str] = {}
+
+    for template in plugin.blueprint_templates:
+        try:
+            if template.display_name in excluded_set:
+                soft_delete_plugin_template(created_by=plugin_id_str, display_name=template.display_name)
+                logger.debug(f"soft-deleted excluded template {template.display_name!r} from plugin {plugin_id_str!r}")
+                continue
+            existing_id = find_plugin_template_id(created_by=plugin_id_str, display_name=template.display_name)
+            builder = template_to_builder(template, plugin_id)
+            if glyph_remapping:
+                builder = remap_builder_glyphs(builder, glyph_remapping)
+            validation_builder = resolve_builder_with_examples(builder, template.example_values, template.example_glyphs)
+            result = validate_expand_sync(validation_builder, auth, validate_only=True)
+            all_errors: list[str] = tag_name_errors([Tag(key=tag) for tag in template.tags])
+            all_errors.extend(result.global_errors)
+            for block_errs in result.block_errors.values():
+                all_errors.extend(block_errs)
+            if all_errors:
+                template_errors[template.display_name] = "; ".join(all_errors)
+                logger.warning(
+                    f"template {template.display_name!r} from plugin {plugin_id_str!r} failed validation, skipping upsert: {all_errors}"
+                )
+                continue
+            upsert_blueprint(
+                auth_context=auth,
+                blueprint_id=existing_id,
+                source="plugin_template",
+                created_by=plugin_id_str,
+                builder=builder.model_dump(mode="json"),
+                display_name=template.display_name,
+                display_description=template.display_description,
+                tags=[{"key": tag} for tag in template.tags] or None,
+            )
+            logger.debug(f"ingested template {template.display_name!r} from plugin {plugin_id_str!r}")
+        except Exception as e:
+            template_errors[template.display_name] = repr(e)
+            logger.error(f"failed to ingest template {template.display_name!r} from plugin {plugin_id_str!r}: {repr(e)}")
+
+    update_template_errors(plugin_id=plugin_id_str, template_errors=template_errors)

--- a/backend/src/forecastbox/domain/plugin/template_ingest.py
+++ b/backend/src/forecastbox/domain/plugin/template_ingest.py
@@ -116,3 +116,13 @@ def ingest_plugin_templates(plugin_id: PluginCompositeId, plugin: Plugin) -> Non
             logger.error(f"failed to ingest template {template.display_name!r} from plugin {plugin_id_str!r}: {repr(e)}")
 
     update_template_errors(plugin_id=plugin_id_str, template_errors=template_errors)
+
+
+def unload_plugin_templates(plugin_id: PluginCompositeId) -> None:
+    """Marks all templates by a particular plugin as deleted, to complete a plugin unloading.
+
+    Similarly to ingest, this is hierarchy-breaching until refactored to events"""
+    from forecastbox.domain.blueprint.db import soft_delete_all_plugin_templates
+
+    plugin_id_str = PluginCompositeId.to_str(plugin_id)
+    soft_delete_all_plugin_templates(created_by=plugin_id_str)

--- a/backend/src/forecastbox/domain/run/compile.py
+++ b/backend/src/forecastbox/domain/run/compile.py
@@ -26,7 +26,7 @@ from forecastbox.domain.blueprint.configuration_values import convert_known_conf
 from forecastbox.domain.blueprint.service import BlueprintBuilder
 from forecastbox.domain.glyphs.intrinsic import AvailableIntrinsicGlyphs, get_values_and_examples
 from forecastbox.domain.glyphs.resolution import ExtractedGlyphs, extract_glyphs, merge_glyph_values, resolve_configurations
-from forecastbox.domain.plugin.manager import PluginManager
+from forecastbox.domain.plugin.state import PluginManager
 from forecastbox.domain.run.cascade import ExecutionSpecification, RawCascadeJob, RunOutputCharacteristic, RunOutputs
 from forecastbox.domain.run.detail import CompilationDetail, TaskDetail, _fluentName_to_taskId, fluentNode_to_detail
 from forecastbox.domain.run.types import RunId

--- a/backend/src/forecastbox/entrypoint/app.py
+++ b/backend/src/forecastbox/entrypoint/app.py
@@ -39,8 +39,8 @@ from forecastbox.domain.experiment.scheduling.background import start_scheduler,
 from forecastbox.domain.gateway.service import shutdown_processes
 from forecastbox.domain.lens.manager import shutdown_all_lens_instances
 from forecastbox.domain.notification.service import init_broadcaster
-from forecastbox.domain.plugin.manager import submit_load_plugins
 from forecastbox.domain.plugin.store import submit_initialize_stores
+from forecastbox.domain.plugin.submit import submit_load_all as submit_load_plugins
 from forecastbox.utility.concurrency.manager import execution_manager
 from forecastbox.utility.config import ConcurrentThreads, config, validate_runtime
 from forecastbox.utility.dispatcher import (

--- a/backend/src/forecastbox/entrypoint/app.py
+++ b/backend/src/forecastbox/entrypoint/app.py
@@ -39,8 +39,8 @@ from forecastbox.domain.experiment.scheduling.background import start_scheduler,
 from forecastbox.domain.gateway.service import shutdown_processes
 from forecastbox.domain.lens.manager import shutdown_all_lens_instances
 from forecastbox.domain.notification.service import init_broadcaster
-from forecastbox.domain.plugin.manager import PluginManager, join_updater_thread, submit_load_plugins
-from forecastbox.domain.plugin.store import join_stores_thread, submit_initialize_stores
+from forecastbox.domain.plugin.manager import submit_load_plugins
+from forecastbox.domain.plugin.store import submit_initialize_stores
 from forecastbox.utility.concurrency.manager import execution_manager
 from forecastbox.utility.config import ConcurrentThreads, config, validate_runtime
 from forecastbox.utility.dispatcher import (
@@ -153,8 +153,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             shutdown_all_lens_instances()
             await shutdown_processes()
             shutdown_tunnels()
-            join_updater_thread(timeout_sec=10)
-            join_stores_thread(timeout_sec=10)
             join_artifact_manager(timeout_sec=10)
         finally:
             execution_manager.shutdown(timeout=config.backend.concurrency.shutdown_timeout_seconds)

--- a/backend/src/forecastbox/routes/blueprint.py
+++ b/backend/src/forecastbox/routes/blueprint.py
@@ -64,7 +64,7 @@ from forecastbox.domain.glyphs.jinja_interpolation import get_custom_functions
 from forecastbox.domain.glyphs.types import GlobalGlyphId
 from forecastbox.domain.glyphs.validation import validate_glyph
 from forecastbox.domain.plugin.compatibility import get_fiabcore_version
-from forecastbox.domain.plugin.manager import catalogue_view, plugins_ready
+from forecastbox.domain.plugin.status import catalogue_view, plugins_ready
 from forecastbox.schemata.blueprint import BlueprintSource
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.concurrency.manager import execution_manager

--- a/backend/src/forecastbox/routes/plugins.py
+++ b/backend/src/forecastbox/routes/plugins.py
@@ -145,9 +145,11 @@ def get_plugin_versions(pluginCompositeId: Annotated[PluginCompositeId, Depends(
 
 
 @router.post("/install")
-def install_plugin(request: Request, pluginCompositeId: PluginCompositeId, admin: UserRead | None = Depends(get_admin_user)) -> Response:
+async def install_plugin(
+    request: Request, pluginCompositeId: PluginCompositeId, admin: UserRead | None = Depends(get_admin_user)
+) -> Response:
     # TODO possibly add optional version parameter
-    submit_install_single(pluginCompositeId)
+    await submit_install_single(pluginCompositeId)
     return get_catalogue_redirect(request)
 
 

--- a/backend/src/forecastbox/routes/plugins.py
+++ b/backend/src/forecastbox/routes/plugins.py
@@ -29,7 +29,8 @@ from forecastbox.domain.plugin.compatibility import get_compatible_versions
 from forecastbox.domain.plugin.db import PluginStateRecord, get_plugin_state, upsert_plugin_state
 from forecastbox.domain.plugin.detail import PluginListing, build_plugin_listing
 from forecastbox.domain.plugin.exceptions import PluginManagerBusy, PluginNotFound
-from forecastbox.domain.plugin.manager import PluginManager, submit_update_single, uninstall_plugin, unload_single
+from forecastbox.domain.plugin.manager import submit_unload_single, submit_update_single, uninstall_plugin
+from forecastbox.domain.plugin.state import PluginManager
 from forecastbox.domain.plugin.store import get_plugins_detail, submit_install_plugin
 from forecastbox.routes.admin import get_admin_user
 from forecastbox.utility.concurrency.manager import execution_manager
@@ -192,7 +193,8 @@ async def update_plugin_settings_endpoint(
     except PluginNotFound:
         raise HTTPException(status_code=404, detail=f"Plugin {plugin_id_str} not found")
     if body.isEnabled is False:
-        unload_single(body.pluginCompositeId)
+        await submit_unload_single(body.pluginCompositeId)
+        return get_catalogue_redirect(request)
     result = submit_update_single(body.pluginCompositeId, install=False, version=None)
     if result:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=result)

--- a/backend/src/forecastbox/routes/plugins.py
+++ b/backend/src/forecastbox/routes/plugins.py
@@ -29,9 +29,9 @@ from forecastbox.domain.plugin.compatibility import get_compatible_versions
 from forecastbox.domain.plugin.db import PluginStateRecord, get_plugin_state, upsert_plugin_state
 from forecastbox.domain.plugin.detail import PluginListing, build_plugin_listing
 from forecastbox.domain.plugin.exceptions import PluginManagerBusy, PluginNotFound
-from forecastbox.domain.plugin.manager import submit_unload_single, submit_update_single, uninstall_plugin
 from forecastbox.domain.plugin.state import PluginManager
-from forecastbox.domain.plugin.store import get_plugins_detail, submit_install_plugin
+from forecastbox.domain.plugin.store import get_plugins_detail, submit_install_single
+from forecastbox.domain.plugin.submit import submit_uninstall_single, submit_unload_single, submit_update_single
 from forecastbox.routes.admin import get_admin_user
 from forecastbox.utility.concurrency.manager import execution_manager
 from forecastbox.utility.config import PluginSettings, config
@@ -69,7 +69,7 @@ get_catalogue_redirect = lambda request: Response(status_code=202)
 
 
 @router.post("/update")
-def update_plugin(
+async def update_plugin(
     request: Request,
     pluginCompositeId: PluginCompositeId,
     version: str | None = None,
@@ -100,7 +100,7 @@ def update_plugin(
                 detail=f"No compatible versions found for plugin {pluginCompositeId!r}",
             )
         target = Version(versions.versions[0])
-    result = submit_update_single(pluginCompositeId, install=True, version=target)
+    result = await submit_update_single(pluginCompositeId, install=True, version=target)
     if result:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=result)
     return get_catalogue_redirect(request)
@@ -147,7 +147,7 @@ def get_plugin_versions(pluginCompositeId: Annotated[PluginCompositeId, Depends(
 @router.post("/install")
 def install_plugin(request: Request, pluginCompositeId: PluginCompositeId, admin: UserRead | None = Depends(get_admin_user)) -> Response:
     # TODO possibly add optional version parameter
-    submit_install_plugin(pluginCompositeId)
+    submit_install_single(pluginCompositeId)
     return get_catalogue_redirect(request)
 
 
@@ -155,7 +155,7 @@ def install_plugin(request: Request, pluginCompositeId: PluginCompositeId, admin
 async def uninstall_plugin_endpoint(
     request: Request, pluginCompositeId: PluginCompositeId, admin: UserRead | None = Depends(get_admin_user)
 ) -> Response:
-    await uninstall_plugin(pluginCompositeId)
+    await submit_uninstall_single(pluginCompositeId)
     return get_catalogue_redirect(request)
 
 
@@ -195,7 +195,7 @@ async def update_plugin_settings_endpoint(
     if body.isEnabled is False:
         await submit_unload_single(body.pluginCompositeId)
         return get_catalogue_redirect(request)
-    result = submit_update_single(body.pluginCompositeId, install=False, version=None)
+    result = await submit_update_single(body.pluginCompositeId, install=False, version=None)
     if result:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=result)
     return get_catalogue_redirect(request)

--- a/backend/src/forecastbox/routes/status.py
+++ b/backend/src/forecastbox/routes/status.py
@@ -18,7 +18,7 @@ from fastapi import APIRouter, Request
 
 from forecastbox.domain.experiment.scheduling.background import status_scheduler
 from forecastbox.domain.gateway.service import get_gateway_url
-from forecastbox.domain.plugin.manager import status_brief
+from forecastbox.domain.plugin.status import status_brief
 from forecastbox.utility.concurrency.manager import ExecutionStatus, execution_manager
 from forecastbox.utility.config import config
 

--- a/backend/src/forecastbox/utility/config.py
+++ b/backend/src/forecastbox/utility/config.py
@@ -78,6 +78,7 @@ class ConcurrencySettings(FiabBaseModel):
     startup_timeout_seconds: float = Field(default=10, gt=0)
     shutdown_timeout_seconds: float = Field(default=10, gt=0)
 
+    # TODO this actually can be default pydantic validator, not needed to be runtime-only
     def validate_runtime(self) -> list[str]:
         errors: list[str] = []
         required_pools = set(ConcurrentPools)

--- a/backend/tests/unit/conftest.py
+++ b/backend/tests/unit/conftest.py
@@ -1,5 +1,7 @@
 import inspect
 from collections.abc import Awaitable, Callable
+from concurrent.futures import Future
+from typing import Any
 
 import pytest
 
@@ -19,5 +21,36 @@ def inline_execution_manager(monkeypatch: pytest.MonkeyPatch) -> None:
         if inspect.isawaitable(result):
             raise TypeError(f"unit test inline submit_monitored received awaitable result for {task_name!r}")
 
+    def _submit_after(
+        dependency: "Future[Any]",
+        pool_name: object,
+        task_name: object,
+        task: Callable[[], object],
+        *,
+        run_if_dependency_failed: bool = False,
+    ) -> None:
+        """Model both successful and failed dependency futures inline: run ``task``
+        synchronously once ``dependency`` is done, unless it failed and
+        ``run_if_dependency_failed`` is False.
+        """
+
+        def _on_done(done: "Future[Any]") -> None:
+            dependency_failed = False
+            try:
+                done.result()
+            except BaseException:
+                dependency_failed = True
+            if dependency_failed and not run_if_dependency_failed:
+                return
+            result = task()
+            if inspect.isawaitable(result):
+                raise TypeError(f"unit test inline submit_after received awaitable result for {task_name!r}")
+
+        if dependency.done():
+            _on_done(dependency)
+        else:
+            dependency.add_done_callback(_on_done)
+
     monkeypatch.setattr(execution_manager, "awaitable_submit", _awaitable_submit)
     monkeypatch.setattr(execution_manager, "submit_monitored", _submit_monitored)
+    monkeypatch.setattr(execution_manager, "submit_after", _submit_after)

--- a/backend/tests/unit/domain/artifact/test_artifact_manager_refresh.py
+++ b/backend/tests/unit/domain/artifact/test_artifact_manager_refresh.py
@@ -1,0 +1,48 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Focused unit tests for domain.artifact.manager's catalog-refresh future contract.
+
+``submit_refresh_catalog()`` is the startup dependency that
+``domain.plugin.manager.submit_load_plugins`` waits on via ``submit_after``. A
+failed refresh must both retain the existing ``ArtifactManager.refresh_error``
+behaviour and leave the returned ``Future`` carrying the exception, so that
+dependents can observe the failure through the future's own contract.
+"""
+
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+
+from forecastbox.domain.artifact.manager import ArtifactManager, _refresh_catalog_task, submit_refresh_catalog
+
+
+@pytest.fixture(autouse=True)
+def _reset_artifact_manager() -> Generator[None, None, None]:
+    ArtifactManager.refresh_error = None
+    yield
+    ArtifactManager.refresh_error = None
+
+
+def test_refresh_catalog_task_reraises_and_retains_refresh_error() -> None:
+    with patch("forecastbox.domain.artifact.manager.get_artifacts_catalog", side_effect=RuntimeError("catalog boom")):
+        with pytest.raises(RuntimeError, match="catalog boom"):
+            _refresh_catalog_task()
+    assert ArtifactManager.refresh_error is not None
+    assert "catalog boom" in ArtifactManager.refresh_error
+
+
+def test_submit_refresh_catalog_future_carries_exception_on_failure() -> None:
+    with patch("forecastbox.domain.artifact.manager.get_artifacts_catalog", side_effect=RuntimeError("catalog boom")):
+        future = submit_refresh_catalog()
+        with pytest.raises(RuntimeError, match="catalog boom"):
+            future.result(timeout=5)
+    assert ArtifactManager.refresh_error is not None
+    assert "catalog boom" in ArtifactManager.refresh_error

--- a/backend/tests/unit/domain/plugins/test_plugin_manager.py
+++ b/backend/tests/unit/domain/plugins/test_plugin_manager.py
@@ -9,36 +9,29 @@
 
 """Unit tests for PluginManager utility functions -- status_brief and plugins_ready."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from forecastbox.domain.plugin.manager import plugins_ready, status_brief
-
-
-def _make_manager(*, updater_error: str | None, alive: bool) -> MagicMock:
-    mock = MagicMock()
-    mock.updater_error = updater_error
-    mock.updater = MagicMock(is_alive=MagicMock(return_value=alive))
-    return mock
 
 
 def test_status_brief_ok() -> None:
     with patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm:
         mock_pm.updater_error = None
-        mock_pm.updater = MagicMock(is_alive=MagicMock(return_value=False))
+        mock_pm.operation_in_progress = False
         assert status_brief() == "ok"
 
 
 def test_status_brief_running() -> None:
     with patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm:
         mock_pm.updater_error = None
-        mock_pm.updater = MagicMock(is_alive=MagicMock(return_value=True))
+        mock_pm.operation_in_progress = True
         assert status_brief() == "running"
 
 
 def test_status_brief_failure() -> None:
     with patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm:
         mock_pm.updater_error = "some error"
-        mock_pm.updater = MagicMock(is_alive=MagicMock(return_value=False))
+        mock_pm.operation_in_progress = False
         result = status_brief()
         assert result.startswith("failure:")
         assert "some error" in result
@@ -47,19 +40,19 @@ def test_status_brief_failure() -> None:
 def test_plugins_ready_true_when_ok() -> None:
     with patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm:
         mock_pm.updater_error = None
-        mock_pm.updater = MagicMock(is_alive=MagicMock(return_value=False))
+        mock_pm.operation_in_progress = False
         assert plugins_ready() is True
 
 
 def test_plugins_ready_false_when_running() -> None:
     with patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm:
         mock_pm.updater_error = None
-        mock_pm.updater = MagicMock(is_alive=MagicMock(return_value=True))
+        mock_pm.operation_in_progress = True
         assert plugins_ready() is False
 
 
 def test_plugins_ready_false_when_failed() -> None:
     with patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm:
         mock_pm.updater_error = "crash"
-        mock_pm.updater = MagicMock(is_alive=MagicMock(return_value=False))
+        mock_pm.operation_in_progress = False
         assert plugins_ready() is False

--- a/backend/tests/unit/domain/plugins/test_plugin_operations.py
+++ b/backend/tests/unit/domain/plugins/test_plugin_operations.py
@@ -16,7 +16,7 @@ uninstall use the correct pool/task names without creating or joining a thread.
 
 from collections.abc import Generator
 from concurrent.futures import Future
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fiab_core.fable import PluginCompositeId, PluginId, PluginStoreId
@@ -145,7 +145,7 @@ def _fake_config_with_plugin() -> MagicMock:
 async def test_submit_update_single_uses_plugin_management_pool_and_task_name() -> None:
     with (
         patch.object(submit_module, "config", _fake_config_with_plugin()),
-        patch.object(submit_module.execution_manager, "submit_monitored") as mock_submit,
+        patch.object(submit_module.execution_manager, "awaitable_submit", new=AsyncMock()) as mock_submit,
     ):
         result = await submit_module.submit_update_single(_PLUGIN_ID, install=True, version=None)
     assert result == ""
@@ -167,7 +167,7 @@ async def test_submit_update_single_rejects_overlapping_operation() -> None:
 async def test_submit_update_single_rolls_back_reservation_on_submission_rejected() -> None:
     with (
         patch.object(submit_module, "config", _fake_config_with_plugin()),
-        patch.object(submit_module.execution_manager, "submit_monitored", side_effect=SubmissionRejected("pool full")),
+        patch.object(submit_module.execution_manager, "awaitable_submit", side_effect=SubmissionRejected("pool full")),
     ):
         with pytest.raises(SubmissionRejected):
             await submit_module.submit_update_single(_PLUGIN_ID, install=True, version=None)

--- a/backend/tests/unit/domain/plugins/test_plugin_operations.py
+++ b/backend/tests/unit/domain/plugins/test_plugin_operations.py
@@ -1,0 +1,242 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Unit tests for the plugin-operation submission boundary in domain.plugin.manager.
+
+Covers reservation/rollback, the submit_after-based initial-load continuation, the
+managed-operation wrapper's error/notification behaviour, and that update/unload/
+uninstall use the correct pool/task names without creating or joining a thread.
+"""
+
+from collections.abc import Generator
+from concurrent.futures import Future
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fiab_core.fable import PluginCompositeId, PluginId, PluginStoreId
+from pyrsistent import pmap
+
+import forecastbox.domain.plugin.manager as manager_module
+from forecastbox.domain.plugin.errors import PluginErrors
+from forecastbox.domain.plugin.state import PluginManager
+from forecastbox.utility.concurrency.manager import ConcurrentPools, SubmissionRejected
+
+_PLUGIN_ID = PluginCompositeId(store=PluginStoreId("store"), local=PluginId("plugin"))
+
+
+@pytest.fixture(autouse=True)
+def _reset_plugin_state() -> Generator[None, None, None]:
+    PluginManager.plugins = pmap()
+    PluginManager.errors = pmap()
+    PluginManager.operation_in_progress = False
+    PluginManager.updater_error = None
+    yield
+    PluginManager.plugins = pmap()
+    PluginManager.errors = pmap()
+    PluginManager.operation_in_progress = False
+    PluginManager.updater_error = None
+
+
+# ---------------------------------------------------------------------------
+# submit_load_plugins / initial load continuation
+# ---------------------------------------------------------------------------
+
+
+def test_submit_load_plugins_uses_submit_after_not_delayed_thread() -> None:
+    catalog_future: Future[None] = Future()
+    assert not hasattr(manager_module, "delayed_thread")
+    with patch.object(manager_module.execution_manager, "submit_after") as mock_submit_after:
+        manager_module.submit_load_plugins(catalog_future)
+    mock_submit_after.assert_called_once()
+    args, kwargs = mock_submit_after.call_args
+    assert args[0] is catalog_future
+    assert args[1] == ConcurrentPools.PluginManagement
+    assert args[2] == "plugin.initial-load"
+    assert PluginManager.operation_in_progress is True
+    assert manager_module.plugins_ready() is False
+
+
+def test_failed_catalog_dependency_leaves_not_ready_and_does_not_run_loader() -> None:
+    catalog_future: Future[None] = Future()
+    ran_loader = False
+
+    def _fake_run_initial_load(plugins: object) -> None:
+        nonlocal ran_loader
+        ran_loader = True
+
+    with (
+        patch.object(manager_module.execution_manager, "submit_after") as mock_submit_after,
+        patch.object(manager_module, "run_initial_load", side_effect=_fake_run_initial_load),
+    ):
+        manager_module.submit_load_plugins(catalog_future)
+        # Simulate the dependency failing -- the real ExecutionManager.submit_after would not
+        # invoke the task in this case; only our own done-callback runs.
+        catalog_future.set_exception(RuntimeError("catalog refresh boom"))
+
+    mock_submit_after.assert_called_once()
+    assert ran_loader is False
+    assert manager_module.plugins_ready() is False
+    assert PluginManager.updater_error is not None
+    assert "catalog refresh boom" in PluginManager.updater_error
+
+
+# ---------------------------------------------------------------------------
+# _run_managed wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_run_managed_records_error_notifies_and_reraises_on_unexpected_exception() -> None:
+    PluginManager.operation_in_progress = True
+
+    def _boom() -> None:
+        raise RuntimeError("worker exploded")
+
+    with patch.object(manager_module, "_notify_failure") as mock_notify:
+        with pytest.raises(RuntimeError):
+            manager_module._run_managed("Some trigger", _boom)
+
+    mock_notify.assert_called_once()
+    trigger_arg, message_arg = mock_notify.call_args.args
+    assert trigger_arg == "Some trigger"
+    assert "worker exploded" in message_arg
+    assert PluginManager.updater_error is not None
+    assert PluginManager.operation_in_progress is False
+
+
+def test_run_managed_finishes_ok_on_normal_completion() -> None:
+    PluginManager.operation_in_progress = True
+    manager_module._run_managed("trigger", lambda: None)
+    assert PluginManager.operation_in_progress is False
+    assert PluginManager.updater_error is None
+
+
+def test_run_managed_does_not_convert_per_plugin_errors_to_global_failure() -> None:
+    """A worker that records per-plugin PluginErrors without raising is a normal completion."""
+    PluginManager.operation_in_progress = True
+
+    def _worker_with_per_plugin_error() -> None:
+        PluginManager.errors = PluginManager.errors.set(_PLUGIN_ID, PluginErrors([]))
+
+    manager_module._run_managed("trigger", _worker_with_per_plugin_error)
+    assert PluginManager.updater_error is None
+    assert PluginManager.operation_in_progress is False
+
+
+# ---------------------------------------------------------------------------
+# submit_update_single
+# ---------------------------------------------------------------------------
+
+
+def _fake_config_with_plugin() -> MagicMock:
+    settings = MagicMock()
+    fake_config = MagicMock()
+    fake_config.external.plugins = {_PLUGIN_ID: settings}
+    return fake_config
+
+
+def test_submit_update_single_uses_plugin_management_pool_and_task_name() -> None:
+    with (
+        patch.object(manager_module, "config", _fake_config_with_plugin()),
+        patch.object(manager_module.execution_manager, "submit_monitored") as mock_submit,
+    ):
+        result = manager_module.submit_update_single(_PLUGIN_ID, install=True, version=None)
+    assert result == ""
+    mock_submit.assert_called_once()
+    args, _ = mock_submit.call_args
+    assert args[0] == ConcurrentPools.PluginManagement
+    assert args[1] == "plugin.update"
+
+
+def test_submit_update_single_rejects_overlapping_operation() -> None:
+    PluginManager.operation_in_progress = True
+    with patch.object(manager_module, "config", _fake_config_with_plugin()):
+        result = manager_module.submit_update_single(_PLUGIN_ID, install=True, version=None)
+    assert "not idle" in result
+
+
+def test_submit_update_single_rolls_back_reservation_on_submission_rejected() -> None:
+    with (
+        patch.object(manager_module, "config", _fake_config_with_plugin()),
+        patch.object(manager_module.execution_manager, "submit_monitored", side_effect=SubmissionRejected("pool full")),
+    ):
+        with pytest.raises(SubmissionRejected):
+            manager_module.submit_update_single(_PLUGIN_ID, install=True, version=None)
+    assert PluginManager.operation_in_progress is False
+
+
+def test_submit_update_single_blocked_by_existing_global_failure() -> None:
+    PluginManager.updater_error = "prior failure"
+    with patch.object(manager_module, "config", _fake_config_with_plugin()):
+        result = manager_module.submit_update_single(_PLUGIN_ID, install=True, version=None)
+    assert "failed" in result
+
+
+# ---------------------------------------------------------------------------
+# submit_unload_single / uninstall_plugin -- available after a failed update
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_submit_unload_single_available_after_prior_update_failure() -> None:
+    PluginManager.updater_error = "prior failure"
+    with (
+        patch.object(manager_module.execution_manager, "awaitable_submit") as mock_await_submit,
+        patch.object(manager_module, "unload_single") as mock_unload_single,
+    ):
+
+        async def _run(pool_name: object, task_name: object, task: object) -> None:
+            task()
+
+        mock_await_submit.side_effect = _run
+        await manager_module.submit_unload_single(_PLUGIN_ID)
+    mock_unload_single.assert_called_once_with(_PLUGIN_ID)
+    mock_await_submit.assert_called_once()
+    args, _ = mock_await_submit.call_args
+    assert args[0] == ConcurrentPools.PluginManagement
+    assert args[1] == "plugin.unload"
+
+
+@pytest.mark.asyncio
+async def test_submit_unload_single_rejects_overlapping_operation() -> None:
+    PluginManager.operation_in_progress = True
+    with pytest.raises(SubmissionRejected):
+        await manager_module.submit_unload_single(_PLUGIN_ID)
+
+
+@pytest.mark.asyncio
+async def test_uninstall_plugin_uses_plugin_management_pool_and_task_name() -> None:
+    fake_config = _fake_config_with_plugin()
+    with (
+        patch.object(manager_module, "config", fake_config),
+        patch.object(manager_module.execution_manager, "awaitable_submit") as mock_await_submit,
+        patch.object(manager_module, "uninstall_plugin_sync") as mock_uninstall_sync,
+    ):
+
+        async def _run(pool_name: object, task_name: object, task: object) -> None:
+            task()
+
+        mock_await_submit.side_effect = _run
+        await manager_module.uninstall_plugin(_PLUGIN_ID)
+    mock_uninstall_sync.assert_called_once_with(_PLUGIN_ID)
+    mock_await_submit.assert_called_once()
+    args, _ = mock_await_submit.call_args
+    assert args[0] == ConcurrentPools.PluginManagement
+    assert args[1] == "plugin.uninstall"
+
+
+@pytest.mark.asyncio
+async def test_uninstall_plugin_rolls_back_reservation_on_submission_rejected() -> None:
+    fake_config = _fake_config_with_plugin()
+    with (
+        patch.object(manager_module, "config", fake_config),
+        patch.object(manager_module.execution_manager, "awaitable_submit", side_effect=SubmissionRejected("pool full")),
+    ):
+        with pytest.raises(SubmissionRejected):
+            await manager_module.uninstall_plugin(_PLUGIN_ID)
+    assert PluginManager.operation_in_progress is False

--- a/backend/tests/unit/domain/plugins/test_plugin_operations.py
+++ b/backend/tests/unit/domain/plugins/test_plugin_operations.py
@@ -7,7 +7,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-"""Unit tests for the plugin-operation submission boundary in domain.plugin.manager.
+"""Unit tests for the plugin-operation submission boundary in domain.plugin.submit.
 
 Covers reservation/rollback, the submit_after-based initial-load continuation, the
 managed-operation wrapper's error/notification behaviour, and that update/unload/
@@ -22,9 +22,10 @@ import pytest
 from fiab_core.fable import PluginCompositeId, PluginId, PluginStoreId
 from pyrsistent import pmap
 
-import forecastbox.domain.plugin.manager as manager_module
+import forecastbox.domain.plugin.submit as submit_module
 from forecastbox.domain.plugin.errors import PluginErrors
 from forecastbox.domain.plugin.state import PluginManager
+from forecastbox.domain.plugin.status import plugins_ready
 from forecastbox.utility.concurrency.manager import ConcurrentPools, SubmissionRejected
 
 _PLUGIN_ID = PluginCompositeId(store=PluginStoreId("store"), local=PluginId("plugin"))
@@ -44,22 +45,22 @@ def _reset_plugin_state() -> Generator[None, None, None]:
 
 
 # ---------------------------------------------------------------------------
-# submit_load_plugins / initial load continuation
+# submit_load_all / initial load continuation
 # ---------------------------------------------------------------------------
 
 
-def test_submit_load_plugins_uses_submit_after_not_delayed_thread() -> None:
+def test_submit_load_all_uses_submit_after_not_delayed_thread() -> None:
     catalog_future: Future[None] = Future()
-    assert not hasattr(manager_module, "delayed_thread")
-    with patch.object(manager_module.execution_manager, "submit_after") as mock_submit_after:
-        manager_module.submit_load_plugins(catalog_future)
+    assert not hasattr(submit_module, "delayed_thread")
+    with patch.object(submit_module.execution_manager, "submit_after") as mock_submit_after:
+        submit_module.submit_load_all(catalog_future)
     mock_submit_after.assert_called_once()
     args, kwargs = mock_submit_after.call_args
     assert args[0] is catalog_future
     assert args[1] == ConcurrentPools.PluginManagement
     assert args[2] == "plugin.initial-load"
     assert PluginManager.operation_in_progress is True
-    assert manager_module.plugins_ready() is False
+    assert plugins_ready() is False
 
 
 def test_failed_catalog_dependency_leaves_not_ready_and_does_not_run_loader() -> None:
@@ -71,17 +72,17 @@ def test_failed_catalog_dependency_leaves_not_ready_and_does_not_run_loader() ->
         ran_loader = True
 
     with (
-        patch.object(manager_module.execution_manager, "submit_after") as mock_submit_after,
-        patch.object(manager_module, "run_initial_load", side_effect=_fake_run_initial_load),
+        patch.object(submit_module.execution_manager, "submit_after") as mock_submit_after,
+        patch.object(submit_module, "_run_load_all", side_effect=_fake_run_initial_load),
     ):
-        manager_module.submit_load_plugins(catalog_future)
+        submit_module.submit_load_all(catalog_future)
         # Simulate the dependency failing -- the real ExecutionManager.submit_after would not
         # invoke the task in this case; only our own done-callback runs.
         catalog_future.set_exception(RuntimeError("catalog refresh boom"))
 
     mock_submit_after.assert_called_once()
     assert ran_loader is False
-    assert manager_module.plugins_ready() is False
+    assert plugins_ready() is False
     assert PluginManager.updater_error is not None
     assert "catalog refresh boom" in PluginManager.updater_error
 
@@ -97,9 +98,9 @@ def test_run_managed_records_error_notifies_and_reraises_on_unexpected_exception
     def _boom() -> None:
         raise RuntimeError("worker exploded")
 
-    with patch.object(manager_module, "_notify_failure") as mock_notify:
+    with patch.object(submit_module, "_notify_failure") as mock_notify:
         with pytest.raises(RuntimeError):
-            manager_module._run_managed("Some trigger", _boom)
+            submit_module._run_managed("Some trigger", _boom)
 
     mock_notify.assert_called_once()
     trigger_arg, message_arg = mock_notify.call_args.args
@@ -111,7 +112,7 @@ def test_run_managed_records_error_notifies_and_reraises_on_unexpected_exception
 
 def test_run_managed_finishes_ok_on_normal_completion() -> None:
     PluginManager.operation_in_progress = True
-    manager_module._run_managed("trigger", lambda: None)
+    submit_module._run_managed("trigger", lambda: None)
     assert PluginManager.operation_in_progress is False
     assert PluginManager.updater_error is None
 
@@ -123,7 +124,7 @@ def test_run_managed_does_not_convert_per_plugin_errors_to_global_failure() -> N
     def _worker_with_per_plugin_error() -> None:
         PluginManager.errors = PluginManager.errors.set(_PLUGIN_ID, PluginErrors([]))
 
-    manager_module._run_managed("trigger", _worker_with_per_plugin_error)
+    submit_module._run_managed("trigger", _worker_with_per_plugin_error)
     assert PluginManager.updater_error is None
     assert PluginManager.operation_in_progress is False
 
@@ -140,12 +141,13 @@ def _fake_config_with_plugin() -> MagicMock:
     return fake_config
 
 
-def test_submit_update_single_uses_plugin_management_pool_and_task_name() -> None:
+@pytest.mark.asyncio
+async def test_submit_update_single_uses_plugin_management_pool_and_task_name() -> None:
     with (
-        patch.object(manager_module, "config", _fake_config_with_plugin()),
-        patch.object(manager_module.execution_manager, "submit_monitored") as mock_submit,
+        patch.object(submit_module, "config", _fake_config_with_plugin()),
+        patch.object(submit_module.execution_manager, "submit_monitored") as mock_submit,
     ):
-        result = manager_module.submit_update_single(_PLUGIN_ID, install=True, version=None)
+        result = await submit_module.submit_update_single(_PLUGIN_ID, install=True, version=None)
     assert result == ""
     mock_submit.assert_called_once()
     args, _ = mock_submit.call_args
@@ -153,32 +155,35 @@ def test_submit_update_single_uses_plugin_management_pool_and_task_name() -> Non
     assert args[1] == "plugin.update"
 
 
-def test_submit_update_single_rejects_overlapping_operation() -> None:
+@pytest.mark.asyncio
+async def test_submit_update_single_rejects_overlapping_operation() -> None:
     PluginManager.operation_in_progress = True
-    with patch.object(manager_module, "config", _fake_config_with_plugin()):
-        result = manager_module.submit_update_single(_PLUGIN_ID, install=True, version=None)
+    with patch.object(submit_module, "config", _fake_config_with_plugin()):
+        result = await submit_module.submit_update_single(_PLUGIN_ID, install=True, version=None)
     assert "not idle" in result
 
 
-def test_submit_update_single_rolls_back_reservation_on_submission_rejected() -> None:
+@pytest.mark.asyncio
+async def test_submit_update_single_rolls_back_reservation_on_submission_rejected() -> None:
     with (
-        patch.object(manager_module, "config", _fake_config_with_plugin()),
-        patch.object(manager_module.execution_manager, "submit_monitored", side_effect=SubmissionRejected("pool full")),
+        patch.object(submit_module, "config", _fake_config_with_plugin()),
+        patch.object(submit_module.execution_manager, "submit_monitored", side_effect=SubmissionRejected("pool full")),
     ):
         with pytest.raises(SubmissionRejected):
-            manager_module.submit_update_single(_PLUGIN_ID, install=True, version=None)
+            await submit_module.submit_update_single(_PLUGIN_ID, install=True, version=None)
     assert PluginManager.operation_in_progress is False
 
 
-def test_submit_update_single_blocked_by_existing_global_failure() -> None:
+@pytest.mark.asyncio
+async def test_submit_update_single_blocked_by_existing_global_failure() -> None:
     PluginManager.updater_error = "prior failure"
-    with patch.object(manager_module, "config", _fake_config_with_plugin()):
-        result = manager_module.submit_update_single(_PLUGIN_ID, install=True, version=None)
+    with patch.object(submit_module, "config", _fake_config_with_plugin()):
+        result = await submit_module.submit_update_single(_PLUGIN_ID, install=True, version=None)
     assert "failed" in result
 
 
 # ---------------------------------------------------------------------------
-# submit_unload_single / uninstall_plugin -- available after a failed update
+# submit_unload_single / submit_uninstall_single -- available after a failed update
 # ---------------------------------------------------------------------------
 
 
@@ -186,15 +191,15 @@ def test_submit_update_single_blocked_by_existing_global_failure() -> None:
 async def test_submit_unload_single_available_after_prior_update_failure() -> None:
     PluginManager.updater_error = "prior failure"
     with (
-        patch.object(manager_module.execution_manager, "awaitable_submit") as mock_await_submit,
-        patch.object(manager_module, "unload_single") as mock_unload_single,
+        patch.object(submit_module.execution_manager, "awaitable_submit") as mock_await_submit,
+        patch.object(submit_module, "unload_single") as mock_unload_single,
     ):
 
         async def _run(pool_name: object, task_name: object, task: object) -> None:
             task()
 
         mock_await_submit.side_effect = _run
-        await manager_module.submit_unload_single(_PLUGIN_ID)
+        await submit_module.submit_unload_single(_PLUGIN_ID)
     mock_unload_single.assert_called_once_with(_PLUGIN_ID)
     mock_await_submit.assert_called_once()
     args, _ = mock_await_submit.call_args
@@ -206,23 +211,23 @@ async def test_submit_unload_single_available_after_prior_update_failure() -> No
 async def test_submit_unload_single_rejects_overlapping_operation() -> None:
     PluginManager.operation_in_progress = True
     with pytest.raises(SubmissionRejected):
-        await manager_module.submit_unload_single(_PLUGIN_ID)
+        await submit_module.submit_unload_single(_PLUGIN_ID)
 
 
 @pytest.mark.asyncio
-async def test_uninstall_plugin_uses_plugin_management_pool_and_task_name() -> None:
+async def test_submit_uninstall_single_uses_plugin_management_pool_and_task_name() -> None:
     fake_config = _fake_config_with_plugin()
     with (
-        patch.object(manager_module, "config", fake_config),
-        patch.object(manager_module.execution_manager, "awaitable_submit") as mock_await_submit,
-        patch.object(manager_module, "uninstall_plugin_sync") as mock_uninstall_sync,
+        patch.object(submit_module, "config", fake_config),
+        patch.object(submit_module.execution_manager, "awaitable_submit") as mock_await_submit,
+        patch.object(submit_module, "uninstall_plugin_sync") as mock_uninstall_sync,
     ):
 
         async def _run(pool_name: object, task_name: object, task: object) -> None:
             task()
 
         mock_await_submit.side_effect = _run
-        await manager_module.uninstall_plugin(_PLUGIN_ID)
+        await submit_module.submit_uninstall_single(_PLUGIN_ID)
     mock_uninstall_sync.assert_called_once_with(_PLUGIN_ID)
     mock_await_submit.assert_called_once()
     args, _ = mock_await_submit.call_args
@@ -231,12 +236,12 @@ async def test_uninstall_plugin_uses_plugin_management_pool_and_task_name() -> N
 
 
 @pytest.mark.asyncio
-async def test_uninstall_plugin_rolls_back_reservation_on_submission_rejected() -> None:
+async def test_submit_uninstall_single_rolls_back_reservation_on_submission_rejected() -> None:
     fake_config = _fake_config_with_plugin()
     with (
-        patch.object(manager_module, "config", fake_config),
-        patch.object(manager_module.execution_manager, "awaitable_submit", side_effect=SubmissionRejected("pool full")),
+        patch.object(submit_module, "config", fake_config),
+        patch.object(submit_module.execution_manager, "awaitable_submit", side_effect=SubmissionRejected("pool full")),
     ):
         with pytest.raises(SubmissionRejected):
-            await manager_module.uninstall_plugin(_PLUGIN_ID)
+            await submit_module.submit_uninstall_single(_PLUGIN_ID)
     assert PluginManager.operation_in_progress is False

--- a/backend/tests/unit/domain/plugins/test_plugin_state.py
+++ b/backend/tests/unit/domain/plugins/test_plugin_state.py
@@ -1,0 +1,104 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Unit tests for domain.plugin.state's reservation/publication helpers."""
+
+from collections.abc import Generator
+
+import pytest
+from fiab_core.fable import PluginCompositeId, PluginId, PluginStoreId
+from pyrsistent import pmap
+
+from forecastbox.domain.plugin import state as state_module
+from forecastbox.domain.plugin.errors import PluginErrors
+from forecastbox.domain.plugin.state import PluginManager, reserve_operation
+
+_PLUGIN_ID = PluginCompositeId(store=PluginStoreId("store"), local=PluginId("plugin"))
+
+
+@pytest.fixture(autouse=True)
+def _reset_plugin_state() -> Generator[None, None, None]:
+    PluginManager.plugins = pmap()
+    PluginManager.errors = pmap()
+    PluginManager.operation_in_progress = False
+    PluginManager.updater_error = None
+    yield
+    PluginManager.plugins = pmap()
+    PluginManager.errors = pmap()
+    PluginManager.operation_in_progress = False
+    PluginManager.updater_error = None
+
+
+def test_reserve_operation_succeeds_when_idle() -> None:
+    result = state_module.reserve_operation()
+    assert result.accepted is True
+    assert PluginManager.operation_in_progress is True
+
+
+def test_reserve_operation_rejects_when_already_in_progress() -> None:
+    PluginManager.operation_in_progress = True
+    result = reserve_operation()
+    assert result.accepted is False
+    assert PluginManager.operation_in_progress is True
+
+
+def test_reserve_operation_blocked_by_error_by_default() -> None:
+    PluginManager.updater_error = "boom"
+    result = reserve_operation()
+    assert result.accepted is False
+
+
+def test_reserve_operation_ignores_error_when_block_on_error_false() -> None:
+    PluginManager.updater_error = "boom"
+    result = reserve_operation(block_on_error=False)
+    assert result.accepted is True
+
+
+def test_release_reservation_clears_in_progress_without_recording_error() -> None:
+    PluginManager.operation_in_progress = True
+    state_module.release_reservation()
+    assert PluginManager.operation_in_progress is False
+    assert PluginManager.updater_error is None
+
+
+def test_finish_ok_clears_in_progress() -> None:
+    PluginManager.operation_in_progress = True
+    state_module.finish_ok()
+    assert PluginManager.operation_in_progress is False
+    assert PluginManager.updater_error is None
+
+
+def test_finish_with_error_records_message_and_clears_in_progress() -> None:
+    PluginManager.operation_in_progress = True
+    state_module.finish_with_error("kaboom")
+    assert PluginManager.operation_in_progress is False
+    assert PluginManager.updater_error == "kaboom"
+
+
+def test_publish_bulk_snapshot_replaces_maps_atomically() -> None:
+    errs = PluginErrors([])
+    ok = state_module.publish_bulk_snapshot({_PLUGIN_ID: object()}, {_PLUGIN_ID: errs})  # type: ignore[arg-type]
+    assert ok is True
+    assert _PLUGIN_ID in PluginManager.plugins
+    assert PluginManager.errors[_PLUGIN_ID] == errs
+
+
+def test_publish_single_snapshot_sets_and_clears_errors() -> None:
+    plugin = object()
+    state_module.publish_single_snapshot(_PLUGIN_ID, plugin, PluginErrors([]))  # type: ignore[arg-type]
+    assert PluginManager.plugins[_PLUGIN_ID] is plugin
+    assert _PLUGIN_ID not in PluginManager.errors
+
+
+def test_publish_unloaded_removes_plugin_and_errors() -> None:
+    state_module.publish_bulk_snapshot({_PLUGIN_ID: object()}, {_PLUGIN_ID: PluginErrors([])})  # type: ignore[arg-type]
+    ok = state_module.publish_unloaded(_PLUGIN_ID)
+    assert ok is True
+    assert _PLUGIN_ID not in PluginManager.plugins
+    assert _PLUGIN_ID not in PluginManager.errors

--- a/backend/tests/unit/domain/plugins/test_plugin_state.py
+++ b/backend/tests/unit/domain/plugins/test_plugin_state.py
@@ -54,9 +54,9 @@ def test_reserve_operation_blocked_by_error_by_default() -> None:
     assert result.accepted is False
 
 
-def test_reserve_operation_ignores_error_when_block_on_error_false() -> None:
+def test_reserve_operation_ignores_error_when_refuse_on_error_false() -> None:
     PluginManager.updater_error = "boom"
-    result = reserve_operation(block_on_error=False)
+    result = reserve_operation(refuse_on_error=False)
     assert result.accepted is True
 
 

--- a/backend/tests/unit/domain/plugins/test_plugin_status.py
+++ b/backend/tests/unit/domain/plugins/test_plugin_status.py
@@ -7,29 +7,29 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-"""Unit tests for PluginManager utility functions -- status_brief and plugins_ready."""
+"""Unit tests for plugin status utility functions -- status_brief and plugins_ready."""
 
 from unittest.mock import patch
 
-from forecastbox.domain.plugin.manager import plugins_ready, status_brief
+from forecastbox.domain.plugin.status import plugins_ready, status_brief
 
 
 def test_status_brief_ok() -> None:
-    with patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm:
+    with patch("forecastbox.domain.plugin.status.PluginManager") as mock_pm:
         mock_pm.updater_error = None
         mock_pm.operation_in_progress = False
         assert status_brief() == "ok"
 
 
 def test_status_brief_running() -> None:
-    with patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm:
+    with patch("forecastbox.domain.plugin.status.PluginManager") as mock_pm:
         mock_pm.updater_error = None
         mock_pm.operation_in_progress = True
         assert status_brief() == "running"
 
 
 def test_status_brief_failure() -> None:
-    with patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm:
+    with patch("forecastbox.domain.plugin.status.PluginManager") as mock_pm:
         mock_pm.updater_error = "some error"
         mock_pm.operation_in_progress = False
         result = status_brief()
@@ -38,21 +38,21 @@ def test_status_brief_failure() -> None:
 
 
 def test_plugins_ready_true_when_ok() -> None:
-    with patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm:
+    with patch("forecastbox.domain.plugin.status.PluginManager") as mock_pm:
         mock_pm.updater_error = None
         mock_pm.operation_in_progress = False
         assert plugins_ready() is True
 
 
 def test_plugins_ready_false_when_running() -> None:
-    with patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm:
+    with patch("forecastbox.domain.plugin.status.PluginManager") as mock_pm:
         mock_pm.updater_error = None
         mock_pm.operation_in_progress = True
         assert plugins_ready() is False
 
 
 def test_plugins_ready_false_when_failed() -> None:
-    with patch("forecastbox.domain.plugin.manager.PluginManager") as mock_pm:
+    with patch("forecastbox.domain.plugin.status.PluginManager") as mock_pm:
         mock_pm.updater_error = "crash"
         mock_pm.operation_in_progress = False
         assert plugins_ready() is False

--- a/backend/tests/unit/domain/plugins/test_plugin_status.py
+++ b/backend/tests/unit/domain/plugins/test_plugin_status.py
@@ -7,11 +7,26 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-"""Unit tests for plugin status utility functions -- status_brief and plugins_ready."""
+"""Unit tests for plugin status utility functions -- status_brief, plugins_ready, catalogue_view."""
 
-from unittest.mock import patch
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
 
-from forecastbox.domain.plugin.status import plugins_ready, status_brief
+import pytest
+from fiab_core.fable import PluginCompositeId, PluginId, PluginStoreId
+from pyrsistent import pmap
+
+from forecastbox.domain.plugin.state import PluginManager
+from forecastbox.domain.plugin.status import catalogue_view, plugins_ready, status_brief
+
+_PLUGIN_ID = PluginCompositeId(store=PluginStoreId("store"), local=PluginId("plugin"))
+
+
+@pytest.fixture(autouse=True)
+def _reset_plugin_state() -> Generator[None, None, None]:
+    PluginManager.plugins = pmap()
+    yield
+    PluginManager.plugins = pmap()
 
 
 def test_status_brief_ok() -> None:
@@ -56,3 +71,27 @@ def test_plugins_ready_false_when_failed() -> None:
         mock_pm.updater_error = "crash"
         mock_pm.operation_in_progress = False
         assert plugins_ready() is False
+
+
+# ---------------------------------------------------------------------------
+# catalogue_view
+# ---------------------------------------------------------------------------
+
+
+def test_catalogue_view_returns_snapshot_of_published_plugins() -> None:
+    plugin = MagicMock()
+    plugin.catalogue = "fake-catalogue"
+    PluginManager.plugins = pmap({_PLUGIN_ID: plugin})
+
+    result = catalogue_view()
+
+    assert result == {_PLUGIN_ID: "fake-catalogue"}
+
+
+def test_catalogue_view_returns_false_when_lock_not_acquired() -> None:
+    busy_lock = PluginManager.lock
+    busy_lock.acquire()
+    try:
+        assert catalogue_view() is False
+    finally:
+        busy_lock.release()

--- a/backend/tests/unit/domain/plugins/test_plugin_template_ingest.py
+++ b/backend/tests/unit/domain/plugins/test_plugin_template_ingest.py
@@ -25,7 +25,7 @@ import forecastbox.domain.plugin.db as plugin_db
 import forecastbox.schemata.jobs as _jobs_module
 from forecastbox.domain.blueprint.service import CORE_VERSION_MISMATCH_TAG_KEY, BlueprintBuilder, BlueprintValidationExpansion
 from forecastbox.domain.plugin.db import get_plugin_state, upsert_plugin_state
-from forecastbox.domain.plugin.manager import _ingest_plugin_templates
+from forecastbox.domain.plugin.template_ingest import ingest_plugin_templates
 from forecastbox.schemata.jobs import Base
 
 _PLUGIN_ID = PluginCompositeId(store=PluginStoreId("myStore"), local=PluginId("myPlugin"))
@@ -85,7 +85,7 @@ def test_ingest_plugin_templates_reserved_tag_recorded_as_template_error(
     _patch_validation_ok(monkeypatch)
     plugin = _make_plugin(tags=[CORE_VERSION_MISMATCH_TAG_KEY])
 
-    _ingest_plugin_templates(_PLUGIN_ID, plugin)
+    ingest_plugin_templates(_PLUGIN_ID, plugin)
 
     state = get_plugin_state(_PLUGIN_ID_STR)
     assert state is not None
@@ -98,7 +98,7 @@ def test_ingest_plugin_templates_normal_tag_not_flagged(mem_session_maker: sessi
     _patch_validation_ok(monkeypatch)
     plugin = _make_plugin(tags=["normal-tag"])
 
-    _ingest_plugin_templates(_PLUGIN_ID, plugin)
+    ingest_plugin_templates(_PLUGIN_ID, plugin)
 
     state = get_plugin_state(_PLUGIN_ID_STR)
     assert state is not None

--- a/backend/tests/unit/domain/run/test_compile.py
+++ b/backend/tests/unit/domain/run/test_compile.py
@@ -20,7 +20,7 @@ from pyrsistent import pmap
 
 from forecastbox.domain.blueprint.service import BlueprintBuilder, RoutableBlock
 from forecastbox.domain.glyphs.resolution import merge_glyph_values
-from forecastbox.domain.plugin.manager import PluginManager
+from forecastbox.domain.plugin.state import PluginManager
 from forecastbox.domain.run.compile import compile_builder
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/plugins/test_stores.py
+++ b/backend/tests/unit/plugins/test_stores.py
@@ -1,12 +1,12 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import httpx
 import orjson
 import pytest
 from fiab_core.fable import PluginId
 
-from forecastbox.domain.plugin.store import PluginStore, PluginStoreEntry, fetch_store
-from forecastbox.utility.config import PluginStoreConfig
+from forecastbox.domain.plugin.store import PluginStore, PluginStoreEntry, StoresManager, fetch_store, get_plugins_detail
+from forecastbox.utility.config import ConcurrentPools, PluginStoreConfig
 
 
 def test_fetch() -> None:
@@ -38,3 +38,70 @@ def test_fetch() -> None:
             result = fetch_store(client, store_config)
 
     assert result == fake_store
+
+
+def test_submit_initialize_stores_submits_one_monitored_io_task(monkeypatch: pytest.MonkeyPatch) -> None:
+    """submit_initialize_stores() must submit exactly one monitored task to the shared Io
+    pool -- no fallback thread, no blocking for completion."""
+    from forecastbox.domain.plugin import store as store_module
+
+    submissions: list[tuple[object, object]] = []
+
+    def _fake_submit_monitored(pool_name: object, task_name: object, task: object) -> None:
+        submissions.append((pool_name, task_name))
+
+    monkeypatch.setattr(store_module.execution_manager, "submit_monitored", _fake_submit_monitored)
+
+    store_module.submit_initialize_stores()
+
+    assert len(submissions) == 1
+    pool_name, task_name = submissions[0]
+    assert pool_name == ConcurrentPools.Io
+    assert task_name == "plugin.stores.initialize"
+
+
+def test_initialize_stores_publishes_only_after_successful_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An exception during fetch/populate must propagate (for monitored-task handling) and
+    must not publish a partial store map."""
+    from forecastbox.domain.plugin import store as store_module
+
+    monkeypatch.setattr(store_module.StoresManager, "stores", store_module.pmap())
+
+    def _boom(client: httpx.Client, plugin_store_config: object) -> PluginStore:
+        raise RuntimeError("network exploded")
+
+    monkeypatch.setattr(store_module, "fetch_store", _boom)
+
+    with pytest.raises(RuntimeError):
+        store_module.initialize_stores({"someStore": MagicMock()})
+
+    assert dict(StoresManager.stores) == {}
+
+
+def test_get_plugins_detail_is_lock_free_over_published_map(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_plugins_detail() must not need StoresManager.stores_lock to read."""
+    from forecastbox.domain.plugin.store import PluginRemoteInfo
+
+    fake_store = PluginStore(
+        display_name="ecmwf",
+        plugins={
+            PluginId("plugin1"): PluginStoreEntry(
+                pip_source="pip_source",
+                module_name="module_name",
+                display_title="display_title",
+                display_description="display_description",
+                display_author="display_author",
+            ),
+        },
+    )
+    fake_store.remote[PluginId("plugin1")] = PluginRemoteInfo(version="1.0")
+
+    from forecastbox.domain.plugin import store as store_module
+
+    monkeypatch.setattr(store_module.StoresManager, "stores", store_module.pmap({"ecmwfStore": fake_store}))
+    StoresManager.stores_lock.acquire()
+    try:
+        detail = get_plugins_detail()
+    finally:
+        StoresManager.stores_lock.release()
+    assert len(detail) == 1

--- a/backend/tests/unit/routes/test_plugins.py
+++ b/backend/tests/unit/routes/test_plugins.py
@@ -33,7 +33,7 @@ from packaging.version import Version
 from pyrsistent import pmap
 
 from forecastbox.domain.plugin.store import PluginRemoteInfo, PluginStoreEntry
-from forecastbox.routes.plugins import get_plugin_versions, get_template_example_values, update_plugin
+from forecastbox.routes.plugins import get_plugin_versions, get_template_example_values, install_plugin, update_plugin
 from forecastbox.utility.config import PluginSettings
 
 # ---------------------------------------------------------------------------
@@ -185,26 +185,40 @@ def test_versions_pip_source_passed_to_get_package_versions() -> None:
     mock_gpv.assert_called_once_with("fiab-plugin-ecmwf")
 
 
-def test_update_without_version_selects_newest_compatible_version() -> None:
+@pytest.mark.asyncio
+async def test_update_without_version_selects_newest_compatible_version() -> None:
     with (
         _patch_store(),
         _patch_versions(["1.0.0", "1.2.0", "2.0.0"]),
         _patch_fiabcore("1.0.0"),
-        patch("forecastbox.routes.plugins.submit_update_single", return_value="") as mock_submit,
+        patch("forecastbox.routes.plugins.submit_update_single", new=AsyncMock(return_value="")) as mock_submit,
     ):
-        update_plugin(MagicMock(), _COMPOSITE_ID)
+        await update_plugin(MagicMock(), _COMPOSITE_ID)
     mock_submit.assert_called_once_with(_COMPOSITE_ID, install=True, version=Version("1.2.0"))
 
 
-def test_update_without_version_rejects_when_no_compatible_version_exists() -> None:
+@pytest.mark.asyncio
+async def test_update_without_version_rejects_when_no_compatible_version_exists() -> None:
     with (
         _patch_store(),
         _patch_versions(["2.0.0"]),
         _patch_fiabcore("1.0.0"),
     ):
         with pytest.raises(HTTPException) as exc_info:
-            update_plugin(MagicMock(), _COMPOSITE_ID)
+            await update_plugin(MagicMock(), _COMPOSITE_ID)
     assert exc_info.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# /install route -- must await the now-async submit_install_single
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_install_plugin_awaits_submit_install_single() -> None:
+    with patch("forecastbox.routes.plugins.submit_install_single", new=AsyncMock()) as mock_submit:
+        await install_plugin(MagicMock(), _COMPOSITE_ID)
+    mock_submit.assert_awaited_once_with(_COMPOSITE_ID)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/developer/changeSpecs/backend-concurrencyRework-phase3.2and3-plan.md
+++ b/docs/developer/changeSpecs/backend-concurrencyRework-phase3.2and3-plan.md
@@ -114,23 +114,31 @@ executor until Phase 3.1 migrates it; do not move it to `Io` in this work.
 
 ## Module layout and responsibility split
 
-Refactor only within `domain/plugin`; do not add a new cross-domain abstraction.
-The desired result is small modules with an explicit dependency direction:
+Refactor only the code currently in `domain/plugin/manager.py` and
+`domain/plugin/store.py`; do not add a new cross-domain abstraction. The layout
+below is the target for that extracted/reorganized code, not a complete listing
+of the plugin package. Existing `compatibility.py`, `db.py`, `detail.py`,
+`errors.py`, `events.py`, and `exceptions.py` remain separate concerns unless a
+step below explicitly updates their imports or documentation.
 
 ```text
 state.py             shared immutable plugin state and short synchronized state changes
-manager.py           public orchestration facade and execution-manager submission boundary
-loading.py           synchronous pip/import/load/reload/unload worker operations
+manager.py           execution-manager submission boundary and public operation orchestration
+loading.py           synchronous plugin load/update/reload/unload worker orchestration
 template_ingest.py   temporary synchronous plugin-to-blueprint template work
 store.py             store models, fetch/populate work, immutable store publication, Io submission
+compatibility.py     version compatibility and isolated environment-install policy
 ```
 
-`manager.py` should continue to expose `PluginManager` as the stable import
-location for current consumers (`routes`, `run`, `blueprint`, and `detail`),
-while the implementation class/state helpers live in `state.py`. This avoids a
-large unrelated import-path migration. It is acceptable for `manager.py` to be
-a thin facade around `state.py` and `loading.py`; it must no longer own a Python
-thread or the long-running worker implementation.
+Do not add compatibility re-exports. Every consumer must import from the module
+that defines the symbol after the split. In particular, callers that currently
+need `PluginManager` (`routes/plugins.py`, `routes/blueprint.py`,
+`domain/blueprint/service.py`, `domain/run/compile.py`, and
+`domain/plugin/detail.py`) import it from `forecastbox.domain.plugin.state`;
+callers of submission, unload, readiness, status, and catalogue operations
+import those functions from `forecastbox.domain.plugin.manager`. Update all production and test
+imports atomically, then ensure `manager.py` does not re-export `PluginManager`
+or worker implementation details merely to preserve an old path.
 
 `template_ingest.py` should contain the existing `_ingest_plugin_templates`
 logic and the temporary direct blueprint imports. Those imports remain lazy only
@@ -141,11 +149,24 @@ handlers in Phase 5. Do not make the imports top-level and do not change the
 current per-template error isolation, glyph remapping, validation, soft-delete,
 or persistence behavior.
 
-`loading.py` should contain the synchronous worker-only functions: loading one
-plugin, version extraction, initial bulk loading, single update, and the
-synchronous unload primitive. It uses the state helpers for short publications
-and calls the synchronous locked DB helpers directly. It must not import routes,
-the entrypoint, or an event loop.
+`loading.py` owns the synchronous worker workflow: loading one plugin, version
+extraction, initial bulk loading, deciding whether installation is necessary,
+calling the compatibility policy, import/reload, state publication, template
+ingestion, and the synchronous unload primitive. It uses state helpers for
+short publications and calls synchronous locked DB helpers directly. It must
+not import routes, the entrypoint, or an event loop.
+
+Keep `compatibility.py` intact as the independent policy/helper module. Its
+public version helpers are used outside plugin loading by route code, and its
+installation function encapsulates the detailed environment-freeze,
+constraints, dry-run, real-install, and post-install policy without knowing
+about `PluginManager`, pool submission, plugin state, or database publication.
+`loading.py` invokes `check_environment_baseline()` and
+`install_plugin_compatibly()` at the existing points in the worker workflow;
+those calls must not move into `manager.py` or be duplicated. This gives a
+clear separation: `compatibility.py` answers whether and how the active Python
+environment may change, while `loading.py` decides when a particular configured
+plugin is installed, imported, reloaded, and published.
 
 `state.py` should retain the existing `PMap` publication pattern and the one
 short state lock. Replace thread-object state with minimal semantic state:
@@ -165,10 +186,8 @@ read a compact state snapshot and continue returning `running`, `ok`, or
 execution-manager status response.
 
 Preserve the present policy that a recorded global updater failure prevents a
-later single update until the process is restarted. In particular, do not add an
-implicit retry, reset endpoint, or automatic task retry. If the existing
-behavior is intentionally changed during review, it must be called out as a
-separate product/operational decision.
+later single update until the process is restarted. Do not add an implicit
+retry, reset endpoint, or automatic task retry.
 
 ## Implementation steps
 
@@ -210,15 +229,21 @@ Create the state and worker split described above before changing submission
 sites. Move code without changing its business ordering first, then replace the
 thread ownership.
 
-1. Move `PluginManager`, immutable map publication, updater-error recording,
-   concise status/readiness queries, and catalogue snapshot access into
-   `state.py` plus the `manager.py` facade. Remove the `updater` field entirely.
+1. Move `PluginManager` and its immutable-map publication plus short state
+   transitions into `state.py`. Keep `manager.py` limited to operation
+   reservation, execution-manager submission, readiness/status/catalogue
+   queries, and async request-facing orchestration. Remove the `updater` field
+   entirely and migrate every production/test import to the defining module;
+   do not leave a `PluginManager` re-export in `manager.py`.
 2. Move the current template-ingestion body to `template_ingest.py`, preserving
    its synchronous direct DB calls and existing temporary lazy blueprint
    imports. Update the current template-ingest unit tests to import it from its
    defining module.
 3. Move `load_single`, `_version_from_install`, `load_plugins`,
-   `update_single`, and the synchronous unload body to `loading.py`. Preserve:
+   `update_single`, and the synchronous unload body to `loading.py`. Keep
+   `compatibility.py` as the environment/version policy dependency described
+   above, rather than merging its tested resolver policy into the loader.
+   Preserve:
    - current bulk load ordering and all per-plugin DB writes;
    - publish-before-template-ingestion behavior so validation can resolve the
      newly loaded plugin catalogue;
@@ -255,7 +280,16 @@ thread ownership.
 Implement the facade methods in `domain/plugin/manager.py` using the state and
 worker wrappers.
 
-1. `submit_load_plugins(catalog_future)` must atomically reserve the initial
+1. Make the limited catalog-future contract correction before wiring the
+   continuation: in the legacy
+   `domain/artifact/manager.py::_refresh_catalog_task`, retain the existing
+   `refresh_error` update and logging, then re-raise the original exception.
+   This does not migrate the artifact executor, state, or shutdown ownership
+   from Phase 3.1; it makes the already returned startup `Future` accurately
+   represent a failed refresh so its existing consumer can honor the dependency
+   contract. Add focused coverage for the failed future and retained
+   `refresh_error` state.
+2. `submit_load_plugins(catalog_future)` must atomically reserve the initial
    operation, set readiness to not-ready while the catalog is pending, and call:
 
    ```python
@@ -270,7 +304,7 @@ worker wrappers.
    This replaces `delayed_thread`. It is a continuation, so no worker is
    occupied while waiting for catalog refresh. It is manager-monitored and does
    not return a domain-owned thread or executor.
-2. Attach a small completion callback to `catalog_future` solely to update the
+3. Attach a small completion callback to `catalog_future` solely to update the
    domain operation state if the dependency itself fails. It must consume the
    dependency exception, record a clear startup dependency error, leave
    `plugins_ready()` false, and not invoke the load worker. The manager's
@@ -278,22 +312,22 @@ worker wrappers.
    monitored failure history. The callback must only make a short state update;
    it must not acquire the jobs lock, publish plugins, or submit work while
    holding the state lock.
-3. `submit_update_single(...)` must retain its current synchronous acceptance
+4. `submit_update_single(...)` must retain its current synchronous acceptance
    contract for routes: validate that the configured plugin exists, reject an
    existing global failure or in-progress operation, reserve the operation, and
    submit the worker wrapper with `submit_monitored` to
    `PluginManagement` using `TaskName("plugin.update")`. The route may still
    return its current immediate 202-style response after acceptance.
-4. If normal monitored submission is rejected synchronously, roll back the
+5. If normal monitored submission is rejected synchronously, roll back the
    in-progress reservation before re-raising `SubmissionRejected`. Do not mark
    it as a completed plugin update and do not leave the domain permanently
    `running`. The existing common 503 handler then reports temporary pool or
    lifecycle saturation.
-5. Remove `join_updater_thread` and all thread liveness/join logic. Replace
+6. Remove `join_updater_thread` and all thread liveness/join logic. Replace
    `status_brief()`'s `updater.is_alive()` check with the semantic operation
    state. It must correctly handle the pre-startup and waiting-for-catalog
    cases without dereferencing a missing thread.
-6. Keep task names stable and specific: `plugin.initial-load` and
+7. Keep task names stable and specific: `plugin.initial-load` and
    `plugin.update`. These names, along with pool counters/failures, are the
    operational task detail; the top-level plugin status remains the existing
    compact domain-facing readiness/error summary until the later status
@@ -464,33 +498,3 @@ test.
   artifact legacy join remains untouched for Phase 3.1.
 - Phase 5's event-based blueprint reaction and the already delivered
   notification handler remain behaviorally unchanged.
-
-## Open question and implementation concern
-
-### Artifact catalog failure is not currently observable through its Future
-
-Phase 3.3 requires `submit_after(catalog_future, ...)` to skip initial plugin
-loading when catalog refresh fails. The current legacy
-`artifact.manager._refresh_catalog_task` catches every exception, records
-`ArtifactManager.refresh_error`, and returns normally. Consequently its
-`Future` succeeds even when refresh failed, so the execution manager's
-`submit_after` cannot detect the dependency failure and would start plugin
-loading anyway.
-
-This conflicts with the Phase 3.3 required semantics, but changing artifact
-execution ownership is explicitly deferred to Phase 3.1. Before implementation,
-the reviewer should choose one of these narrowly scoped resolutions:
-
-1. Recommended: make the legacy refresh task re-raise after it records
-   `refresh_error`. This does not migrate its executor or state ownership, but
-   makes its already-public startup `Future` accurately represent failure and
-   permits the required continuation behavior.
-2. Preserve the legacy successful-Future behavior and explicitly accept that
-   initial plugin loading still proceeds after a failed catalog refresh. This
-   is contrary to the migration requirement and should only be chosen with an
-   approved deviation recorded in the result document.
-
-No other open design decision is expected. In particular, do not add a
-per-task-status API to `ExecutionManager`: its existing pool counters and
-failure history plus the plugin domain's minimal operation state are sufficient
-for this fixed set of operations.

--- a/docs/developer/changeSpecs/backend-concurrencyRework-phase3.2and3-plan.md
+++ b/docs/developer/changeSpecs/backend-concurrencyRework-phase3.2and3-plan.md
@@ -1,0 +1,496 @@
+# Backend concurrency rework: Phase 3.2 and 3.3 implementation plan
+
+## Purpose and scope
+
+Implement Phase 3.2 (plugin-store initialization) and Phase 3.3 (plugin
+installation, import, reload, and related plugin-operation ownership) together.
+The work moves both concerns from domain-owned ad hoc threads to already running,
+bounded `ExecutionManager` pools. It also reduces the current plugin manager's
+mixed responsibilities into a few small, domain-local modules.
+
+This is deliberately not a general plugin-framework redesign. The domain has a
+fixed, small set of operations, so the implementation should use direct
+functions, the existing immutable state snapshots, and the existing execution
+manager APIs rather than introduce new generic operation registries, task
+objects, or domain-specific executors.
+
+### Original design references
+
+Look at these original files only if you encounter an unexpected situation. This
+plan is self-contained and implementation should not normally require reading
+them.
+
+- [`backend-concurrencyRework-design.md`](backend-concurrencyRework-design.md)
+- [`backend-concurrencyRework-migration.md`](backend-concurrencyRework-migration.md)
+- [`backend-concurrencyRework-phase0-result.md`](backend-concurrencyRework-phase0-result.md)
+- [`backend-concurrencyRework-phase1-result.md`](backend-concurrencyRework-phase1-result.md)
+- [`backend-concurrencyRework-phase2-result.md`](backend-concurrencyRework-phase2-result.md)
+- [`backend-concurrencyRework-phase2.1-result.md`](backend-concurrencyRework-phase2.1-result.md)
+
+## Delivered baseline and boundaries
+
+The implementation must rely on these existing facts rather than recreate them.
+
+- Phase 0 moved concurrency helpers to `utility/concurrency/` and isolated the
+  users database lock/retry path.
+- Phase 1 created and starts the module-level `execution_manager`, including
+  bounded `Io` and one-worker `PluginManagement` pools. It also provides
+  `submit_monitored`, `submit_after`, `awaitable_submit`, task failure history,
+  pool status, and lifecycle-owned pool shutdown.
+- Phase 2 made jobs-database helpers synchronous and internally protected by
+  the jobs `RLock`. Plugin-management workers must call those helpers directly,
+  not submit them back through `JobsDb` and not retain an event-loop reference.
+- Phase 2.1 maps unhandled `ExecutionManagerError` subclasses, including
+  `SubmissionRejected`, to the common 503 route response.
+- The notification dispatcher handler and its FastAPI-loop bridge are already
+  operational. This work must keep the existing `PluginGlobalErrorEvent` path
+  and must not redesign notification delivery or dispatcher registration.
+- The artifact manager is still on its legacy private executor because Phase
+  3.1 is intentionally out of scope. Its startup `Future` remains the initial
+  plugin-load dependency.
+- Phase 5 is also out of scope. The current temporary plugin-to-blueprint
+  template-ingestion and unload coupling must remain behaviorally intact. It
+  may be isolated into a small module, but must not be converted to events in
+  this change.
+
+No configuration changes are needed. `ConcurrentPools.Io` and
+`ConcurrentPools.PluginManagement` already have the required configured limits
+and are registered before domain startup work begins.
+
+## Current state to replace
+
+### Plugin stores
+
+`domain/plugin/store.py` stores `StoresManager.stores_updater` and creates a
+`threading.Thread` in `submit_initialize_stores`. `initialize_stores` performs
+blocking file/HTTP store discovery and PyPI version lookups, then atomically
+publishes a `pyrsistent` store map under `stores_lock`. `join_stores_thread` is
+called from the application lifespan.
+
+### Plugin operations
+
+`domain/plugin/manager.py` currently combines all of the following in one
+large module:
+
+- mutable immutable-snapshot state (`plugins`, `errors`, and `updater_error`);
+- ownership and joining of `PluginManager.updater`;
+- startup dependency waiting through `delayed_thread`;
+- pip/install/import/reload worker logic;
+- plugin status and readiness queries;
+- configuration editing and uninstall orchestration; and
+- the temporary template-ingestion/unload implementation that reaches into the
+  blueprint domain.
+
+The updater thread is used for both initial loading and single-plugin updates.
+It is not centrally supervised. The current exception notifier records a domain
+error but swallows the exception, so the execution manager would not be able to
+record the managed task failure if this behavior were copied unchanged.
+
+`detail.build_plugin_listing()` also currently holds `PluginManager.lock` while
+awaiting a jobs-DB-pool operation. This is not necessary for its immutable
+in-memory snapshot and can cause an unnecessarily long lock hold.
+
+## Target ownership and behavior
+
+| Concern | Target owner | Submission and failure ownership |
+| --- | --- | --- |
+| Plugin-store initialization | `ConcurrentPools.Io` | Fire-and-forget monitored task; manager records unexpected task failures. |
+| Initial plugin load after catalog refresh | `ConcurrentPools.PluginManagement` | `submit_after(catalog_future, ...)`; manager monitors the worker task and the domain maintains readiness/error state. |
+| Install, import, and reload one plugin | `ConcurrentPools.PluginManagement` | Fire-and-forget monitored task; manager records uncaught task failures and the domain preserves its error notification/status surface. |
+| Unload and uninstall mutation | `ConcurrentPools.PluginManagement` | Request-owned awaited task, because the caller needs completion before reporting success; domain records its failure state before re-raising. |
+| Jobs database work from a plugin-management worker | Current worker thread plus jobs `RLock` | Call synchronous plugin/blueprint DB helpers directly. |
+
+The one-worker `PluginManagement` pool is a correctness boundary, not merely an
+I/O pool. Add a concise comment beside its use explaining that pip installation,
+module reload/import, and plugin catalogue publication mutate process-global
+state and therefore must not overlap. Do not hold `PluginManager.lock` across
+pip, import/reload, blueprint processing, database work, or a wait for a
+future. The existing short locks remain only for atomic state transitions and
+immutable snapshot swaps.
+
+The plugin store does not share this restriction. Its HTTP/file reads are safe
+to use the shared `Io` pool. Artifact work remains on the legacy artifact
+executor until Phase 3.1 migrates it; do not move it to `Io` in this work.
+
+## Module layout and responsibility split
+
+Refactor only within `domain/plugin`; do not add a new cross-domain abstraction.
+The desired result is small modules with an explicit dependency direction:
+
+```text
+state.py             shared immutable plugin state and short synchronized state changes
+manager.py           public orchestration facade and execution-manager submission boundary
+loading.py           synchronous pip/import/load/reload/unload worker operations
+template_ingest.py   temporary synchronous plugin-to-blueprint template work
+store.py             store models, fetch/populate work, immutable store publication, Io submission
+```
+
+`manager.py` should continue to expose `PluginManager` as the stable import
+location for current consumers (`routes`, `run`, `blueprint`, and `detail`),
+while the implementation class/state helpers live in `state.py`. This avoids a
+large unrelated import-path migration. It is acceptable for `manager.py` to be
+a thin facade around `state.py` and `loading.py`; it must no longer own a Python
+thread or the long-running worker implementation.
+
+`template_ingest.py` should contain the existing `_ingest_plugin_templates`
+logic and the temporary direct blueprint imports. Those imports remain lazy only
+because they are required to avoid the existing circular domain dependency.
+Its module docstring and the plugin domain docstring must explicitly say that
+the dependency is temporary and will move to blueprint-owned dispatcher
+handlers in Phase 5. Do not make the imports top-level and do not change the
+current per-template error isolation, glyph remapping, validation, soft-delete,
+or persistence behavior.
+
+`loading.py` should contain the synchronous worker-only functions: loading one
+plugin, version extraction, initial bulk loading, single update, and the
+synchronous unload primitive. It uses the state helpers for short publications
+and calls the synchronous locked DB helpers directly. It must not import routes,
+the entrypoint, or an event loop.
+
+`state.py` should retain the existing `PMap` publication pattern and the one
+short state lock. Replace thread-object state with minimal semantic state:
+
+- `operation_in_progress: bool`, true from accepted startup/update/unload/
+  uninstall work until its wrapper completes;
+- `updater_error: str | None`, preserving the existing global failure surface;
+- the existing `plugins` and `errors` immutable maps.
+
+Provide a small set of private, lock-protected state transitions/snapshot
+helpers rather than allow each worker path to edit these fields ad hoc. They
+should reserve an operation, publish initial/bulk/single/unloaded snapshots,
+finish successfully, and finish with a recorded error. The helpers must not
+perform I/O. There is no need for a new public status DTO: `status_brief()` can
+read a compact state snapshot and continue returning `running`, `ok`, or
+`failure: ...`, while pool-level task and failure details remain in the existing
+execution-manager status response.
+
+Preserve the present policy that a recorded global updater failure prevents a
+later single update until the process is restarted. In particular, do not add an
+implicit retry, reset endpoint, or automatic task retry. If the existing
+behavior is intentionally changed during review, it must be called out as a
+separate product/operational decision.
+
+## Implementation steps
+
+### 1. Move plugin-store initialization to `Io`
+
+Modify `backend/src/forecastbox/domain/plugin/store.py` as follows.
+
+1. Retain `StoresManager.stores` and its short lock, because the completed map
+   must still be published as one immutable `pmap` swap and readers remain
+   lock-free.
+2. Remove `stores_updater`, the `threading` lifecycle dependency that exists
+   only for that updater, and `join_stores_thread`.
+3. Keep `initialize_stores(plugin_stores_config)` synchronous. It continues to
+   own all blocking HTTP/file/PyPI work and publishes only after the complete
+   map is available. A partial store map must never be published.
+4. Change `submit_initialize_stores()` to submit a `functools.partial` of that
+   synchronous function through:
+
+   ```python
+   execution_manager.submit_monitored(
+       ConcurrentPools.Io,
+       TaskName("plugin.stores.initialize"),
+       partial(initialize_stores, config.external.plugin_stores),
+   )
+   ```
+
+   Do not create a fallback thread, block for completion, or silently suppress
+   `SubmissionRejected`. The common FastAPI handling applies if this is ever
+   called from a request path. An unexpected task exception is recorded by the
+   execution manager; existing callers continue to see an empty store map until
+   a successful immutable publication.
+5. Preserve `submit_install_plugin` behavior. It continues to read the
+   immutable store map and then asks the plugin-operation facade to submit the
+   requested install; it does not itself perform pip work.
+
+### 2. Establish plugin operation state and synchronous worker wrappers
+
+Create the state and worker split described above before changing submission
+sites. Move code without changing its business ordering first, then replace the
+thread ownership.
+
+1. Move `PluginManager`, immutable map publication, updater-error recording,
+   concise status/readiness queries, and catalogue snapshot access into
+   `state.py` plus the `manager.py` facade. Remove the `updater` field entirely.
+2. Move the current template-ingestion body to `template_ingest.py`, preserving
+   its synchronous direct DB calls and existing temporary lazy blueprint
+   imports. Update the current template-ingest unit tests to import it from its
+   defining module.
+3. Move `load_single`, `_version_from_install`, `load_plugins`,
+   `update_single`, and the synchronous unload body to `loading.py`. Preserve:
+   - current bulk load ordering and all per-plugin DB writes;
+   - publish-before-template-ingestion behavior so validation can resolve the
+     newly loaded plugin catalogue;
+   - per-plugin install/load errors versus unexpected operation-wide failures;
+   - current plugin-state/template-error persistence; and
+   - direct synchronous calls to the jobs DB helpers.
+4. Wrap each managed operation in one small synchronous wrapper that:
+   - assumes the operation reservation has already been made;
+   - runs the worker operation without holding the state lock;
+   - marks the state idle on normal completion;
+   - records `updater_error` and emits the existing `PluginGlobalErrorEvent` on
+     an unexpected exception; and
+   - re-raises that exception after recording the domain error.
+
+   Re-raising is intentional. It lets the manager's monitored submission record
+   the failure in its bounded common history, while the existing domain status
+   and notification behavior remain available. Expected per-plugin outcomes
+   that are currently represented as persisted/in-memory `PluginErrors` remain
+   normal completion and must not be converted into global task failures.
+5. Replace the current unsafe no-lock error fallback with the centralized short
+   state transition. Long-running operations no longer hold the state lock, so
+   a bounded failed acquisition should be exceptional and logged rather than
+   writing a shared field without synchronization.
+6. Change `detail.build_plugin_listing()` to capture copies of `plugins` and
+   `errors` under the short lock, release it, then await
+   `execution_manager.await_jobs_db(...)` for database state. Update its
+   docstring to describe a best-effort composed snapshot rather than claiming
+   the lock covers database work. This keeps the route's existing response
+   shape and `PluginManagerBusy` handling while preventing a jobs-pool wait
+   from blocking publication or status reads.
+
+### 3. Replace startup loading and update threads with managed submissions
+
+Implement the facade methods in `domain/plugin/manager.py` using the state and
+worker wrappers.
+
+1. `submit_load_plugins(catalog_future)` must atomically reserve the initial
+   operation, set readiness to not-ready while the catalog is pending, and call:
+
+   ```python
+   execution_manager.submit_after(
+       catalog_future,
+       ConcurrentPools.PluginManagement,
+       TaskName("plugin.initial-load"),
+       partial(run_initial_load, config.external.plugins),
+   )
+   ```
+
+   This replaces `delayed_thread`. It is a continuation, so no worker is
+   occupied while waiting for catalog refresh. It is manager-monitored and does
+   not return a domain-owned thread or executor.
+2. Attach a small completion callback to `catalog_future` solely to update the
+   domain operation state if the dependency itself fails. It must consume the
+   dependency exception, record a clear startup dependency error, leave
+   `plugins_ready()` false, and not invoke the load worker. The manager's
+   `submit_after` implementation already records the dependency failure in its
+   monitored failure history. The callback must only make a short state update;
+   it must not acquire the jobs lock, publish plugins, or submit work while
+   holding the state lock.
+3. `submit_update_single(...)` must retain its current synchronous acceptance
+   contract for routes: validate that the configured plugin exists, reject an
+   existing global failure or in-progress operation, reserve the operation, and
+   submit the worker wrapper with `submit_monitored` to
+   `PluginManagement` using `TaskName("plugin.update")`. The route may still
+   return its current immediate 202-style response after acceptance.
+4. If normal monitored submission is rejected synchronously, roll back the
+   in-progress reservation before re-raising `SubmissionRejected`. Do not mark
+   it as a completed plugin update and do not leave the domain permanently
+   `running`. The existing common 503 handler then reports temporary pool or
+   lifecycle saturation.
+5. Remove `join_updater_thread` and all thread liveness/join logic. Replace
+   `status_brief()`'s `updater.is_alive()` check with the semantic operation
+   state. It must correctly handle the pre-startup and waiting-for-catalog
+   cases without dereferencing a missing thread.
+6. Keep task names stable and specific: `plugin.initial-load` and
+   `plugin.update`. These names, along with pool counters/failures, are the
+   operational task detail; the top-level plugin status remains the existing
+   compact domain-facing readiness/error summary until the later status
+   consolidation phase.
+
+### 4. Serialize unload and uninstall mutations too
+
+Although the migration text emphasizes pip/install/import/reload, unloading
+also mutates the same process-global plugin catalogue. Leaving it on the route
+thread would permit an unload to race a managed update and would undermine the
+one-worker correctness boundary. Include it in this combined implementation;
+this is a small completion of the same ownership rule, not a new feature. A
+recorded global updater failure must continue to block a new update, but it must
+not prevent an administrator from unloading or uninstalling the failed plugin;
+those cleanup operations are blocked only by an operation that is currently in
+progress.
+
+1. Keep the synchronous unload primitive in `loading.py`: remove the immutable
+   plugin/error entries under the short state lock, then perform its existing
+   blueprint-template soft delete outside that lock. Do not introduce the Phase
+   5 event yet.
+2. Add an async facade operation that reserves the plugin operation, awaits an
+   unmonitored `awaitable_submit` to `PluginManagement` with
+   `TaskName("plugin.unload")`, and lets the request own success/failure. The
+   worker wrapper still updates the domain error/idle state before re-raising.
+3. Make `uninstall_plugin` one synchronous worker operation submitted through
+   the same pool and awaited by its async facade. Preserve the current sequence:
+   delete the plugin state through the direct locked DB helper, remove/save the
+   config entry under `config_edit_lock`, then unload the in-memory catalogue
+   and soft-delete templates. Since the code is now on a synchronous
+   plugin-management worker, direct DB access is correct and avoids a nested
+   async/JobsDb bridge.
+4. Update `routes/plugins.py` so the disable-settings path awaits the managed
+   unload operation after its existing settings DB write. It should not enqueue
+   the old redundant `update_single(..., install=False)` call when the plugin
+   is disabled. The normal enabled-settings path continues to submit its
+   asynchronous update. Update the uninstall route to use the new awaited
+   facade.
+5. Map an operation-busy rejection in these async routes to the same 503
+   behavior as the existing `PluginManagerBusy` listing route. Reuse the
+   existing exception if its documented meaning remains accurate; otherwise
+   introduce one narrowly named plugin-operation-busy exception. Do not return
+   a misleading 500 for an explicitly serialized operation that is already
+   running.
+
+### 5. Integrate startup and shutdown
+
+Modify `backend/src/forecastbox/entrypoint/app.py` only for ownership changes.
+
+1. Keep the current sequence in which the execution runtime starts before
+   domain-specific initialization. This guarantees both destination pools exist
+   before `submit_initialize_stores`, `submit_refresh_catalog`, and
+   `submit_load_plugins` are called.
+2. Keep the existing startup order and independence: initialize the already
+   delivered notification broadcaster, submit store initialization, begin the
+   legacy artifact catalog refresh, then install the initial plugin-load
+   continuation from the catalog future. Store initialization is not made an
+   artificial dependency of plugin loading because it is not one today.
+3. Remove imports and shutdown calls for `join_stores_thread` and
+   `join_updater_thread`. Do not replace them with component-specific joins.
+   The existing `execution_manager.shutdown(...)` closes managed pools after
+   the still-legacy component cleanup and waits/reports according to its common
+   lifecycle policy.
+4. Retain `join_artifact_manager` unchanged. It belongs to the intentionally
+   deferred Phase 3.1 artifact migration.
+5. Update module/docstring/comments that describe updater threads to describe
+   managed plugin-operation tasks. In particular update `plugin/events.py` so
+   its event documentation does not claim that a thread is the failure source.
+
+### 6. Remove only obsolete execution code
+
+At the end of the combined change, remove from production plugin code:
+
+- `PluginManager.updater` and `StoresManager.stores_updater`;
+- plugin/store uses of `threading.Thread` and `Thread.is_alive()`;
+- `join_updater_thread` and `join_stores_thread`;
+- the plugin use/import of `delayed_thread`; and
+- the duplicated manual join-budget code.
+
+Leave `utility/concurrency/synchronization.py::delayed_thread` in place for
+this phase. Its removal is Phase 9 work even though this migration should leave
+no remaining production caller.
+
+Do not alter the legacy artifact executor, scheduler thread, run work, blocking
+routes, dispatcher implementation, notification bridge, or status-route
+network probes. They belong to other phases.
+
+## Tests and validation
+
+Add focused tests with deterministic fakes or fresh execution-manager instances;
+do not run actual pip operations, network calls, or dependency waits in a unit
+test.
+
+1. Update the unit-test inline execution-manager fixture, or add narrower
+   fixtures for these tests, so it supports the manager API actually used by
+   the new code: `submit_monitored`, `awaitable_submit`, and `submit_after`.
+   The `submit_after` fake must model both successful and failed dependency
+   futures rather than silently running work after failure.
+2. Store tests:
+   - `submit_initialize_stores` submits exactly one monitored
+     `plugin.stores.initialize` task to `ConcurrentPools.Io`;
+   - the submitted callable publishes the complete immutable map only after
+     successful fetch/population;
+   - an exception is allowed to reach monitored task handling and no updater
+     thread is created; and
+   - `get_plugins_detail` remains lock-free over the published map.
+3. Plugin operation tests:
+   - startup creates a `submit_after` continuation to
+     `PluginManagement`, does not use `delayed_thread`, and remains not-ready
+     until the continuation succeeds;
+   - a failed catalog dependency leaves readiness false and records the domain
+     startup error without running the plugin loader;
+   - a worker exception sets the existing domain error, emits the existing
+     notification fact, re-raises for manager monitoring, and clears the
+     in-progress state;
+   - normal per-plugin install/load errors preserve their current
+     `PluginErrors` behavior without becoming a global failure;
+   - a second update/unload/uninstall cannot overlap a reserved operation,
+     while unload/uninstall remain available to clean up after a prior update
+     failure;
+   - synchronous submission rejection rolls back the reservation; and
+   - update, unload, and uninstall use the correct pool/task boundary and do
+     not create or join a thread.
+4. Preserve and adapt the current template-ingestion tests after the extraction.
+   Confirm the extraction did not change excluded-template deletion, glyph
+   remapping, validation error collection, or template-error persistence.
+5. Add a focused `build_plugin_listing` test proving the plugin state lock is
+   released before the awaited jobs-DB call. Preserve the existing 503 behavior
+   when the short snapshot lock itself cannot be obtained.
+6. Add/update lifespan integration coverage to prove the runtime accepts the
+   store/plugin tasks and normal shutdown no longer calls the removed joins.
+   The test should avoid a real plugin install by patching the worker functions,
+   then assert that the common execution status exposes activity/failure under
+   `Io` and `PluginManagement` as appropriate.
+7. Run targeted plugin/store/template tests, affected route tests, type
+   checking, and `uv run prek`. Before completion, search production sources
+   for:
+
+   ```text
+   threading.Thread
+   ThreadPoolExecutor
+   delayed_thread
+   join_updater_thread
+   join_stores_thread
+   PluginManager.updater
+   StoresManager.stores_updater
+   ```
+
+   The only expected `ThreadPoolExecutor`/`threading.Thread` hits are inside
+   the central concurrency runtime and intentionally deferred concerns. There
+   must be no plugin store or plugin operation ownership hit.
+
+## Completion criteria
+
+- Plugin stores initialize through the monitored shared `Io` pool and have no
+  private updater thread or join function.
+- Initial plugin loading uses `submit_after` and the one-worker
+  `PluginManagement` pool; single updates, unloads, and uninstalls cannot
+  overlap plugin package/catalogue mutation.
+- No plugin worker keeps or needs the FastAPI event loop. All jobs DB access in
+  those workers is synchronous and protected by the existing jobs `RLock`.
+- Plugin state locks are short, immutable maps remain safely published, and the
+  plugin listing does not hold the state lock while waiting for database work.
+- Unexpected managed plugin task failures appear in both the domain-facing
+  error/notification surface and the execution-manager monitored failure
+  history.
+- The entrypoint no longer directly joins plugin/store threads, while the
+  artifact legacy join remains untouched for Phase 3.1.
+- Phase 5's event-based blueprint reaction and the already delivered
+  notification handler remain behaviorally unchanged.
+
+## Open question and implementation concern
+
+### Artifact catalog failure is not currently observable through its Future
+
+Phase 3.3 requires `submit_after(catalog_future, ...)` to skip initial plugin
+loading when catalog refresh fails. The current legacy
+`artifact.manager._refresh_catalog_task` catches every exception, records
+`ArtifactManager.refresh_error`, and returns normally. Consequently its
+`Future` succeeds even when refresh failed, so the execution manager's
+`submit_after` cannot detect the dependency failure and would start plugin
+loading anyway.
+
+This conflicts with the Phase 3.3 required semantics, but changing artifact
+execution ownership is explicitly deferred to Phase 3.1. Before implementation,
+the reviewer should choose one of these narrowly scoped resolutions:
+
+1. Recommended: make the legacy refresh task re-raise after it records
+   `refresh_error`. This does not migrate its executor or state ownership, but
+   makes its already-public startup `Future` accurately represent failure and
+   permits the required continuation behavior.
+2. Preserve the legacy successful-Future behavior and explicitly accept that
+   initial plugin loading still proceeds after a failed catalog refresh. This
+   is contrary to the migration requirement and should only be chosen with an
+   approved deviation recorded in the result document.
+
+No other open design decision is expected. In particular, do not add a
+per-task-status API to `ExecutionManager`: its existing pool counters and
+failure history plus the plugin domain's minimal operation state are sufficient
+for this fixed set of operations.


### PR DESCRIPTION
Removes the manually managed threads for plugin updates and stores initialization in favour of the utility.concurrency pools

Consequentially, breaks down the bloated plugin manager module into multiple narrower modules