### PR TITLE
backend: type-check tests with ty; fix test typing issues

### DIFF
--- a/backend/justfile
+++ b/backend/justfile
@@ -1,5 +1,7 @@
 val:
     uv run ty check src/
+    uv run ty check tests/unit
+    uv run ty check tests/integration
     just test
 
 test:

--- a/backend/tests/unit/domain/blueprint/test_configuration_values.py
+++ b/backend/tests/unit/domain/blueprint/test_configuration_values.py
@@ -7,6 +7,7 @@ from fiab_core.fable import (
     BlockInstance,
     ConfigurationOptionId,
 )
+from fiab_core.types.definitions import IntType, StringType
 
 from forecastbox.domain.blueprint.configuration_values import convert_known_configuration_values
 
@@ -27,8 +28,8 @@ def _make_factory() -> BlockFactory:
         title="Increment",
         description="Adds amount",
         configuration_options={
-            AMOUNT: BlockConfigurationOption(title="", description="", value_type="int"),
-            TEXT: BlockConfigurationOption(title="", description="", value_type="str"),
+            AMOUNT: BlockConfigurationOption(title="", description="", value_type=IntType()),
+            TEXT: BlockConfigurationOption(title="", description="", value_type=StringType()),
         },
         inputs=["a"],
     )

--- a/backend/tests/unit/domain/plugins/test_plugin_db.py
+++ b/backend/tests/unit/domain/plugins/test_plugin_db.py
@@ -22,7 +22,7 @@ from sqlalchemy.pool import StaticPool
 
 import forecastbox.domain.plugin.db as plugin_db
 import forecastbox.schemata.jobs as _jobs_module
-from forecastbox.domain.plugin.errors import PluginError
+from forecastbox.domain.plugin.errors import PluginError, PluginErrors
 from forecastbox.domain.plugin.exceptions import PluginNotFound
 from forecastbox.schemata.jobs import Base
 from forecastbox.schemata.plugin import PluginState
@@ -76,7 +76,7 @@ def test_upsert_updates_version_without_clobbering(mem_session_maker: sessionmak
         session.commit()
 
     # Re-install (update) -- new version triggers asset_ingest_needed=True
-    plugin_db.upsert_plugin_state(plugin_id="myStore:myPlugin", version="0.2.0", plugin_errors=[])
+    plugin_db.upsert_plugin_state(plugin_id="myStore:myPlugin", version="0.2.0", plugin_errors=PluginErrors([]))
 
     state = plugin_db.get_plugin_state("myStore:myPlugin")
     assert state is not None
@@ -123,7 +123,7 @@ def test_upsert_none_version_on_missing_row_raises(mem_session_maker: sessionmak
 def test_upsert_persists_plugin_errors(mem_session_maker: sessionmaker[Session]) -> None:
     """An install failure writes structured errors and records the attempt."""
     install_err = PluginError(source="install", severity="error", detail="pip failed: some reason")
-    plugin_db.upsert_plugin_state(plugin_id="bad:plugin", version="unknown", enabled=True, plugin_errors=[install_err])
+    plugin_db.upsert_plugin_state(plugin_id="bad:plugin", version="unknown", enabled=True, plugin_errors=PluginErrors([install_err]))
 
     state = plugin_db.get_plugin_state("bad:plugin")
     assert state is not None
@@ -135,14 +135,14 @@ def test_upsert_persists_plugin_errors(mem_session_maker: sessionmaker[Session])
 def test_upsert_clears_plugin_errors_with_empty_list(mem_session_maker: sessionmaker[Session]) -> None:
     """Passing plugin_errors=[] clears previously stored errors; passing None leaves them untouched."""
     old_err = PluginError(source="install", severity="error", detail="old error")
-    plugin_db.upsert_plugin_state(plugin_id="bad:plugin", version="0.1.0", plugin_errors=[old_err])
+    plugin_db.upsert_plugin_state(plugin_id="bad:plugin", version="0.1.0", plugin_errors=PluginErrors([old_err]))
     # None should not touch the errors
     plugin_db.upsert_plugin_state(plugin_id="bad:plugin")
     state = plugin_db.get_plugin_state("bad:plugin")
     assert state is not None
     assert state.plugin_errors == [old_err.model_dump()]
     # [] should clear them
-    plugin_db.upsert_plugin_state(plugin_id="bad:plugin", plugin_errors=[])
+    plugin_db.upsert_plugin_state(plugin_id="bad:plugin", plugin_errors=PluginErrors([]))
     state = plugin_db.get_plugin_state("bad:plugin")
     assert state is not None
     assert state.plugin_errors == []
@@ -155,7 +155,7 @@ def test_get_all_plugin_states(mem_session_maker: sessionmaker[Session]) -> None
         plugin_id="storeA:p2",
         version="unknown",
         enabled=True,
-        plugin_errors=[PluginError(source="install", severity="error", detail="err")],
+        plugin_errors=PluginErrors([PluginError(source="install", severity="error", detail="err")]),
     )
 
     states = plugin_db.get_all_plugin_states()

--- a/backend/tests/unit/domain/plugins/test_plugin_detail.py
+++ b/backend/tests/unit/domain/plugins/test_plugin_detail.py
@@ -14,7 +14,7 @@ fields derived from the in-memory plugin state and DB rows.
 """
 
 import threading
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, _patch, patch
 
 import pytest
 from fiab_core.fable import (
@@ -80,15 +80,15 @@ def _make_db_state(
     return state
 
 
-def _patch_db(states: list[MagicMock]) -> object:
+def _patch_db(states: list[MagicMock]) -> _patch:
     return patch("forecastbox.domain.plugin.detail.get_all_plugin_states", new=AsyncMock(return_value=states))
 
 
-def _patch_store(detail: dict | None = None) -> object:
+def _patch_store(detail: dict | None = None) -> _patch:
     return patch("forecastbox.domain.plugin.detail.get_plugins_detail", return_value=detail or {})
 
 
-def _patch_time() -> object:
+def _patch_time() -> _patch:
     return patch("forecastbox.domain.plugin.detail.value_dt2str", return_value="2024-01-01T00:00:00")
 
 

--- a/backend/tests/unit/domain/plugins/test_plugin_operations.py
+++ b/backend/tests/unit/domain/plugins/test_plugin_operations.py
@@ -14,7 +14,7 @@ managed-operation wrapper's error/notification behaviour, and that update/unload
 uninstall use the correct pool/task names without creating or joining a thread.
 """
 
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from concurrent.futures import Future
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -195,7 +195,7 @@ async def test_submit_unload_single_available_after_prior_update_failure() -> No
         patch.object(submit_module, "unload_single") as mock_unload_single,
     ):
 
-        async def _run(pool_name: object, task_name: object, task: object) -> None:
+        async def _run(pool_name: object, task_name: object, task: Callable[[], object]) -> None:
             task()
 
         mock_await_submit.side_effect = _run
@@ -223,7 +223,7 @@ async def test_submit_uninstall_single_uses_plugin_management_pool_and_task_name
         patch.object(submit_module, "uninstall_plugin_sync") as mock_uninstall_sync,
     ):
 
-        async def _run(pool_name: object, task_name: object, task: object) -> None:
+        async def _run(pool_name: object, task_name: object, task: Callable[[], object]) -> None:
             task()
 
         mock_await_submit.side_effect = _run

--- a/backend/tests/unit/domain/run/test_compile.py
+++ b/backend/tests/unit/domain/run/test_compile.py
@@ -16,6 +16,7 @@ from fiab_core.fable import (
     PluginCompositeId,
 )
 from fiab_core.plugin import BlockValidation, Plugin
+from fiab_core.types.definitions import IntType
 from pyrsistent import pmap
 
 from forecastbox.domain.blueprint.service import BlueprintBuilder, RoutableBlock
@@ -158,7 +159,7 @@ def test_compile_builder_fails_missing_config_before_plugin_compile(monkeypatch:
                     title="",
                     description="",
                     configuration_options={
-                        option_id: BlockConfigurationOption(title="", description="", value_type="int"),
+                        option_id: BlockConfigurationOption(title="", description="", value_type=IntType()),
                     },
                     inputs=[],
                 )

--- a/backend/tests/unit/domain/run/test_run_detailed_report.py
+++ b/backend/tests/unit/domain/run/test_run_detailed_report.py
@@ -10,12 +10,12 @@ from fiab_core.fable import BlockInstanceId
 
 from forecastbox.domain.blueprint.types import BlueprintId
 from forecastbox.domain.run import service as run_service
+from forecastbox.domain.run.db import RunRecord
 from forecastbox.domain.run.detail import CompilationDetail, TaskDetail
 from forecastbox.domain.run.exceptions import CompilationDetailNotFound
 from forecastbox.domain.run.service import RunDetail
 from forecastbox.domain.run.types import RunId
 from forecastbox.routes.run import RunLookup, get_run, list_runs
-from forecastbox.schemata.run import Run
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.pagination import PaginationSpec
 
@@ -79,7 +79,7 @@ async def test_poll_and_update_requests_detailed_report_and_translates_to_block_
         patch("forecastbox.domain.run.service.get_gateway_url", return_value="tcp://localhost:8067"),
         patch("forecastbox.domain.run.service.run_db.update_run_runtime", new=AsyncMock()),
     ):
-        detail = await run_service.poll_and_update(cast(Run, execution), detailed_report=True)
+        detail = await run_service.poll_and_update(cast(RunRecord, execution), detailed_report=True)
 
     request = mock_request.call_args.args[0]
     assert request.detailed_report is True
@@ -121,7 +121,7 @@ async def test_poll_and_update_disables_detailed_report_when_cache_misses() -> N
         patch("forecastbox.domain.run.service.get_gateway_url", return_value="tcp://localhost:8067"),
         patch("forecastbox.domain.run.service.run_db.update_run_runtime", new=AsyncMock()),
     ):
-        detail = await run_service.poll_and_update(cast(Run, execution), detailed_report=True)
+        detail = await run_service.poll_and_update(cast(RunRecord, execution), detailed_report=True)
 
     request = mock_request.call_args.args[0]
     assert request.detailed_report is False
@@ -149,7 +149,7 @@ async def test_poll_and_update_returns_empty_detailed_fields_for_completed_runs(
         compiler_runtime_context={},
     )
 
-    detail = await run_service.poll_and_update(cast(Run, execution), detailed_report=True)
+    detail = await run_service.poll_and_update(cast(RunRecord, execution), detailed_report=True)
 
     assert detail.completed_block_ids == None
     assert detail.planned_block_ids == None

--- a/backend/tests/unit/domain/run/test_service.py
+++ b/backend/tests/unit/domain/run/test_service.py
@@ -10,12 +10,12 @@ from fiab_core.fable import BlockInstanceId
 
 from forecastbox.domain.run import service
 from forecastbox.domain.run.cascade import RunOutputCharacteristic, RunOutputs
-from forecastbox.schemata.run import Run
+from forecastbox.domain.run.db import RunRecord
 
 
 def test_get_mime_of_output_returns_declared_mime() -> None:
     execution = cast(
-        Run,
+        RunRecord,
         SimpleNamespace(
             run_id="run-1",
             outputs=RunOutputs(
@@ -37,7 +37,7 @@ def test_get_mime_of_output_returns_declared_mime() -> None:
 
 def test_get_mime_of_output_rejects_unknown_task() -> None:
     execution = cast(
-        Run,
+        RunRecord,
         SimpleNamespace(
             run_id="run-1",
             outputs=RunOutputs(
@@ -129,7 +129,7 @@ async def test_poll_and_update_fetches_textual_value_for_newly_available_task() 
         patch("forecastbox.domain.run.service.run_db.update_run_runtime", new=update_mock),
         patch("forecastbox.domain.run.service.api.decoded_result", return_value=text_bytes),
     ):
-        detail = await service.poll_and_update(cast(Run, execution))
+        detail = await service.poll_and_update(cast(RunRecord, execution))
 
     assert detail.status == "completed"
     # The outputs kwarg passed to update_run_runtime must include the fetched value
@@ -160,7 +160,7 @@ async def test_poll_and_update_skips_non_textual_output() -> None:
         patch("forecastbox.domain.run.service.get_gateway_url", return_value="tcp://gw"),
         patch("forecastbox.domain.run.service.run_db.update_run_runtime", new=update_mock),
     ):
-        await service.poll_and_update(cast(Run, execution))
+        await service.poll_and_update(cast(RunRecord, execution))
 
     # Only the JobProgressRequest was made — no ResultRetrievalRequest
     assert call_count == 1
@@ -194,7 +194,7 @@ async def test_poll_and_update_does_not_refetch_already_cached_value() -> None:
         patch("forecastbox.domain.run.service.get_gateway_url", return_value="tcp://gw"),
         patch("forecastbox.domain.run.service.run_db.update_run_runtime", new=update_mock),
     ):
-        await service.poll_and_update(cast(Run, execution))
+        await service.poll_and_update(cast(RunRecord, execution))
 
     # Only the JobProgressRequest, no ResultRetrievalRequest
     assert call_count == 1
@@ -225,7 +225,7 @@ async def test_poll_and_update_handles_fetch_failure_gracefully() -> None:
         patch("forecastbox.domain.run.service.get_gateway_url", return_value="tcp://gw"),
         patch("forecastbox.domain.run.service.run_db.update_run_runtime", new=update_mock),
     ):
-        detail = await service.poll_and_update(cast(Run, execution))
+        detail = await service.poll_and_update(cast(RunRecord, execution))
 
     # Polling itself must succeed — the fetch failure is non-fatal
     assert detail.status == "running"
@@ -244,7 +244,7 @@ async def test_poll_and_update_failed_job_exposes_cached_values_as_available() -
         }
     )
     execution = cast(
-        Run,
+        RunRecord,
         SimpleNamespace(
             run_id="run-1",
             attempt_count=1,
@@ -284,7 +284,7 @@ async def test_poll_and_update_completed_job_with_changed_gateway_exposes_cached
     execution.cascade_proc = 41
 
     with patch("forecastbox.domain.run.service.get_current_cascade_proc", return_value=42):
-        detail = await service.poll_and_update(cast(Run, execution))
+        detail = await service.poll_and_update(cast(RunRecord, execution))
 
     assert detail.status == "completed"
     assert detail.available_task_ids == [TaskId("task-text")]

--- a/backend/tests/unit/plugins/test_stores.py
+++ b/backend/tests/unit/plugins/test_stores.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import orjson
 import pytest
-from fiab_core.fable import PluginId
+from fiab_core.fable import PluginId, PluginStoreId
 
 from forecastbox.domain.plugin.store import PluginStore, PluginStoreEntry, StoresManager, fetch_store, get_plugins_detail
 from forecastbox.utility.config import ConcurrentPools, PluginStoreConfig
@@ -73,7 +73,7 @@ def test_initialize_stores_publishes_only_after_successful_fetch(monkeypatch: py
     monkeypatch.setattr(store_module, "fetch_store", _boom)
 
     with pytest.raises(RuntimeError):
-        store_module.initialize_stores({"someStore": MagicMock()})
+        store_module.initialize_stores({PluginStoreId("someStore"): MagicMock()})
 
     assert dict(StoresManager.stores) == {}
 

--- a/backend/tests/unit/utility/test_dispatcher.py
+++ b/backend/tests/unit/utility/test_dispatcher.py
@@ -10,7 +10,7 @@
 """Unit tests for the protocol-based dispatch matching in utility/dispatcher.py."""
 
 from concurrent.futures import Future
-from typing import cast
+from typing import Callable, cast
 
 import pytest
 
@@ -28,10 +28,10 @@ from forecastbox.utility.dispatcher import (
 class _FakeManager:
     """Runs handler tasks inline, sidestepping ExecutionManager pool registration entirely."""
 
-    def _submit_monitored_receipt(self, pool_name: object, task_name: object, task: object) -> Future:  # ty: ignore[invalid-argument]
+    def _submit_monitored_receipt(self, pool_name: object, task_name: object, task: Callable[[], object]) -> Future:
         future: Future = Future()
         try:
-            future.set_result(cast(object, task)())  # ty: ignore[call-non-callable]
+            future.set_result(task())
         except BaseException as error:
             future.set_exception(error)
         return future


### PR DESCRIPTION
- Add ty check for tests/unit and tests/integration to the val recipe.
- Replace duck-typed casts to the Run ORM model with the RunRecord dataclass actually expected by run.service functions.
- Wrap plugin_errors test arguments in the PluginErrors NewType.
- Use PluginStoreId keys for initialize_stores test input.
- Construct FableType instances (IntType/StringType) instead of raw string literals for BlockConfigurationOption.value_type.
- Give _submit_monitored_receipt/_run test helpers a proper Callable type for the task argument instead of object, dropping now-unneeded ty:ignore comments.
- Annotate _patch_db/_patch_store/_patch_time helpers with unittest.mock._patch instead of object so they can be used as context managers.
