### PR TITLE
plugins: activate editable installs in-process, no restart needed

### DIFF
--- a/backend/src/forecastbox/domain/plugin/compatibility.py
+++ b/backend/src/forecastbox/domain/plugin/compatibility.py
@@ -45,8 +45,12 @@ Algorithm for ``install_plugin_compatibly``
    requirements, and the requested plugin requirement.
 6. Only if the dry run succeeds, run the identical command for real (differing only by the
    absence of ``--dry-run``).
-7. Run ``uv pip check`` again as a post-install check.
-8. Return the parsed installed-version mapping (from the real install's output only) for the
+7. If the real install's target interpreter is the one actually running this code (see
+   ``forecastbox.utility.pth_activation``), activate any ``.pth`` files newly created by the
+   install (as happens for editable/``-e`` installs), so the plugin becomes importable in this
+   process without a restart.
+8. Run ``uv pip check`` again as a post-install check.
+9. Return the parsed installed-version mapping (from the real install's output only) for the
    plugin manager to persist and reload.
 
 Known limitations (read before touching this module)
@@ -80,6 +84,10 @@ Known limitations (read before touching this module)
 8. Repeated single-plugin installs are order-dependent and can leave unnecessary transitive
    packages installed over time (see point 2). This is an accepted limitation of this immediate
    hardening, to be addressed by the candidate-environment design referenced above.
+9. Editable-install activation (see ``forecastbox.utility.pth_activation``) only extends ``sys.path``/
+   ``sys.meta_path`` for ``.pth`` files newly created by this install; it never removes entries for a
+   plugin that is later moved or uninstalled. Combined with point 3, a full process restart remains
+   the only way to guarantee a fully coherent set of importable modules.
 
 Public API
 ----------
@@ -121,6 +129,12 @@ from forecastbox.utility.packages import (
     run_pip_check,
     run_pip_install,
     temporary_constraints_file,
+)
+from forecastbox.utility.pth_activation import (
+    activate_editable_installs,
+    is_running_interpreter,
+    own_site_packages_dir,
+    snapshot_pth_filenames,
 )
 
 logger = logging.getLogger(__name__)
@@ -276,6 +290,9 @@ def install_plugin_compatibly(pip_source: str, version: Version | None, module_n
         f"{len(extra_requirement_args)} preserved editable/local requirement tokens"
     )
 
+    activation_site_dir = own_site_packages_dir() if is_running_interpreter(python) else None
+    before_pth = snapshot_pth_filenames(activation_site_dir) if activation_site_dir is not None else set()
+
     with temporary_constraints_file(constraints_text) as constraints_path:
         dry_run = run_pip_install(python, constraints_path, extra_requirement_args, plugin_requirement_args, dry_run=True)
         if not dry_run.ok:
@@ -290,6 +307,14 @@ def install_plugin_compatibly(pip_source: str, version: Version | None, module_n
             return Either.error(msg)
 
     installed_versions = parse_install_output(real_install.stderr)
+
+    if activation_site_dir is not None:
+        activated = activate_editable_installs(python, activation_site_dir, before_pth)
+        if activated:
+            logger.info(
+                f"activated {len(activated)} newly created .pth file(s) so {plugin_requirement_args} is importable "
+                f"without a restart: {activated}"
+            )
 
     post_check = run_pip_check(python)
     if not post_check.ok:

--- a/backend/src/forecastbox/utility/pth_activation.py
+++ b/backend/src/forecastbox/utility/pth_activation.py
@@ -1,0 +1,110 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Runtime activation of freshly created ``.pth`` files, so that an editable (``pip install -e``)
+plugin install becomes importable in the *current* process without a restart.
+
+Background
+----------
+A regular (non-editable) install drops a distribution's files directly under an existing
+``sys.path`` entry (``site-packages``), so it becomes importable as soon as the import system
+notices the new files -- which it normally does on its own (``FileFinder`` re-stats directories).
+
+An editable install is different: nothing is placed under an existing ``sys.path`` entry. Instead,
+pip/uv write a new ``*.pth`` file into ``site-packages`` -- either a plain source path (classic
+setuptools "compat"/pth mode, any layout) or an ``import ...`` line that registers a PEP 660
+meta-path finder (setuptools "finder" mode, hatchling, pdm, flit, ...). ``.pth`` files are only
+read by the ``site`` module once, at interpreter start-up (``site.addsitedir``); a long-running
+process never re-scans ``site-packages`` for new ones, so the editable install stays unimportable
+until the process restarts.
+
+This module replays exactly what ``site.addsitedir``/``site.addpackage`` would do at start-up, but
+scoped to only the ``.pth`` files a specific install just created -- so it works regardless of the
+editable-install layout/backend, without guessing (contrast with assuming a PEP 517 ``src/`` layout
+and manually extending ``sys.path``).
+
+Safety: this only makes sense, and is only safe, to do *in-process* for the interpreter that is
+actually running this code -- mutating ``sys.path``/``sys.meta_path`` of some other, unrelated
+interpreter would be meaningless. Since the plugin installer always targets ``sys.executable``,
+``is_running_interpreter`` compares against the executable path captured once at import time
+(before any caller could reassign ``sys.executable``, which is done in some test harnesses to
+target a separate scratch interpreter while the actual running process stays the original one).
+"""
+
+import importlib
+import logging
+import os
+import site
+import sys
+import sysconfig
+
+logger = logging.getLogger(__name__)
+
+# Captured once at import time, so that later reassignment of ``sys.executable`` (done by some
+# test harnesses to point the plugin installer at a separate, disposable interpreter while this
+# process itself keeps running under the original one) cannot fool `is_running_interpreter`.
+_RUNNING_EXECUTABLE = os.path.realpath(sys.executable)
+
+
+def is_running_interpreter(python: str) -> bool:
+    """Return whether *python* is the interpreter actually executing this code, rather than merely
+    equal to a (possibly reassigned) ``sys.executable``."""
+    try:
+        return os.path.realpath(python) == _RUNNING_EXECUTABLE
+    except OSError:
+        return False
+
+
+def own_site_packages_dir() -> str:
+    """Return this running interpreter's ``site-packages`` (``purelib``) directory."""
+    return sysconfig.get_paths()["purelib"]
+
+
+def snapshot_pth_filenames(site_dir: str) -> set[str]:
+    """Return the set of ``*.pth`` filenames currently present in *site_dir*. Best-effort: an
+    unreadable/missing directory yields an empty set rather than raising."""
+    try:
+        return {name for name in os.listdir(site_dir) if name.endswith(".pth") and not name.startswith(".")}
+    except OSError as e:
+        logger.debug(f"failed to list {site_dir!r} for .pth activation: {repr(e)}")
+        return set()
+
+
+def activate_new_pth_files(site_dir: str, before: set[str], after: set[str]) -> list[str]:
+    """Process every ``.pth`` filename present in *after* but not in *before* the same way
+    ``site.addsitedir`` would at interpreter start-up (extending ``sys.path`` for plain source-path
+    entries, or executing the ``import ...`` line for PEP 660 finder-based editable installs).
+
+    Only genuinely new filenames are processed, so ``.pth`` files already activated by an earlier
+    call (e.g. from a previous plugin install in this same process) are never replayed -- this
+    avoids double-registering PEP 660 meta-path finders on every unrelated subsequent install.
+
+    Returns the sorted list of filenames that were activated, for logging; does not itself call
+    ``importlib.invalidate_caches()`` -- callers should do so if the returned list is non-empty.
+    """
+    new_names = sorted(after - before)
+    for name in new_names:
+        try:
+            site.addpackage(site_dir, name, known_paths=None)
+        except Exception as e:  # noqa: BLE001 -- best-effort activation, a failure here should not fail the install
+            logger.warning(f"failed to activate .pth file {name!r} in {site_dir!r}: {repr(e)}")
+    return new_names
+
+
+def activate_editable_installs(python: str, site_dir: str, before: set[str]) -> list[str]:
+    """Convenience wrapper: re-snapshot *site_dir*, activate any ``.pth`` files created since
+    *before* was taken, and invalidate import caches if anything was activated. No-op (and returns
+    an empty list) if *python* is not the interpreter actually running this code."""
+    if not is_running_interpreter(python):
+        return []
+    after = snapshot_pth_filenames(site_dir)
+    activated = activate_new_pth_files(site_dir, before, after)
+    if activated:
+        importlib.invalidate_caches()
+    return activated

--- a/backend/tests/adhoc/README.md
+++ b/backend/tests/adhoc/README.md
@@ -16,6 +16,10 @@ It implements the following scenarios:
 5. An editable/local selected plugin can be updated.
 6. A successful real installation passes `uv pip check` and can be imported after cache
    invalidation.
+7. A freshly editable-installed plugin becomes importable in the *same* interpreter process that
+   performed the install, without a restart -- exercising `forecastbox.utility.pth_activation`
+   directly (not `install_plugin_compatibly`, since that module's other dependencies, e.g. `git`,
+   are not installed in the scratch venv; `pth_activation` has none beyond the standard library).
 
 ## Running
 
@@ -70,6 +74,10 @@ other adhoc package (e.g. `fiab-adhoctest-plugin-beta` depends on `fiab-adhoctes
   conflicting with the pinned `1.0.0` already installed.
 * `plugin_delta_v1` / `plugin_delta_v2` -- `fiab-adhoctest-plugin-delta` at `1.0.0`/`1.1.0`,
   depends on `fiab-core` only. `v1` is the seeded baseline; `v2` is the requested update.
+* `plugin_epsilon` -- `fiab-adhoctest-plugin-epsilon` at `1.0.0`, no deps. Unlike every other
+  package here, it is never pre-built into the wheelhouse or pre-seeded into the scratch venv:
+  scenario 7 performs its editable install itself (via a nested subprocess running under the
+  scratch venv's own interpreter), so it can observe the environment both before and after.
 
 `fiab-core` itself is built from `backend/packages/fiab-core` into the same wheelhouse, so the
 scratch environment never needs any package from outside this repository.

--- a/backend/tests/adhoc/packages/plugin_epsilon/pyproject.toml
+++ b/backend/tests/adhoc/packages/plugin_epsilon/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools>=70"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "fiab-adhoctest-plugin-epsilon"
+version = "1.0.0"
+requires-python = ">=3.10"
+dependencies = []
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/backend/tests/adhoc/packages/plugin_epsilon/src/fiab_adhoctest_plugin_epsilon/__init__.py
+++ b/backend/tests/adhoc/packages/plugin_epsilon/src/fiab_adhoctest_plugin_epsilon/__init__.py
@@ -1,0 +1,18 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Tiny local test-only distribution built and installed by backend/tests/adhoc/run_scenarios.py.
+
+Unlike the other adhoctest plugins, this one is deliberately never pre-built into the wheelhouse
+or pre-seeded into the scratch venv: it exists solely to exercise a *fresh* editable install
+performed during a scenario, to prove that forecastbox.utility.pth_activation makes it importable
+in the same process without a restart. See backend/tests/adhoc/README.md.
+"""
+
+__version__ = "1.0.0"

--- a/backend/tests/adhoc/run_scenarios.py
+++ b/backend/tests/adhoc/run_scenarios.py
@@ -73,6 +73,7 @@ from forecastbox.utility.packages import freeze_environment, run_pip_check
 HERE = Path(__file__).resolve().parent
 PACKAGES_DIR = HERE / "packages"
 FIAB_CORE_DIR = HERE.parents[1] / "packages" / "fiab-core"
+BACKEND_SRC = HERE.parents[1] / "src"
 
 SOURCES = {
     "pseudonumpy_v1": PACKAGES_DIR / "pseudonumpy_v1",
@@ -84,6 +85,9 @@ SOURCES = {
     "plugin_gamma": PACKAGES_DIR / "plugin_gamma",
     "plugin_delta_v1": PACKAGES_DIR / "plugin_delta_v1",
     "plugin_delta_v2": PACKAGES_DIR / "plugin_delta_v2",
+    # deliberately *not* built into the wheelhouse/seeded baseline -- see
+    # scenario_editable_install_becomes_importable_without_restart.
+    "plugin_epsilon": PACKAGES_DIR / "plugin_epsilon",
 }
 
 # built into the wheelhouse (used via --find-links, "as if it was a registry"); plugin_alpha is
@@ -336,6 +340,68 @@ def scenario_successful_install_passes_check_and_is_importable(scratch: Scratch)
         raise ScenarioError(f"imported plugin reported unexpected version: {proc.stdout!r}")
 
 
+def scenario_editable_install_becomes_importable_without_restart(scratch: Scratch) -> None:
+    """7. A freshly editable-installed plugin becomes importable in the *same* interpreter process
+    that performed the install, without a restart.
+
+    This exercises ``forecastbox.utility.pth_activation`` -- the mechanism
+    ``install_plugin_compatibly`` relies on to fix the problem this scenario is named after (see
+    that module's docstring). We deliberately do *not* call ``install_plugin_compatibly`` itself
+    here: it lives in ``forecastbox.domain.plugin.compatibility``, which pulls in dependencies
+    (``git``, ``pydantic``, ...) that are not installed in the scratch venv. ``pth_activation`` has
+    no dependencies beyond the standard library, so it can be imported directly in a subprocess
+    running under the scratch venv's *own* interpreter (via ``PYTHONPATH``) -- which is essential:
+    the activation mechanism only does anything when it is asked to act on the interpreter that is
+    actually running it (see ``is_running_interpreter``), which the ``targeting()`` context manager
+    used by the other scenarios deliberately is not (it only reassigns ``sys.executable`` on *this*
+    process, which keeps running under the outer, non-scratch interpreter throughout).
+
+    ``fiab-adhoctest-plugin-epsilon`` is used here specifically because, unlike every other adhoc
+    package, it is never pre-built into the wheelhouse or pre-seeded into the scratch venv: this
+    scenario performs its editable install itself, so it can observe the *before* state.
+    """
+    epsilon_dir = SOURCES["plugin_epsilon"]
+    script = f"""
+import sys
+sys.path.insert(0, {str(BACKEND_SRC)!r})
+import importlib
+import subprocess
+
+from forecastbox.utility.pth_activation import (
+    activate_new_pth_files,
+    is_running_interpreter,
+    own_site_packages_dir,
+    snapshot_pth_filenames,
+)
+
+assert is_running_interpreter(sys.executable), "sanity: pth_activation must see this as its own interpreter"
+
+site_dir = own_site_packages_dir()
+before = snapshot_pth_filenames(site_dir)
+
+result = subprocess.run(
+    ["uv", "pip", "install", "--python", sys.executable, "-e", {str(epsilon_dir)!r}],
+    capture_output=True,
+    text=True,
+)
+assert result.returncode == 0, f"editable install failed: {{result.stderr}}"
+
+after = snapshot_pth_filenames(site_dir)
+activated = activate_new_pth_files(site_dir, before, after)
+assert activated, f"expected at least one new .pth file, before={{before}} after={{after}}"
+importlib.invalidate_caches()
+
+import fiab_adhoctest_plugin_epsilon as m
+
+print(m.__version__)
+"""
+    proc = subprocess.run([str(scratch.venv_python), "-c", script], capture_output=True, text=True, env=scratch.env)
+    if proc.returncode != 0:
+        raise ScenarioError(f"editable-install activation scenario failed: {proc.stderr}")
+    if proc.stdout.strip() != "1.0.0":
+        raise ScenarioError(f"unexpected version after in-process activation: {proc.stdout!r} (stderr: {proc.stderr})")
+
+
 SCENARIOS: list[Callable[[Scratch], None]] = [
     scenario_new_dependency_installs_without_touching_others,
     scenario_conflicting_version_fails_dry_run,
@@ -343,6 +409,7 @@ SCENARIOS: list[Callable[[Scratch], None]] = [
     scenario_editable_local_protected_package_preserved,
     scenario_editable_local_selected_plugin_can_be_updated,
     scenario_successful_install_passes_check_and_is_importable,
+    scenario_editable_install_becomes_importable_without_restart,
 ]
 
 

--- a/backend/tests/unit/utility/test_pth_activation.py
+++ b/backend/tests/unit/utility/test_pth_activation.py
@@ -1,0 +1,144 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from forecastbox.utility.pth_activation import (
+    activate_editable_installs,
+    activate_new_pth_files,
+    is_running_interpreter,
+    own_site_packages_dir,
+    snapshot_pth_filenames,
+)
+
+
+def test_is_running_interpreter_true_for_sys_executable() -> None:
+    assert is_running_interpreter(sys.executable)
+
+
+def test_is_running_interpreter_false_for_other_path(tmp_path: Path) -> None:
+    other = tmp_path / "not-a-real-python"
+    other.write_text("")
+    assert not is_running_interpreter(str(other))
+
+
+def test_own_site_packages_dir_matches_sysconfig() -> None:
+    import sysconfig
+
+    assert own_site_packages_dir() == sysconfig.get_paths()["purelib"]
+
+
+def test_snapshot_pth_filenames_lists_only_pth_and_ignores_hidden(tmp_path: Path) -> None:
+    (tmp_path / "a.pth").write_text("/some/path\n")
+    (tmp_path / "b.pth").write_text("/some/other/path\n")
+    (tmp_path / ".hidden.pth").write_text("/ignored\n")
+    (tmp_path / "not-a-pth.txt").write_text("irrelevant\n")
+
+    assert snapshot_pth_filenames(str(tmp_path)) == {"a.pth", "b.pth"}
+
+
+def test_snapshot_pth_filenames_missing_dir_returns_empty_set(tmp_path: Path) -> None:
+    assert snapshot_pth_filenames(str(tmp_path / "does-not-exist")) == set()
+
+
+def test_activate_new_pth_files_extends_sys_path_for_plain_path_entries(tmp_path: Path) -> None:
+    new_dir = tmp_path / "src-like"
+    new_dir.mkdir()
+    (tmp_path / "editable.pth").write_text(f"{new_dir}\n")
+
+    before: set[str] = set()
+    after = snapshot_pth_filenames(str(tmp_path))
+    try:
+        activated = activate_new_pth_files(str(tmp_path), before, after)
+        assert activated == ["editable.pth"]
+        assert str(new_dir) in sys.path
+    finally:
+        if str(new_dir) in sys.path:
+            sys.path.remove(str(new_dir))
+
+
+def test_activate_new_pth_files_executes_import_lines_for_finder_based_editables(tmp_path: Path) -> None:
+    """PEP 660 finder-based editable installs write a ``.pth`` file whose content is a single
+    ``import ...`` line (registering a meta-path finder). Emulate that shape with a line that
+    just sets a recognisable marker, since we only care that it gets ``exec``'d."""
+    marker_attr = "_pth_activation_test_marker"
+    (tmp_path / "finder-based.pth").write_text(f"import sys; sys.{marker_attr} = True\n")
+
+    before: set[str] = set()
+    after = snapshot_pth_filenames(str(tmp_path))
+    try:
+        activated = activate_new_pth_files(str(tmp_path), before, after)
+        assert activated == ["finder-based.pth"]
+        assert getattr(sys, marker_attr, False) is True
+    finally:
+        if hasattr(sys, marker_attr):
+            delattr(sys, marker_attr)
+
+
+def test_activate_new_pth_files_does_not_reprocess_already_known_files(tmp_path: Path) -> None:
+    new_dir = tmp_path / "src-like"
+    new_dir.mkdir()
+    (tmp_path / "editable.pth").write_text(f"{new_dir}\n")
+
+    after = snapshot_pth_filenames(str(tmp_path))
+    try:
+        first = activate_new_pth_files(str(tmp_path), set(), after)
+        assert first == ["editable.pth"]
+
+        # Same before/after (nothing new since the first call) -> no-op.
+        second = activate_new_pth_files(str(tmp_path), after, after)
+        assert second == []
+    finally:
+        if str(new_dir) in sys.path:
+            sys.path.remove(str(new_dir))
+
+
+def test_activate_new_pth_files_warns_and_continues_on_a_broken_pth_file(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    (tmp_path / "broken.pth").write_text("import this_module_does_not_exist_anywhere\n")
+
+    activated = activate_new_pth_files(str(tmp_path), set(), snapshot_pth_filenames(str(tmp_path)))
+    # site.addpackage itself swallows per-line exec errors (prints to stderr, keeps going), so the
+    # file is still reported as "activated" -- we assert this call does not raise.
+    assert activated == ["broken.pth"]
+
+
+def test_activate_editable_installs_noop_for_a_different_interpreter(tmp_path: Path) -> None:
+    new_dir = tmp_path / "src-like"
+    new_dir.mkdir()
+    (tmp_path / "editable.pth").write_text(f"{new_dir}\n")
+
+    other_python = tmp_path / "not-the-running-python"
+    other_python.write_text("")
+
+    activated = activate_editable_installs(str(other_python), str(tmp_path), before=set())
+    assert activated == []
+    assert str(new_dir) not in sys.path
+
+
+def test_activate_editable_installs_activates_for_the_running_interpreter(tmp_path: Path) -> None:
+    new_dir = tmp_path / "src-like"
+    new_dir.mkdir()
+
+    before = snapshot_pth_filenames(str(tmp_path))
+    (tmp_path / "editable.pth").write_text(f"{new_dir}\n")
+
+    try:
+        activated = activate_editable_installs(sys.executable, str(tmp_path), before)
+        assert activated == ["editable.pth"]
+        assert str(new_dir) in sys.path
+    finally:
+        if str(new_dir) in sys.path:
+            sys.path.remove(str(new_dir))
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
An editable (-e) plugin install writes a new .pth file into site-packages instead of placing files under an existing sys.path entry. .pth files are only read by the site module at interpreter start-up, so a long-running backend process never picks up the new source location and the plugin stays unimportable until restarted.

Add forecastbox.utility.pth_activation, a stdlib-only module that replays what site.addsitedir/site.addpackage would do at start-up, but scoped to only the .pth file(s) a specific install just created. This handles both the classic setuptools path-based editable mode and PEP 660 finder-based editable installs (hatchling, pdm, flit, ...), without assuming a particular source layout.

Wire this into install_plugin_compatibly, right after a successful real install: snapshot .pth filenames before/after, activate any new ones, and invalidate import caches. Activation only runs in-process when the target python is verified to be the interpreter actually executing this code (captured once at import time), so it is a no-op for callers that target a different interpreter (e.g. tests/adhoc's scratch venv, which only reassigns sys.executable on the outer process).

Add unit tests for the new module, and a new adhoc scenario that performs a fresh editable install and import in a subprocess running under the scratch venv's own interpreter, genuinely exercising the fix end-to-end. The integration tests are unchanged  -- they currently assume the plugin is pre-installed and don't exercise the runtime pip-install path.