### PR TITLE
[frontend] plugin event toasts and run status colours

### DIFF
--- a/frontend/src/api/hooks/usePlugins.ts
+++ b/frontend/src/api/hooks/usePlugins.ts
@@ -49,6 +49,8 @@ const log = createLogger('usePlugins')
 export const pluginKeys = {
   all: ['plugin'] as const,
   list: () => [...pluginKeys.all, 'list'] as const,
+  /** Mutation key — lets notification dispatch skip what this tab started. */
+  mutation: () => [...pluginKeys.all, 'mutation'] as const,
 }
 
 /**
@@ -159,6 +161,7 @@ function usePluginMutation<TVariables>(
   const queryClient = useQueryClient()
 
   return useMutation({
+    mutationKey: pluginKeys.mutation(),
     mutationFn: async (variables: TVariables) => {
       await action(variables)
       // Poll until the catalogue is available again (plugins finished reloading)

--- a/frontend/src/api/notifications/dispatch.ts
+++ b/frontend/src/api/notifications/dispatch.ts
@@ -15,8 +15,10 @@
  * map to query keys, server state keeps flowing through TanStack Query, so
  * a missed notification is a slower update, not data loss. Unknown routes
  * only log — each new backend producer costs one registry line.
+ * Plugin events also toast: they finish as background tasks, silent otherwise.
  */
 
+import i18n from 'i18next'
 import type { QueryKey } from '@tanstack/react-query'
 import type { ClientNotification } from '@/api/types/notification.types'
 import { clientNotificationSchema } from '@/api/types/notification.types'
@@ -26,6 +28,7 @@ import { fableKeys } from '@/api/hooks/useFable'
 import { pluginKeys } from '@/api/hooks/usePlugins'
 import { createLogger } from '@/lib/logger'
 import { queryClient } from '@/lib/queryClient'
+import { showToast } from '@/lib/toast'
 
 const log = createLogger('Notifications')
 
@@ -72,6 +75,83 @@ const domainHandlers = new Map<
   ],
 ])
 
+/** Backend ships `store:local`; the UI shows `store/local`. */
+function pluginDisplayId(pluginId: string): string {
+  const separator = pluginId.indexOf(':')
+  return separator === -1
+    ? pluginId
+    : `${pluginId.slice(0, separator)}/${pluginId.slice(separator + 1)}`
+}
+
+/** Plugin mutations take either the id itself or `{ compositeId }`. */
+function mutationPluginId(variables: unknown): string | null {
+  if (typeof variables !== 'object' || variables === null) return null
+  const candidate =
+    'compositeId' in variables ? variables.compositeId : variables
+  if (typeof candidate !== 'object' || candidate === null) return null
+  const { store, local } = candidate as { store?: unknown; local?: unknown }
+  return typeof store === 'string' && typeof local === 'string'
+    ? `${store}/${local}`
+    : null
+}
+
+/** True while this tab's own mutation for that plugin is still in flight. */
+function trackedHere(displayId: string): boolean {
+  return (
+    queryClient.isMutating({
+      mutationKey: pluginKeys.mutation(),
+      predicate: (mutation) =>
+        mutationPluginId(mutation.state.variables) === displayId,
+    }) > 0
+  )
+}
+
+/** Success event -> copy key, spelled out because i18next types the key. */
+type PluginSuccessCopy =
+  | 'plugins:notifications.installed'
+  | 'plugins:notifications.updated'
+  | 'plugins:notifications.settingsApplied'
+  | 'plugins:notifications.unloaded'
+  | 'plugins:notifications.uninstalled'
+
+const pluginSuccessCopy = new Map<string, PluginSuccessCopy>([
+  ['pluginInstalled', 'plugins:notifications.installed'],
+  ['pluginUpdated', 'plugins:notifications.updated'],
+  ['pluginSettingsApplied', 'plugins:notifications.settingsApplied'],
+  ['pluginUnloaded', 'plugins:notifications.unloaded'],
+  ['pluginUninstalled', 'plugins:notifications.uninstalled'],
+])
+
+/** Toast a plugin event unless this tab started it. Failures always toast:
+ *  the route only submits, so the mutation resolves even when the task fails. */
+function toastPluginNotification(notification: ClientNotification): void {
+  if (notification.sourceDomainEvent === 'pluginGlobalError') {
+    const { trigger, error } = notification.context
+    showToast.error(
+      typeof trigger === 'string'
+        ? i18n.t('plugins:notifications.globalError', { trigger })
+        : i18n.t('plugins:notifications.globalErrorGeneric'),
+      typeof error === 'string' ? error : undefined,
+    )
+    return
+  }
+
+  const copyKey = pluginSuccessCopy.get(notification.sourceDomainEvent)
+  if (!copyKey) return
+
+  const pluginId = notification.context.plugin_id
+  if (typeof pluginId !== 'string') {
+    log.warn('Plugin notification without plugin_id', {
+      event: notification.sourceDomainEvent,
+    })
+    return
+  }
+
+  const displayId = pluginDisplayId(pluginId)
+  if (trackedHere(displayId)) return
+  showToast.success(i18n.t(copyKey, { plugin: displayId }))
+}
+
 export function dispatchClientNotification(
   notification: ClientNotification,
 ): void {
@@ -92,6 +172,10 @@ export function dispatchClientNotification(
   domainHandlers.get(
     `${notification.sourceDomainName}:${notification.sourceDomainEvent}`,
   )?.(notification)
+
+  if (notification.sourceDomainName === 'plugin') {
+    toastPluginNotification(notification)
+  }
 }
 
 /** Raw frame -> validated notification -> dispatch; malformed input logs and drops. */

--- a/frontend/src/api/notifications/dispatch.ts
+++ b/frontend/src/api/notifications/dispatch.ts
@@ -22,6 +22,7 @@ import type { ClientNotification } from '@/api/types/notification.types'
 import { clientNotificationSchema } from '@/api/types/notification.types'
 import { API_PREFIX } from '@/api/endpoints'
 import { artifactKeys, wakeDownloadPolling } from '@/api/hooks/useArtifacts'
+import { fableKeys } from '@/api/hooks/useFable'
 import { pluginKeys } from '@/api/hooks/usePlugins'
 import { createLogger } from '@/lib/logger'
 import { queryClient } from '@/lib/queryClient'
@@ -31,8 +32,11 @@ const log = createLogger('Notifications')
 /** Normalized backend refresh route -> query keys it makes stale. */
 const refreshRouteQueryKeys = new Map<string, ReadonlyArray<QueryKey>>([
   ['artifacts/list_models', [artifactKeys.list()]],
-  // plugin.pluginGlobalError — the listing's 60s staleTime would hide it.
-  ['plugin/list', [pluginKeys.list()]],
+  // Every plugin event ships this route; a change stales all three caches.
+  [
+    'plugin/list',
+    [pluginKeys.list(), fableKeys.catalogue(), fableKeys.blueprintsBase()],
+  ],
 ])
 
 /** Routes arrive as "api/v1/artifacts/list_models", with or without a leading slash. */

--- a/frontend/src/components/common/StatusBadge.tsx
+++ b/frontend/src/components/common/StatusBadge.tsx
@@ -58,6 +58,12 @@ export const STATUS_BADGE_VARIANTS = {
     badgeClass:
       'bg-red-50 text-red-600 dark:bg-red-900/20 dark:text-red-400 border-red-200 dark:border-red-800',
   },
+  /** In-progress work, in brand blue — `--primary` carries both themes. */
+  busy: {
+    dotClass: 'bg-primary',
+    barClass: 'bg-primary',
+    badgeClass: 'bg-primary/10 text-primary border-primary/20',
+  },
   warning: {
     dotClass: 'bg-amber-500',
     barClass: 'bg-amber-500',

--- a/frontend/src/features/executions/utils/job-status.ts
+++ b/frontend/src/features/executions/utils/job-status.ts
@@ -20,9 +20,9 @@ const JOB_STATUS_VARIANT: Record<
   JobStatus,
   keyof typeof STATUS_BADGE_VARIANTS
 > = {
-  submitted: 'available',
-  preparing: 'available',
-  running: 'warning',
+  submitted: 'warning',
+  preparing: 'warning',
+  running: 'busy',
   completed: 'active',
   failed: 'error',
   unknown: 'disabled',

--- a/frontend/src/locales/en/plugins.json
+++ b/frontend/src/locales/en/plugins.json
@@ -171,6 +171,15 @@
     "updateFailed": "Update failed",
     "failedWithReason": "{{label}}: {{reason}}"
   },
+  "notifications": {
+    "installed": "Plugin {{plugin}} installed",
+    "updated": "Plugin {{plugin}} updated",
+    "settingsApplied": "Plugin {{plugin}} settings applied",
+    "unloaded": "Plugin {{plugin}} disabled",
+    "uninstalled": "Plugin {{plugin}} uninstalled",
+    "globalError": "{{trigger}} failed",
+    "globalErrorGeneric": "A plugin operation failed"
+  },
   "admin": {
     "verifyAccessError": "Could not verify admin access. Please try again."
   }

--- a/frontend/tests/unit/api/notifications/dispatch.test.ts
+++ b/frontend/tests/unit/api/notifications/dispatch.test.ts
@@ -8,7 +8,10 @@
  * does it submit to any jurisdiction.
  */
 
+import { MutationObserver } from '@tanstack/react-query'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+// Real copy, so the toast assertions read the interpolated English.
+import '@/lib/i18n'
 import type { MockInstance } from 'vitest'
 import type { ClientNotification } from '@/api/types/notification.types'
 import {
@@ -21,6 +24,7 @@ import { artifactKeys, wakeDownloadPolling } from '@/api/hooks/useArtifacts'
 import { fableKeys } from '@/api/hooks/useFable'
 import { pluginKeys } from '@/api/hooks/usePlugins'
 import { queryClient } from '@/lib/queryClient'
+import { showToast } from '@/lib/toast'
 
 vi.mock('@/api/hooks/useArtifacts', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>()
@@ -62,6 +66,20 @@ function pluginNotification(
     detailRoute: 'api/v1/plugin/list',
     refreshRoutes: ['api/v1/plugin/list'],
   })
+}
+
+/** Real in-flight plugin mutation; returns a settler to release it. */
+function startPluginMutation(variables: unknown): () => void {
+  let release = (): void => {}
+  const gate = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const observer = new MutationObserver<void, Error, unknown>(queryClient, {
+    mutationKey: pluginKeys.mutation(),
+    mutationFn: () => gate,
+  })
+  void observer.mutate(variables)
+  return release
 }
 
 describe('normalizeRefreshRoute', () => {
@@ -154,6 +172,95 @@ describe('dispatchClientNotification', () => {
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: artifactKeys.list(),
     })
+  })
+})
+
+describe('passive plugin toasts', () => {
+  let successSpy: MockInstance
+  let errorSpy: MockInstance
+
+  beforeEach(() => {
+    vi.spyOn(queryClient, 'invalidateQueries').mockResolvedValue()
+    successSpy = vi.spyOn(showToast, 'success').mockReturnValue('')
+    errorSpy = vi.spyOn(showToast, 'error').mockReturnValue('')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    queryClient.getMutationCache().clear()
+  })
+
+  it.each([
+    'pluginInstalled',
+    'pluginUpdated',
+    'pluginSettingsApplied',
+    'pluginUnloaded',
+    'pluginUninstalled',
+  ])('toasts %s when this tab did not start it', (event) => {
+    dispatchClientNotification(pluginNotification(event))
+    expect(successSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the plugin id as store/local', () => {
+    dispatchClientNotification(pluginNotification('pluginInstalled'))
+    expect(successSpy.mock.calls[0][0]).toContain('ecmwf/toy1')
+  })
+
+  it('stays silent in the tab that started the operation', () => {
+    const release = startPluginMutation({ store: 'ecmwf', local: 'toy1' })
+    dispatchClientNotification(pluginNotification('pluginInstalled'))
+    expect(successSpy).not.toHaveBeenCalled()
+    release()
+  })
+
+  // Toggles create no activity task — what broke the first suppression.
+  it('stays silent for a toggle this tab started', () => {
+    const release = startPluginMutation({ store: 'ecmwf', local: 'toy1' })
+    dispatchClientNotification(pluginNotification('pluginUnloaded'))
+    expect(successSpy).not.toHaveBeenCalled()
+    release()
+  })
+
+  it('stays silent for a settings update, whose variables are wrapped', () => {
+    const release = startPluginMutation({
+      compositeId: { store: 'ecmwf', local: 'toy1' },
+      settings: { isEnabled: true },
+    })
+    dispatchClientNotification(pluginNotification('pluginSettingsApplied'))
+    expect(successSpy).not.toHaveBeenCalled()
+    release()
+  })
+
+  it('still toasts while an unrelated plugin op runs here', () => {
+    const release = startPluginMutation({ store: 'ecmwf', local: 'other' })
+    dispatchClientNotification(pluginNotification('pluginInstalled'))
+    expect(successSpy).toHaveBeenCalledTimes(1)
+    release()
+  })
+
+  // The route only submits, so the mutation resolves even on failure.
+  it('toasts a global error even in the initiating tab', () => {
+    const release = startPluginMutation({ store: 'ecmwf', local: 'toy1' })
+    dispatchClientNotification(
+      pluginNotification('pluginGlobalError', {
+        trigger: 'Update of plugin ecmwf:toy1',
+        error: 'boom',
+      }),
+    )
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    expect(errorSpy.mock.calls[0][1]).toBe('boom')
+    release()
+  })
+
+  it('skips a success event whose context lacks plugin_id', () => {
+    dispatchClientNotification(pluginNotification('pluginInstalled', {}))
+    expect(successSpy).not.toHaveBeenCalled()
+  })
+
+  it('leaves non-plugin domains untoasted', () => {
+    dispatchClientNotification(notification())
+    expect(successSpy).not.toHaveBeenCalled()
+    expect(errorSpy).not.toHaveBeenCalled()
   })
 })
 

--- a/frontend/tests/unit/api/notifications/dispatch.test.ts
+++ b/frontend/tests/unit/api/notifications/dispatch.test.ts
@@ -18,6 +18,7 @@ import {
   resyncRegisteredRoutes,
 } from '@/api/notifications/dispatch'
 import { artifactKeys, wakeDownloadPolling } from '@/api/hooks/useArtifacts'
+import { fableKeys } from '@/api/hooks/useFable'
 import { pluginKeys } from '@/api/hooks/usePlugins'
 import { queryClient } from '@/lib/queryClient'
 
@@ -47,6 +48,20 @@ function notification(
     refreshRoutes: ['api/v1/artifacts/list_models'],
     ...overrides,
   }
+}
+
+function pluginNotification(
+  event: string,
+  context: Record<string, unknown> = { plugin_id: 'ecmwf:toy1' },
+): ClientNotification {
+  return notification({
+    text: `Plugin ecmwf:toy1 ${event}`,
+    sourceDomainName: 'plugin',
+    sourceDomainEvent: event,
+    context,
+    detailRoute: 'api/v1/plugin/list',
+    refreshRoutes: ['api/v1/plugin/list'],
+  })
 }
 
 describe('normalizeRefreshRoute', () => {
@@ -91,18 +106,23 @@ describe('dispatchClientNotification', () => {
 
   it('invalidates the plugin listing on a plugin global error', () => {
     dispatchClientNotification(
-      notification({
-        text: 'Initial plugin load failed: environment already broken',
-        sourceDomainName: 'plugin',
-        sourceDomainEvent: 'pluginGlobalError',
-        context: { trigger: 'Initial plugin load', error: 'broken' },
-        detailRoute: 'api/v1/plugin/list',
-        refreshRoutes: ['api/v1/plugin/list'],
+      pluginNotification('pluginGlobalError', {
+        trigger: 'Initial plugin load',
+        error: 'broken',
       }),
     )
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: pluginKeys.list(),
     })
+  })
+
+  // The listing alone would leave the builder's catalogue stale.
+  it.each([
+    ['the block catalogue', () => fableKeys.catalogue()],
+    ['the blueprint listing', () => fableKeys.blueprintsBase()],
+  ])('also invalidates %s on a plugin event', (_label, queryKey) => {
+    dispatchClientNotification(pluginNotification('pluginInstalled'))
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKey() })
   })
 
   it('ignores unmapped refresh routes without invalidating', () => {

--- a/frontend/tests/unit/features/executions/utils/job-status.test.ts
+++ b/frontend/tests/unit/features/executions/utils/job-status.test.ts
@@ -24,16 +24,16 @@ const ALL_STATUSES: Array<JobStatus> = [
 ]
 
 describe('getStatusBadgeClasses', () => {
-  it('returns blue classes for submitted', () => {
-    expect(getStatusBadgeClasses('submitted')).toContain('bg-blue-50')
+  it('returns amber classes for submitted', () => {
+    expect(getStatusBadgeClasses('submitted')).toContain('bg-amber-100')
   })
 
-  it('returns blue classes for preparing', () => {
-    expect(getStatusBadgeClasses('preparing')).toContain('bg-blue-50')
+  it('returns amber classes for preparing', () => {
+    expect(getStatusBadgeClasses('preparing')).toContain('bg-amber-100')
   })
 
-  it('returns amber classes for running', () => {
-    expect(getStatusBadgeClasses('running')).toContain('bg-amber-100')
+  it('returns brand-blue classes for running', () => {
+    expect(getStatusBadgeClasses('running')).toContain('bg-primary/10')
   })
 
   it('returns emerald classes for completed', () => {
@@ -52,12 +52,12 @@ describe('getStatusBadgeClasses', () => {
 })
 
 describe('getStatusBarColor', () => {
-  it('returns blue bar for submitted', () => {
-    expect(getStatusBarColor('submitted')).toBe('bg-blue-500')
+  it('returns amber bar for submitted', () => {
+    expect(getStatusBarColor('submitted')).toBe('bg-amber-500')
   })
 
-  it('returns amber bar for running', () => {
-    expect(getStatusBarColor('running')).toBe('bg-amber-500')
+  it('returns brand-blue bar for running', () => {
+    expect(getStatusBarColor('running')).toBe('bg-primary')
   })
 
   it('returns emerald bar for completed', () => {


### PR DESCRIPTION
### Description

Plugin operations (install, update, uninstall, enable, disable) complete as backend background tasks and announce themselves over the `/notification/ws` push channel. The frontend was under-using those events in two ways. 

This PR also recolours run status so the pill and progress bar read at a glance.

### Widen what a plugin event invalidates

`plugin/list` mapped to the plugin listing alone, while `usePluginMutation` stales three caches locally. A plugin change this tab did not initiate therefore left the builder on a block catalogue with a five-minute `staleTime`, and on plugin templates ingested as blueprints. The push path now invalidates the same three keys the local path does.

### Toast plugin events this tab did not start

A tab that did not start an operation previously saw the change land silently. Plugin events now toast, suppressed in the tab that started them. Suppression keys on a shared mutation key rather than the activity shelf: the shelf only tracks install/uninstall/update, so a shelf-based check toasted over the user's own enable/disable toggles. 

### Brand blue for running, amber for submitted

Run status went submitted/preparing blue and running amber, which read as a warning for the healthy case. It now runs amber (submitted, preparing) to brand blue (running) to emerald (completed), for both the status pill and the progress bar. This adds a `busy` variant rather than recolouring `available`/`warning`, because `STATUS_BADGE_VARIANTS` is shared with plugins, schedules and artifacts and editing those would have repainted unrelated pages. `busy` uses the `--primary`.
### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
