### PR TITLE
feat/lensProxy

### DIFF
--- a/backend/src/forecastbox/domain/artifact/events.py
+++ b/backend/src/forecastbox/domain/artifact/events.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 
 from forecastbox.domain.artifact.base import CompositeArtifactId
 from forecastbox.domain.notification.models import ClientNotification
+from forecastbox.utility.config import ROUTE_PREFIX
 
 
 @dataclass(frozen=True, eq=True, slots=True)
@@ -38,6 +39,6 @@ class ArtifactDownloadFinishedEvent:
                 "artifact_local_id": self.composite_id.artifact_local_id,
                 "success": self.is_success,
             },
-            detailRoute="api/v1/artifacts/model_details",
-            refreshRoutes=["api/v1/artifacts/list_models"],
+            detailRoute=f"{ROUTE_PREFIX}/artifacts/model_details",
+            refreshRoutes=[f"{ROUTE_PREFIX}/artifacts/list_models"],
         )

--- a/backend/src/forecastbox/domain/lens/core.py
+++ b/backend/src/forecastbox/domain/lens/core.py
@@ -1,0 +1,13 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from forecastbox.utility.config import ROUTE_PREFIX
+
+# exposed here as its needed both inside routes and elsewhere in domain
+PREFIX = f"{ROUTE_PREFIX}/lens"

--- a/backend/src/forecastbox/domain/lens/exceptions.py
+++ b/backend/src/forecastbox/domain/lens/exceptions.py
@@ -1,0 +1,21 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Domain exceptions for the lens layer.
+
+Translated to HTTP exceptions in the routes layer.
+"""
+
+
+class NoLensFound(Exception):
+    """Raised when retrieving details of a LensId for which no Lens exists."""
+
+
+class UnproxyableLens(Exception):
+    """Raised when trying to proxy a Lens which is unproxyable, eg, has more than one port or is not running."""

--- a/backend/src/forecastbox/domain/lens/manager.py
+++ b/backend/src/forecastbox/domain/lens/manager.py
@@ -28,6 +28,7 @@ from cascade.low.func import assert_never
 from pyrsistent import pmap
 from pyrsistent.typing import PMap
 
+from forecastbox.domain.lens.exceptions import NoLensFound
 from forecastbox.utility.concurrency.ports import FreePortsManager, NoFreePortsException
 from forecastbox.utility.concurrency.shutdown import shutdown_popen
 from forecastbox.utility.concurrency.synchronization import timed_acquire
@@ -160,7 +161,7 @@ def get_status(instance_id: LensInstanceId) -> LensInstanceDetail:
     """Return the status of a lens instance. Raises KeyError if not found."""
     instance = LensInstanceManager.instances.get(instance_id)
     if instance is None:
-        raise KeyError(instance_id)
+        raise NoLensFound(instance_id)
     return _compute_status(instance)
 
 

--- a/backend/src/forecastbox/domain/lens/proxy.py
+++ b/backend/src/forecastbox/domain/lens/proxy.py
@@ -1,0 +1,229 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Lens proxy -- exposing internally launched lens processes via the backend's own port.
+
+A lens is an external process (e.g. skinnyWMS) that the backend launches and which
+binds to 127.0.0.1:<port> on a dynamically chosen port. In containerized deployments
+we cannot expose those dynamic ports to the outside world, so instead every lens is
+reachable through a fixed path on the backend's own port:
+
+    /api/v1/lens/proxy/<lens_instance_id>/<upstream path>[?<query>]
+
+This module implements a streaming HTTP reverse proxy for that path. The following is
+the contract between the backend proxy, the clients that call it, and the lens
+processes being proxied. It is authoritative; new clients (beyond the current
+frontend, e.g. the CLI) and new lens types must adhere to it.
+
+Supported traffic
+------------------
+- HTTP/1.1 request/response only, in both directions, fully streamed (no whole-body
+  buffering). Request bodies of arbitrary size are streamed upstream; response bodies
+  are streamed back downstream. Range requests, conditional requests, and chunked
+  responses are supported.
+- NOT supported (at the time of writing): WebSocket upgrades, Server-Sent Events kept
+  open indefinitely (they will "work" but hold a worker), HTTP/2-only features, and
+  any non-HTTP protocol. A lens that a client must reach through this proxy MUST speak
+  plain HTTP request/response. See lensProxy-backend-extension.md for how these could
+  be added later.
+
+Authentication
+--------------
+- The proxy route requires an authenticated caller (or passthrough mode). There is
+  currently NO per-lens ownership check: any authenticated caller may reach any lens.
+  Restricting a lens to the user who started it is a planned extension (a user-lens
+  matrix); until then, treat lens contents as visible to all authenticated users.
+
+URL handling -- the client's responsibility
+-------------------------------------------
+- The lens is mounted under the path prefix /api/v1/lens/proxy/<lens_instance_id>/ .
+  The proxy strips that prefix before forwarding: a client request for
+  `/api/v1/lens/proxy/<id>/wms?...` reaches the lens as `/wms?...`.
+- Clients MUST address the lens using that prefix and MUST treat it as the base
+  origin+path of the lens. Because the base has a non-root path, clients that consume
+  absolute URLs emitted by the lens (see below) must rebase those URLs onto this
+  prefix rather than using them verbatim.
+- The proxy sets X-Forwarded-Proto / -Host / -Prefix and a Forwarded header describing
+  the external mount point. A forwarded-header-aware lens SHOULD use these to emit
+  correct absolute self-URLs. skinnyWMS does not, hence the client-side rebasing
+  requirement below.
+
+URL handling -- the lens's responsibility
+-----------------------------------------
+- A lens SHOULD emit relative URLs, or honour the X-Forwarded-* / Forwarded headers
+  (e.g. via a WSGI SCRIPT_NAME / ProxyFix equivalent) when constructing absolute
+  self-URLs, so that clients receive URLs already pointing at the proxy path.
+- A lens that instead bakes its internal bind address (e.g. http://0.0.0.0:<port>/...)
+  into structured, machine-parseable responses (like a WMS GetCapabilities document)
+  is tolerable ONLY if clients can and do rebase those URLs onto the proxy prefix. A
+  lens that bakes absolute self-origin URLs into opaque payloads that clients cannot
+  rewrite is NOT proxyable by this mechanism.
+- A lens MUST NOT rely on being reachable on its own port from outside the backend
+  host; the only supported ingress is this proxy.
+
+The proxy does NOT rewrite response bodies. Any URL adaptation is the client's job,
+per the rules above.
+"""
+
+import logging
+from collections.abc import AsyncIterator
+
+import httpx
+from fastapi import HTTPException, Request
+from fastapi.responses import StreamingResponse
+from starlette.datastructures import Headers
+
+from forecastbox.domain.lens.manager import LensInstanceId, get_status
+
+logger = logging.getLogger(__name__)
+
+PREFIX = "/api/v1/lens/proxy"
+
+#: Headers that are meaningful only for a single hop and must not be forwarded
+#: verbatim in either direction (RFC 7230 section 6.1, plus Content-Length since
+#: we let the receiving side recompute framing for a re-streamed body).
+HOP_BY_HOP_HEADERS = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+    "content-length",
+}
+
+#: Timeout applied to the upstream connection. Generous read timeout because some
+#: lens responses (e.g. large tile renders) can take a while to produce.
+_TIMEOUT = httpx.Timeout(connect=5.0, read=120.0, write=120.0, pool=5.0)
+
+_client: httpx.AsyncClient | None = None
+
+
+def get_client() -> httpx.AsyncClient:
+    """Return the module-level `httpx.AsyncClient`, creating it lazily on first use."""
+    global _client
+    if _client is None:
+        _client = httpx.AsyncClient(timeout=_TIMEOUT)
+    return _client
+
+
+async def aclose_client() -> None:
+    """Close the module-level client, if one was created. Intended for use during
+    application shutdown."""
+    global _client
+    if _client is not None:
+        await _client.aclose()
+        _client = None
+
+
+def _resolve_port(lens_instance_id: LensInstanceId) -> int:
+    """Resolve a lens_instance_id to its bound port.
+
+    Raises KeyError if the instance is unknown, and RuntimeError if it is known but
+    not `running`, or if it has a number of ports other than exactly one (an
+    invariant violation for the currently supported lens types).
+    """
+    detail = get_status(lens_instance_id)
+    if detail.status != "running":
+        raise RuntimeError(f"Lens instance {lens_instance_id!r} is not running (status={detail.status!r})")
+    if len(detail.ports) != 1:
+        logger.error(f"Lens instance {lens_instance_id!r} does not expose exactly one port: {detail.ports!r}")
+        raise RuntimeError(f"Lens instance {lens_instance_id!r} does not expose exactly one port")
+    return next(iter(detail.ports))
+
+
+def _filtered_headers(headers: httpx.Headers | Headers, *, drop: frozenset[str] = frozenset()) -> list[tuple[str, str]]:
+    drop_names = HOP_BY_HOP_HEADERS | drop
+    return [(name, value) for name, value in headers.items() if name.lower() not in drop_names]
+
+
+def _build_upstream_headers(request: Request, port: int, lens_instance_id: LensInstanceId) -> list[tuple[str, str]]:
+    headers = _filtered_headers(request.headers, drop=frozenset({"host"}))
+
+    client_host = request.client.host if request.client is not None else None
+    existing_xff = request.headers.get("x-forwarded-for")
+    if client_host:
+        xff = f"{existing_xff}, {client_host}" if existing_xff else client_host
+        headers.append(("X-Forwarded-For", xff))
+    elif existing_xff:
+        headers.append(("X-Forwarded-For", existing_xff))
+
+    headers.append(("X-Forwarded-Proto", request.url.scheme))
+    original_host = request.headers.get("host")
+    if original_host:
+        headers.append(("X-Forwarded-Host", original_host))
+    prefix = f"{PREFIX}/{lens_instance_id}"
+    headers.append(("X-Forwarded-Prefix", prefix))
+
+    forwarded_parts = [f"proto={request.url.scheme}"]
+    if original_host:
+        forwarded_parts.append(f"host={original_host}")
+    if client_host:
+        forwarded_parts.append(f"for={client_host}")
+    headers.append(("Forwarded", ";".join(forwarded_parts)))
+
+    headers.append(("Host", f"127.0.0.1:{port}"))
+    return headers
+
+
+def _build_upstream_url(port: int, upstream_path: str, query: str) -> str:
+    url = f"http://127.0.0.1:{port}/{upstream_path}"
+    if query:
+        url = f"{url}?{query}"
+    return url
+
+
+async def forward(lens_instance_id: LensInstanceId, upstream_path: str, request: Request) -> StreamingResponse:
+    """Forward `request` to the lens identified by `lens_instance_id`, streaming both
+    the request body upstream and the response body back downstream.
+
+    Raises HTTPException(404) if the lens instance is unknown or not running, and
+    HTTPException(502/503) if the upstream connection fails.
+    """
+    try:
+        port = _resolve_port(lens_instance_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail=f"Lens instance {lens_instance_id!r} not found")
+    except RuntimeError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    url = _build_upstream_url(port, upstream_path, request.url.query)
+    headers = _build_upstream_headers(request, port, lens_instance_id)
+    client = get_client()
+
+    upstream_request = client.build_request(
+        request.method,
+        url,
+        headers=headers,
+        content=request.stream(),
+    )
+
+    try:
+        upstream_response = await client.send(upstream_request, stream=True)
+    except httpx.ConnectError:
+        raise HTTPException(status_code=502, detail=f"Lens instance {lens_instance_id!r} is unreachable")
+    except httpx.TimeoutException:
+        raise HTTPException(status_code=504, detail=f"Lens instance {lens_instance_id!r} timed out")
+
+    async def body_iterator() -> AsyncIterator[bytes]:
+        try:
+            async for chunk in upstream_response.aiter_raw():
+                yield chunk
+        finally:
+            await upstream_response.aclose()
+
+    response_headers = _filtered_headers(upstream_response.headers)
+
+    return StreamingResponse(
+        body_iterator(),
+        status_code=upstream_response.status_code,
+        headers=dict(response_headers),
+    )

--- a/backend/src/forecastbox/domain/lens/proxy.py
+++ b/backend/src/forecastbox/domain/lens/proxy.py
@@ -80,6 +80,7 @@ from fastapi.responses import StreamingResponse
 from starlette.datastructures import Headers
 
 from forecastbox.domain.lens.core import PREFIX as PREFIX_ROOT
+from forecastbox.domain.lens.exceptions import UnproxyableLens
 from forecastbox.domain.lens.manager import LensInstanceId, get_status
 
 logger = logging.getLogger(__name__)
@@ -128,17 +129,17 @@ async def aclose_client() -> None:
 def _resolve_port(lens_instance_id: LensInstanceId) -> int:
     """Resolve a lens_instance_id to its bound port.
 
-    Raises KeyError if the instance is unknown, and RuntimeError if it is known but
-    not `running`, or if it has a number of ports other than exactly one (an
-    invariant violation for the currently supported lens types).
+    Forwards NoLensFound if the instance is unknown, and raises UnproxyableRens if it
+    is known but not `running`, or if it has a number of ports other than exactly one
+    (an invariant violation for the currently supported lens types).
     """
     detail = get_status(lens_instance_id)
     if detail.status != "running":
-        raise RuntimeError(f"Lens instance {lens_instance_id!r} is not running (status={detail.status!r})")
+        raise UnproxyableLens(f"Lens instance {lens_instance_id!r} is not running (status={detail.status!r})")
     if len(detail.ports) != 1:
         logger.error(f"Lens instance {lens_instance_id!r} does not expose exactly one port: {detail.ports!r}")
-        raise RuntimeError(f"Lens instance {lens_instance_id!r} does not expose exactly one port")
-    return next(iter(detail.ports))
+        raise UnproxyableLens(f"Lens instance {lens_instance_id!r} does not expose exactly one port")
+    return next(iter(detail.ports))  # odd but its a set, we cant just [0] it
 
 
 def _filtered_headers(headers: httpx.Headers | Headers, *, drop: frozenset[str] = frozenset()) -> list[tuple[str, str]]:
@@ -186,15 +187,10 @@ async def forward(lens_instance_id: LensInstanceId, upstream_path: str, request:
     """Forward `request` to the lens identified by `lens_instance_id`, streaming both
     the request body upstream and the response body back downstream.
 
-    Raises HTTPException(404) if the lens instance is unknown or not running, and
-    HTTPException(502/503) if the upstream connection fails.
+    Forwards exceptions such as NoLensFound or UnproxyableLens.
+    Raises HTTP exceptions in case of upstream connection failure.
     """
-    try:
-        port = _resolve_port(lens_instance_id)
-    except KeyError:
-        raise HTTPException(status_code=404, detail=f"Lens instance {lens_instance_id!r} not found")
-    except RuntimeError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+    port = _resolve_port(lens_instance_id)
 
     url = _build_upstream_url(port, upstream_path, request.url.query)
     headers = _build_upstream_headers(request, port, lens_instance_id)
@@ -207,6 +203,8 @@ async def forward(lens_instance_id: LensInstanceId, upstream_path: str, request:
         content=request.stream(),
     )
 
+    # NOTE here we raise HTTP exceptions directly, not domain exceptions -- because we are indeed
+    # converting underlying http errors
     try:
         upstream_response = await client.send(upstream_request, stream=True)
     except httpx.ConnectError:

--- a/backend/src/forecastbox/domain/lens/proxy.py
+++ b/backend/src/forecastbox/domain/lens/proxy.py
@@ -79,11 +79,12 @@ from fastapi import HTTPException, Request
 from fastapi.responses import StreamingResponse
 from starlette.datastructures import Headers
 
+from forecastbox.domain.lens.core import PREFIX as PREFIX_ROOT
 from forecastbox.domain.lens.manager import LensInstanceId, get_status
 
 logger = logging.getLogger(__name__)
 
-PREFIX = "/api/v1/lens/proxy"
+PREFIX = f"{PREFIX_ROOT}/proxy"
 
 #: Headers that are meaningful only for a single hop and must not be forwarded
 #: verbatim in either direction (RFC 7230 section 6.1, plus Content-Length since

--- a/backend/src/forecastbox/domain/plugin/events.py
+++ b/backend/src/forecastbox/domain/plugin/events.py
@@ -12,6 +12,7 @@
 from dataclasses import dataclass
 
 from forecastbox.domain.notification.models import ClientNotification
+from forecastbox.utility.config import ROUTE_PREFIX
 
 
 @dataclass(frozen=True, eq=True, slots=True)
@@ -31,8 +32,8 @@ class PluginGlobalErrorEvent:
             sourceDomainName="plugin",
             sourceDomainEvent="pluginGlobalError",
             context={"trigger": self.trigger, "error": self.error},
-            detailRoute="api/v1/plugin/list",
-            refreshRoutes=["api/v1/plugin/list"],
+            detailRoute=f"{ROUTE_PREFIX}/plugin/list",
+            refreshRoutes=[f"{ROUTE_PREFIX}/plugin/list"],
         )
 
 
@@ -49,8 +50,8 @@ class PluginInstalledEvent:
             sourceDomainName="plugin",
             sourceDomainEvent="pluginInstalled",
             context={"plugin_id": self.plugin_id},
-            detailRoute="api/v1/plugin/list",
-            refreshRoutes=["api/v1/plugin/list"],
+            detailRoute=f"{ROUTE_PREFIX}/plugin/list",
+            refreshRoutes=[f"{ROUTE_PREFIX}/plugin/list"],
         )
 
 
@@ -67,8 +68,8 @@ class PluginUpdatedEvent:
             sourceDomainName="plugin",
             sourceDomainEvent="pluginUpdated",
             context={"plugin_id": self.plugin_id},
-            detailRoute="api/v1/plugin/list",
-            refreshRoutes=["api/v1/plugin/list"],
+            detailRoute=f"{ROUTE_PREFIX}/plugin/list",
+            refreshRoutes=[f"{ROUTE_PREFIX}/plugin/list"],
         )
 
 
@@ -86,8 +87,8 @@ class PluginSettingsAppliedEvent:
             sourceDomainName="plugin",
             sourceDomainEvent="pluginSettingsApplied",
             context={"plugin_id": self.plugin_id},
-            detailRoute="api/v1/plugin/list",
-            refreshRoutes=["api/v1/plugin/list"],
+            detailRoute=f"{ROUTE_PREFIX}/plugin/list",
+            refreshRoutes=[f"{ROUTE_PREFIX}/plugin/list"],
         )
 
 
@@ -104,8 +105,8 @@ class PluginUnloadedEvent:
             sourceDomainName="plugin",
             sourceDomainEvent="pluginUnloaded",
             context={"plugin_id": self.plugin_id},
-            detailRoute="api/v1/plugin/list",
-            refreshRoutes=["api/v1/plugin/list"],
+            detailRoute=f"{ROUTE_PREFIX}/plugin/list",
+            refreshRoutes=[f"{ROUTE_PREFIX}/plugin/list"],
         )
 
 
@@ -122,8 +123,8 @@ class PluginUninstalledEvent:
             sourceDomainName="plugin",
             sourceDomainEvent="pluginUninstalled",
             context={"plugin_id": self.plugin_id},
-            detailRoute="api/v1/plugin/list",
-            refreshRoutes=["api/v1/plugin/list"],
+            detailRoute=f"{ROUTE_PREFIX}/plugin/list",
+            refreshRoutes=[f"{ROUTE_PREFIX}/plugin/list"],
         )
 
 

--- a/backend/src/forecastbox/entrypoint/app.py
+++ b/backend/src/forecastbox/entrypoint/app.py
@@ -29,7 +29,7 @@ from starlette.exceptions import HTTPException
 import forecastbox.routes
 from forecastbox.domain.admin import get_local_release
 from forecastbox.entrypoint.initializers import build_initializers
-from forecastbox.utility.config import config, validate_runtime
+from forecastbox.utility.config import ROUTE_PREFIX, config, validate_runtime
 from forecastbox.utility.fastapi import register_common_exception_handling
 
 logger = logging.getLogger(__name__)
@@ -52,8 +52,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
 
 app = FastAPI(
-    docs_url="/api/v1/docs",
-    openapi_url="/api/v1/openapi.json",
+    docs_url=f"{ROUTE_PREFIX}/docs",
+    openapi_url=f"{ROUTE_PREFIX}/openapi.json",
     title="Forecast in a Box API",
     version="1.0.0",
     lifespan=lifespan,
@@ -97,17 +97,17 @@ async def add_process_time_header(request: Request, call_next: Callable[[Request
 @app.middleware("http")
 async def circumvent_auth(request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
     # TODO this is a hotfix, we'd instead like to fix properly in api/routers/auth.py
-    if request.url.path == "/api/v1/users/me" and config.auth.passthrough:
+    if request.url.path == f"{ROUTE_PREFIX}/users/me" and config.auth.passthrough:
         return JSONResponse({"is_superuser": True})
     else:
         return await call_next(request)
 
 
-@app.get("/api/v1/share/{job_id}/{dataset_id}", response_class=HTMLResponse, tags=["share"], summary="Share Image")
+@app.get(ROUTE_PREFIX + "/share/{job_id}/{dataset_id}", response_class=HTMLResponse, tags=["share"], summary="Share Image")
 async def share_image(request: Request, job_id: str, dataset_id: str) -> HTMLResponse:
     """Endpoint to share an image from a job and dataset ID."""
     base_url = str(request.base_url).rstrip("/")
-    image_url = f"{base_url}/api/v1/job/{job_id}/{dataset_id}"
+    image_url = f"{base_url}{ROUTE_PREFIX}/job/{job_id}/{dataset_id}"
     return templates.TemplateResponse(request, "share.html", {"image_url": image_url, "image_name": f"{job_id}_{dataset_id}"})
 
 

--- a/backend/src/forecastbox/entrypoint/bootstrap/checks.py
+++ b/backend/src/forecastbox/entrypoint/bootstrap/checks.py
@@ -8,7 +8,7 @@ import httpx
 from cascade.low.func import assert_never
 
 from forecastbox.entrypoint.bootstrap.procs import ChildProcessGroup
-from forecastbox.utility.config import FIABConfig, StatusMessage, _default_plugins
+from forecastbox.utility.config import ROUTE_PREFIX, FIABConfig, StatusMessage, _default_plugins
 
 logger = logging.getLogger(__name__)
 
@@ -57,11 +57,11 @@ def check_backend_ready(
 ) -> None:
     try:
         with httpx.Client() as client:
-            _wait_for(client, config.backend.local_url() + "/api/v1/status", attempts, _call_succ)
+            _wait_for(client, config.backend.local_url() + f"{ROUTE_PREFIX}/status", attempts, _call_succ)
             if spawn_gateway:
-                client.post(config.backend.local_url() + "/api/v1/gateway/start").raise_for_status()
+                client.post(config.backend.local_url() + f"{ROUTE_PREFIX}/gateway/start").raise_for_status()
             gw_check = lambda resp, _: resp.raise_for_status().text == f'"{StatusMessage.gateway_running}"'
-            _wait_for(client, config.backend.local_url() + "/api/v1/gateway/status", attempts, gw_check)
+            _wait_for(client, config.backend.local_url() + f"{ROUTE_PREFIX}/gateway/status", attempts, gw_check)
     except StartupError as e:
         logger.error(f"failed to start the backend: {e}")
         if handles is not None:
@@ -74,7 +74,7 @@ def install_default_plugins(config: FIABConfig) -> None:
     try:
         with httpx.Client(follow_redirects=True) as client:
             for pluginId in _default_plugins().keys():
-                url = config.backend.local_url() + "/api/v1/plugin/install"
+                url = config.backend.local_url() + f"{ROUTE_PREFIX}/plugin/install"
                 try:
                     client.post(url, json=pluginId.model_dump()).raise_for_status()
                 except Exception:

--- a/backend/src/forecastbox/entrypoint/initializers.py
+++ b/backend/src/forecastbox/entrypoint/initializers.py
@@ -30,6 +30,7 @@ from forecastbox.domain.artifact.manager import ArtifactManager, join_artifact_m
 from forecastbox.domain.experiment.scheduling.background import start_scheduler, stop_scheduler
 from forecastbox.domain.gateway.service import shutdown_processes
 from forecastbox.domain.lens.manager import shutdown_all_lens_instances
+from forecastbox.domain.lens.proxy import aclose_client as aclose_lens_proxy_client
 from forecastbox.domain.notification.service import init_broadcaster
 from forecastbox.domain.plugin.store import submit_initialize_stores
 from forecastbox.domain.plugin.submit import submit_load_all as submit_load_plugins
@@ -172,6 +173,10 @@ def _stop_lens() -> None:
     shutdown_all_lens_instances()
 
 
+async def _stop_lens_proxy_client() -> None:
+    await aclose_lens_proxy_client()
+
+
 def build_initializers() -> Initializers:
     """Assemble the ordered list of startup/teardown steps for the application lifespan.
 
@@ -197,6 +202,7 @@ def build_initializers() -> Initializers:
             Initializer("tunnels", stop=_stop_tunnels),
             Initializer("processes", stop=_stop_processes),
             Initializer("lens", stop=_stop_lens),
+            Initializer("lens_proxy_client", stop=_stop_lens_proxy_client),
         ]
     )
     return Initializers(initializers)

--- a/backend/src/forecastbox/routes/admin.py
+++ b/backend/src/forecastbox/routes/admin.py
@@ -25,11 +25,11 @@ from pydantic import UUID4
 from forecastbox.domain.admin import Release, get_local_release, get_most_recent_release, get_pylock, mark_release, save_pylock
 from forecastbox.domain.auth.db import delete_user_by_id, get_user_by_id, list_users, patch_user_by_id, update_user_by_id
 from forecastbox.domain.auth.users import UserRead, UserUpdate, current_active_user
-from forecastbox.utility.config import BackendSettings, CascadeSettings, ExternalServicesSettings, config
+from forecastbox.utility.config import ROUTE_PREFIX, BackendSettings, CascadeSettings, ExternalServicesSettings, config
 from forecastbox.utility.pydantic import FiabBaseModel
 from forecastbox.utility.rsjf import ExportedSchemas, FormDefinition, from_pydantic
 
-PREFIX = "/api/v1/admin"
+PREFIX = f"{ROUTE_PREFIX}/admin"
 
 logger = logging.getLogger(__name__)
 

--- a/backend/src/forecastbox/routes/artifacts.py
+++ b/backend/src/forecastbox/routes/artifacts.py
@@ -19,8 +19,9 @@ from forecastbox.domain.artifact.base import CompositeArtifactId, MlModelDetail,
 from forecastbox.domain.artifact.manager import delete_model, get_model_details, list_models, submit_artifact_download
 from forecastbox.domain.auth.users import UserRead
 from forecastbox.routes.admin import get_admin_user
+from forecastbox.utility.config import ROUTE_PREFIX
 
-PREFIX = "/api/v1/artifacts"
+PREFIX = f"{ROUTE_PREFIX}/artifacts"
 
 router = APIRouter(
     tags=["artifacts"],

--- a/backend/src/forecastbox/routes/auth.py
+++ b/backend/src/forecastbox/routes/auth.py
@@ -17,9 +17,9 @@ from fastapi import APIRouter
 
 from forecastbox.domain.auth.oidc import oauth_client
 from forecastbox.domain.auth.users import UserCreate, UserRead, UserUpdate, auth_backend, fastapi_users
-from forecastbox.utility.config import config
+from forecastbox.utility.config import ROUTE_PREFIX, config
 
-PREFIX = "/api/v1"
+PREFIX = ROUTE_PREFIX
 
 router = APIRouter()
 SECRET = config.auth.jwt_secret.get_secret_value()
@@ -33,7 +33,7 @@ if oauth_client is not None:
         oauth_client,
         auth_backend,
         SECRET,
-        redirect_url=config.auth.public_url + "/api/v1/auth/oidc/callback",
+        redirect_url=config.auth.public_url + f"{ROUTE_PREFIX}/auth/oidc/callback",
         is_verified_by_default=True,
         associate_by_email=True,
     )

--- a/backend/src/forecastbox/routes/blueprint.py
+++ b/backend/src/forecastbox/routes/blueprint.py
@@ -68,12 +68,13 @@ from forecastbox.domain.plugin.status import catalogue_view, plugins_ready
 from forecastbox.schemata.blueprint import BlueprintSource
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.concurrency.manager import execution_manager
+from forecastbox.utility.config import ROUTE_PREFIX
 from forecastbox.utility.pagination import PaginationSpec
 from forecastbox.utility.pydantic import FiabBaseModel
 from forecastbox.utility.time import value_dt2str
 
 logger = logging.getLogger(__name__)
-PREFIX = "/api/v1/blueprint"
+PREFIX = f"{ROUTE_PREFIX}/blueprint"
 
 router = APIRouter(
     tags=["blueprint"],

--- a/backend/src/forecastbox/routes/experiment.py
+++ b/backend/src/forecastbox/routes/experiment.py
@@ -33,11 +33,12 @@ from forecastbox.domain.experiment.scheduling.background import start_scheduler,
 from forecastbox.domain.experiment.types import ExperimentDefinitionId
 from forecastbox.domain.run.types import RunId
 from forecastbox.utility.auth import AuthContext
+from forecastbox.utility.config import ROUTE_PREFIX
 from forecastbox.utility.pagination import PaginationSpec
 from forecastbox.utility.pydantic import FiabBaseModel
 from forecastbox.utility.time import current_time, value_dt2str
 
-PREFIX = "/api/v1/experiment"
+PREFIX = f"{ROUTE_PREFIX}/experiment"
 
 logger = logging.getLogger(__name__)
 

--- a/backend/src/forecastbox/routes/gateway.py
+++ b/backend/src/forecastbox/routes/gateway.py
@@ -23,9 +23,9 @@ from forecastbox.domain.gateway.exceptions import (
     GatewayNotStarted,
 )
 from forecastbox.domain.gateway.service import launch_gateway, status_gateway, stop_gateway
-from forecastbox.utility.config import UnmanagedGateway, config
+from forecastbox.utility.config import ROUTE_PREFIX, UnmanagedGateway, config
 
-PREFIX = "/api/v1/gateway"
+PREFIX = f"{ROUTE_PREFIX}/gateway"
 
 router = APIRouter(
     tags=["gateway"],

--- a/backend/src/forecastbox/routes/lens.py
+++ b/backend/src/forecastbox/routes/lens.py
@@ -35,6 +35,7 @@ from forecastbox.domain.auth.users import get_auth_context
 from forecastbox.domain.lens import metadata_db
 from forecastbox.domain.lens import proxy as lens_proxy
 from forecastbox.domain.lens.core import PREFIX
+from forecastbox.domain.lens.exceptions import NoLensFound, UnproxyableLens
 from forecastbox.domain.lens.manager import (
     LensInstanceDetail,
     LensInstanceId,
@@ -126,7 +127,7 @@ def get_lens_status(lens_instance_id: LensInstanceId) -> LensInstanceDetailRespo
     """Get the status of a lens instance."""
     try:
         return LensInstanceDetailResponse.from_detail(lens_instance_id, get_status(lens_instance_id))
-    except KeyError:
+    except NoLensFound:
         raise HTTPException(status_code=404, detail=f"Lens instance {lens_instance_id!r} not found")
 
 
@@ -135,7 +136,7 @@ def stop_lens(lens_instance_id: LensInstanceId) -> str:
     """Stop and remove a lens instance."""
     try:
         stop_instance(lens_instance_id)
-    except KeyError:
+    except NoLensFound:
         raise HTTPException(status_code=404, detail=f"Lens instance {lens_instance_id!r} not found")
     except TimeoutError:
         raise HTTPException(status_code=503, detail="Lens manager is busy")
@@ -165,7 +166,12 @@ async def proxy_lens(
     # TODO implement granual auth: user-lens matrix
     # (auth_context is currently only used to require an authenticated caller;
     #  once the user-lens matrix exists, check ownership here.)
-    return await lens_proxy.forward(lens_instance_id, upstream_path, request)
+    try:
+        return await lens_proxy.forward(lens_instance_id, upstream_path, request)
+    except NoLensFound:
+        raise HTTPException(status_code=404, detail=f"Lens instance {lens_instance_id!r} not found")
+    except UnproxyableLens as e:
+        raise HTTPException(status_code=404, detail=str(e))
 
 
 @router.get("/supported")

--- a/backend/src/forecastbox/routes/lens.py
+++ b/backend/src/forecastbox/routes/lens.py
@@ -28,10 +28,12 @@ import pathlib
 from functools import partial
 from typing import TYPE_CHECKING, Annotated, Any, Self, cast, get_args
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import StreamingResponse
 
 from forecastbox.domain.auth.users import get_auth_context
 from forecastbox.domain.lens import metadata_db
+from forecastbox.domain.lens import proxy as lens_proxy
 from forecastbox.domain.lens.manager import (
     LensInstanceDetail,
     LensInstanceId,
@@ -145,6 +147,26 @@ def stop_lens(lens_instance_id: LensInstanceId) -> str:
 def list_lenses() -> list[LensInstanceDetailResponse]:
     """List all active lens instances with their current status."""
     return [LensInstanceDetailResponse.from_detail(iid, detail) for iid, detail in list_instances()]
+
+
+@router.api_route(
+    "/proxy/{lens_instance_id}/{upstream_path:path}",
+    methods=["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"],
+)
+async def proxy_lens(
+    lens_instance_id: LensInstanceId,
+    upstream_path: str,
+    request: Request,
+    auth_context: AuthContext = Depends(get_auth_context),
+) -> StreamingResponse:
+    """Reverse-proxy a request to the running lens instance identified by `lens_instance_id`.
+
+    See `domain.lens.proxy` for the full client/lens contract.
+    """
+    # TODO implement granual auth: user-lens matrix
+    # (auth_context is currently only used to require an authenticated caller;
+    #  once the user-lens matrix exists, check ownership here.)
+    return await lens_proxy.forward(lens_instance_id, upstream_path, request)
 
 
 @router.get("/supported")

--- a/backend/src/forecastbox/routes/lens.py
+++ b/backend/src/forecastbox/routes/lens.py
@@ -34,6 +34,7 @@ from fastapi.responses import StreamingResponse
 from forecastbox.domain.auth.users import get_auth_context
 from forecastbox.domain.lens import metadata_db
 from forecastbox.domain.lens import proxy as lens_proxy
+from forecastbox.domain.lens.core import PREFIX
 from forecastbox.domain.lens.manager import (
     LensInstanceDetail,
     LensInstanceId,
@@ -50,8 +51,6 @@ from forecastbox.utility.concurrency.ports import NoFreePortsException
 from forecastbox.utility.pagination import PaginationSpec
 from forecastbox.utility.pydantic import FiabBaseModel
 from forecastbox.utility.time import value_dt2str
-
-PREFIX = "/api/v1/lens"
 
 logger = logging.getLogger(__name__)
 

--- a/backend/src/forecastbox/routes/notification.py
+++ b/backend/src/forecastbox/routes/notification.py
@@ -22,10 +22,11 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from forecastbox.domain.notification.events import PlaceholderNotificationEvent
 from forecastbox.domain.notification.service import register_client, unregister_client
+from forecastbox.utility.config import ROUTE_PREFIX
 from forecastbox.utility.dispatcher import Event, EventName, submit_event
 from forecastbox.utility.pydantic import FiabBaseModel
 
-PREFIX = "/api/v1/notification"
+PREFIX = f"{ROUTE_PREFIX}/notification"
 
 logger = logging.getLogger(__name__)
 

--- a/backend/src/forecastbox/routes/plugins.py
+++ b/backend/src/forecastbox/routes/plugins.py
@@ -34,13 +34,13 @@ from forecastbox.domain.plugin.store import get_plugins_detail, submit_install_s
 from forecastbox.domain.plugin.submit import submit_uninstall_single, submit_unload_single, submit_update_single
 from forecastbox.routes.admin import get_admin_user
 from forecastbox.utility.concurrency.manager import execution_manager
-from forecastbox.utility.config import PluginSettings, config
+from forecastbox.utility.config import ROUTE_PREFIX, PluginSettings, config
 from forecastbox.utility.packages import get_package_versions
 from forecastbox.utility.pydantic import FiabBaseModel
 
 logger = logging.getLogger(__name__)
 
-PREFIX = "/api/v1/plugin"
+PREFIX = f"{ROUTE_PREFIX}/plugin"
 
 router = APIRouter(
     tags=["blueprint"],

--- a/backend/src/forecastbox/routes/run.py
+++ b/backend/src/forecastbox/routes/run.py
@@ -44,11 +44,12 @@ from forecastbox.domain.run.exceptions import CompilationDetailCorrupted, Compil
 from forecastbox.domain.run.types import RunId
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.concurrency.manager import execution_manager
+from forecastbox.utility.config import ROUTE_PREFIX
 from forecastbox.utility.httpx import get_encoding
 from forecastbox.utility.pagination import PaginationSpec
 from forecastbox.utility.pydantic import FiabBaseModel
 
-PREFIX = "/api/v1/run"
+PREFIX = f"{ROUTE_PREFIX}/run"
 
 logger = logging.getLogger(__name__)
 

--- a/backend/src/forecastbox/routes/status.py
+++ b/backend/src/forecastbox/routes/status.py
@@ -20,9 +20,9 @@ from forecastbox.domain.experiment.scheduling.background import status_scheduler
 from forecastbox.domain.gateway.service import get_gateway_url
 from forecastbox.domain.plugin.status import status_brief
 from forecastbox.utility.concurrency.manager import ExecutionStatus, execution_manager
-from forecastbox.utility.config import config
+from forecastbox.utility.config import ROUTE_PREFIX, config
 
-PREFIX = "/api/v1/status"
+PREFIX = f"{ROUTE_PREFIX}/status"
 
 logger = logging.getLogger(__name__)
 

--- a/backend/src/forecastbox/utility/config.py
+++ b/backend/src/forecastbox/utility/config.py
@@ -27,6 +27,10 @@ from forecastbox.utility.pydantic import FiabBaseModel
 fiab_home = Path(os.environ["FIAB_ROOT"]) if "FIAB_ROOT" in os.environ else (Path.home() / ".fiab")
 logger = logging.getLogger(__name__)
 
+# NOTE not the best place for this to be, but better than spread adhoc all over. It is actually needed
+# inside various domains as well due to eg proxies and responses, its not just for routes
+ROUTE_PREFIX = "/api/v1"
+
 
 def _validate_url(url: str) -> bool:
     # TODO add DNS resolution attempt or something

--- a/backend/tests/integration/test_model.py
+++ b/backend/tests/integration/test_model.py
@@ -89,13 +89,13 @@ def test_download_model(backend_client_admin: httpx.Client, backend_client: http
             assert is_success
             remaining_checkpoints.discard(local_id)
             refresh_routes.update(notification.refreshRoutes)
-            assert notification.detailRoute == "api/v1/artifacts/model_details"
+            assert notification.detailRoute == "/api/v1/artifacts/model_details"
 
         assert not remaining_checkpoints, f"did not receive artifactDownloadFinished notifications for {remaining_checkpoints}"
         assert len(refresh_routes) == 1, f"expected exactly one distinct refresh route, got {refresh_routes}"
         refresh_route = next(iter(refresh_routes))
-        assert refresh_route.startswith("api/v1/")
-        stripped_route = refresh_route.removeprefix("api/v1/")
+        assert refresh_route.startswith("/api/v1/")
+        stripped_route = refresh_route.removeprefix("/api/v1/")
 
         refreshed = backend_client_admin.get(f"/{stripped_route}").raise_for_status().json()
         refreshed_available = {

--- a/backend/tests/unit/domain/lens/test_lens_manager.py
+++ b/backend/tests/unit/domain/lens/test_lens_manager.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pyrsistent import pmap
 
+from forecastbox.domain.lens.exceptions import NoLensFound
 from forecastbox.domain.lens.manager import (
     LensInstance,
     LensInstanceDetail,
@@ -82,8 +83,8 @@ class TestComputeStatus:
 
 
 class TestGetStatus:
-    def test_raises_key_error_for_unknown_id(self) -> None:
-        with pytest.raises(KeyError):
+    def test_raises_no_lens_found_for_unknown_id(self) -> None:
+        with pytest.raises(NoLensFound):
             get_status(LensInstanceId("no-such-id"))
 
     def test_returns_status_for_known_id(self) -> None:

--- a/backend/tests/unit/domain/lens/test_proxy.py
+++ b/backend/tests/unit/domain/lens/test_proxy.py
@@ -1,0 +1,162 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+"""Unit tests for the lens reverse proxy."""
+
+import subprocess
+from collections.abc import AsyncIterator, Iterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastapi import HTTPException, Request
+from pyrsistent import pmap
+
+from forecastbox.domain.lens import proxy as lens_proxy
+from forecastbox.domain.lens.manager import LensInstance, LensInstanceId, LensInstanceManager
+
+
+def _make_request(method: str = "GET", headers: list[tuple[bytes, bytes]] | None = None, query: bytes = b"") -> Request:
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": "/api/v1/lens/proxy/some-id/wms",
+        "query_string": query,
+        "headers": headers or [(b"host", b"example.com")],
+        "client": ("10.0.0.5", 12345),
+        "scheme": "http",
+    }
+    return Request(scope)
+
+
+@pytest.fixture(autouse=True)
+def reset_lens_manager() -> Iterator[None]:
+    original = LensInstanceManager.instances
+    yield
+    LensInstanceManager.instances = original
+
+
+@pytest.fixture(autouse=True)
+def reset_proxy_client() -> Iterator[None]:
+    yield
+    lens_proxy._client = None
+
+
+class TestResolvePort:
+    def test_unknown_instance_raises_key_error(self) -> None:
+        LensInstanceManager.instances = pmap()
+        with pytest.raises(KeyError):
+            lens_proxy._resolve_port(LensInstanceId("ghost"))
+
+    def test_not_running_instance_raises_runtime_error(self) -> None:
+        iid = LensInstanceId("starting-id")
+        LensInstanceManager.instances = pmap({iid: LensInstance(process=None, lens_params={}, lens_name="skinnyWMS", ports={19000})})
+        with pytest.raises(RuntimeError):
+            lens_proxy._resolve_port(iid)
+
+    def test_running_instance_returns_sole_port(self) -> None:
+        iid = LensInstanceId("running-id")
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.poll.return_value = None
+        LensInstanceManager.instances = pmap({iid: LensInstance(process=mock_proc, lens_params={}, lens_name="skinnyWMS", ports={19042})})
+        assert lens_proxy._resolve_port(iid) == 19042
+
+    def test_multiple_ports_raises_runtime_error(self) -> None:
+        iid = LensInstanceId("multi-port-id")
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.poll.return_value = None
+        LensInstanceManager.instances = pmap(
+            {iid: LensInstance(process=mock_proc, lens_params={}, lens_name="skinnyWMS", ports={19042, 19043})}
+        )
+        with pytest.raises(RuntimeError):
+            lens_proxy._resolve_port(iid)
+
+
+class TestBuildUpstreamUrl:
+    def test_without_query(self) -> None:
+        assert lens_proxy._build_upstream_url(19042, "wms", "") == "http://127.0.0.1:19042/wms"
+
+    def test_with_query(self) -> None:
+        url = lens_proxy._build_upstream_url(19042, "wms", "service=WMS&request=GetCapabilities")
+        assert url == "http://127.0.0.1:19042/wms?service=WMS&request=GetCapabilities"
+
+
+class TestBuildUpstreamHeaders:
+    def test_sets_forwarding_headers(self) -> None:
+        request = _make_request()
+        headers = dict(lens_proxy._build_upstream_headers(request, 19042, LensInstanceId("id-1")))
+        assert headers["X-Forwarded-For"] == "10.0.0.5"
+        assert headers["X-Forwarded-Proto"] == "http"
+        assert headers["X-Forwarded-Host"] == "example.com"
+        assert headers["X-Forwarded-Prefix"] == "/api/v1/lens/proxy/id-1"
+        assert headers["Host"] == "127.0.0.1:19042"
+        assert "for=10.0.0.5" in headers["Forwarded"]
+
+    def test_drops_hop_by_hop_and_host(self) -> None:
+        request = _make_request(headers=[(b"host", b"example.com"), (b"connection", b"keep-alive")])
+        headers = lens_proxy._build_upstream_headers(request, 19042, LensInstanceId("id-1"))
+        names = {name.lower() for name, _ in headers}
+        assert "connection" not in names
+
+
+class TestForward:
+    @pytest.mark.asyncio
+    async def test_unknown_instance_yields_404(self) -> None:
+        LensInstanceManager.instances = pmap()
+        request = _make_request()
+        with pytest.raises(HTTPException) as exc_info:
+            await lens_proxy.forward(LensInstanceId("ghost"), "wms", request)
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_not_running_instance_yields_404(self) -> None:
+        iid = LensInstanceId("starting-id")
+        LensInstanceManager.instances = pmap({iid: LensInstance(process=None, lens_params={}, lens_name="skinnyWMS", ports={19000})})
+        request = _make_request()
+        with pytest.raises(HTTPException) as exc_info:
+            await lens_proxy.forward(iid, "wms", request)
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_connect_error_yields_502(self) -> None:
+        iid = LensInstanceId("running-id")
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.poll.return_value = None
+        LensInstanceManager.instances = pmap({iid: LensInstance(process=mock_proc, lens_params={}, lens_name="skinnyWMS", ports={19042})})
+        request = _make_request()
+        with patch.object(httpx.AsyncClient, "send", AsyncMock(side_effect=httpx.ConnectError("refused"))):
+            with pytest.raises(HTTPException) as exc_info:
+                await lens_proxy.forward(iid, "wms", request)
+        assert exc_info.value.status_code == 502
+
+    @pytest.mark.asyncio
+    async def test_success_streams_response(self) -> None:
+        iid = LensInstanceId("running-id")
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.poll.return_value = None
+        LensInstanceManager.instances = pmap({iid: LensInstance(process=mock_proc, lens_params={}, lens_name="skinnyWMS", ports={19042})})
+        request = _make_request()
+
+        async def fake_aiter_raw() -> AsyncIterator[bytes]:
+            yield b"hello "
+            yield b"world"
+
+        upstream_response = AsyncMock()
+        upstream_response.status_code = 200
+        upstream_response.headers = httpx.Headers({"content-type": "text/plain"})
+        upstream_response.aiter_raw = fake_aiter_raw
+        upstream_response.aclose = AsyncMock()
+
+        with patch.object(httpx.AsyncClient, "send", AsyncMock(return_value=upstream_response)):
+            response = await lens_proxy.forward(iid, "wms", request)
+
+        assert response.status_code == 200
+        chunks: list[bytes] = [chunk async for chunk in response.body_iterator]  # type: ignore[misc]
+        assert b"".join(chunks) == b"hello world"
+        upstream_response.aclose.assert_awaited_once()

--- a/backend/tests/unit/domain/lens/test_proxy.py
+++ b/backend/tests/unit/domain/lens/test_proxy.py
@@ -19,6 +19,7 @@ from fastapi import HTTPException, Request
 from pyrsistent import pmap
 
 from forecastbox.domain.lens import proxy as lens_proxy
+from forecastbox.domain.lens.exceptions import NoLensFound, UnproxyableLens
 from forecastbox.domain.lens.manager import LensInstance, LensInstanceId, LensInstanceManager
 
 
@@ -49,15 +50,15 @@ def reset_proxy_client() -> Iterator[None]:
 
 
 class TestResolvePort:
-    def test_unknown_instance_raises_key_error(self) -> None:
+    def test_unknown_instance_raises_no_lens_found(self) -> None:
         LensInstanceManager.instances = pmap()
-        with pytest.raises(KeyError):
+        with pytest.raises(NoLensFound):
             lens_proxy._resolve_port(LensInstanceId("ghost"))
 
-    def test_not_running_instance_raises_runtime_error(self) -> None:
+    def test_not_running_instance_raises_unproxyable(self) -> None:
         iid = LensInstanceId("starting-id")
         LensInstanceManager.instances = pmap({iid: LensInstance(process=None, lens_params={}, lens_name="skinnyWMS", ports={19000})})
-        with pytest.raises(RuntimeError):
+        with pytest.raises(UnproxyableLens):
             lens_proxy._resolve_port(iid)
 
     def test_running_instance_returns_sole_port(self) -> None:
@@ -67,14 +68,14 @@ class TestResolvePort:
         LensInstanceManager.instances = pmap({iid: LensInstance(process=mock_proc, lens_params={}, lens_name="skinnyWMS", ports={19042})})
         assert lens_proxy._resolve_port(iid) == 19042
 
-    def test_multiple_ports_raises_runtime_error(self) -> None:
+    def test_multiple_ports_raises_unproxyable(self) -> None:
         iid = LensInstanceId("multi-port-id")
         mock_proc = MagicMock(spec=subprocess.Popen)
         mock_proc.poll.return_value = None
         LensInstanceManager.instances = pmap(
             {iid: LensInstance(process=mock_proc, lens_params={}, lens_name="skinnyWMS", ports={19042, 19043})}
         )
-        with pytest.raises(RuntimeError):
+        with pytest.raises(UnproxyableLens):
             lens_proxy._resolve_port(iid)
 
 
@@ -107,21 +108,19 @@ class TestBuildUpstreamHeaders:
 
 class TestForward:
     @pytest.mark.asyncio
-    async def test_unknown_instance_yields_404(self) -> None:
+    async def test_unknown_instance_raises_no_lens_found(self) -> None:
         LensInstanceManager.instances = pmap()
         request = _make_request()
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(NoLensFound):
             await lens_proxy.forward(LensInstanceId("ghost"), "wms", request)
-        assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
-    async def test_not_running_instance_yields_404(self) -> None:
+    async def test_not_running_instance_raises_unproxyable(self) -> None:
         iid = LensInstanceId("starting-id")
         LensInstanceManager.instances = pmap({iid: LensInstance(process=None, lens_params={}, lens_name="skinnyWMS", ports={19000})})
         request = _make_request()
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(UnproxyableLens):
             await lens_proxy.forward(iid, "wms", request)
-        assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
     async def test_connect_error_yields_502(self) -> None:

--- a/docs/developer/changeSpecs/lensProxy-backend-extension.md
+++ b/docs/developer/changeSpecs/lensProxy-backend-extension.md
@@ -1,0 +1,99 @@
+# Lens Proxy -- Extending Beyond HTTP Streaming
+
+## Status and audience
+
+This is a forward-looking, architect-oriented note. It assumes the initial HTTP
+streaming proxy (`lensProxy-backend-initial.md`) and its frontend adaptation
+(`lensProxy-frontend.md`) are in place, but that the codebase may have evolved
+considerably in unrelated ways since. Treat file/function names below as anchors to
+re-locate, not as guarantees.
+
+Nothing here may ever be needed. It exists so that, when a lens type or a client shows
+up that needs more than plain HTTP request/response, the person doing it has a map of
+the terrain and of the decisions already baked into the contract.
+
+## The framing that still holds
+
+The proxy exists because we want a **static set of exposed ports**, with lenses
+reachable via a path prefix on the backend's port. The contract docstring in
+`domain/lens/proxy.py` is the source of truth for what clients and lenses may assume.
+Any extension here means **extending that contract** and updating that docstring in the
+same change -- otherwise clients (frontend, CLI, and whatever else exists by then)
+have no way to know the new capability is available.
+
+Also recall: with a **browser** client you are limited to what browsers can originate
+(HTTP, WebSocket, SSE/fetch-streaming). The moment a non-browser client (the `cli/`) is
+in play, that ceiling lifts and genuinely arbitrary transports become conceivable --
+at the cost of the client having to speak whatever tunnelling scheme we define. Decide
+per-transport whether browser support is required; it strongly shapes the design.
+
+## WebSocket
+
+Most tractable extension; browsers speak it natively.
+
+- Starlette/FastAPI support a `@app.websocket_route` / `WebSocket` endpoint. Add a
+  websocket route mirroring the HTTP proxy path, e.g.
+  `/api/v1/lens/proxy/{lens_instance_id}/{path:path}` on the WS side.
+- On connect: run the same instance-resolution + auth as the HTTP path (note: browser
+  WebSocket handshakes cannot set arbitrary headers, so cookie-based auth is the
+  realistic path; the existing JWT cookie transport helps here).
+- Open an upstream WebSocket to `ws://127.0.0.1:<port>/<path>` (the `websockets`
+  package is already a dependency) and pump frames bidirectionally with two tasks
+  (client->upstream, upstream->client), propagating close codes and reasons, and
+  cancelling the sibling task on either side closing.
+- Forward the `Sec-WebSocket-Protocol` subprotocol negotiation and the `X-Forwarded-*`
+  headers on the upstream handshake.
+- Watch-outs: backpressure (don't let one side outrun the other unboundedly),
+  half-close semantics, ping/pong keepalive, and the fact that every open socket pins
+  an event-loop task on the single worker -- reinforces the sidecar discussion
+  (`lensProxy-backend-sidecar.md`).
+
+## Server-Sent Events (SSE) and long-lived streaming HTTP
+
+- Mechanically these already "work" over the HTTP streaming proxy: the response body is
+  streamed. The problem is **lifetime** -- a kept-open SSE stream holds a connection
+  (and, on the single worker, contends with everything else) indefinitely.
+- If SSE becomes a first-class lens capability, add: explicit disabling of any response
+  buffering/`Content-Length` re-framing, idle timeouts, a cap on concurrent long-lived
+  streams per user, and disconnect detection so upstream connections are torn down when
+  the client goes away. Document in the contract that SSE lenses are supported but
+  count against a concurrency budget.
+
+## Arbitrary TCP (and the "any protocol" dream)
+
+This is where "it's just up to us how many options we implement" is technically true
+but the cost jumps.
+
+- **Non-browser clients only.** A browser cannot open a raw TCP socket, so this is a
+  CLI-and-friends feature. Do not promise it to the frontend.
+- Two broad shapes:
+  1. **Tunnel over HTTP/WebSocket.** Define a framing (e.g. length-prefixed binary over
+     a WebSocket, or HTTP `CONNECT`-style semantics) at
+     `/api/v1/lens/proxy/{id}/_tcp`. The proxy opens a raw TCP connection to
+     `127.0.0.1:<port>` and shovels bytes both ways. The client library (in `cli/`)
+     must implement the same framing. Auth/validation reuse the HTTP path's logic.
+  2. **Dedicated port range with per-connection auth.** Rejected in spirit by the whole
+     premise of this feature (static ports), but noted for completeness -- if a
+     transport truly cannot be tunnelled, the only alternative is exposing more ports,
+     which is exactly what we set out to avoid.
+- Watch-outs: with raw byte tunnelling you lose all protocol awareness -- no URL
+  rebasing, no header injection, no per-request auth (auth is per-tunnel). The
+  security surface widens: a tunnel is effectively "authenticated user gets a socket to
+  an internal port", so instance-scoped (and eventually user-scoped) validation at
+  tunnel-open time is the only gate. UDP does not tunnel cleanly over TCP-based
+  transports; treat it as out of scope unless a concrete need appears.
+
+## Cross-cutting concerns for any extension
+
+- **Contract first.** Extend the `domain/lens/proxy.py` docstring and bump whatever
+  client-facing capability discovery exists (e.g. `/lens/supported` could grow to
+  advertise which transports a lens type offers).
+- **Auth parity.** Every new transport must run the same instance validation and (once
+  it exists) the user-lens matrix check. Do not let a new transport become an auth
+  bypass.
+- **Worker pressure.** WebSocket and long-lived streams multiply the "single worker"
+  concern. If any of these ship at scale, the sidecar/offload design becomes a
+  prerequisite, not an optimisation -- see `lensProxy-backend-sidecar.md`.
+- **Client symmetry.** Each transport needs matching support in every client that will
+  use it. HTTP is free (any HTTP client); WebSocket needs a WS client; raw tunnelling
+  needs a bespoke client library. Budget for the client side, not just the backend.

--- a/docs/developer/changeSpecs/lensProxy-backend-initial.md
+++ b/docs/developer/changeSpecs/lensProxy-backend-initial.md
@@ -1,0 +1,229 @@
+# Lens Proxy -- Backend Initial Implementation
+
+## Context
+
+Lenses are external processes (currently only skinnyWMS) launched by the backend via
+`domain/lens/manager.py`. Each instance binds `gunicorn` to `127.0.0.1:<port>` where
+`<port>` is claimed from `FreePortsManager` (pool 19000-19100). The instance detail
+(`LensInstanceDetail`) currently exposes the raw `ports` set, and the frontend talks
+to the lens **directly** on that port, cross-origin (hence skinnyWMS is launched with
+`SKINNYWMS_CORS_ORIGINS=*`).
+
+This works only when the browser can reach the backend host's dynamic ports -- i.e.
+local / single-host deployments. In a container (docker on k8s) we want a **static set
+of exposed ports**. Therefore we want the lens to be reachable through a path on the
+backend's own port: `GET/POST/... /api/v1/lens/proxy/<lens_id>/<upstream path>`.
+
+## Goal of this task
+
+Implement a reverse-proxy route on the backend that:
+
+1. Accepts requests at `/api/v1/lens/proxy/{lens_instance_id}/{path:path}` for all
+   relevant HTTP methods.
+2. Validates that `lens_instance_id` refers to a known, `running` lens instance
+   (404 otherwise).
+3. Performs **basic** auth: the caller must be an authenticated user (or passthrough).
+   Do **not** implement per-user ownership of lenses in this task -- see below.
+4. Forwards the request to `127.0.0.1:<port>/<path>` (preserving query string) and
+   **streams** both the request body upstream and the response body back downstream,
+   using `httpx` (already a dependency).
+5. Sets the standard forwarding headers (`X-Forwarded-*`, `Forwarded`) even though
+   skinnyWMS does not currently honour them -- they are part of the published contract
+   and future lenses / a future body-rewriting layer may rely on them.
+
+This is a **breaking switch**: after this task, lenses are reachable **only** via the
+proxy route. No config flag, no backwards-compatible dual mode. The frontend change
+(see `lensProxy-frontend.md`) ships in the same pull request.
+
+## Non-goals (explicit)
+
+- **Granular auth (user-lens matrix).** We will eventually track which user started
+  which lens and restrict proxy access accordingly. That is *not* part of this task.
+  The implementer must leave a marker in the code where that check would go:
+
+  ```python
+  # TODO implement granual auth: user-lens matrix
+  ```
+
+- WebSocket / SSE / arbitrary TCP forwarding -- HTTP request/response streaming only.
+  (See `lensProxy-backend-extension.md`.)
+- Offloading proxy traffic off the single uvicorn worker -- accepted as a known
+  concern for now. (See `lensProxy-backend-sidecar.md`.)
+
+## Where the code goes
+
+Create a new module `backend/src/forecastbox/domain/lens/proxy.py`. As much of the
+logic as possible lives here (the forwarding engine, header construction, upstream URL
+building, instance validation helper). The route in `routes/lens.py` should be a thin
+wrapper that wires FastAPI's `Request`/`StreamingResponse` and the auth dependency to
+the domain function.
+
+`proxy.py` must open with a **module-level docstring containing the client/lens
+contract** reproduced verbatim below (see "Contract docstring"). This docstring is the
+single source of truth for what any client (today the frontend, tomorrow the `cli/`)
+and any lens instance must abide by. It is placed here deliberately so that, when we
+add more clients, the contract is discoverable next to the implementation.
+
+## Implementation notes
+
+### Route
+
+In `routes/lens.py`, add something like:
+
+```python
+from fastapi import Request
+from fastapi.responses import StreamingResponse
+from forecastbox.domain.lens import proxy as lens_proxy
+
+@router.api_route(
+    "/proxy/{lens_instance_id}/{upstream_path:path}",
+    methods=["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"],
+)
+async def proxy_lens(
+    lens_instance_id: LensInstanceId,
+    upstream_path: str,
+    request: Request,
+    auth_context: AuthContext = Depends(get_auth_context),
+) -> StreamingResponse:
+    # TODO implement granual auth: user-lens matrix
+    # (auth_context is currently only used to require an authenticated caller;
+    #  once the user-lens matrix exists, check ownership here.)
+    return await lens_proxy.forward(lens_instance_id, upstream_path, request)
+```
+
+Notes:
+- The `Depends(get_auth_context)` dependency already enforces "authenticated or
+  passthrough" (see `domain/auth/users.py::get_auth_context`, which raises in
+  non-passthrough deployments when unauthenticated). That satisfies "basic auth".
+- Keep `auth_context` in the signature even though its fields are unused for now, so
+  the auth is actually enforced and the granular-auth TODO has an obvious home.
+
+### Instance resolution
+
+Add a helper in `manager.py` (or `proxy.py` reaching into the manager) that resolves a
+`lens_instance_id` to its bound port, raising `KeyError` when the id is unknown and a
+distinct error when the instance exists but is not `running` (so the route can map to
+404 vs 409/503 as appropriate). Reuse `get_status` / the `instances` map. A lens has a
+`ports: set[int]`; skinnyWMS uses exactly one. For this task assume a single HTTP port
+(take the sole element; if the set is not a singleton, that's a 500-worthy invariant
+violation -- log and raise).
+
+### Forwarding engine (in `proxy.py`)
+
+- Use a module-level `httpx.AsyncClient` (lazily created / lifespan-managed) with a
+  reasonable timeout. Target base URL `http://127.0.0.1:<port>`.
+- Build the upstream URL: `f"http://127.0.0.1:{port}/{upstream_path}"` plus
+  `request.url.query`.
+- Stream the request body with `request.stream()` into `client.stream(...)` so large
+  uploads are not buffered.
+- Stream the response back with `StreamingResponse(resp.aiter_raw(), ...)`, propagating
+  the upstream `status_code`, and copying response headers **minus hop-by-hop headers**
+  (`Connection`, `Keep-Alive`, `Proxy-Authenticate`, `Proxy-Authorization`, `TE`,
+  `Trailer`, `Transfer-Encoding`, `Upgrade`, and `Content-Length` if you re-stream
+  chunked -- let Starlette recompute framing). Also forward `Content-Type`,
+  `Cache-Control`, `Content-Range`, `Accept-Ranges` etc. as-is.
+- Forward the incoming request headers upstream **minus** hop-by-hop headers and
+  `Host` (set `Host` to `127.0.0.1:<port>` or let httpx set it). Preserve `Range`,
+  `If-*`, `Accept*`, cookies.
+- Set forwarding headers on the upstream request:
+  - `X-Forwarded-For`: append `request.client.host` to any existing value.
+  - `X-Forwarded-Proto`: `request.url.scheme`.
+  - `X-Forwarded-Host`: the original `Host` header.
+  - `X-Forwarded-Prefix`: `/api/v1/lens/proxy/{lens_instance_id}` (the path segment
+    the upstream is mounted under -- lets a forwarded-aware lens emit correct absolute
+    URLs; skinnyWMS ignores it today).
+  - Equivalent `Forwarded:` header (RFC 7239) may also be set.
+- Ensure the `httpx` streaming response is properly closed when the client
+  disconnects (use `StreamingResponse` with a `background`/`aclose` hook, or the
+  `client.stream` context managed within the generator). Handle
+  `httpx.ConnectError` / connection-refused (lens died) as 502/503.
+
+### Optional: tighten skinnyWMS CORS
+
+Because traffic is now same-origin (browser -> backend origin -> loopback), the lens no
+longer needs `SKINNYWMS_CORS_ORIGINS=*`. You *may* remove or restrict that env in
+`manager.start_skinny_wms` (e.g. drop it, or set it to the loopback origin). This is a
+minor hardening; **skip it if it turns out to break skinnyWMS boot or the request
+path** -- we do not worry about it overly. If in doubt, leave a comment and move on.
+
+## Contract docstring (move verbatim into `proxy.py`)
+
+The following block is the intended module-level docstring for
+`domain/lens/proxy.py`. Move it verbatim.
+
+```python
+"""Lens proxy -- exposing internally launched lens processes via the backend's own port.
+
+A lens is an external process (e.g. skinnyWMS) that the backend launches and which
+binds to 127.0.0.1:<port> on a dynamically chosen port. In containerized deployments
+we cannot expose those dynamic ports to the outside world, so instead every lens is
+reachable through a fixed path on the backend's own port:
+
+    /api/v1/lens/proxy/<lens_instance_id>/<upstream path>[?<query>]
+
+This module implements a streaming HTTP reverse proxy for that path. The following is
+the contract between the backend proxy, the clients that call it, and the lens
+processes being proxied. It is authoritative; new clients (beyond the current
+frontend, e.g. the CLI) and new lens types must adhere to it.
+
+Supported traffic
+------------------
+- HTTP/1.1 request/response only, in both directions, fully streamed (no whole-body
+  buffering). Request bodies of arbitrary size are streamed upstream; response bodies
+  are streamed back downstream. Range requests, conditional requests, and chunked
+  responses are supported.
+- NOT supported (at the time of writing): WebSocket upgrades, Server-Sent Events kept
+  open indefinitely (they will "work" but hold a worker), HTTP/2-only features, and
+  any non-HTTP protocol. A lens that a client must reach through this proxy MUST speak
+  plain HTTP request/response. See lensProxy-backend-extension.md for how these could
+  be added later.
+
+Authentication
+--------------
+- The proxy route requires an authenticated caller (or passthrough mode). There is
+  currently NO per-lens ownership check: any authenticated caller may reach any lens.
+  Restricting a lens to the user who started it is a planned extension (a user-lens
+  matrix); until then, treat lens contents as visible to all authenticated users.
+
+URL handling -- the client's responsibility
+-------------------------------------------
+- The lens is mounted under the path prefix /api/v1/lens/proxy/<lens_instance_id>/ .
+  The proxy strips that prefix before forwarding: a client request for
+  `/api/v1/lens/proxy/<id>/wms?...` reaches the lens as `/wms?...`.
+- Clients MUST address the lens using that prefix and MUST treat it as the base
+  origin+path of the lens. Because the base has a non-root path, clients that consume
+  absolute URLs emitted by the lens (see below) must rebase those URLs onto this
+  prefix rather than using them verbatim.
+- The proxy sets X-Forwarded-Proto / -Host / -Prefix and a Forwarded header describing
+  the external mount point. A forwarded-header-aware lens SHOULD use these to emit
+  correct absolute self-URLs. skinnyWMS does not, hence the client-side rebasing
+  requirement below.
+
+URL handling -- the lens's responsibility
+-----------------------------------------
+- A lens SHOULD emit relative URLs, or honour the X-Forwarded-* / Forwarded headers
+  (e.g. via a WSGI SCRIPT_NAME / ProxyFix equivalent) when constructing absolute
+  self-URLs, so that clients receive URLs already pointing at the proxy path.
+- A lens that instead bakes its internal bind address (e.g. http://0.0.0.0:<port>/...)
+  into structured, machine-parseable responses (like a WMS GetCapabilities document)
+  is tolerable ONLY if clients can and do rebase those URLs onto the proxy prefix. A
+  lens that bakes absolute self-origin URLs into opaque payloads that clients cannot
+  rewrite is NOT proxyable by this mechanism.
+- A lens MUST NOT rely on being reachable on its own port from outside the backend
+  host; the only supported ingress is this proxy.
+
+The proxy does NOT rewrite response bodies. Any URL adaptation is the client's job,
+per the rules above.
+"""
+```
+
+## Acceptance
+
+- `GET /api/v1/lens/proxy/<id>/wms?service=WMS&request=GetCapabilities` returns the
+  same document as hitting the lens port directly (modulo the internal absolute URLs
+  it advertises, which the frontend rebases).
+- Unknown / non-running `<id>` -> 404. Unauthenticated (non-passthrough) -> 401/403.
+- Large tile responses stream without buffering the whole body in memory.
+- `# TODO implement granual auth: user-lens matrix` present at the ownership-check
+  site.
+- `proxy.py` opens with the verbatim contract docstring.

--- a/docs/developer/changeSpecs/lensProxy-backend-sidecar.md
+++ b/docs/developer/changeSpecs/lensProxy-backend-sidecar.md
@@ -1,0 +1,153 @@
+# Lens Proxy -- Offloading Traffic From the Main Worker
+
+## Status and audience
+
+Forward-looking, architect-oriented. Assumes the initial HTTP streaming proxy
+(`lensProxy-backend-initial.md`) and the frontend adaptation (`lensProxy-frontend.md`)
+are shipped, but that the codebase may have moved on for unrelated reasons. Names below
+are anchors, not guarantees.
+
+## The problem
+
+The initial implementation runs the proxy **inside the FastAPI app on a single uvicorn
+worker** (`workers=1`, see `entrypoint/bootstrap/launchers.py`). Every lens byte --
+WMS tiles, which are many and can be large -- flows through that one async event loop,
+contending with all normal API traffic. We accepted this for the first milestone. This
+document is about what to do when that becomes a real bottleneck.
+
+Constraints that make this non-trivial, and rule out a naive "just put nginx in front":
+
+- **Auth and lens-id validation live in the backend.** A request to
+  `/api/v1/lens/proxy/<id>/...` must be checked for (a) a valid authenticated session
+  and (b) that `<id>` maps to a running lens (and eventually: that this user owns it --
+  the user-lens matrix). A stock reverse proxy has no knowledge of either. So we cannot
+  simply hand the whole route to nginx and forget about it.
+- **The mapping id -> internal port is dynamic**, chosen at runtime by the backend's
+  `FreePortsManager`. Whatever does the forwarding must learn that mapping from the
+  backend.
+
+## Recommended option: a dedicated proxy process, backend as auth/validation authority
+
+Launch, at backend startup, a **dedicated proxy process** whose sole job is forwarding
+lens traffic. Written in **Rust** (for throughput and predictable latency under load;
+the team already ships Rust in `cli/`). Responsibilities split:
+
+- **Backend** remains the authority for auth and lens-id (and future user-lens)
+  validation, and owns the id -> port mapping (it launches the lenses).
+- **Proxy process** does the heavy lifting: accepts the proxy-route connections,
+  consults the backend for an authorization decision, then streams bytes to/from
+  `127.0.0.1:<port>` itself, out of the main event loop.
+
+### Ingress / routing
+
+Something must route `/api/v1/lens/proxy/*` to the proxy process and everything else to
+the backend. Two sub-shapes; **prefer the second**:
+
+1. A third front process (e.g. nginx) doing a **static prefix match**: `/.../lens/proxy`
+   -> proxy process, everything else -> backend. This is legitimate for nginx because
+   the split is a static route prefix; nginx never needs the dynamic id->port map or
+   the auth logic. The container exposes only this front process.
+
+2. **The proxy process itself fronts everything**: it terminates the single exposed
+   port, handles the proxy prefix natively, and reverse-proxies all other paths to the
+   backend. This collapses "front router" and "proxy" into one hop -- simpler mental
+   model, one less process, one less network hop. Given the proxy is already a
+   competent HTTP proxy, making it the single front door is the smaller conceptual
+   surface. Prefer this unless a reason to keep a separate off-the-shelf front door
+   appears (e.g. you want nginx's TLS termination / static-file serving / battle-tested
+   edge behaviour).
+
+So the container topology becomes, in the preferred shape:
+
+```
+world -> [Rust proxy: front door]
+              |-- /api/v1/lens/proxy/* : validate w/ backend, then stream to 127.0.0.1:<lens port>
+              |-- everything else      : reverse-proxy to 127.0.0.1:<backend port>
+         [Python backend (uvicorn, workers=1)] -- launches lenses, owns id->port map,
+                                                   serves the auth/validation endpoint
+```
+
+### The auth/validation interface
+
+The proxy must get, per lens request (or cached per session+id), an authorization
+decision plus the target port. Design choices, roughly in order of preference:
+
+- **Auth-subrequest endpoint on the backend**, e.g.
+  `GET /api/v1/lens/_authz/<id>` that takes the caller's credentials (forwarded cookie
+  / token) and returns `{ authorized: bool, port: int }` (nginx `auth_request` style).
+  The proxy caches the decision briefly (per session+id, short TTL) to avoid a backend
+  round-trip per tile. Simple, keeps all policy in Python, tolerates backend evolution.
+- **Push the mapping + a validation hook to the proxy**: backend notifies the proxy of
+  id->port on lens start/stop (so the proxy resolves the port locally) but still calls
+  back for the auth decision. Lower latency for the port lookup; more state to keep
+  consistent (leaks if a stop notification is missed -- add reconciliation).
+- **Signed capability tokens**: backend hands the client a short-lived signed token
+  scoping `<id>` (and later the user); the proxy validates the signature locally with a
+  shared key and needs no per-request backend call. Fastest, but introduces key
+  management and token-lifetime/revocation concerns; hardest to get right. Consider
+  only if the subrequest round-trip proves too costly even with caching.
+
+### Watch-outs for the recommended option
+
+- **Credential forwarding.** The proxy must forward the caller's auth (JWT cookie) to
+  the backend's authz endpoint faithfully; get cookie domain/path right so the same
+  cookie authenticates both the SPA and the proxy.
+- **Lens lifecycle races.** A lens can die or be stopped mid-stream. The proxy needs
+  clean handling of connection-refused / mid-stream reset (map to 502/503), and the
+  cached authz/port entries need invalidation on stop. If the backend pushes state,
+  handle missed notifications with periodic reconciliation.
+- **Startup ordering & health.** The proxy is now the front door; it must come up,
+  discover the backend, and pass health checks before the container is "ready". Mind
+  `entrypoint/main.py` / bootstrap health-check flow -- the readiness probe target
+  changes.
+- **Forwarded headers / URL contract unchanged.** The contract in
+  `domain/lens/proxy.py` (client rebasing, `X-Forwarded-*`, no body rewriting) must be
+  honoured identically by the Rust proxy. Keep that docstring the single source of
+  truth; the Rust code implements the same contract.
+- **Streaming semantics.** Preserve range requests, chunked responses, disconnect
+  propagation, and backpressure -- the same properties the Python version had.
+- **Operational surface.** A second long-lived process to supervise, log, crash-restart
+  and version in lockstep with the backend. Include it in the shutdown/sigterm
+  propagation already handled for child processes.
+
+### Limitations
+
+- More moving parts and a cross-language boundary (Python policy, Rust data plane). The
+  authz interface is now a versioned internal contract that both sides must respect.
+- The auth-subrequest cache introduces a small window where a just-revoked session may
+  still stream; bound it with a short TTL.
+- Does not, by itself, solve horizontal scaling across pods (the lens processes are
+  local to the backend pod); this is about offloading within a pod, not distributing
+  lenses.
+
+## Alternatives considered
+
+- **Off-the-shelf reverse proxy (nginx/traefik/envoy) doing the whole lens route.**
+  *Why not:* it cannot make the auth / lens-id / user-lens decision, and cannot resolve
+  the dynamic id->port map, without bespoke integration (Lua/`auth_request`, dynamic
+  upstream config). At that point you have reimplemented most of the custom proxy inside
+  someone else's extension model, with worse ergonomics. *If you must:* use nginx purely
+  as the **static-prefix front door** (option 1 above) and keep auth+forwarding in our
+  own process; use `auth_request` against the backend's authz endpoint and a dynamic
+  upstream (resolver + variable) fed by the backend -- and accept the config complexity.
+
+- **More uvicorn workers / a separate uvicorn app for the proxy route.**
+  *Why not:* multiple workers complicate the in-process `FreePortsManager` and
+  `LensInstanceManager` state (currently single-process, lock-guarded, lock-free
+  reads) -- the id->port map would need to be shared across workers. It also keeps the
+  data plane in Python, which is the throughput concern we are trying to escape. *If you
+  must:* run the proxy as a **separate** Python ASGI app (not just more workers of the
+  main app) that queries the backend for authz+port over a small internal API, so the
+  lens-state ownership stays single-process in the backend. You get process isolation
+  without Rust, at the cost of Python's throughput ceiling.
+
+- **In-process but move forwarding to a threadpool / raw asyncio streaming tuning.**
+  *Why not:* it still burns the main process's CPU and event loop; buys headroom, not a
+  category change. *If you must:* ensure zero whole-body buffering, generous connection
+  pooling to the lenses, and cap concurrent lens streams so they cannot starve the API;
+  treat it strictly as a stopgap before the dedicated process.
+
+- **Signed-token-only, no dedicated process (client talks to lens through a thin edge).**
+  *Why not:* without a data-plane process you are back to the main worker doing the
+  bytes; the token only removes the authz round-trip, not the load. Only meaningful in
+  combination with the dedicated proxy above, as an optimisation of its authz interface.

--- a/docs/developer/changeSpecs/lensProxy-frontend.md
+++ b/docs/developer/changeSpecs/lensProxy-frontend.md
@@ -1,0 +1,156 @@
+# Lens Proxy -- Frontend Adaptation
+
+## Context
+
+This spec assumes `lensProxy-backend-initial.md` has been implemented in the **same
+pull request**. The backend no longer serves lenses on their own dynamic port; a lens
+is reachable only via:
+
+    /api/v1/lens/proxy/<lens_instance_id>/<upstream path>[?<query>]
+
+We do synchronized releases and this ships together with the backend change, so there
+is **no backwards compatibility** to preserve: remove the direct-port path entirely.
+
+## Current frontend behaviour (to be changed)
+
+- `src/api/endpoints/lens.ts`:
+  - `buildLensBaseUrl(port)` builds `http(s)://<backendHost>:<port>` -- a direct
+    origin on the lens's dynamic port.
+  - `buildWmsCapabilitiesUrl(port)` builds the GetCapabilities URL off that.
+- `src/features/visualise/hooks/useComparisonSource.ts` reads
+  `detail.ports[0]` and calls `buildLensBaseUrl(port)` to produce the `baseUrl` for a
+  running lens source.
+- `src/features/viewer/wms-capabilities.ts`:
+  - `toWmsEndpoint(baseUrl)` -- for a bare origin base (`pathname === '/' && !search`)
+    it appends `/wms`; otherwise returns the base verbatim (treats it as an external,
+    fully-formed endpoint).
+  - `rebaseLensUrl(url, baseUrl)` -- grafts `baseUrl` onto the upstream URL's
+    path+query **only when** `baseUrl` has a root pathname and no query; otherwise it
+    returns the upstream URL verbatim (the "external endpoint" branch).
+  - `isLoopbackUrl(url)` -- true for `localhost` / `127.0.0.0/8` / `[::1]`; used to
+    pick a more patient GetCapabilities retry ladder while skinnyWMS boots, and to
+    reason about CORS.
+
+The key problem: the new lens base URL is a **same-origin path** with a non-root
+pathname (`/api/v1/lens/proxy/<id>`). Under the current logic, `toWmsEndpoint` and
+`rebaseLensUrl` would both take their "external endpoint / use verbatim" branch,
+because they special-case only root-pathname bases. That is wrong for the proxy base:
+we still need `/wms` appended and we still need the lens's internally-advertised
+absolute URLs (e.g. `http://0.0.0.0:<port>/wms?...` in GetCapabilities) rebased onto
+the proxy path.
+
+## Goal of this task
+
+Adapt the frontend so that a running lens is addressed via the proxy path, and WMS URL
+handling works with a non-root, same-origin base.
+
+### 1. Build the lens base URL from the instance id, not the port
+
+In `src/api/endpoints/lens.ts`:
+
+- Replace `buildLensBaseUrl(port: number)` with a function that takes the lens
+  instance id and returns the same-origin proxy base, e.g.:
+
+  ```ts
+  export function buildLensBaseUrl(lensInstanceId: string): string {
+    // Same-origin proxy path; the backend forwards to the internal lens process.
+    return `${API_ENDPOINTS.lens.proxyBase}/${encodeURIComponent(lensInstanceId)}`
+  }
+  ```
+
+  where a new `proxyBase` (e.g. `${API_PREFIX}/lens/proxy`) is added to
+  `src/api/endpoints.ts` under the `lens` group.
+
+- The base is now relative (same origin). Consumers that need an absolute URL (e.g. to
+  paste into an external WMS client) should resolve it against
+  `getBackendBaseUrl() || window.location.origin`. Provide a small helper if needed;
+  the in-app viewer can use the relative base directly since fetches are same-origin.
+
+- Update `buildWmsCapabilitiesUrl` to take the instance id and build
+  `${buildLensBaseUrl(id)}/wms?service=WMS&version=1.3.0&request=GetCapabilities`.
+
+- The instance detail's `ports` field is no longer needed by the client for
+  addressing. It may remain in the response type (the backend still returns it) but the
+  frontend must not use it to construct URLs. Consider dropping its use entirely.
+
+### 2. Feed the instance id (not the port) through the source hook
+
+In `src/features/visualise/hooks/useComparisonSource.ts`:
+
+- Where it currently does
+  `const port = detail?.status === 'running' ? detail.ports[0] : undefined` and
+  `baseUrl: buildLensBaseUrl(port)`, switch to using
+  `detail.lens_instance_id` (already present on the detail) and
+  `buildLensBaseUrl(detail.lens_instance_id)`.
+- Keep the `phase: 'running'` gate on `detail.status === 'running'`.
+
+### 3. Make WMS URL handling prefix-aware
+
+In `src/features/viewer/wms-capabilities.ts`, the base is now a same-origin path like
+`/api/v1/lens/proxy/<id>` (no query). Two functions need to treat "our lens base" as a
+rebasing target rather than an opaque external endpoint.
+
+The cleanest approach is to distinguish "our lens proxy base" from "a fully-formed
+external WMS endpoint" explicitly, rather than inferring it from `pathname === '/'`.
+Options (pick one, keep it simple):
+
+- **Preferred:** pass an explicit flag/branch. Since the code already threads a
+  `baseUrl` that originates from `buildLensBaseUrl`, mark lens sources distinctly (the
+  source object already knows it is a lens vs an external/curated WMS). Then:
+  - `toWmsEndpoint`: for a lens base, append `/wms` (join respecting the existing
+    trailing-slash handling) regardless of pathname.
+  - `rebaseLensUrl`: for a lens base, always graft the upstream URL's `pathname +
+    search` onto the lens base (strip any trailing slash on the base first), regardless
+    of the base's own pathname. This makes the lens's internally-advertised absolute
+    URLs (which still contain the internal `0.0.0.0:<port>`) resolve through the proxy.
+
+- If threading a flag is awkward, recognise the proxy prefix by string
+  (`baseUrl.includes('/lens/proxy/')`) -- acceptable but less clean; document it.
+
+Concretely, `rebaseLensUrl` should, for a lens base:
+
+```ts
+const upstream = new URL(url)  // url may be http://0.0.0.0:<port>/wms?...
+return `${lensBase.replace(/\/$/, '')}${upstream.pathname}${upstream.search}`
+```
+
+so `http://0.0.0.0:41234/wms?...` becomes `/api/v1/lens/proxy/<id>/wms?...`.
+
+### 4. Loopback / retry-ladder handling
+
+`isLoopbackUrl` was used to (a) pick the patient retry ladder for our own booting
+SkinnyWMS and (b) reason that our lens is not CORS territory.
+
+- The base is now same-origin and relative, so `new URL(base).hostname` is the app's
+  own host -- `isLoopbackUrl` will no longer reliably identify "our lens" (it may be a
+  public hostname behind an ingress). Replace the "is this our lens" decision with the
+  explicit lens-source signal used in step 3, so the patient
+  `LOOPBACK_RETRY_DELAYS_MS` ladder still applies while SkinnyWMS boots (see
+  `useLensSource.ts`, which selects the ladder via `isLoopbackUrl(baseUrl)`).
+- CORS is no longer a concern for lens traffic (same-origin), so any CORS-motivated
+  branching for lenses can be simplified/removed. External/curated WMS servers keep
+  their existing treatment.
+
+### 5. Same-origin cleanups
+
+- Remove any code that special-cased the cross-origin direct-port lens (e.g.
+  `crossOrigin` handling that existed solely because the lens was a different origin).
+  Same-origin means normal fetch/tile loading; keep `crossOrigin` only where external
+  WMS servers still need it.
+
+## Non-goals
+
+- No dual-mode / feature flag. One breaking switch.
+- No handling of WebSocket/SSE lens traffic (backend does not support it yet).
+- No change to the lens start/status/stop/list API calls other than how the base URL
+  is derived.
+
+## Acceptance
+
+- Starting a skinnyWMS lens and opening the geo viewer loads GetCapabilities and tiles
+  through `/api/v1/lens/proxy/<id>/...`, same-origin, with no direct `:<port>` requests
+  in the network tab.
+- The lens's internally-advertised absolute URLs (GetMap/GetLegendGraphic hrefs from
+  GetCapabilities) are rebased onto the proxy path and load correctly.
+- The patient retry ladder still applies while SkinnyWMS is booting.
+- No remaining use of `detail.ports[*]` for URL construction.

--- a/frontend/mocks/data/lens.data.ts
+++ b/frontend/mocks/data/lens.data.ts
@@ -103,10 +103,11 @@ export function pollMockLens(id: string): LensInstanceDetailResponse | null {
         ports: [port],
       }
       // Serve WMS behind every mock lens so the viewer/compare flows work
-      // end-to-end in dev:mock. Tests that pre-registered the port keep
-      // their fixture.
-      if (!hasMockWmsServer(port)) {
-        registerMockWmsServer(port, DEFAULT_LENS_WMS_CONFIG)
+      // end-to-end in dev:mock. Tests that pre-registered the id keep
+      // their fixture. Keyed by instance id — the browser reaches it via
+      // `/api/v1/lens/proxy/<id>`, never the (backend-only) port above.
+      if (!hasMockWmsServer(id)) {
+        registerMockWmsServer(id, DEFAULT_LENS_WMS_CONFIG)
       }
     } else {
       instance.pollsUntilRunning--

--- a/frontend/mocks/data/wms.data.ts
+++ b/frontend/mocks/data/wms.data.ts
@@ -9,12 +9,18 @@
  */
 
 /**
- * Mock state for SkinnyWMS lens servers, keyed by port. Tests register a
- * server per fake lens port; the `*\/wms` handler serves a capabilities
- * document in the exact shape SkinnyWMS emits (decoration layers, per-layer
- * TIME dimension, legend URLs on the internal bind address so `rebaseLensUrl`
- * is exercised). Unregistered ports answer 503, mirroring the real race where
- * a lens reports `running` before its WMS port accepts requests.
+ * Mock state for SkinnyWMS lens servers, keyed by a generic string key — a
+ * literal port (tests that talk to `http://localhost:<port>` directly, as
+ * an external-style bare origin) or a lens instance id (tests that go
+ * through the real `/api/v1/lens/proxy/<id>` route, matching production).
+ * The `*\/wms` handler serves a capabilities document in the exact shape
+ * SkinnyWMS emits (decoration layers, per-layer TIME dimension, legend URLs
+ * on an internal bind address so `rebaseLensUrl` is exercised). Unregistered
+ * keys answer 503, mirroring the real race where a lens reports `running`
+ * before its WMS port accepts requests — unless a default config was
+ * registered via `registerDefaultMockWmsServer`, which seeds any
+ * unregistered key on first use (a running lens whose exact id/port a test
+ * doesn't need to predict).
  */
 
 export interface MockWmsLayerConfig {
@@ -42,57 +48,92 @@ interface MockWmsServer {
   config: MockWmsServerConfig
   remainingFailures: number
   capabilitiesRequests: number
+  /** Fake internal bind port advertised in legend URLs, independent of the
+   *  routing key (which may be a non-numeric lens instance id). */
+  internalPort: number
 }
 
-let servers = new Map<number, MockWmsServer>()
+let servers = new Map<string, MockWmsServer>()
+let defaultConfig: MockWmsServerConfig | null = null
+let internalPortCounter = 40000
 
 export function resetWmsState(): void {
   servers = new Map()
+  defaultConfig = null
+  internalPortCounter = 40000
   getMapLog.clear()
 }
 
-export function hasMockWmsServer(port: number): boolean {
-  return servers.has(port)
+export function hasMockWmsServer(key: string | number): boolean {
+  return servers.has(String(key))
 }
 
-export function registerMockWmsServer(
-  port: number,
-  config: MockWmsServerConfig,
-): void {
-  servers.set(port, {
+function createServer(config: MockWmsServerConfig): MockWmsServer {
+  return {
     config,
     remainingFailures: config.failuresBeforeSuccess ?? 0,
     capabilitiesRequests: 0,
-  })
+    internalPort: internalPortCounter++,
+  }
 }
 
-/** GetMap requests seen per port (TIME param values, in order). */
-const getMapLog = new Map<number, Array<string | null>>()
+export function registerMockWmsServer(
+  key: string | number,
+  config: MockWmsServerConfig,
+): void {
+  servers.set(String(key), createServer(config))
+}
 
-export function recordGetMap(port: number, time: string | null): void {
-  const log = getMapLog.get(port) ?? []
+/** Seed any unregistered key with this config on first use — for flows
+ *  (auto-started lenses) where the test doesn't predict the exact key. */
+export function registerDefaultMockWmsServer(
+  config: MockWmsServerConfig,
+): void {
+  defaultConfig = config
+}
+
+function serverFor(key: string): MockWmsServer | undefined {
+  const existing = servers.get(key)
+  if (existing) return existing
+  if (!defaultConfig) return undefined
+  const created = createServer(defaultConfig)
+  servers.set(key, created)
+  return created
+}
+
+/** GetMap requests seen per key (TIME param values, in order). */
+const getMapLog = new Map<string, Array<string | null>>()
+
+export function recordGetMap(key: string | number, time: string | null): void {
+  const k = String(key)
+  const log = getMapLog.get(k) ?? []
   log.push(time)
-  getMapLog.set(port, log)
+  getMapLog.set(k, log)
 }
 
-export function getMapRequests(port: number): ReadonlyArray<string | null> {
-  return getMapLog.get(port) ?? []
+export function getMapRequests(
+  key: string | number,
+): ReadonlyArray<string | null> {
+  return getMapLog.get(String(key)) ?? []
 }
 
-/** Should this port's GetMap fail for the given TIME? */
-export function getMapFailsFor(port: number, time: string | null): boolean {
-  const times = servers.get(port)?.config.failGetMapTimes
+/** Should this key's GetMap fail for the given TIME? */
+export function getMapFailsFor(
+  key: string | number,
+  time: string | null,
+): boolean {
+  const times = servers.get(String(key))?.config.failGetMapTimes
   return !!time && !!times && times.includes(time)
 }
 
-/** Configured GetMap response delay for a port (0 = respond immediately). */
-export function getMapDelayFor(port: number): number {
-  return servers.get(port)?.config.getMapDelayMs ?? 0
+/** Configured GetMap response delay for a key (0 = respond immediately). */
+export function getMapDelayFor(key: string | number): number {
+  return servers.get(String(key))?.config.getMapDelayMs ?? 0
 }
 
 /** Capabilities requests seen by a server (asserting retry behaviour). */
-export function wmsCapabilitiesRequestCount(port: number): number {
-  return servers.get(port)?.capabilitiesRequests ?? 0
+export function wmsCapabilitiesRequestCount(key: string | number): number {
+  return servers.get(String(key))?.capabilitiesRequests ?? 0
 }
 
 /**
@@ -100,19 +141,22 @@ export function wmsCapabilitiesRequestCount(port: number): number {
  * `unregistered` and `failing` both surface to the client as 503.
  */
 export function serveCapabilities(
-  port: number,
+  key: string | number,
 ): { kind: 'ok'; xml: string } | { kind: 'unavailable' } {
-  const server = servers.get(port)
+  const server = serverFor(String(key))
   if (!server) return { kind: 'unavailable' }
   server.capabilitiesRequests++
   if (server.remainingFailures > 0) {
     server.remainingFailures--
     return { kind: 'unavailable' }
   }
-  return { kind: 'ok', xml: capabilitiesXml(port, server.config) }
+  return {
+    kind: 'ok',
+    xml: capabilitiesXml(server.internalPort, server.config),
+  }
 }
 
-function layerXml(port: number, layer: MockWmsLayerConfig): string {
+function layerXml(internalPort: number, layer: MockWmsLayerConfig): string {
   const time = layer.time
     ? `<Dimension name="time" units="ISO8601">${layer.time}</Dimension>`
     : ''
@@ -123,13 +167,16 @@ function layerXml(port: number, layer: MockWmsLayerConfig): string {
     <Style>
       <Name>default</Name>
       <LegendURL>
-        <OnlineResource xlink:href="http://0.0.0.0:${port}/legend?layer=${encodeURIComponent(layer.name)}"/>
+        <OnlineResource xlink:href="http://0.0.0.0:${internalPort}/legend?layer=${encodeURIComponent(layer.name)}"/>
       </LegendURL>
     </Style>
   </Layer>`
 }
 
-function capabilitiesXml(port: number, config: MockWmsServerConfig): string {
+function capabilitiesXml(
+  internalPort: number,
+  config: MockWmsServerConfig,
+): string {
   const [west, south, east, north] = config.bbox ?? [-180, -90, 180, 90]
   const decorations = (config.decorations ?? ['background', 'foreground'])
     .map((name) => `<Layer><Name>${name}</Name><Title>${name}</Title></Layer>`)
@@ -149,7 +196,7 @@ function capabilitiesXml(port: number, config: MockWmsServerConfig): string {
         <northBoundLatitude>${north}</northBoundLatitude>
       </EX_GeographicBoundingBox>
       ${decorations}
-      ${config.layers.map((l) => layerXml(port, l)).join('\n')}
+      ${config.layers.map((l) => layerXml(internalPort, l)).join('\n')}
     </Layer>
   </Capability>
 </WMS_Capabilities>`

--- a/frontend/mocks/handlers/wms.handlers.ts
+++ b/frontend/mocks/handlers/wms.handlers.ts
@@ -12,10 +12,13 @@
  * MSW handlers for SkinnyWMS lens servers (the WMS endpoints behind lens
  * ports, not the backend lens-manager API — that's lens.handlers.ts).
  *
- * The viewer talks to lenses cross-origin with `crossOrigin: 'anonymous'`
- * image sources, so every response carries CORS headers. GetMap and legend
- * requests return a 1×1 transparent PNG — tests assert on controls and
- * state, never on rendered pixels.
+ * Production reaches a lens only through the backend's same-origin proxy
+ * (`/api/v1/lens/proxy/<id>/...`); requests routed there are keyed by
+ * instance id. Tests that talk to a bare `http://localhost:<port>` origin
+ * directly (exercising the viewer against an "external-style" WMS) are
+ * keyed by port instead — both share the same mock registry via a
+ * string key. GetMap and legend requests return a 1×1 transparent PNG —
+ * tests assert on controls and state, never on rendered pixels.
  */
 
 import { HttpResponse, delay, http } from 'msw'
@@ -25,6 +28,7 @@ import {
   recordGetMap,
   serveCapabilities,
 } from '../data/wms.data'
+import { API_ENDPOINTS } from '@/api/endpoints'
 
 // Translucent 1×1 PNGs (red / blue) — GetMap alternates the color by
 // port so two mock lenses are visually distinguishable and comparison
@@ -45,8 +49,19 @@ const PNG_BLUE = Uint8Array.from(
 
 const CORS = { 'Access-Control-Allow-Origin': '*' }
 
-function pngResponse(port = 0) {
-  const png = port % 2 === 0 ? PNG_RED : PNG_BLUE
+/** `id` from `/api/v1/lens/proxy/<id>/...`, when present. */
+const LENS_PROXY_ID_RE = new RegExp(`${API_ENDPOINTS.lens.proxyBase}/([^/]+)/`)
+
+/** Routing key for the mock registry: the lens instance id when the
+ *  request went through the proxy path, else the origin's port (bare
+ *  `http://host:port` test doubles). */
+function wmsKeyFor(url: URL): string {
+  const proxied = LENS_PROXY_ID_RE.exec(url.pathname)
+  return proxied ? decodeURIComponent(proxied[1]) : url.port
+}
+
+function pngResponse(key: string) {
+  const png = Number(key) % 2 === 0 ? PNG_RED : PNG_BLUE
   return new HttpResponse(png.slice().buffer, {
     headers: { ...CORS, 'Content-Type': 'image/png' },
   })
@@ -86,10 +101,10 @@ export const wmsHandlers = [
     const param = (key: string) =>
       url.searchParams.get(key) ?? url.searchParams.get(key.toUpperCase())
     const req = (param('request') ?? '').toLowerCase()
-    const port = Number(url.port)
+    const key = wmsKeyFor(url)
 
     if (req === 'getcapabilities') {
-      const result = serveCapabilities(port)
+      const result = serveCapabilities(key)
       if (result.kind === 'unavailable') {
         return new HttpResponse(null, { status: 503, headers: CORS })
       }
@@ -100,21 +115,21 @@ export const wmsHandlers = [
     // GetMap and anything else image-like. Registered failure TIMEs get
     // a WMS service exception (stale-capabilities servers do this).
     if (req === 'getmap') {
-      recordGetMap(port, param('TIME'))
-      const delayMs = getMapDelayFor(port)
+      recordGetMap(key, param('TIME'))
+      const delayMs = getMapDelayFor(key)
       if (delayMs > 0) await delay(delayMs)
     }
-    if (req === 'getmap' && getMapFailsFor(port, param('TIME'))) {
+    if (req === 'getmap' && getMapFailsFor(key, param('TIME'))) {
       return new HttpResponse('<ServiceExceptionReport/>', {
         headers: { ...CORS, 'Content-Type': 'text/xml' },
       })
     }
-    return pngResponse(port)
+    return pngResponse(key)
   }),
 
   // Legend images — capabilities advertise them on the lens's internal bind
   // address; the viewer rebases them onto the browser-reachable origin.
-  http.get('*/legend', () => pngResponse()),
+  http.get('*/legend', () => pngResponse('0')),
 
   // Carto vector basemap style requested by the viewer on mount.
   http.get('https://basemaps.cartocdn.com/*', () =>

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -190,6 +190,9 @@ export const API_ENDPOINTS = {
     list: `${API_PREFIX}/lens/list`,
     /** GET - List supported lens types */
     supported: `${API_PREFIX}/lens/supported`,
+    /** GET/POST - Proxy base; the running lens is reached at
+     *  `${proxyBase}/<lens_instance_id>/<upstream path>` */
+    proxyBase: `${API_PREFIX}/lens/proxy`,
   },
 
   /**

--- a/frontend/src/api/endpoints/lens.ts
+++ b/frontend/src/api/endpoints/lens.ts
@@ -10,8 +10,9 @@
 
 /**
  * Lens API client. The lens routes are passthroughs to the backend lens
- * manager, which spawns external tools (e.g. SkinnyWMS) on dynamic ports.
- * Always check status until `running` before talking to the lens directly.
+ * manager, which spawns external tools (e.g. SkinnyWMS) internally and
+ * exposes them only through the same-origin proxy path. Always check
+ * status until `running` before talking to the lens directly.
  */
 
 import { z } from 'zod'
@@ -69,20 +70,29 @@ export async function listSupportedLenses(): Promise<
 }
 
 /**
- * A lens binds to 127.0.0.1:<port> next to the backend, so the browser can
- * reach it only when it runs on the backend's host (local / single-host
- * deployments). Build the direct URL on the backend host at the lens port.
+ * A lens is reachable only through the backend's same-origin proxy path,
+ * which forwards to the internal process. Build that path from the lens
+ * instance id.
  */
-export function buildLensBaseUrl(port: number): string {
-  const backendBase = getBackendBaseUrl()
-  const base = new URL(backendBase || window.location.origin)
-  return `${base.protocol}//${base.hostname}:${port}`
+export function buildLensBaseUrl(lensInstanceId: string): string {
+  return `${API_ENDPOINTS.lens.proxyBase}/${encodeURIComponent(lensInstanceId)}`
 }
 
 /**
- * GetCapabilities URL for the WMS instance behind a lens. Suitable for
- * pasting into external WMS clients (QGIS, ArcGIS, etc.).
+ * GetCapabilities URL for the WMS instance behind a lens, in-app fetches
+ * only (relative, same-origin).
  */
-export function buildWmsCapabilitiesUrl(port: number): string {
-  return `${buildLensBaseUrl(port)}/wms?service=WMS&version=1.3.0&request=GetCapabilities`
+export function buildWmsCapabilitiesUrl(lensInstanceId: string): string {
+  return `${buildLensBaseUrl(lensInstanceId)}/wms?service=WMS&version=1.3.0&request=GetCapabilities`
+}
+
+/**
+ * Absolute GetCapabilities URL, suitable for pasting into external WMS
+ * clients (QGIS, ArcGIS, etc.) that don't share the app's origin.
+ */
+export function buildAbsoluteWmsCapabilitiesUrl(
+  lensInstanceId: string,
+): string {
+  const origin = getBackendBaseUrl() || window.location.origin
+  return `${origin}${buildWmsCapabilitiesUrl(lensInstanceId)}`
 }

--- a/frontend/src/api/types/lens.types.ts
+++ b/frontend/src/api/types/lens.types.ts
@@ -14,7 +14,8 @@
  * A lens is an external inspection tool (e.g. SkinnyWMS) launched against a
  * filesystem path produced by a sink block. The frontend starts a lens via
  * POST, polls its status until `running`, then mounts a viewer that talks
- * directly to the lens's exposed port.
+ * to the lens through the backend's same-origin proxy path (see
+ * `buildLensBaseUrl` in `@/api/endpoints/lens`).
  */
 
 import { z } from 'zod'
@@ -33,6 +34,8 @@ export const LensInstanceDetailResponseSchema = z.object({
   status: LensStatusSchema,
   lens_name: z.string(),
   lens_params: z.record(z.string(), z.unknown()),
+  /** Retained for backend introspection only; the frontend addresses the
+   *  lens through the proxy path, not these ports directly. */
   ports: z.array(z.number()),
 })
 

--- a/frontend/src/features/executions/components/StoredOutputsCard.tsx
+++ b/frontend/src/features/executions/components/StoredOutputsCard.tsx
@@ -35,7 +35,7 @@ import {
   useStartSkinnyWms,
   useStopLens,
 } from '@/api/hooks/useLens'
-import { buildWmsCapabilitiesUrl } from '@/api/endpoints/lens'
+import { buildAbsoluteWmsCapabilitiesUrl } from '@/api/endpoints/lens'
 import { useStoredDirPath } from '@/features/executions/outputs/stored-dir'
 import { GRIB_DIR_MIME } from '@/features/executions/outputs/adapters/grib'
 import { SLOT_B_OFF, entryRef } from '@/features/visualise/entry-ref'
@@ -185,17 +185,18 @@ function StoredOutputRowItem({
   const statusQuery = useLensStatus(lensId ?? undefined)
 
   const status = lensId ? statusQuery.data?.status : undefined
-  const port = lensId ? statusQuery.data?.ports[0] : undefined
-  const running = status === 'running' && port !== undefined
+  const running = status === 'running'
   const failed =
     !!lensId &&
     (statusQuery.isError || status === 'failed' || status === 'terminated')
 
-  const copyUrl = (lensPort: number) => {
-    void navigator.clipboard.writeText(buildWmsCapabilitiesUrl(lensPort)).then(
-      () => showToast.success(t('storedOutputs.wmsUrlCopied')),
-      () => showToast.error(t('storedOutputs.wmsUrlCopyFailed')),
-    )
+  const copyUrl = (lensInstanceId: string) => {
+    void navigator.clipboard
+      .writeText(buildAbsoluteWmsCapabilitiesUrl(lensInstanceId))
+      .then(
+        () => showToast.success(t('storedOutputs.wmsUrlCopied')),
+        () => showToast.error(t('storedOutputs.wmsUrlCopyFailed')),
+      )
   }
 
   const copyPath = (path: string) => {
@@ -246,7 +247,7 @@ function StoredOutputRowItem({
   }
 
   const copy = () => {
-    if (port !== undefined) copyUrl(port)
+    if (lensId) copyUrl(lensId)
   }
 
   const stop = () => {

--- a/frontend/src/features/viewer/geo/GeoViewer.tsx
+++ b/frontend/src/features/viewer/geo/GeoViewer.tsx
@@ -41,7 +41,7 @@ import { AUTOFIT_KEY, createViewerView } from '../hooks/useOlMapBase'
 import { formatStep } from '../format'
 import { BASEMAPS, DEFAULT_BASEMAP_ID, SKINNYWMS_BASEMAP } from '../ol-layers'
 import {
-  isLoopbackUrl,
+  isLensProxyUrl,
   rebaseLensUrl,
   skinnyWmsBasemap,
 } from '../wms-capabilities'
@@ -706,7 +706,7 @@ export function GeoViewer({
     return (
       <div className="flex h-full flex-col items-center justify-center gap-3 rounded-md border border-border bg-card p-6 text-center text-sm">
         <P className="max-w-md text-danger">{sourceA.error}</P>
-        {!isLoopbackUrl(a.baseUrl) && (
+        {!isLensProxyUrl(a.baseUrl) && (
           <P className="text-xs text-muted-foreground">{t('panel.corsHint')}</P>
         )}
         <Button

--- a/frontend/src/features/viewer/hooks/useLensSource.ts
+++ b/frontend/src/features/viewer/hooks/useLensSource.ts
@@ -21,7 +21,7 @@ import {
   CapabilitiesError,
   fetchCapabilities,
   groupLayers,
-  isLoopbackUrl,
+  isLensProxyUrl,
 } from '../wms-capabilities'
 import type {
   LayerGroup,
@@ -30,11 +30,11 @@ import type {
 } from '../wms-capabilities'
 
 // GetCapabilities retry — lens `running` precedes WMS-port readiness.
-// Loopback = our own lens: a cold SkinnyWMS boot can take tens of
-// seconds, so keep trying (~35 s) instead of parking on an error the
-// next attempt would clear. External servers keep the snappy ladder.
+// Our lens proxy: a cold SkinnyWMS boot can take tens of seconds, so keep
+// trying (~35 s) instead of parking on an error the next attempt would
+// clear. External servers keep the snappy ladder.
 const EXTERNAL_RETRY_DELAYS_MS = [300, 600, 1200, 2400, 4800] as const
-const LOOPBACK_RETRY_DELAYS_MS = [
+const LENS_RETRY_DELAYS_MS = [
   300, 600, 1200, 2400, 4800, 5000, 5000, 5000, 5000, 5000,
 ] as const
 
@@ -61,8 +61,8 @@ export interface LensSource {
 /** `baseUrl: null` yields an inert source: no fetch, empty layers. */
 export function useLensSource(baseUrl: string | null): LensSource {
   const retryDelays =
-    baseUrl !== null && isLoopbackUrl(baseUrl)
-      ? LOOPBACK_RETRY_DELAYS_MS
+    baseUrl !== null && isLensProxyUrl(baseUrl)
+      ? LENS_RETRY_DELAYS_MS
       : EXTERNAL_RETRY_DELAYS_MS
   const query = useQuery({
     queryKey: wmsCapabilitiesKey(baseUrl ?? ''),

--- a/frontend/src/features/viewer/wms-capabilities.ts
+++ b/frontend/src/features/viewer/wms-capabilities.ts
@@ -20,6 +20,7 @@
 
 // The singleton, not `@/lib/i18n` — no init side-effect in a plain module.
 import i18n from 'i18next'
+import { API_ENDPOINTS } from '@/api/endpoints'
 
 export interface ParsedStyle {
   name: string
@@ -55,19 +56,13 @@ export interface ParsedCapabilities {
   bbox: [number, number, number, number]
 }
 
-/** Loopback origins host our own lens servers — never CORS territory,
- *  and worth a patient capabilities retry while SkinnyWMS boots. */
-export function isLoopbackUrl(url: string): boolean {
-  try {
-    const host = new URL(url).hostname
-    return (
-      host === 'localhost' ||
-      host === '[::1]' ||
-      /^127(\.\d{1,3}){3}$/.test(host)
-    )
-  } catch {
-    return false
-  }
+/** True when `baseUrl` is our own lens proxy path (a same-origin, relative
+ *  path under `/lens/proxy/<id>`) rather than an external/curated WMS
+ *  endpoint (always an absolute URL — see `allowedWmsUrl`). Lens traffic is
+ *  never CORS territory and is worth a patient capabilities retry while
+ *  SkinnyWMS boots behind it. */
+export function isLensProxyUrl(baseUrl: string): boolean {
+  return baseUrl.startsWith(`${API_ENDPOINTS.lens.proxyBase}/`)
 }
 
 const DEFAULT_BBOX: [number, number, number, number] = [-180, -90, 180, 90]
@@ -772,20 +767,22 @@ export function uniquePressureLevels(
 }
 
 /**
- * Rewrite an absolute URL emitted by the lens (which embeds its local bind
- * address, e.g. `http://0.0.0.0:54321/wms?...`) so it is fetched via
- * `baseUrl` (the browser-reachable lens origin): the upstream path + query
- * are grafted onto it. Returns the input unchanged on parse failure.
+ * Rewrite an absolute URL emitted by the lens (which embeds its internal
+ * bind address, e.g. `http://0.0.0.0:54321/wms?...`) so it is fetched via
+ * `baseUrl` (the browser-reachable lens proxy path): the upstream path +
+ * query are grafted onto it. Returns the input unchanged on parse failure.
  */
 export function rebaseLensUrl(url: string, baseUrl: string): string {
   try {
-    // Rebasing exists for loopback lens servers that advertise internal
-    // origins. External endpoints carry a path and/or query in the base
-    // (e.g. `…/wms/?token=…`) and advertise public URLs — grafting the
-    // base onto those doubles the path/query, so use them verbatim.
+    const upstream = new URL(url)
+    if (isLensProxyUrl(baseUrl)) {
+      return `${baseUrl.replace(/\/$/, '')}${upstream.pathname}${upstream.search}`
+    }
+    // External endpoints carry a path and/or query in the base (e.g.
+    // `…/wms/?token=…`) and advertise public URLs — grafting the base onto
+    // those doubles the path/query, so use them verbatim.
     const base = new URL(baseUrl)
     if (base.pathname !== '/' || base.search !== '') return url
-    const upstream = new URL(url)
     return `${baseUrl.replace(/\/$/, '')}${upstream.pathname}${upstream.search}`
   } catch {
     return url
@@ -793,13 +790,16 @@ export function rebaseLensUrl(url: string, baseUrl: string): string {
 }
 
 /**
- * Resolve a source's WMS request endpoint. Lens sources are bare origins
- * (`http://host:port`) whose service lives at `/wms`; external servers
- * arrive as full endpoints that may carry a path and/or query (e.g.
- * `https://eccharts.ecmwf.int/wms/?token=…`) and must be used verbatim —
- * appending `/wms` to those produces garbage URLs.
+ * Resolve a source's WMS request endpoint. The lens proxy base is a
+ * same-origin path whose service lives at `<proxyBase>/wms`; external
+ * servers arrive as full endpoints that may carry a path and/or query
+ * (e.g. `https://eccharts.ecmwf.int/wms/?token=…`) and must be used
+ * verbatim — appending `/wms` to those produces garbage URLs.
  */
 export function toWmsEndpoint(baseUrl: string): string {
+  if (isLensProxyUrl(baseUrl)) {
+    return `${baseUrl.replace(/\/+$/, '')}/wms`
+  }
   try {
     const url = new URL(baseUrl)
     if (url.pathname !== '/' || url.search !== '') return baseUrl

--- a/frontend/src/features/visualise/hooks/useComparisonSource.ts
+++ b/frontend/src/features/visualise/hooks/useComparisonSource.ts
@@ -284,11 +284,10 @@ export function useComparisonSource(
     }
   }
 
-  const port = detail?.status === 'running' ? detail.ports[0] : undefined
-  if (detail && port !== undefined) {
+  if (detail?.status === 'running') {
     return {
       phase: 'running',
-      baseUrl: buildLensBaseUrl(port),
+      baseUrl: buildLensBaseUrl(detail.lens_instance_id),
       lensId: detail.lens_instance_id,
       localPath,
     }

--- a/frontend/tests/integration/features/viewer/lens-source.test.tsx
+++ b/frontend/tests/integration/features/viewer/lens-source.test.tsx
@@ -11,7 +11,10 @@
 /**
  * useLensSource capabilities retry ladder: the backend reports a lens
  * `running` when the process spawns, but SkinnyWMS serves its WMS port
- * seconds later — early 503s must be retried away, not parked on.
+ * seconds later — early 503s must be retried away, not parked on. Our own
+ * lens (reached via the proxy path) gets the patient ladder; an external
+ * WMS gets the snappy one — this asserts the patient ladder actually
+ * outlasts the snappy one, not just that some retrying happens.
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -21,10 +24,11 @@ import {
   registerMockWmsServer,
   wmsCapabilitiesRequestCount,
 } from '@tests/../mocks/data/wms.data'
+import { buildLensBaseUrl } from '@/api/endpoints/lens'
 import { useLensSource } from '@/features/viewer/hooks/useLensSource'
 
-function Probe({ port }: { port: number }) {
-  const source = useLensSource(`http://localhost:${port}`)
+function Probe({ baseUrl }: { baseUrl: string }) {
+  const source = useLensSource(baseUrl)
   return (
     <output data-testid="state">
       {source.layers.length > 0
@@ -39,27 +43,28 @@ function Probe({ port }: { port: number }) {
 }
 
 describe('useLensSource cold-boot retry', () => {
-  it('retries early 503s away and serves the capabilities', async () => {
-    const port = 21900
-    // Two boot-race failures before the server responds (see
-    // MockWmsServerConfig.failuresBeforeSuccess) — the 300/600 ms rungs
-    // must absorb them without surfacing an error.
-    registerMockWmsServer(port, {
+  it('outlasts the snappy external ladder for our own lens proxy base', async () => {
+    const lensId = 'lens-cold-boot'
+    const baseUrl = buildLensBaseUrl(lensId)
+    // 6 boot-race failures before the server responds: the external ladder
+    // (5 retries, 6 attempts total) would give up before this succeeds —
+    // only the lens proxy's patient ladder (10 retries) absorbs it.
+    registerMockWmsServer(lensId, {
       layers: [{ name: '2t', title: '2 m temperature' }],
-      failuresBeforeSuccess: 2,
+      failuresBeforeSuccess: 6,
     })
     const queryClient = new QueryClient()
     const screen = await render(
       <QueryClientProvider client={queryClient}>
-        <Probe port={port} />
+        <Probe baseUrl={baseUrl} />
       </QueryClientProvider>,
     )
 
     await expect
       .poll(() => screen.getByTestId('state').element().textContent, {
-        timeout: 8000,
+        timeout: 20000,
       })
       .toBe('ready:2t')
-    expect(wmsCapabilitiesRequestCount(port)).toBe(3)
+    expect(wmsCapabilitiesRequestCount(lensId)).toBe(7)
   })
 })

--- a/frontend/tests/integration/features/visualise/visualise-page.test.tsx
+++ b/frontend/tests/integration/features/visualise/visualise-page.test.tsx
@@ -47,6 +47,7 @@ import {
   stopMockLens,
 } from '@tests/../mocks/data/lens.data'
 import {
+  registerDefaultMockWmsServer,
   registerMockWmsServer,
   wmsCapabilitiesRequestCount,
 } from '@tests/../mocks/data/wms.data'
@@ -146,13 +147,12 @@ beforeEach(() => {
   injectMockExecution(secondGribRunExecution)
   resetLensState()
   viewerCrash.armed = false
-  // Mock lenses allocate ports from 54300 — serve WMS on the first few so
-  // panels that reach `running` can load capabilities.
-  for (let port = 54300; port < 54306; port++) {
-    registerMockWmsServer(port, {
-      layers: [{ name: '2t', title: '2 m temperature' }],
-    })
-  }
+  // Auto-started lenses get sequential ids (lens-1, lens-2, …) unknown to
+  // the test in advance — seed a default WMS config so any of them can
+  // load capabilities once running.
+  registerDefaultMockWmsServer({
+    layers: [{ name: '2t', title: '2 m temperature' }],
+  })
 })
 
 describe('VisualisePage', () => {

--- a/frontend/tests/unit/api/endpoints/lens.test.ts
+++ b/frontend/tests/unit/api/endpoints/lens.test.ts
@@ -9,35 +9,48 @@
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { buildLensBaseUrl, buildWmsCapabilitiesUrl } from '@/api/endpoints/lens'
+import {
+  buildAbsoluteWmsCapabilitiesUrl,
+  buildLensBaseUrl,
+  buildWmsCapabilitiesUrl,
+} from '@/api/endpoints/lens'
 
 afterEach(() => {
   vi.unstubAllEnvs()
 })
 
 describe('buildLensBaseUrl', () => {
-  it('targets the backend host at the lens port when a backend base URL is set', () => {
-    vi.stubEnv('VITE_API_BASE_URL', 'http://backend.example:8000')
-    expect(buildLensBaseUrl(54321)).toBe('http://backend.example:54321')
+  it('builds a same-origin proxy path from the lens instance id', () => {
+    expect(buildLensBaseUrl('lens-42')).toBe('/api/v1/lens/proxy/lens-42')
   })
 
-  it('keeps the backend scheme', () => {
-    vi.stubEnv('VITE_API_BASE_URL', 'https://fiab.example')
-    expect(buildLensBaseUrl(54321)).toBe('https://fiab.example:54321')
-  })
-
-  it('falls back to the page origin host when no backend base URL is set', () => {
-    vi.stubEnv('VITE_API_BASE_URL', '')
-    const { protocol, hostname } = window.location
-    expect(buildLensBaseUrl(54321)).toBe(`${protocol}//${hostname}:54321`)
+  it('encodes the instance id', () => {
+    expect(buildLensBaseUrl('lens/weird id')).toBe(
+      '/api/v1/lens/proxy/lens%2Fweird%20id',
+    )
   })
 })
 
 describe('buildWmsCapabilitiesUrl', () => {
-  it('appends the WMS GetCapabilities query to the lens base URL', () => {
+  it('appends the WMS GetCapabilities query to the lens proxy base', () => {
+    expect(buildWmsCapabilitiesUrl('lens-42')).toBe(
+      '/api/v1/lens/proxy/lens-42/wms?service=WMS&version=1.3.0&request=GetCapabilities',
+    )
+  })
+})
+
+describe('buildAbsoluteWmsCapabilitiesUrl', () => {
+  it('resolves against the configured backend base URL', () => {
     vi.stubEnv('VITE_API_BASE_URL', 'http://backend.example:8000')
-    expect(buildWmsCapabilitiesUrl(54321)).toBe(
-      'http://backend.example:54321/wms?service=WMS&version=1.3.0&request=GetCapabilities',
+    expect(buildAbsoluteWmsCapabilitiesUrl('lens-42')).toBe(
+      'http://backend.example:8000/api/v1/lens/proxy/lens-42/wms?service=WMS&version=1.3.0&request=GetCapabilities',
+    )
+  })
+
+  it('falls back to the page origin when no backend base URL is set', () => {
+    vi.stubEnv('VITE_API_BASE_URL', '')
+    expect(buildAbsoluteWmsCapabilitiesUrl('lens-42')).toBe(
+      `${window.location.origin}/api/v1/lens/proxy/lens-42/wms?service=WMS&version=1.3.0&request=GetCapabilities`,
     )
   })
 })

--- a/frontend/tests/unit/features/viewer/wms-capabilities.test.ts
+++ b/frontend/tests/unit/features/viewer/wms-capabilities.test.ts
@@ -19,7 +19,7 @@ import {
   expandTimeSteps,
   fetchCapabilities,
   groupLayers,
-  isLoopbackUrl,
+  isLensProxyUrl,
   parseCapabilities,
   parseWmsTimestamp,
   partitionGroups,
@@ -412,7 +412,7 @@ describe('expandTimeSteps', () => {
 })
 
 describe('rebaseLensUrl', () => {
-  it('grafts the upstream path and query onto the base URL', () => {
+  it('grafts the upstream path and query onto a bare-origin external base', () => {
     expect(
       rebaseLensUrl(
         'http://0.0.0.0:54321/wms?service=WMS&request=GetMap',
@@ -439,6 +439,26 @@ describe('rebaseLensUrl', () => {
     expect(
       rebaseLensUrl(advertised, 'https://eccharts.ecmwf.int/wms/?token=public'),
     ).toBe(advertised)
+  })
+
+  it('grafts onto the lens proxy path regardless of its own pathname', () => {
+    // The proxy base is same-origin and non-root (`/api/v1/lens/proxy/<id>`)
+    // — unlike external bases, it must still rebase, not be used verbatim.
+    expect(
+      rebaseLensUrl(
+        'http://0.0.0.0:54321/wms?service=WMS&request=GetMap',
+        '/api/v1/lens/proxy/lens-1',
+      ),
+    ).toBe('/api/v1/lens/proxy/lens-1/wms?service=WMS&request=GetMap')
+  })
+
+  it('tolerates a trailing slash on the lens proxy base', () => {
+    expect(
+      rebaseLensUrl(
+        'http://0.0.0.0:54321/legend?layer=2t',
+        '/api/v1/lens/proxy/lens-1/',
+      ),
+    ).toBe('/api/v1/lens/proxy/lens-1/legend?layer=2t')
   })
 })
 
@@ -535,6 +555,15 @@ describe('toWmsEndpoint / appendWmsParams', () => {
     expect(toWmsEndpoint('not a url')).toBe('not a url')
   })
 
+  it('appends /wms to the lens proxy path despite its non-root pathname', () => {
+    expect(toWmsEndpoint('/api/v1/lens/proxy/lens-1')).toBe(
+      '/api/v1/lens/proxy/lens-1/wms',
+    )
+    expect(toWmsEndpoint('/api/v1/lens/proxy/lens-1/')).toBe(
+      '/api/v1/lens/proxy/lens-1/wms',
+    )
+  })
+
   it('joins params with the correct separator', () => {
     expect(appendWmsParams('http://h/wms', 'request=GetCapabilities')).toBe(
       'http://h/wms?request=GetCapabilities',
@@ -545,17 +574,16 @@ describe('toWmsEndpoint / appendWmsParams', () => {
   })
 })
 
-describe('isLoopbackUrl', () => {
-  it('recognises our lens hosts', () => {
-    expect(isLoopbackUrl('http://localhost:54301/wms')).toBe(true)
-    expect(isLoopbackUrl('http://127.0.0.1:8080')).toBe(true)
-    expect(isLoopbackUrl('http://[::1]:9000/x')).toBe(true)
+describe('isLensProxyUrl', () => {
+  it('recognises our lens proxy path', () => {
+    expect(isLensProxyUrl('/api/v1/lens/proxy/lens-1')).toBe(true)
+    expect(isLensProxyUrl('/api/v1/lens/proxy/lens-1/wms')).toBe(true)
   })
 
-  it('rejects external servers and junk', () => {
-    expect(isLoopbackUrl('https://maps.dwd.de/geoserver/ows?')).toBe(false)
-    expect(isLoopbackUrl('https://localhost.evil.example')).toBe(false)
-    expect(isLoopbackUrl('not a url')).toBe(false)
+  it('rejects external servers and unrelated paths', () => {
+    expect(isLensProxyUrl('https://maps.dwd.de/geoserver/ows?')).toBe(false)
+    expect(isLensProxyUrl('http://localhost:54301/wms')).toBe(false)
+    expect(isLensProxyUrl('/api/v1/lens/status')).toBe(false)
   })
 })
 


### PR DESCRIPTION
Changes the lens url -- instead of returning the underlying port, we return an URL that points to backend's new route for proxying, and the backend then proxies itself, additionally applying auth

Minor tech debt / refactor: we centralize the /api/v1 prefix, it now comes from config into all places

*Release Notes*: enables Lens functionality in cloud/containerized deployments. Makes Lens require (any) authentication