### PR TITLE
Chore/refac entrypoint

### DIFF
--- a/backend/src/forecastbox/entrypoint/app.py
+++ b/backend/src/forecastbox/entrypoint/app.py
@@ -9,9 +9,7 @@
 
 """FastAPI Entrypoint"""
 
-import asyncio
 import importlib
-import inspect
 import logging
 import os
 import pkgutil
@@ -26,81 +24,15 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from fiab_core.artifacts import ArtifactsProvider
 from starlette.exceptions import HTTPException
 
-import forecastbox.domain
 import forecastbox.routes
-import forecastbox.schemata
 from forecastbox.domain.admin import get_local_release
-from forecastbox.domain.artifact.base import get_artifact_local_path
-from forecastbox.domain.artifact.manager import ArtifactManager, join_artifact_manager, submit_refresh_catalog
-from forecastbox.domain.experiment.scheduling.background import start_scheduler, stop_scheduler
-from forecastbox.domain.gateway.service import shutdown_processes
-from forecastbox.domain.lens.manager import shutdown_all_lens_instances
-from forecastbox.domain.notification.service import init_broadcaster
-from forecastbox.domain.plugin.store import submit_initialize_stores
-from forecastbox.domain.plugin.submit import submit_load_all as submit_load_plugins
-from forecastbox.utility.concurrency.manager import execution_manager
-from forecastbox.utility.config import ConcurrentThreads, config, validate_runtime
-from forecastbox.utility.dispatcher import (
-    DispatcherRegistration,
-    event_dispatcher_entrypoint,
-    freeze_registration,
-    register_dispatcher,
-)
-from forecastbox.utility.dispatcher import (
-    status as dispatcher_status,
-)
-from forecastbox.utility.dispatcher import (
-    stop_request as dispatcher_stop_request,
-)
+from forecastbox.entrypoint.initializers import build_initializers
+from forecastbox.utility.config import config, validate_runtime
 from forecastbox.utility.fastapi import register_common_exception_handling
-from forecastbox.utility.tunnel import shutdown as shutdown_tunnels
 
 logger = logging.getLogger(__name__)
-
-
-def _discover_dispatchers() -> None:
-    for package_info in pkgutil.iter_modules(forecastbox.domain.__path__):
-        if not package_info.ispkg:
-            continue
-        module_name = f"forecastbox.domain.{package_info.name}.dispatchers"
-        try:
-            module = importlib.import_module(module_name)
-        except ModuleNotFoundError as error:
-            if error.name == module_name:
-                continue
-            raise
-        registrations = getattr(module, "dispatchers", None)
-        if not isinstance(registrations, tuple):
-            raise TypeError(f"{module_name} must export a dispatchers tuple")
-        for registration in registrations:
-            if not isinstance(registration, DispatcherRegistration):
-                raise TypeError(f"{module_name} contains a malformed dispatcher registration")
-            register_dispatcher(registration)
-    freeze_registration()
-
-
-def _start_execution_runtime() -> None:
-    _discover_dispatchers()
-    for pool_name, settings in config.backend.concurrency.pools.items():
-        logger.debug(f"registering {pool_name=}")
-        execution_manager.register_pool(
-            pool_name,
-            max_workers=settings.max_workers,
-            max_pending=settings.max_pending,
-            stage=0,
-        )
-    logger.debug("registering event dispatcher thread")
-    execution_manager.register_thread(
-        ConcurrentThreads.EventDispatcher,
-        event_dispatcher_entrypoint,
-        status_provider=dispatcher_status,
-        stop_request=dispatcher_stop_request,
-        stage=0,
-    )
-    execution_manager.start(timeout=config.backend.concurrency.startup_timeout_seconds)
 
 
 @asynccontextmanager
@@ -109,55 +41,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # NOTE validate_runtime call is ~redundant as all launchers of `app` call it as well.
     # But we do include anyway in case of the serialization or mutation went wrong
     validate_runtime(config)
-    # generic and autodiscoverable inits
+    initializers = build_initializers()
     try:
-        # Import every schemata submodule first, and only then call any discovered
-        # create_db_and_tables. Several domain schema modules share a single Base/engine
-        # (see forecastbox.schemata.jobs) and declare cross-module foreign keys, so all of
-        # them must have registered their ORM classes on that shared metadata before any
-        # create_db_and_tables runs -- calling it mid-iteration could create the database
-        # with tables missing simply because their module hadn't been imported yet.
-        pending_create_db_and_tables = []
-        for module_info in pkgutil.iter_modules(forecastbox.schemata.__path__):
-            module = importlib.import_module(f"forecastbox.schemata.{module_info.name}")
-            if hasattr(module, "create_db_and_tables"):
-                pending_create_db_and_tables.append(module.create_db_and_tables)
-        for create_db_and_tables in pending_create_db_and_tables:
-            result = create_db_and_tables()  # type: ignore[call-non-callable] # NOTE no module protocol
-            if inspect.isawaitable(result):
-                result = await result
-            if result is not None:
-                logger.warning(f"unexpected result from create_db_and_tables: {result.__class__}")
-        _start_execution_runtime()
-    except BaseException:
-        execution_manager.shutdown(timeout=config.backend.concurrency.shutdown_timeout_seconds)
-        raise
-
-    # domain-specific inits
-    try:
-        init_broadcaster(asyncio.get_running_loop())
-        if config.backend.allow_scheduler:
-            start_scheduler()
+        await initializers.initialize()
         release_time, release_version = get_local_release()
         app.version = f"{release_version}@{release_time}"
-        submit_initialize_stores()
-        ArtifactsProvider.register_get_artifacts_lookup(lambda: ArtifactManager.catalog)
-        ArtifactsProvider.register_get_artifact_local_path(
-            lambda composite_id: get_artifact_local_path(composite_id, config.backend.data_path)
-        )
-        catalog_ready = submit_refresh_catalog()
-        submit_load_plugins(start_after=catalog_ready)
         yield
     finally:
-        try:
-            if config.backend.allow_scheduler:
-                stop_scheduler()
-            shutdown_all_lens_instances()
-            await shutdown_processes()
-            shutdown_tunnels()
-            join_artifact_manager(timeout_sec=10)
-        finally:
-            execution_manager.shutdown(timeout=config.backend.concurrency.shutdown_timeout_seconds)
+        await initializers.shutdown()
 
 
 app = FastAPI(

--- a/backend/src/forecastbox/entrypoint/app.py
+++ b/backend/src/forecastbox/entrypoint/app.py
@@ -106,6 +106,8 @@ def _start_execution_runtime() -> None:
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     logger.debug(f"Starting FIAB with config: {config}")
+    # NOTE validate_runtime call is ~redundant as all launchers of `app` call it as well.
+    # But we do include anyway in case of the serialization or mutation went wrong
     validate_runtime(config)
     # generic and autodiscoverable inits
     try:

--- a/backend/src/forecastbox/entrypoint/bootstrap/launchers.py
+++ b/backend/src/forecastbox/entrypoint/bootstrap/launchers.py
@@ -19,6 +19,7 @@ entrypoint/app.py, as it is coupled to FastAPI's API
 
 import asyncio
 import logging
+import sys
 
 import uvicorn
 
@@ -28,7 +29,12 @@ from forecastbox.utility.config import FIABConfig
 logger = logging.getLogger(__name__)
 
 
-async def _uvicorn_run(app_name: str, host: str, port: int) -> None:
+async def _uvicorn_run(app_name: str, host: str, port: int) -> bool:
+    """Runs the uvicorn server until it stops. Returns True if either the startup or the
+    shutdown lifespan sequence failed, per uvicorn's own bookkeeping -- see
+    `forecastbox.entrypoint.app.lifespan` and `forecastbox.utility.initializer` for how such
+    a failure can arise on our side.
+    """
     # NOTE we pass None to log config to not interfere with original logging setting
     config = uvicorn.Config(
         app_name,
@@ -43,6 +49,7 @@ async def _uvicorn_run(app_name: str, host: str, port: int) -> None:
     #    reload_dirs=["forecastbox"],
     server = uvicorn.Server(config)
     await server.serve()
+    return bool(server.lifespan.startup_failed or server.lifespan.shutdown_failed)
 
 
 def launch_backend() -> None:
@@ -56,6 +63,9 @@ def launch_backend() -> None:
     host = config.backend.uvicorn_host
     task = _uvicorn_run("forecastbox.entrypoint.app:app", host, port)
     try:
-        asyncio.run(task)
+        lifespan_failed = asyncio.run(task)
     except KeyboardInterrupt:
-        pass  # no need to spew stacktrace to log
+        return  # no need to spew stacktrace to log
+    if lifespan_failed:
+        logger.error("backend lifespan startup or shutdown failed, exiting with error code")
+        sys.exit(1)

--- a/backend/src/forecastbox/entrypoint/bootstrap/launchers.py
+++ b/backend/src/forecastbox/entrypoint/bootstrap/launchers.py
@@ -10,6 +10,11 @@
 """Launcher methods for backend and cascade -- utilized by
 - entrypoint.main for launch_backend,
 - entrypoint.bootstrap.service for launch_backend,
+
+Basically just a wrapper on uvicorn launching, as we need to override the logging configuration.
+
+The actual logic of instantiating the backend (the FastAPI app, the background threads, etc) happens in
+entrypoint/app.py, as it is coupled to FastAPI's API
 """
 
 import asyncio

--- a/backend/src/forecastbox/entrypoint/bootstrap/launchers.py
+++ b/backend/src/forecastbox/entrypoint/bootstrap/launchers.py
@@ -62,10 +62,11 @@ def launch_backend() -> None:
     port = config.backend.uvicorn_port
     host = config.backend.uvicorn_host
     task = _uvicorn_run("forecastbox.entrypoint.app:app", host, port)
+    lifespan_failed = None
     try:
         lifespan_failed = asyncio.run(task)
     except KeyboardInterrupt:
-        return  # no need to spew stacktrace to log
+        pass  # no need to spew stacktrace to log
     if lifespan_failed:
         logger.error("backend lifespan startup or shutdown failed, exiting with error code")
         sys.exit(1)

--- a/backend/src/forecastbox/entrypoint/bootstrap/service.py
+++ b/backend/src/forecastbox/entrypoint/bootstrap/service.py
@@ -59,3 +59,5 @@ if __name__ == "__main__":
         raise ValueError(f"start failure: {backend.exitcode}")
 
     check_backend_ready(config, handle, not isinstance(config.cascade.gateway, UnmanagedGateway))
+
+    # TODO this is missing the interrupt/term handlers and awaits -- yet another reason to unify

--- a/backend/src/forecastbox/entrypoint/initializers.py
+++ b/backend/src/forecastbox/entrypoint/initializers.py
@@ -1,0 +1,202 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Individual startup/teardown steps used by `forecastbox.entrypoint.app`'s lifespan, plus the
+`build_initializers` factory that assembles them, in order, into an `Initializers` instance.
+
+The order below matters: `initialize()` runs the steps top to bottom, and `shutdown()` unwinds
+them bottom to top -- but only the ones that actually started. See
+`forecastbox.utility.initializer` for the exact semantics.
+"""
+
+import asyncio
+import importlib
+import inspect
+import logging
+import pkgutil
+
+from fiab_core.artifacts import ArtifactsProvider
+
+import forecastbox.domain
+import forecastbox.schemata
+from forecastbox.domain.artifact.base import get_artifact_local_path
+from forecastbox.domain.artifact.manager import ArtifactManager, join_artifact_manager, submit_refresh_catalog
+from forecastbox.domain.experiment.scheduling.background import start_scheduler, stop_scheduler
+from forecastbox.domain.gateway.service import shutdown_processes
+from forecastbox.domain.lens.manager import shutdown_all_lens_instances
+from forecastbox.domain.notification.service import init_broadcaster
+from forecastbox.domain.plugin.store import submit_initialize_stores
+from forecastbox.domain.plugin.submit import submit_load_all as submit_load_plugins
+from forecastbox.utility.concurrency.manager import execution_manager
+from forecastbox.utility.config import ConcurrentThreads, config
+from forecastbox.utility.dispatcher import (
+    DispatcherRegistration,
+    event_dispatcher_entrypoint,
+    freeze_registration,
+    register_dispatcher,
+)
+from forecastbox.utility.dispatcher import (
+    status as dispatcher_status,
+)
+from forecastbox.utility.dispatcher import (
+    stop_request as dispatcher_stop_request,
+)
+from forecastbox.utility.initializer import Initializer, Initializers
+from forecastbox.utility.tunnel import shutdown as shutdown_tunnels
+
+logger = logging.getLogger(__name__)
+
+
+async def _start_db_schema() -> None:
+    """Create db tables declared by every `forecastbox.schemata` submodule.
+
+    Import every schemata submodule first, and only then call any discovered
+    create_db_and_tables. Several domain schema modules share a single Base/engine
+    (see forecastbox.schemata.jobs) and declare cross-module foreign keys, so all of
+    them must have registered their ORM classes on that shared metadata before any
+    create_db_and_tables runs -- calling it mid-iteration could create the database
+    with tables missing simply because their module hadn't been imported yet.
+    """
+    pending_create_db_and_tables = []
+    for module_info in pkgutil.iter_modules(forecastbox.schemata.__path__):
+        module = importlib.import_module(f"forecastbox.schemata.{module_info.name}")
+        if hasattr(module, "create_db_and_tables"):
+            pending_create_db_and_tables.append(module.create_db_and_tables)
+    for create_db_and_tables in pending_create_db_and_tables:
+        result = create_db_and_tables()  # type: ignore[call-non-callable] # NOTE no module protocol
+        if inspect.isawaitable(result):
+            result = await result
+        if result is not None:
+            logger.warning(f"unexpected result from create_db_and_tables: {result.__class__}")
+
+
+def _discover_dispatchers() -> None:
+    for package_info in pkgutil.iter_modules(forecastbox.domain.__path__):
+        if not package_info.ispkg:
+            continue
+        module_name = f"forecastbox.domain.{package_info.name}.dispatchers"
+        try:
+            module = importlib.import_module(module_name)
+        except ModuleNotFoundError as error:
+            if error.name == module_name:
+                continue
+            raise
+        registrations = getattr(module, "dispatchers", None)
+        if not isinstance(registrations, tuple):
+            raise TypeError(f"{module_name} must export a dispatchers tuple")
+        for registration in registrations:
+            if not isinstance(registration, DispatcherRegistration):
+                raise TypeError(f"{module_name} contains a malformed dispatcher registration")
+            register_dispatcher(registration)
+    freeze_registration()
+
+
+def _start_execution_runtime() -> None:
+    try:
+        _discover_dispatchers()
+        for pool_name, settings in config.backend.concurrency.pools.items():
+            logger.debug(f"registering {pool_name=}")
+            execution_manager.register_pool(
+                pool_name,
+                max_workers=settings.max_workers,
+                max_pending=settings.max_pending,
+                stage=0,
+            )
+        logger.debug("registering event dispatcher thread")
+        execution_manager.register_thread(
+            ConcurrentThreads.EventDispatcher,
+            event_dispatcher_entrypoint,
+            status_provider=dispatcher_status,
+            stop_request=dispatcher_stop_request,
+            stage=0,
+        )
+        execution_manager.start(timeout=config.backend.concurrency.startup_timeout_seconds)
+    except BaseException:
+        # NOTE partial registration may have happened above -- make sure it's cleaned up, since
+        # from the Initializers' point of view this step either fully started, or not at all.
+        execution_manager.shutdown(timeout=config.backend.concurrency.shutdown_timeout_seconds)
+        raise
+
+
+def _stop_execution_runtime() -> None:
+    execution_manager.shutdown(timeout=config.backend.concurrency.shutdown_timeout_seconds)
+
+
+def _start_broadcaster() -> None:
+    init_broadcaster(asyncio.get_running_loop())
+
+
+def _start_artifact_stores() -> None:
+    submit_initialize_stores()
+
+
+def _start_artifact_provider() -> None:
+    ArtifactsProvider.register_get_artifacts_lookup(lambda: ArtifactManager.catalog)
+    ArtifactsProvider.register_get_artifact_local_path(lambda composite_id: get_artifact_local_path(composite_id, config.backend.data_path))
+
+
+def _start_artifact_manager_plugin_catalog() -> None:
+    # TODO -- split in two, but there is a dependency between them!
+    catalog_ready = submit_refresh_catalog()
+    submit_load_plugins(start_after=catalog_ready)
+
+
+def _stop_artifact_manager_plugin_catalog() -> None:
+    join_artifact_manager(timeout_sec=10)
+
+
+def _start_scheduler() -> None:
+    # TODO delay the start until plugins are ready
+    start_scheduler()
+
+
+def _stop_scheduler() -> None:
+    stop_scheduler()
+
+
+def _stop_tunnels() -> None:
+    shutdown_tunnels()
+
+
+async def _stop_processes() -> None:
+    await shutdown_processes()
+
+
+def _stop_lens() -> None:
+    shutdown_all_lens_instances()
+
+
+def build_initializers() -> Initializers:
+    """Assemble the ordered list of startup/teardown steps for the application lifespan.
+
+    `initialize()` runs these top to bottom; `shutdown()` unwinds them bottom to top, only
+    for the steps that actually started. See `forecastbox.utility.initializer.Initializers`.
+    """
+    initializers = [
+        Initializer("db_schema", start=_start_db_schema),
+        Initializer("execution_runtime", start=_start_execution_runtime, stop=_stop_execution_runtime),
+        Initializer("broadcaster", start=_start_broadcaster),
+        Initializer("artifact_stores", start=_start_artifact_stores),
+        Initializer("artifact_provider", start=_start_artifact_provider),
+        Initializer(
+            "artifact_manager_plugin_catalog",
+            start=_start_artifact_manager_plugin_catalog,
+            stop=_stop_artifact_manager_plugin_catalog,
+        ),
+    ]
+    if config.backend.allow_scheduler:
+        initializers.append(Initializer("scheduler", start=_start_scheduler, stop=_stop_scheduler))
+    initializers.extend(
+        [
+            Initializer("tunnels", stop=_stop_tunnels),
+            Initializer("processes", stop=_stop_processes),
+            Initializer("lens", stop=_stop_lens),
+        ]
+    )
+    return Initializers(initializers)

--- a/backend/src/forecastbox/entrypoint/main.py
+++ b/backend/src/forecastbox/entrypoint/main.py
@@ -10,6 +10,12 @@
 """Entrypoint for the standalone fiab execution (frontend, backend and cascade spawned by a single process).
 Also used in case backend+cascade were launched by the OS as a service, in which case we only check the service
 for liveness and open the browser window here, with the rest logic happening in standalone.service
+
+The responsibility of this module is to spawn the backend process, and do post-start health checks and setup
+endpoint calls (like http call to install default plugins), and register sigterm handlers.
+
+The actual logic of instantiating the backend (the FastAPI app, the background threads, etc) happens in
+entrypoint/app.py, as it is coupled to FastAPI's API
 """
 
 import logging
@@ -67,26 +73,6 @@ def launch_all(config: FIABConfig, attempts: int = 20) -> ChildProcessGroup:
     return handle
 
 
-def _maybe_shutdown_local_gateway(config: FIABConfig) -> None:
-    """Best-effort shutdown of a locally-managed Cascade gateway process.
-
-    The gateway (when using LocalGateway) is spawned as a child of the `backend` process itself
-    (in response to the `/gateway/start` call in `check_backend_ready`), so `ChildProcessGroup.shutdown`
-    (which only knows about the `backend` process) cannot reach it. We ask the still-alive backend
-    to kill its own gateway child before we tear the backend process down.
-
-    TODO: RemoteGateway also spawns a process (over an ssh tunnel) that is not stopped here. Extend
-    this once we have a reliable way to tear that down as well.
-    """
-    if not isinstance(config.cascade.gateway, LocalGateway):
-        return
-    try:
-        with httpx.Client() as client:
-            client.post(config.backend.local_url() + "/api/v1/gateway/kill", timeout=5)
-    except Exception:
-        logger.warning("failed to shut down the local cascade gateway during teardown", exc_info=True)
-
-
 if __name__ == "__main__":
     # NOTE this is referenced from scripts/fiab.sh -- if you refactor this module, pay attention to it
     config = FIABConfig()
@@ -94,7 +80,7 @@ if __name__ == "__main__":
     handles = launch_all(config)
 
     def sigterm_handler(_signo: int, _stack_frame: types.FrameType | None) -> None:
-        _maybe_shutdown_local_gateway(config)
+        # when receiving sigterm, we need to explicitly propagate it, otherwise we'd get zombies
         handles.shutdown()
         sys.exit(0)
 
@@ -103,4 +89,5 @@ if __name__ == "__main__":
         handles.wait()
     except KeyboardInterrupt:
         logger.info("keyboard interrupt, application shutting down")
+        # NOTE the Keyboard Interrupt propagates to all subprocesses, we dont really need to do anything except await them
         handles.wait()

--- a/backend/src/forecastbox/utility/initializer.py
+++ b/backend/src/forecastbox/utility/initializer.py
@@ -1,0 +1,90 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""General purpose ordered start/stop sequencing, intended for use by application lifespans
+that need to bring up several independent-ish subsystems in a particular order, and tear them
+down again in the reverse order.
+
+See `Initializer` and `Initializers` below.
+"""
+
+import inspect
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+StartStop = Callable[[], "None | Awaitable[None]"]
+
+
+def noop() -> None:
+    """Default no-op implementation for an Initializer's `start` or `stop`, for steps that
+    only need one of the two.
+    """
+    pass
+
+
+@dataclass
+class Initializer:
+    """A single named startup/teardown step.
+
+    `start` is invoked during application startup. `stop` is invoked during teardown, but
+    only if `start` previously completed without raising. Either callable may be
+    synchronous, or return an awaitable -- in which case it is awaited.
+    """
+
+    name: str
+    start: StartStop = noop
+    stop: StartStop = noop
+
+
+class Initializers:
+    """Runs a list of `Initializer` steps in order on `initialize()`, and in reverse order
+    on `shutdown()`.
+
+    This object is stateful: it remembers which steps actually started successfully, so
+    that a partial failure during `initialize()` is correctly unwound by `shutdown()`,
+    starting from the last successful step -- not from the whole list.
+
+    Failure semantics:
+    - a failure in `start()` stops `initialize()` from proceeding to the remaining steps,
+      and propagates the exception to the caller. The steps that did start successfully are
+      still recorded, so a subsequent `shutdown()` call unwinds exactly those.
+    - a failure in `stop()` is logged, but does not stop `shutdown()` from proceeding to the
+      remaining steps. If any `stop()` failed, `shutdown()` raises an `ExceptionGroup` after
+      all steps have been attempted.
+    """
+
+    def __init__(self, initializers: list[Initializer]) -> None:
+        self.initializers = initializers
+        self._started: list[Initializer] = []
+
+    async def initialize(self) -> None:
+        for initializer in self.initializers:
+            logger.debug(f"starting initializer {initializer.name!r}")
+            result = initializer.start()
+            if inspect.isawaitable(result):
+                await result
+            self._started.append(initializer)
+
+    async def shutdown(self) -> None:
+        errors: list[Exception] = []
+        for initializer in reversed(self._started):
+            logger.debug(f"stopping initializer {initializer.name!r}")
+            try:
+                result = initializer.stop()
+                if inspect.isawaitable(result):
+                    await result
+            except Exception as e:
+                logger.exception(f"failed to stop initializer {initializer.name!r}")
+                errors.append(e)
+        self._started = []
+        if errors:
+            raise ExceptionGroup("failed to shut down some initializers", errors)

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -203,7 +203,6 @@ def backend_client() -> Generator[httpx.Client, None, None]:
         p_artifacts = get_mp_ctx("other").Process(target=run_artifact_registry, args=(shutdown_event_artifacts,))
         p_artifacts.start()
 
-        validate_runtime(config)
         handles = launch_all(config)
         client = httpx.Client(base_url=config.backend.local_url() + "/api/v1", follow_redirects=True)
         # we need to call admin register before yielding this to anybody, because the first registered user is admin

--- a/backend/tests/unit/utility/test_initializer.py
+++ b/backend/tests/unit/utility/test_initializer.py
@@ -1,0 +1,116 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Unit tests for `forecastbox.utility.initializer`."""
+
+import pytest
+
+from forecastbox.utility.initializer import Initializer, Initializers, noop
+
+
+@pytest.mark.asyncio
+async def test_start_and_stop_order() -> None:
+    calls: list[str] = []
+    initializers = Initializers(
+        [
+            Initializer("a", start=lambda: calls.append("a.start"), stop=lambda: calls.append("a.stop")),
+            Initializer("b", start=lambda: calls.append("b.start"), stop=lambda: calls.append("b.stop")),
+            Initializer("c", start=lambda: calls.append("c.start"), stop=lambda: calls.append("c.stop")),
+        ]
+    )
+
+    await initializers.initialize()
+    assert calls == ["a.start", "b.start", "c.start"]
+
+    await initializers.shutdown()
+    assert calls == ["a.start", "b.start", "c.start", "c.stop", "b.stop", "a.stop"]
+
+
+@pytest.mark.asyncio
+async def test_defaults_to_noop() -> None:
+    initializer = Initializer("noop-both")
+    assert initializer.start is noop
+    assert initializer.stop is noop
+
+    initializers = Initializers([initializer])
+    await initializers.initialize()
+    await initializers.shutdown()  # should not raise
+
+
+@pytest.mark.asyncio
+async def test_startup_failure_stops_remaining_steps_and_unwinds_only_started_ones() -> None:
+    calls: list[str] = []
+
+    def failing_start() -> None:
+        calls.append("b.start")
+        raise ValueError("boom")
+
+    initializers = Initializers(
+        [
+            Initializer("a", start=lambda: calls.append("a.start"), stop=lambda: calls.append("a.stop")),
+            Initializer("b", start=failing_start, stop=lambda: calls.append("b.stop")),
+            Initializer("c", start=lambda: calls.append("c.start"), stop=lambda: calls.append("c.stop")),
+        ]
+    )
+
+    with pytest.raises(ValueError, match="boom"):
+        await initializers.initialize()
+
+    # "c" never started, so it should not have been attempted
+    assert calls == ["a.start", "b.start"]
+
+    await initializers.shutdown()
+    # only "a" actually completed its start, "b" raised during start so it's not unwound either
+    assert calls == ["a.start", "b.start", "a.stop"]
+
+
+@pytest.mark.asyncio
+async def test_teardown_failure_is_isolated_logged_and_aggregated() -> None:
+    calls: list[str] = []
+
+    def failing_stop() -> None:
+        calls.append("b.stop")
+        raise RuntimeError("teardown boom")
+
+    initializers = Initializers(
+        [
+            Initializer("a", start=lambda: calls.append("a.start"), stop=lambda: calls.append("a.stop")),
+            Initializer("b", start=lambda: calls.append("b.start"), stop=failing_stop),
+            Initializer("c", start=lambda: calls.append("c.start"), stop=lambda: calls.append("c.stop")),
+        ]
+    )
+
+    await initializers.initialize()
+
+    with pytest.raises(ExceptionGroup) as exc_info:
+        await initializers.shutdown()
+
+    # all three stops were attempted, despite "b" raising
+    assert calls == ["a.start", "b.start", "c.start", "c.stop", "b.stop", "a.stop"]
+    assert len(exc_info.value.exceptions) == 1
+    assert isinstance(exc_info.value.exceptions[0], RuntimeError)
+
+
+@pytest.mark.asyncio
+async def test_async_start_and_stop_callables_are_awaited() -> None:
+    calls: list[str] = []
+
+    async def async_start() -> None:
+        calls.append("start")
+
+    async def async_stop() -> None:
+        calls.append("stop")
+
+    initializers = Initializers([Initializer("async-step", start=async_start, stop=async_stop)])
+
+    await initializers.initialize()
+    assert calls == ["start"]
+
+    await initializers.shutdown()
+    assert calls == ["start", "stop"]


### PR DESCRIPTION
    backend: refactor app lifespan into ordered Initializer steps

    Extract the backend's FastAPI lifespan startup/teardown sequence into a
    generic, list-driven Initializer mechanism:

    - utility/initializer.py: Initializer dataclass (name/start/stop) and
      Initializers, which runs steps in order on initialize() and in reverse
      order on shutdown(), unwinding only the steps that actually started.
      Teardown failures are logged and isolated per step, aggregated into an
      ExceptionGroup raised at the end.
    - entrypoint/initializers.py: individual start/stop functions factored out
      of the old lifespan, and build_initializers() assembling them in order.
    - entrypoint/app.py: lifespan is now just building the Initializers,
      calling initialize()/shutdown() around the yield.
    - entrypoint/bootstrap/launchers.py: launch_backend() now checks uvicorn's
      lifespan startup_failed/shutdown_failed after server.serve() returns and
      exits with a non-zero code, since a failure during ASGI lifespan
      shutdown doesn't otherwise affect the process exit code.

    Also moves scheduler startup after the plugin/artifact catalog submission
    step (was starting too early relative to its actual dependents), with a
    TODO to actually delay it until plugins are ready.

    Adds unit tests for Initializer/Initializers covering ordering, noop
    defaults, partial-startup-failure unwinding, and isolated teardown-failure
    aggregation.