### PR TITLE
deployment/v2/justfile: use set tempdir instead of set shell

### DIFF
--- a/.github/workflows/cd-docker.yml
+++ b/.github/workflows/cd-docker.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ["Linux", "platform-builder-docker-xl"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # we need tags to derive release version in case not provided
       - uses: extractions/setup-just@v3
 
       - name: Log in to a Container Registry

--- a/deployment/v2/justfile
+++ b/deployment/v2/justfile
@@ -1,5 +1,11 @@
 # TODO add Dockerfile-gpu and Dockerfile-dist-*, and differentiate commands below with an arg (plain/gpu/dist)
 
+# NOTE some CI runners mount /tmp (just's default location for shebang-recipe
+# scripts) noexec, which makes just fail with "Permission denied (os error 13)"
+# when it tries to execute the generated script. Point just at a directory
+# that is guaranteed to be exec-able instead (the repo checkout itself).
+set tempdir := "."
+
 build release_tag="":
     #!/usr/bin/env bash
     cp ../../scripts/fiab.sh . # NOTE we could have context the repo root -- but too bulky and not needed


### PR DESCRIPTION
The previous 'set shell := ["bash", "-uc"]' workaround for the noexec /tmp CI issue broke multi-line if-blocks, since without a recipe shebang just executes each recipe line as a separate shell invocation and rejects extra indentation on continuation lines ('Recipe line has extra leading whitespace').

Instead, keep the per-recipe '#!/usr/bin/env bash' shebang (so the whole recipe body is written out and run as a single real script) and set tempdir to '.' so the generated script is written into the repo checkout (exec-able) rather than /tmp (which some CI runners mount noexec).
