### PR TITLE
[cicd] fix bugs in release actions

### DIFF
--- a/scripts/cicd/prepareValVenv.sh
+++ b/scripts/cicd/prepareValVenv.sh
@@ -3,5 +3,5 @@ uv venv valVenv
 source valVenv/bin/activate
 export UV_PROJECT_ENVIRONMENT=${SCRIPT_DIR}/buildVenv
 export UV_NO_PROJECT=1
-uv pip install pytest pytest-xdist pytest-asyncio pytest-subtests pytest-mock ty # TODO how to get this from pyproject/justfile?
+uv pip install pytest pytest-xdist pytest-asyncio pytest-subtests pytest-mock "ty==0.0.2" # TODO how to get this from pyproject/justfile?
 uv pip install $*

--- a/scripts/cicd/tearDownVenv.sh
+++ b/scripts/cicd/tearDownVenv.sh
@@ -1,6 +1,6 @@
 # needs to be standalone because we source this
 VENV_COPY=$VIRTUAL_ENV
-deactivate
+source deactivate
 rm -rf $VENV_COPY
 
 # TODO these two variables should be stack-based instead, ie, dont unset but restore previous state instead


### PR DESCRIPTION
ty is pinned to the same version as backend (clumsily), as old installs could have made validation fail falsily

fixed a bug where teardown of a venv called deactivate directly instead of sourcing
