### PR TITLE
[deployment] add slim docker image build

### DIFF
--- a/deployment/v2/.gitignore
+++ b/deployment/v2/.gitignore
@@ -1,0 +1,2 @@
+# possible remnant of the build command
+fiab.sh

--- a/deployment/v2/Dockerfile-plain
+++ b/deployment/v2/Dockerfile-plain
@@ -1,0 +1,18 @@
+# dockerfile with a plain fiab installation
+# - the most recent release, pulled in at the build time
+# - no config override, meaning all defaults
+# - not properly warmed up (a TODO in fiab.sh captures this -- we do *not* install the default plugin, and we do *not* cache any runtime deps)
+
+FROM debian:stable-slim
+
+RUN : \
+    && apt-get update \
+    && apt-get install -y bash curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --system --user-group --create-home --shell /bin/false fiab \
+    && :
+
+USER fiab
+COPY fiab.sh /home/fiab/fiab.sh
+RUN /home/fiab/fiab.sh warmup
+ENTRYPOINT /home/fiab/fiab.sh

--- a/deployment/v2/justfile
+++ b/deployment/v2/justfile
@@ -1,0 +1,12 @@
+# TODO add Dockerfile-gpu and Dockerfile-dist-*, and differentiate commands below with an arg (plain/gpu/dist)
+
+build:
+    cp ../../scripts/fiab.sh . # NOTE we could have context the repo root -- but too bulky and not needed
+    # TODO tag with the release version?
+    docker build -t fiab-base -f Dockerfile-plain .
+
+run:
+    docker run --rm -it -p 8000:8000 fiab-base
+
+# TODO add command for publish
+# TODO add command for integration test


### PR DESCRIPTION
putting to `v2` folder for now to differentiate from the original ewc deploy

for start just `build` and `run` commands, tested both

will add publish and test later