### PR TITLE
[backend] hotfix gpu availability

### DIFF
--- a/backend/src/forecastbox/domain/artifact/compatibility.py
+++ b/backend/src/forecastbox/domain/artifact/compatibility.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import platform
 import subprocess
 from dataclasses import dataclass
@@ -42,7 +43,16 @@ def get_platform_info() -> PlatformInfo | None:
             output = subprocess.check_output(cmd, encoding="utf-8").strip()
 
             # If multiple GPUs exist, this returns multiple lines
-            gpu_memory_mib = sum([int(x) for x in output.split("\n")])
+            gpu_memory_mib = (int(x) for x in output.split("\n"))
+            visible = os.environ.get("CUDA_VISIBLE_DEVICES", None)
+            if visible is None:
+                gpu_memory_mib = sum(gpu_memory_mib)
+            else:
+                if visible:
+                    available = set(int(e) for e in visible.split(","))
+                    gpu_memory_mib = sum(e for (i, e) in enumerate(gpu_memory_mib) if i in available)
+                else:
+                    gpu_memory_mib = None
             return PlatformInfo(platform_name="linux", gpu_memory_mib=gpu_memory_mib)
         except FileNotFoundError:
             logger.debug("nvidia-smi not found. Ensure NVIDIA drivers are installed.")

--- a/backend/src/forecastbox/domain/run/__init__.py
+++ b/backend/src/forecastbox/domain/run/__init__.py
@@ -11,7 +11,7 @@
 Manages the Run domain -- execution of python workflows using the `cascade`
 execution engine, based on a Blueprint.
 
-Depends on Blueprint, Glyph, Plugin and Gateway domains -- all are used when
-compiling and submitting a Run.
+Depends on Artifact, Blueprint, Glyph, Plugin and Gateway domains -- all are
+used when compiling and submitting a Run.
 Depended on by Experiment domain (which spawns Runs).
 """

--- a/backend/src/forecastbox/domain/run/compile.py
+++ b/backend/src/forecastbox/domain/run/compile.py
@@ -9,11 +9,12 @@
 
 """Compilation of a BlueprintBuilder into an ExecutionSpecification."""
 
+import logging
 from dataclasses import dataclass
 from datetime import datetime
 from typing import cast
 
-from cascade.low.core import DatasetId, TaskId
+from cascade.low.core import DatasetId, JobInstance, TaskId
 from cascade.low.func import assert_never
 from earthkit.workflows.compilers import graph2job
 from earthkit.workflows.fluent import PayloadBuildingContext
@@ -21,6 +22,7 @@ from earthkit.workflows.graph import Graph, deduplicate_nodes
 from fiab_core.artifacts import CompositeArtifactId
 from fiab_core.fable import BlockInstanceId, BlockInstanceOutput, ConfigurationOptionId, NoOutput, RawOutput
 
+from forecastbox.domain.artifact.compatibility import get_platform_info
 from forecastbox.domain.blueprint.cascade import EnvironmentSpecification
 from forecastbox.domain.blueprint.configuration_values import convert_known_configuration_values
 from forecastbox.domain.blueprint.service import BlueprintBuilder
@@ -32,6 +34,8 @@ from forecastbox.domain.run.detail import CompilationDetail, TaskDetail, _fluent
 from forecastbox.domain.run.types import RunId
 from forecastbox.utility.graph import topological_order
 from forecastbox.utility.time import value_dt2str
+
+logger = logging.getLogger(__name__)
 
 
 def resolve_intrinsic_glyph_values(
@@ -72,6 +76,29 @@ def _get_artifacts_list(graph: Graph) -> list[CompositeArtifactId]:
         if isinstance(artifact, CompositeArtifactId)
     )
     return list(artifacts)
+
+
+def _hotfix_gpu_availability(job_instance: JobInstance) -> None:
+    """If there is no gpu on the platform, remove all needs_gpu flags from the job.
+
+    Rationale: scheduler always assigns needs_gpu tasks only to gpu workers, there is no
+    middle ground or conditional decision making. Hence all existing plugins put
+    `needs_gpu: True` to any task that benefits from a gpu, they have no way of expressing
+    "nice_to_have_gpu". So on a gpu-less machine, the workflow cannot complete due to
+    scheduler decision. We thus hotfix by removing the needs_gpu on such platform,
+    relying that the user obeyed the is_locally_compatible flag on the Artifact, which
+    additionally takes available memory into account.
+
+    When needs_gpu becomes replaced by `profile(gpu_name|None) -> duration_or_infty`,
+    we will remove this hotfix."""
+    platform = get_platform_info()
+    # unknown platform or gpu available => no need to hotfix
+    if platform is None:
+        return
+    if platform.gpu_memory_mib is not None and platform.gpu_memory_mib > 0:
+        return
+    for taskInstance in job_instance.tasks.values():
+        taskInstance.definition.needs_gpu = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -183,6 +210,9 @@ def compile_builder(blueprint: BlueprintBuilder, glyph_values: dict[str, str]) -
         task_id, detail = fluentNode_to_detail(node, task_block_id)
         task_detail[task_id] = detail
     job_instance = graph2job(graph)
+    logger.info(f"before hotfix {job_instance}")
+    _hotfix_gpu_availability(job_instance)
+    logger.info(f"after hotfix {job_instance}")
 
     job_instance.ext_outputs = [dataset_id for task_id in sink_tasks for dataset_id in job_instance.outputs_of(task_id)]
 


### PR DESCRIPTION
when the platform has no gpu available, we set needs_gpu=False on every task in any job instance, as otherwise the job would have crashed right away

this is aligned with how we treat the artifact local compatibility check -- we show the user whether the artifact is likely to work on the given platform (including memory fit check), but do not prevent submitting explicitly an incompatible one

once the scheduler switches to using profile information properly, as opposed to a coarse `needs_gpu: bool`, we will remove this hotfix
