### PR TITLE
[frontend] feat(notifications): adopt the backend push channel

### DIFF
--- a/frontend/development_guidelines/DEPLOYMENT.md
+++ b/frontend/development_guidelines/DEPLOYMENT.md
@@ -32,7 +32,7 @@ Content-Security-Policy:
 | `style-src` | `'self' 'unsafe-inline'` | Tailwind + runtime style injection (e.g. react-globe.gl / three.js) |
 | `img-src` | `'self' data: blob:` | App icons are same-origin; three.js globe textures use `data:` and `blob:` URIs |
 | `font-src` | `'self'` | IBM Plex Sans is bundled via `@fontsource-variable` |
-| `connect-src` | `'self'` | Fetch API calls and `EventSource` (SSE) to same-origin backend |
+| `connect-src` | `'self'` | Fetch API calls, `EventSource` (SSE), and the notification WebSocket, all same-origin. CSP3 lets `'self'` match the page origin's `ws:`/`wss:` scheme upgrade, which every browser this app supports implements |
 | `worker-src` | `'self'` | MSW service worker (`mockServiceWorker.js`) in dev/test; omit in production if unused |
 | `frame-src` | `'none'` | App does not embed iframes |
 | `object-src` | `'none'` | No plugins (Flash, Java, etc.) |
@@ -42,7 +42,8 @@ Content-Security-Policy:
 
 ### Notes
 
-- If you serve the backend on a different origin (e.g. `https://api.example.com`), add it to `connect-src`.
+- If you serve the backend on a different origin (e.g. `https://api.example.com`), add it to `connect-src` — including `wss://api.example.com` for the notification WebSocket, since `'self'`'s scheme-upgrade leniency applies only to the page's own origin.
+- Reverse proxies in front of the backend must forward WebSocket upgrades on `/api/v1/notification/ws` (nginx: `proxy_http_version 1.1` plus the `Upgrade`/`Connection` headers).
 - `'unsafe-inline'` in `style-src` is required because three.js and some UI libraries inject styles at runtime. If this is unacceptable, consider using a CSP nonce strategy.
 - `worker-src 'self'` can be removed in production if MSW is not used.
 

--- a/frontend/mocks/handlers/artifacts.handlers.ts
+++ b/frontend/mocks/handlers/artifacts.handlers.ts
@@ -23,12 +23,14 @@
  */
 
 import { HttpResponse, delay, http } from 'msw'
+import { broadcastClientNotification } from './notification.handlers'
 import type {
   CompositeArtifactId,
   MlModelDetail,
   MlModelOverview,
   QubeNode,
 } from '@/api/types/artifacts.types'
+import type { ClientNotification } from '@/api/types/notification.types'
 import { API_ENDPOINTS } from '@/api/endpoints'
 
 /**
@@ -405,6 +407,24 @@ export function resetArtifactsHandlerState(): void {
   ongoingDownloads.clear()
 }
 
+/** Mirror of the backend's ArtifactDownloadFinishedEvent.as_client_notification. */
+function downloadFinishedNotification(
+  id: CompositeArtifactId,
+): ClientNotification {
+  return {
+    text: `Artifact ${id.artifact_local_id} finished downloading successfully`,
+    sourceDomainName: 'artifact',
+    sourceDomainEvent: 'artifactDownloadFinished',
+    context: {
+      artifact_store_id: id.artifact_store_id,
+      artifact_local_id: id.artifact_local_id,
+      success: true,
+    },
+    detailRoute: 'api/v1/artifacts/model_details',
+    refreshRoutes: ['api/v1/artifacts/list_models'],
+  }
+}
+
 export const artifactsHandlers = [
   // GET /api/v1/artifacts/list_models
   http.get(API_ENDPOINTS.artifacts.listModels, async () => {
@@ -482,6 +502,7 @@ export const artifactsHandlers = [
     const progress = advanceProgress(key)
     if (progress >= 100) {
       model.is_available = true
+      broadcastClientNotification(downloadFinishedNotification(body))
       return HttpResponse.json({
         status: 'available',
         composite_id: compositeIdStr(body),

--- a/frontend/mocks/handlers/index.ts
+++ b/frontend/mocks/handlers/index.ts
@@ -19,6 +19,7 @@ import { configHandlers } from './config.handlers'
 import { fableHandlers } from './fable.handlers'
 import { jobHandlers } from './job.handlers'
 import { lensHandlers } from './lens.handlers'
+import { notificationHandlers } from './notification.handlers'
 import { pluginsHandlers } from './plugins.handlers'
 import { artifactsHandlers } from './artifacts.handlers'
 import { scheduleHandlers } from './schedule.handlers'
@@ -32,6 +33,7 @@ export const handlers = [
   ...fableHandlers,
   ...jobHandlers,
   ...lensHandlers,
+  ...notificationHandlers,
   ...pluginsHandlers,
   ...artifactsHandlers,
   ...scheduleHandlers,

--- a/frontend/mocks/handlers/notification.handlers.ts
+++ b/frontend/mocks/handlers/notification.handlers.ts
@@ -1,0 +1,34 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Mock of the backend's server-push-only notification channel. Other
+ * handlers push events via `broadcastClientNotification`.
+ */
+
+import { ws } from 'msw'
+import type { ClientNotification } from '@/api/types/notification.types'
+import { API_ENDPOINTS } from '@/api/endpoints'
+
+// Leading `*` matches any scheme://host:port (dev, e2e and vitest all differ)
+const notificationSocket = ws.link(`*${API_ENDPOINTS.notification.ws}`)
+
+/** Push a notification to every connected mock client. */
+export function broadcastClientNotification(
+  notification: ClientNotification,
+): void {
+  notificationSocket.broadcast(JSON.stringify(notification))
+}
+
+export const notificationHandlers = [
+  notificationSocket.addEventListener('connection', () => {
+    // Server-push only — client messages are ignored, as on the backend.
+  }),
+]

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -138,6 +138,14 @@ export const API_ENDPOINTS = {
   },
 
   /**
+   * Notification push channel
+   */
+  notification: {
+    /** WS - Server-push ClientNotification stream */
+    ws: `${API_PREFIX}/notification/ws`,
+  },
+
+  /**
    * Job monitoring and execution endpoints
    */
   job: {

--- a/frontend/src/api/hooks/useArtifacts.ts
+++ b/frontend/src/api/hooks/useArtifacts.ts
@@ -184,6 +184,18 @@ const useDownloadStore = create<DownloadStore>()((set) => ({
 /** Module-level abort controllers — not in Zustand since they're not serialisable */
 const abortControllers = new Map<string, AbortController>()
 
+/** Wake functions of in-flight download polls, keyed like `abortControllers`. */
+const downloadWakers = new Map<string, () => void>()
+
+/**
+ * Re-poll an in-flight download immediately (the notification dispatcher
+ * calls this on artifactDownloadFinished); the poll response stays the
+ * source of truth. No-op when nothing is polling for the model.
+ */
+export function wakeDownloadPolling(compositeId: CompositeArtifactId): void {
+  downloadWakers.get(encodeArtifactId(compositeId))?.()
+}
+
 /**
  * Start a download polling loop for a model.
  * Runs independently of React component lifecycle.
@@ -220,11 +232,13 @@ async function startDownloadPolling(
           status: r.status,
         })
       },
+      onWake: (wake) => downloadWakers.set(key, wake),
     })
     onComplete?.()
     return response
   } finally {
     abortControllers.delete(key)
+    downloadWakers.delete(key)
     removePendingDownload(key)
     useDownloadStore.getState().removeProgress(key)
   }

--- a/frontend/src/api/hooks/useNotificationSocket.ts
+++ b/frontend/src/api/hooks/useNotificationSocket.ts
@@ -1,0 +1,17 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { useEffect } from 'react'
+import { acquireNotificationSocket } from '@/api/notifications/socket'
+
+/** Keeps the app-wide notification socket alive while mounted (refcounted; mount once in the authenticated layout). */
+export function useNotificationSocket(): void {
+  useEffect(() => acquireNotificationSocket(), [])
+}

--- a/frontend/src/api/notifications/dispatch.ts
+++ b/frontend/src/api/notifications/dispatch.ts
@@ -22,6 +22,7 @@ import type { ClientNotification } from '@/api/types/notification.types'
 import { clientNotificationSchema } from '@/api/types/notification.types'
 import { API_PREFIX } from '@/api/endpoints'
 import { artifactKeys, wakeDownloadPolling } from '@/api/hooks/useArtifacts'
+import { pluginKeys } from '@/api/hooks/usePlugins'
 import { createLogger } from '@/lib/logger'
 import { queryClient } from '@/lib/queryClient'
 
@@ -30,6 +31,8 @@ const log = createLogger('Notifications')
 /** Normalized backend refresh route -> query keys it makes stale. */
 const refreshRouteQueryKeys = new Map<string, ReadonlyArray<QueryKey>>([
   ['artifacts/list_models', [artifactKeys.list()]],
+  // plugin.pluginGlobalError — the listing's 60s staleTime would hide it.
+  ['plugin/list', [pluginKeys.list()]],
 ])
 
 /** Routes arrive as "api/v1/artifacts/list_models", with or without a leading slash. */

--- a/frontend/src/api/notifications/dispatch.ts
+++ b/frontend/src/api/notifications/dispatch.ts
@@ -1,0 +1,120 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * ClientNotification dispatch
+ *
+ * Notifications are cache-invalidation hints, never state: refreshRoutes
+ * map to query keys, server state keeps flowing through TanStack Query, so
+ * a missed notification is a slower update, not data loss. Unknown routes
+ * only log — each new backend producer costs one registry line.
+ */
+
+import type { QueryKey } from '@tanstack/react-query'
+import type { ClientNotification } from '@/api/types/notification.types'
+import { clientNotificationSchema } from '@/api/types/notification.types'
+import { API_PREFIX } from '@/api/endpoints'
+import { artifactKeys, wakeDownloadPolling } from '@/api/hooks/useArtifacts'
+import { createLogger } from '@/lib/logger'
+import { queryClient } from '@/lib/queryClient'
+
+const log = createLogger('Notifications')
+
+/** Normalized backend refresh route -> query keys it makes stale. */
+const refreshRouteQueryKeys = new Map<string, ReadonlyArray<QueryKey>>([
+  ['artifacts/list_models', [artifactKeys.list()]],
+])
+
+/** Routes arrive as "api/v1/artifacts/list_models", with or without a leading slash. */
+export function normalizeRefreshRoute(route: string): string {
+  const unslashed = route.startsWith('/') ? route.slice(1) : route
+  const prefix = `${API_PREFIX.slice(1)}/`
+  return unslashed.startsWith(prefix)
+    ? unslashed.slice(prefix.length)
+    : unslashed
+}
+
+/** Enrichment by `domain:event` — accelerative only, never load-bearing. */
+const domainHandlers = new Map<
+  string,
+  (notification: ClientNotification) => void
+>([
+  [
+    'artifact:artifactDownloadFinished',
+    (notification) => {
+      const { artifact_store_id, artifact_local_id } = notification.context
+      if (
+        typeof artifact_store_id !== 'string' ||
+        typeof artifact_local_id !== 'string'
+      ) {
+        log.warn('artifactDownloadFinished without artifact ids', {
+          context: notification.context,
+        })
+        return
+      }
+      // Nudge the in-flight poll; its response stays the source of truth
+      wakeDownloadPolling({ artifact_store_id, artifact_local_id })
+    },
+  ],
+])
+
+export function dispatchClientNotification(
+  notification: ClientNotification,
+): void {
+  for (const route of notification.refreshRoutes) {
+    const keys = refreshRouteQueryKeys.get(normalizeRefreshRoute(route))
+    if (!keys) {
+      log.warn('No query mapping for refresh route', {
+        route,
+        event: `${notification.sourceDomainName}:${notification.sourceDomainEvent}`,
+      })
+      continue
+    }
+    for (const queryKey of keys) {
+      queryClient.invalidateQueries({ queryKey })
+    }
+  }
+
+  domainHandlers.get(
+    `${notification.sourceDomainName}:${notification.sourceDomainEvent}`,
+  )?.(notification)
+}
+
+/** Raw frame -> validated notification -> dispatch; malformed input logs and drops. */
+export function handleNotificationSocketMessage(data: unknown): void {
+  if (typeof data !== 'string') {
+    log.warn('Ignoring non-text notification frame')
+    return
+  }
+  let json: unknown
+  try {
+    json = JSON.parse(data)
+  } catch {
+    log.warn('Ignoring unparseable notification frame', { data })
+    return
+  }
+  const parsed = clientNotificationSchema.safeParse(json)
+  if (!parsed.success) {
+    log.warn('Ignoring malformed notification', {
+      issues: parsed.error.issues,
+    })
+    return
+  }
+  dispatchClientNotification(parsed.data)
+}
+
+/** Invalidate every registered route — reconnects lose gap events (no replay). */
+export function resyncRegisteredRoutes(): void {
+  for (const keys of refreshRouteQueryKeys.values()) {
+    for (const queryKey of keys) {
+      queryClient.invalidateQueries({ queryKey })
+    }
+  }
+}

--- a/frontend/src/api/notifications/socket.ts
+++ b/frontend/src/api/notifications/socket.ts
@@ -1,0 +1,169 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Notification WebSocket transport
+ *
+ * Refcounted singleton to the backend's server-push channel. Messages are
+ * cache-invalidation hints with polling as the freshness floor, so a dead
+ * socket costs speed, not correctness — failures log, never toast.
+ * Reconnects: exponential backoff with jitter, immediate retry on
+ * online/tab-visible, resync of registered routes after reopen (no replay).
+ * A short release grace absorbs StrictMode remounts.
+ */
+
+import type { NotificationConnectionStatus } from '@/stores/notificationStore'
+import { API_ENDPOINTS } from '@/api/endpoints'
+import {
+  handleNotificationSocketMessage,
+  resyncRegisteredRoutes,
+} from '@/api/notifications/dispatch'
+import { createLogger } from '@/lib/logger'
+import { useNotificationStore } from '@/stores/notificationStore'
+
+const log = createLogger('NotificationSocket')
+
+const INITIAL_BACKOFF_MS = 1_000
+const MAX_BACKOFF_MS = 30_000
+/** An open connection must live this long before the backoff resets. */
+const BACKOFF_RESET_AFTER_MS = 10_000
+/** Grace before closing when the last consumer releases (StrictMode remount). */
+const RELEASE_GRACE_MS = 250
+
+let refCount = 0
+let socket: WebSocket | null = null
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+let backoffResetTimer: ReturnType<typeof setTimeout> | null = null
+let releaseTimer: ReturnType<typeof setTimeout> | null = null
+let attempt = 0
+let everOpened = false
+
+function socketUrl(): string {
+  const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+  return `${protocol}//${window.location.host}${API_ENDPOINTS.notification.ws}`
+}
+
+function setStatus(status: NotificationConnectionStatus): void {
+  useNotificationStore.getState().setStatus(status)
+}
+
+function clearTimer(timer: ReturnType<typeof setTimeout> | null): null {
+  if (timer !== null) clearTimeout(timer)
+  return null
+}
+
+function connect(): void {
+  if (socket !== null || refCount === 0) return
+  reconnectTimer = clearTimer(reconnectTimer)
+  // Reconnects keep their 'degraded' status until the socket actually opens
+  if (!everOpened) setStatus('connecting')
+
+  const ws = new WebSocket(socketUrl())
+  socket = ws
+
+  ws.addEventListener('open', () => {
+    if (socket !== ws) return
+    log.debug('Connected')
+    setStatus('connected')
+    // Gap events are lost — refetch everything push-driven
+    if (everOpened) resyncRegisteredRoutes()
+    everOpened = true
+    backoffResetTimer = setTimeout(() => {
+      attempt = 0
+    }, BACKOFF_RESET_AFTER_MS)
+  })
+
+  ws.addEventListener('message', (event) => {
+    if (socket !== ws) return
+    handleNotificationSocketMessage(event.data)
+  })
+
+  ws.addEventListener('close', () => {
+    if (socket !== ws) return
+    socket = null
+    backoffResetTimer = clearTimer(backoffResetTimer)
+    if (refCount === 0) {
+      setStatus('idle')
+      return
+    }
+    setStatus('degraded')
+    scheduleReconnect()
+  })
+}
+
+function scheduleReconnect(): void {
+  if (reconnectTimer !== null) return
+  const base = Math.min(MAX_BACKOFF_MS, INITIAL_BACKOFF_MS * 2 ** attempt)
+  const delay = base * (0.5 + Math.random() * 0.5)
+  attempt += 1
+  log.debug('Reconnecting', { inMs: Math.round(delay), attempt })
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null
+    connect()
+  }, delay)
+}
+
+/** Skip any pending backoff — used when the network/tab plausibly recovered. */
+function reconnectNow(): void {
+  if (refCount === 0 || socket !== null) return
+  reconnectTimer = clearTimer(reconnectTimer)
+  connect()
+}
+
+function handleOnline(): void {
+  reconnectNow()
+}
+
+function handleVisibilityChange(): void {
+  if (document.visibilityState === 'visible') reconnectNow()
+}
+
+function teardown(): void {
+  releaseTimer = null
+  if (refCount > 0) return
+  window.removeEventListener('online', handleOnline)
+  document.removeEventListener('visibilitychange', handleVisibilityChange)
+  reconnectTimer = clearTimer(reconnectTimer)
+  backoffResetTimer = clearTimer(backoffResetTimer)
+  attempt = 0
+  everOpened = false
+  const ws = socket
+  socket = null // detach first so the close listener no-ops
+  ws?.close()
+  setStatus('idle')
+}
+
+/** Keep the singleton alive; the returned release closes it shortly after the last consumer lets go. */
+export function acquireNotificationSocket(): () => void {
+  refCount += 1
+  releaseTimer = clearTimer(releaseTimer)
+  if (refCount === 1) {
+    window.addEventListener('online', handleOnline)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    connect()
+  }
+
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    refCount -= 1
+    if (refCount === 0) {
+      releaseTimer = setTimeout(teardown, RELEASE_GRACE_MS)
+    }
+  }
+}
+
+/** Test-only: tear down the singleton regardless of refcount. */
+export function resetNotificationSocketForTests(): void {
+  refCount = 0
+  releaseTimer = clearTimer(releaseTimer)
+  teardown()
+}

--- a/frontend/src/api/types/notification.types.ts
+++ b/frontend/src/api/types/notification.types.ts
@@ -1,0 +1,34 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Wire schema for the backend's ClientNotification (WS /notification/ws).
+ * Fields are camelCase on the wire, unlike the snake_case REST API;
+ * context is event-specific, so it stays an open record.
+ */
+
+import { z } from 'zod'
+
+export const clientNotificationSchema = z.object({
+  /** Full display text (untranslated backend English — fallback only). */
+  text: z.string(),
+  /** Domain as understood by the backend: artifact, plugin, run, ... */
+  sourceDomainName: z.string(),
+  /** Event name within the domain, e.g. artifactDownloadFinished. */
+  sourceDomainEvent: z.string(),
+  /** Event-specific payload. */
+  context: z.record(z.string(), z.unknown()),
+  /** Optional backend route with more detail (not directly visitable). */
+  detailRoute: z.string().nullable(),
+  /** Backend routes whose data this event staled, e.g. "api/v1/artifacts/list_models". */
+  refreshRoutes: z.array(z.string()),
+})
+
+export type ClientNotification = z.infer<typeof clientNotificationSchema>

--- a/frontend/src/components/common/CoreVersionMismatchBadge.tsx
+++ b/frontend/src/components/common/CoreVersionMismatchBadge.tsx
@@ -48,12 +48,12 @@ export function CoreVersionMismatchBadge({
 
   return (
     <Tooltip>
-      <TooltipTrigger>
+      {/* The trigger is the flex child, so w-fit and layout classes go here. */}
+      <TooltipTrigger className={cn('w-fit', className)}>
         <span
           className={cn(
             'inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium',
             'bg-amber-100 text-amber-700 dark:bg-amber-500/20 dark:text-amber-300',
-            className,
           )}
         >
           <AlertTriangle className="h-3.5 w-3.5" />

--- a/frontend/src/features/dashboard/components/PresetCard.tsx
+++ b/frontend/src/features/dashboard/components/PresetCard.tsx
@@ -79,18 +79,19 @@ export function PresetCard({
         </p>
       )}
 
-      <p className="text-sm text-muted-foreground">
-        {t('item.outputs', { count: outputCount })}
-        {parent?.display_name &&
-          ` · ${t('dashboard:presets.basedOn', { name: parent.display_name })}`}
-      </p>
-
-      {preset.coreVersionMismatch && (
-        <CoreVersionMismatchBadge
-          detail={preset.coreVersionMismatch}
-          className="self-start"
-        />
-      )}
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+        <p className="text-sm text-muted-foreground">
+          {t('item.outputs', { count: outputCount })}
+          {parent?.display_name &&
+            ` · ${t('dashboard:presets.basedOn', { name: parent.display_name })}`}
+        </p>
+        {preset.coreVersionMismatch && (
+          <CoreVersionMismatchBadge
+            detail={preset.coreVersionMismatch}
+            className="ml-auto"
+          />
+        )}
+      </div>
 
       {(modelLabel || outputKinds.length > 0 || preset.tags.length > 0) && (
         <div className="flex flex-wrap gap-1.5">

--- a/frontend/src/features/plugins/utils/plugin-sort.ts
+++ b/frontend/src/features/plugins/utils/plugin-sort.ts
@@ -1,0 +1,24 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/** Ordering for the installed-plugins table. */
+
+import type { PluginInfo } from '@/api/types/plugins.types'
+
+/**
+ * Updatable first, then by name. Deliberately ignores `isEnabled`: sorting on
+ * state the row's own toggle flips makes plugins jump position mid-interaction.
+ */
+export function compareInstalledPlugins(a: PluginInfo, b: PluginInfo): number {
+  if (a.hasUpdate !== b.hasUpdate) {
+    return a.hasUpdate ? -1 : 1
+  }
+  return a.name.localeCompare(b.name)
+}

--- a/frontend/src/routes/_authenticated.tsx
+++ b/frontend/src/routes/_authenticated.tsx
@@ -23,6 +23,7 @@ import { DashboardLayout } from '@/components/layout/DashboardLayout'
 import { OnboardingController } from '@/features/onboarding/OnboardingController'
 import { useConfigStore } from '@/stores/configStore'
 import { checkSession } from '@/api/endpoints/auth'
+import { useNotificationSocket } from '@/api/hooks/useNotificationSocket'
 import { readAnonymousId } from '@/lib/anonymous-id'
 import { createLogger } from '@/lib/logger'
 import { isValidInternalRedirect } from '@/lib/utils'
@@ -51,6 +52,9 @@ function isAnonymousUser(): boolean {
  */
 function AuthenticatedLayout() {
   const { t } = useTranslation('dashboard')
+
+  // Server-push notifications live as long as any authenticated page does.
+  useNotificationSocket()
 
   return (
     <DashboardLayout

--- a/frontend/src/routes/_authenticated/admin/plugins.index.tsx
+++ b/frontend/src/routes/_authenticated/admin/plugins.index.tsx
@@ -46,6 +46,7 @@ import { PluginsList } from '@/features/plugins/components/PluginsList'
 import { UninstalledPluginsSection } from '@/features/plugins/components/UninstalledPluginsSection'
 import { UpdatesAvailableSection } from '@/features/plugins/components/UpdatesAvailableSection'
 import { pluginFailureDescription } from '@/features/plugins/utils/plugin-activity'
+import { compareInstalledPlugins } from '@/features/plugins/utils/plugin-sort'
 import { useActivityStore } from '@/stores/activityStore'
 import { useUiStore } from '@/stores/uiStore'
 import { getPluginStatusError } from '@/types/status.types'
@@ -154,16 +155,7 @@ function PluginsPage() {
     const withUpdates = filteredPlugins.filter((p) => p.hasUpdate)
     const installed = filteredPlugins
 
-    // Sort: updatable first, then enabled, then by name
-    installed.sort((a, b) => {
-      if (a.hasUpdate !== b.hasUpdate) {
-        return a.hasUpdate ? -1 : 1
-      }
-      if (a.isEnabled !== b.isEnabled) {
-        return a.isEnabled ? -1 : 1
-      }
-      return a.name.localeCompare(b.name)
-    })
+    installed.sort(compareInstalledPlugins)
 
     return {
       pluginsWithUpdates: filteringAvailable ? [] : withUpdates,

--- a/frontend/src/stores/notificationStore.ts
+++ b/frontend/src/stores/notificationStore.ts
@@ -1,0 +1,42 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Connection state of the notification WebSocket. Written by the socket
+ * transport; read wherever push-vs-poll behaviour matters.
+ */
+
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+
+export type NotificationConnectionStatus =
+  /** No consumer holds the socket (logged out / not mounted). */
+  | 'idle'
+  /** First connection attempt, nothing received yet. */
+  | 'connecting'
+  /** Live push channel. */
+  | 'connected'
+  /** Connection lost while consumers exist — reconnecting, polling covers. */
+  | 'degraded'
+
+interface NotificationState {
+  status: NotificationConnectionStatus
+  setStatus: (status: NotificationConnectionStatus) => void
+}
+
+export const useNotificationStore = create<NotificationState>()(
+  devtools(
+    (set) => ({
+      status: 'idle',
+      setStatus: (status) => set({ status }, undefined, 'setStatus'),
+    }),
+    { name: 'NotificationStore' },
+  ),
+)

--- a/frontend/src/utils/polling.ts
+++ b/frontend/src/utils/polling.ts
@@ -44,6 +44,9 @@ export interface CreatePollingTaskOptions<T> {
   signal: AbortSignal
   /** Invoked with every polled value, including the terminal one. */
   onProgress?: (result: T) => void
+  /** Receives a `wake()` that ends the current between-poll delay early,
+   *  triggering an immediate re-poll. Called once, before the first poll. */
+  onWake?: (wake: () => void) => void
 }
 
 /**
@@ -59,12 +62,20 @@ export async function createPollingTask<T>({
   interval,
   signal,
   onProgress,
+  onWake,
 }: CreatePollingTaskOptions<T>): Promise<T> {
+  let wake: (() => void) | null = null
+  onWake?.(() => wake?.())
   for (;;) {
     signal.throwIfAborted()
     const result = await poll()
     onProgress?.(result)
     if (until(result)) return result
-    await wait(interval, signal)
+    // A wake during an in-flight poll is a no-op: that poll is already fresh
+    await new Promise<void>((resolve, reject) => {
+      wake = resolve
+      wait(interval, signal).then(resolve, reject)
+    })
+    wake = null
   }
 }

--- a/frontend/tests/integration/api/notification-socket.test.ts
+++ b/frontend/tests/integration/api/notification-socket.test.ts
@@ -1,0 +1,62 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Runs the real transport against the MSW WebSocket mock: proves the link
+ * pattern intercepts the app's URL (a mismatch silently bypasses MSW) and
+ * that a broadcast flows through parse -> dispatch -> invalidation.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { broadcastClientNotification } from '../../../mocks/handlers/notification.handlers'
+import { artifactKeys } from '@/api/hooks/useArtifacts'
+import {
+  acquireNotificationSocket,
+  resetNotificationSocketForTests,
+} from '@/api/notifications/socket'
+import { queryClient } from '@/lib/queryClient'
+import { useNotificationStore } from '@/stores/notificationStore'
+
+describe('notification socket against the MSW mock', () => {
+  afterEach(() => {
+    resetNotificationSocketForTests()
+    vi.restoreAllMocks()
+  })
+
+  it('connects through the mock and dispatches broadcast notifications', async () => {
+    const invalidateSpy = vi
+      .spyOn(queryClient, 'invalidateQueries')
+      .mockResolvedValue()
+
+    acquireNotificationSocket()
+    await vi.waitFor(() => {
+      expect(useNotificationStore.getState().status).toBe('connected')
+    })
+
+    broadcastClientNotification({
+      text: 'Artifact model-a finished downloading successfully',
+      sourceDomainName: 'artifact',
+      sourceDomainEvent: 'artifactDownloadFinished',
+      context: {
+        artifact_store_id: 'store-1',
+        artifact_local_id: 'model-a',
+        success: true,
+      },
+      detailRoute: 'api/v1/artifacts/model_details',
+      refreshRoutes: ['api/v1/artifacts/list_models'],
+    })
+
+    await vi.waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: artifactKeys.list(),
+      })
+    })
+  })
+})

--- a/frontend/tests/integration/features/plugins/plugin-updates.test.tsx
+++ b/frontend/tests/integration/features/plugins/plugin-updates.test.tsx
@@ -50,6 +50,7 @@ import { Button } from '@/components/ui/button'
 import { LoadingSpinner } from '@/components/common/LoadingSpinner'
 import { PageHeader } from '@/components/common/PageHeader'
 import { PluginsFilters } from '@/features/plugins/components/PluginsFilters'
+import { compareInstalledPlugins } from '@/features/plugins/utils/plugin-sort'
 import { PluginsList } from '@/features/plugins/components/PluginsList'
 import { UninstalledPluginsSection } from '@/features/plugins/components/UninstalledPluginsSection'
 import { UpdatesAvailableSection } from '@/features/plugins/components/UpdatesAvailableSection'
@@ -150,15 +151,7 @@ function TestPluginsPage() {
     const withUpdates = filteredPlugins.filter((p) => p.hasUpdate)
     const installed = filteredPlugins
 
-    installed.sort((a, b) => {
-      if (a.hasUpdate !== b.hasUpdate) {
-        return a.hasUpdate ? -1 : 1
-      }
-      if (a.isEnabled !== b.isEnabled) {
-        return a.isEnabled ? -1 : 1
-      }
-      return a.name.localeCompare(b.name)
-    })
+    installed.sort(compareInstalledPlugins)
 
     return {
       pluginsWithUpdates: filteringAvailable ? [] : withUpdates,

--- a/frontend/tests/integration/features/plugins/plugins-management.test.tsx
+++ b/frontend/tests/integration/features/plugins/plugins-management.test.tsx
@@ -46,6 +46,7 @@ import { Button } from '@/components/ui/button'
 import { LoadingSpinner } from '@/components/common/LoadingSpinner'
 import { PageHeader } from '@/components/common/PageHeader'
 import { PluginsFilters } from '@/features/plugins/components/PluginsFilters'
+import { compareInstalledPlugins } from '@/features/plugins/utils/plugin-sort'
 import { PluginsList } from '@/features/plugins/components/PluginsList'
 import { UninstalledPluginsSection } from '@/features/plugins/components/UninstalledPluginsSection'
 import { UpdatesAvailableSection } from '@/features/plugins/components/UpdatesAvailableSection'
@@ -134,15 +135,7 @@ function TestPluginsPage() {
     const withUpdates = filteredPlugins.filter((p) => p.hasUpdate)
     const installed = filteredPlugins
 
-    installed.sort((a, b) => {
-      if (a.hasUpdate !== b.hasUpdate) {
-        return a.hasUpdate ? -1 : 1
-      }
-      if (a.isEnabled !== b.isEnabled) {
-        return a.isEnabled ? -1 : 1
-      }
-      return a.name.localeCompare(b.name)
-    })
+    installed.sort(compareInstalledPlugins)
 
     return {
       pluginsWithUpdates: filteringAvailable ? [] : withUpdates,

--- a/frontend/tests/unit/api/notifications/dispatch.test.ts
+++ b/frontend/tests/unit/api/notifications/dispatch.test.ts
@@ -18,6 +18,7 @@ import {
   resyncRegisteredRoutes,
 } from '@/api/notifications/dispatch'
 import { artifactKeys, wakeDownloadPolling } from '@/api/hooks/useArtifacts'
+import { pluginKeys } from '@/api/hooks/usePlugins'
 import { queryClient } from '@/lib/queryClient'
 
 vi.mock('@/api/hooks/useArtifacts', async (importOriginal) => {
@@ -85,6 +86,22 @@ describe('dispatchClientNotification', () => {
     dispatchClientNotification(notification())
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: artifactKeys.list(),
+    })
+  })
+
+  it('invalidates the plugin listing on a plugin global error', () => {
+    dispatchClientNotification(
+      notification({
+        text: 'Initial plugin load failed: environment already broken',
+        sourceDomainName: 'plugin',
+        sourceDomainEvent: 'pluginGlobalError',
+        context: { trigger: 'Initial plugin load', error: 'broken' },
+        detailRoute: 'api/v1/plugin/list',
+        refreshRoutes: ['api/v1/plugin/list'],
+      }),
+    )
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: pluginKeys.list(),
     })
   })
 

--- a/frontend/tests/unit/api/notifications/dispatch.test.ts
+++ b/frontend/tests/unit/api/notifications/dispatch.test.ts
@@ -1,0 +1,164 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MockInstance } from 'vitest'
+import type { ClientNotification } from '@/api/types/notification.types'
+import {
+  dispatchClientNotification,
+  handleNotificationSocketMessage,
+  normalizeRefreshRoute,
+  resyncRegisteredRoutes,
+} from '@/api/notifications/dispatch'
+import { artifactKeys, wakeDownloadPolling } from '@/api/hooks/useArtifacts'
+import { queryClient } from '@/lib/queryClient'
+
+vi.mock('@/api/hooks/useArtifacts', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, wakeDownloadPolling: vi.fn() }
+})
+
+// Wipe the module-mock's call history, which restoreAllMocks leaves alone
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+function notification(
+  overrides: Partial<ClientNotification> = {},
+): ClientNotification {
+  return {
+    text: 'Artifact model-a finished downloading successfully',
+    sourceDomainName: 'artifact',
+    sourceDomainEvent: 'artifactDownloadFinished',
+    context: {
+      artifact_store_id: 'store-1',
+      artifact_local_id: 'model-a',
+      success: true,
+    },
+    detailRoute: 'api/v1/artifacts/model_details',
+    refreshRoutes: ['api/v1/artifacts/list_models'],
+    ...overrides,
+  }
+}
+
+describe('normalizeRefreshRoute', () => {
+  it('strips the api prefix', () => {
+    expect(normalizeRefreshRoute('api/v1/artifacts/list_models')).toBe(
+      'artifacts/list_models',
+    )
+  })
+
+  it('tolerates a leading slash', () => {
+    expect(normalizeRefreshRoute('/api/v1/artifacts/list_models')).toBe(
+      'artifacts/list_models',
+    )
+  })
+
+  it('passes through already-bare routes', () => {
+    expect(normalizeRefreshRoute('artifacts/list_models')).toBe(
+      'artifacts/list_models',
+    )
+  })
+})
+
+describe('dispatchClientNotification', () => {
+  let invalidateSpy: MockInstance
+
+  beforeEach(() => {
+    invalidateSpy = vi
+      .spyOn(queryClient, 'invalidateQueries')
+      .mockResolvedValue()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('invalidates the queries mapped to each refresh route', () => {
+    dispatchClientNotification(notification())
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: artifactKeys.list(),
+    })
+  })
+
+  it('ignores unmapped refresh routes without invalidating', () => {
+    dispatchClientNotification(
+      notification({ refreshRoutes: ['api/v1/some/unknown_route'] }),
+    )
+    expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+
+  it('wakes the download poll for artifactDownloadFinished', () => {
+    dispatchClientNotification(notification())
+    expect(wakeDownloadPolling).toHaveBeenCalledWith({
+      artifact_store_id: 'store-1',
+      artifact_local_id: 'model-a',
+    })
+  })
+
+  it('skips the wake when the context lacks artifact ids', () => {
+    dispatchClientNotification(notification({ context: { success: true } }))
+    expect(wakeDownloadPolling).not.toHaveBeenCalled()
+  })
+
+  it('runs no domain handler for unknown events', () => {
+    dispatchClientNotification(
+      notification({ sourceDomainEvent: 'somethingElse' }),
+    )
+    expect(wakeDownloadPolling).not.toHaveBeenCalled()
+    // Generic invalidation still applies
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: artifactKeys.list(),
+    })
+  })
+})
+
+describe('handleNotificationSocketMessage', () => {
+  let invalidateSpy: MockInstance
+
+  beforeEach(() => {
+    invalidateSpy = vi
+      .spyOn(queryClient, 'invalidateQueries')
+      .mockResolvedValue()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('parses and dispatches a valid frame', () => {
+    handleNotificationSocketMessage(JSON.stringify(notification()))
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: artifactKeys.list(),
+    })
+  })
+
+  it.each([
+    ['non-text frame', new Blob(['x'])],
+    ['unparseable JSON', '{not json'],
+    ['schema-invalid object', JSON.stringify({ text: 'only text' })],
+  ])('drops a %s without throwing', (_label, frame) => {
+    expect(() => handleNotificationSocketMessage(frame)).not.toThrow()
+    expect(invalidateSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('resyncRegisteredRoutes', () => {
+  it('invalidates every registered route', () => {
+    const invalidateSpy = vi
+      .spyOn(queryClient, 'invalidateQueries')
+      .mockResolvedValue()
+    resyncRegisteredRoutes()
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: artifactKeys.list(),
+    })
+    vi.restoreAllMocks()
+  })
+})

--- a/frontend/tests/unit/api/notifications/socket.test.ts
+++ b/frontend/tests/unit/api/notifications/socket.test.ts
@@ -1,0 +1,189 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  acquireNotificationSocket,
+  resetNotificationSocketForTests,
+} from '@/api/notifications/socket'
+import { artifactKeys } from '@/api/hooks/useArtifacts'
+import { queryClient } from '@/lib/queryClient'
+import { useNotificationStore } from '@/stores/notificationStore'
+
+/** Records instances and lets tests fire open/message/close; never touches the network. */
+class FakeWebSocket extends EventTarget {
+  static instances: Array<FakeWebSocket> = []
+  url: string
+  closed = false
+
+  constructor(url: string) {
+    super()
+    this.url = url
+    FakeWebSocket.instances.push(this)
+  }
+
+  close(): void {
+    this.closed = true
+  }
+
+  open(): void {
+    this.dispatchEvent(new Event('open'))
+  }
+
+  message(data: unknown): void {
+    this.dispatchEvent(new MessageEvent('message', { data }))
+  }
+
+  closeFromServer(): void {
+    this.dispatchEvent(new CloseEvent('close'))
+  }
+}
+
+function status() {
+  return useNotificationStore.getState().status
+}
+
+function lastSocket(): FakeWebSocket {
+  return FakeWebSocket.instances[FakeWebSocket.instances.length - 1]
+}
+
+describe('notification socket', () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = []
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+    vi.useFakeTimers()
+    // Kill jitter: backoff factor (0.5 + random * 0.5) becomes exactly 1
+    vi.spyOn(Math, 'random').mockReturnValue(1)
+  })
+
+  afterEach(() => {
+    resetNotificationSocketForTests()
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('connects to the notification endpoint on acquire', () => {
+    acquireNotificationSocket()
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    expect(lastSocket().url).toMatch(/^ws:\/\/.+\/api\/v1\/notification\/ws$/)
+    expect(status()).toBe('connecting')
+  })
+
+  it('reports connected on open and degraded on close', () => {
+    acquireNotificationSocket()
+    lastSocket().open()
+    expect(status()).toBe('connected')
+    lastSocket().closeFromServer()
+    expect(status()).toBe('degraded')
+  })
+
+  it('dispatches received notifications into query invalidation', () => {
+    const invalidateSpy = vi
+      .spyOn(queryClient, 'invalidateQueries')
+      .mockResolvedValue()
+    acquireNotificationSocket()
+    lastSocket().open()
+    lastSocket().message(
+      JSON.stringify({
+        text: 'Artifact model-a finished downloading successfully',
+        sourceDomainName: 'artifact',
+        sourceDomainEvent: 'artifactDownloadFinished',
+        context: {},
+        detailRoute: null,
+        refreshRoutes: ['api/v1/artifacts/list_models'],
+      }),
+    )
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: artifactKeys.list(),
+    })
+  })
+
+  it('reconnects with growing backoff after repeated closes', () => {
+    acquireNotificationSocket()
+    lastSocket().open()
+
+    // First drop: reconnect after 1s
+    lastSocket().closeFromServer()
+    vi.advanceTimersByTime(999)
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    vi.advanceTimersByTime(1)
+    expect(FakeWebSocket.instances).toHaveLength(2)
+
+    // Second drop without a stable connection in between: 2s
+    lastSocket().closeFromServer()
+    vi.advanceTimersByTime(1_999)
+    expect(FakeWebSocket.instances).toHaveLength(2)
+    vi.advanceTimersByTime(1)
+    expect(FakeWebSocket.instances).toHaveLength(3)
+  })
+
+  it('resets the backoff once a connection stays open', () => {
+    acquireNotificationSocket()
+    lastSocket().open()
+    lastSocket().closeFromServer()
+    vi.advanceTimersByTime(1_000) // attempt 1 fires
+
+    // Stays open past the stability window -> attempt counter resets
+    lastSocket().open()
+    vi.advanceTimersByTime(10_000)
+
+    lastSocket().closeFromServer()
+    vi.advanceTimersByTime(1_000) // back to the initial 1s delay
+    expect(FakeWebSocket.instances).toHaveLength(3)
+  })
+
+  it('resyncs registered routes after a reconnect, not on first open', () => {
+    const invalidateSpy = vi
+      .spyOn(queryClient, 'invalidateQueries')
+      .mockResolvedValue()
+    acquireNotificationSocket()
+    lastSocket().open()
+    expect(invalidateSpy).not.toHaveBeenCalled()
+
+    lastSocket().closeFromServer()
+    vi.advanceTimersByTime(1_000)
+    lastSocket().open()
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: artifactKeys.list(),
+    })
+  })
+
+  it('reconnects immediately when the network comes back online', () => {
+    acquireNotificationSocket()
+    lastSocket().open()
+    lastSocket().closeFromServer()
+    // Long backoff pending; online event short-circuits it
+    window.dispatchEvent(new Event('online'))
+    expect(FakeWebSocket.instances).toHaveLength(2)
+  })
+
+  it('survives a StrictMode remount without a second connection', () => {
+    const release = acquireNotificationSocket()
+    release()
+    acquireNotificationSocket()
+    vi.advanceTimersByTime(1_000)
+    expect(FakeWebSocket.instances).toHaveLength(1)
+    expect(lastSocket().closed).toBe(false)
+  })
+
+  it('closes and goes idle after the last release', () => {
+    const release = acquireNotificationSocket()
+    lastSocket().open()
+    release()
+    vi.advanceTimersByTime(250)
+    expect(lastSocket().closed).toBe(true)
+    expect(status()).toBe('idle')
+
+    // No reconnect attempts afterwards
+    vi.advanceTimersByTime(60_000)
+    expect(FakeWebSocket.instances).toHaveLength(1)
+  })
+})

--- a/frontend/tests/unit/features/plugins/plugin-sort.test.ts
+++ b/frontend/tests/unit/features/plugins/plugin-sort.test.ts
@@ -1,0 +1,70 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { PluginInfo } from '@/api/types/plugins.types'
+import { compareInstalledPlugins } from '@/features/plugins/utils/plugin-sort'
+
+function plugin(overrides: Partial<PluginInfo> = {}): PluginInfo {
+  return {
+    id: { store: 'ecmwf', local: 'demo' },
+    displayId: 'ecmwf/demo',
+    name: 'Demo Plugin',
+    description: '',
+    author: 'ECMWF',
+    version: '0.0.0',
+    latestVersion: null,
+    capabilities: [],
+    status: 'loaded',
+    isEnabled: true,
+    isInstalled: true,
+    hasUpdate: false,
+    updatedAt: null,
+    errorDetail: null,
+    errorSeverity: null,
+    comment: null,
+    pipSource: null,
+    moduleName: null,
+    ...overrides,
+  }
+}
+
+const names = (list: Array<PluginInfo>) =>
+  [...list].sort(compareInstalledPlugins).map((p) => p.name)
+
+describe('compareInstalledPlugins', () => {
+  it('orders by name', () => {
+    const list = [
+      plugin({ name: 'ECMWF Plugin' }),
+      plugin({ name: 'Demo Plugin' }),
+    ]
+    expect(names(list)).toEqual(['Demo Plugin', 'ECMWF Plugin'])
+  })
+
+  it('floats updatable plugins above the rest', () => {
+    const list = [
+      plugin({ name: 'Demo Plugin' }),
+      plugin({ name: 'ECMWF Plugin', hasUpdate: true }),
+    ]
+    expect(names(list)).toEqual(['ECMWF Plugin', 'Demo Plugin'])
+  })
+
+  it('keeps a plugin in place when it is disabled', () => {
+    const enabled = [
+      plugin({ name: 'ECMWF Plugin', isEnabled: true }),
+      plugin({ name: 'Demo Plugin', isEnabled: false }),
+    ]
+    const toggled = [
+      plugin({ name: 'ECMWF Plugin', isEnabled: false }),
+      plugin({ name: 'Demo Plugin', isEnabled: false }),
+    ]
+    expect(names(toggled)).toEqual(names(enabled))
+  })
+})

--- a/frontend/tests/unit/utils/polling.test.ts
+++ b/frontend/tests/unit/utils/polling.test.ts
@@ -110,4 +110,40 @@ describe('createPollingTask', () => {
       }),
     ).rejects.toThrow('boom')
   })
+
+  it('wake() ends the between-poll delay early', async () => {
+    let n = 0
+    let wake: (() => void) | null = null
+    const controller = new AbortController()
+
+    const task = createPollingTask<number>({
+      poll: () => Promise.resolve(++n),
+      until: (v) => v >= 2,
+      // Far beyond the test timeout — only a wake can finish this quickly
+      interval: 600_000,
+      signal: controller.signal,
+      onWake: (w) => {
+        wake = w
+      },
+    })
+    setTimeout(() => wake?.(), 20)
+
+    expect(await task).toBe(2)
+  })
+
+  it('aborting rejects even while a wake is registered', async () => {
+    let n = 0
+    const controller = new AbortController()
+
+    const task = createPollingTask<number>({
+      poll: () => Promise.resolve(++n),
+      until: (v) => v >= 2,
+      interval: 600_000,
+      signal: controller.signal,
+      onWake: () => {},
+    })
+    setTimeout(() => controller.abort(), 20)
+
+    await expect(task).rejects.toThrow(/aborted/i)
+  })
 })

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -121,6 +121,8 @@ export default defineConfig(({ mode }) => {
             target: env.VITE_API_BASE || 'http://localhost:8000',
             changeOrigin: true,
             secure: false,
+            // Forward WebSocket upgrades (notification push channel)
+            ws: true,
             cookieDomainRewrite: 'localhost',
             // Rewrite Location headers in redirect responses to use the proxy host
             // This fixes issues with backend 303 redirects containing absolute URLs to port 8000


### PR DESCRIPTION
### Description

Connects the frontend to the backend's `/notification/ws` channel, plus two small UI fixes found while testing against a live backend.

### Notifications

Notifications are treated as **cache-invalidation hints, never state**: a notification's `refreshRoutes` map to query keys, server state keeps flowing through TanStack Query, so a missed notification means a slower update rather than lost data. The socket reconnects with backoff and re-invalidates every registered route on reconnect. Malformed frames are validated away with Zod and logged.

Two producers are wired today. `artifact:artifactDownloadFinished` wakes the in-flight download poll — the poll's own response stays the source of truth, the notification only accelerates it. `plugin:pluginGlobalError`, added by #641 whenever the plugin updater thread fails, invalidates the plugin listing, which would otherwise sit on its 60 s `staleTime` while the Plugin Store showed nothing wrong. The polled `/status` route needs no mapping: it carries the same failure text and self-heals on its refetch interval.

Each new backend producer costs one line in the route registry. Unregistered routes log and continue rather than failing.

### Plugin table: rows no longer jump when toggled

The installed-plugins table sorted on `isEnabled`, so disabling a plugin re-sorted it under the cursor and you had to search for the row before you could re-enable it. 

### Core-version-mismatch badge alignment

Core-version-mismatch badge is now on the same row as the outputs row, right-aligned. 

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
