### PR TITLE
[frontend] fix: unwatermarked picker basemap + steady template-params dialog

### DIFF
--- a/frontend/src/features/fable-builder/components/TemplateParamsDialog.tsx
+++ b/frontend/src/features/fable-builder/components/TemplateParamsDialog.tsx
@@ -18,7 +18,7 @@
  * the rest stay plain text.
  */
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   CheckCircle2,
   ChevronRight,
@@ -166,6 +166,10 @@ export function TemplateParamsDialog({
   )
   // The expansion lags the inputs (debounce + fetch) — verdicts wait for it.
   const settled = !isValidating && debouncedValues === values
+  // The inputs `expansion` was actually computed for (frozen while revalidating).
+  const verdictValuesRef = useRef(values)
+  if (settled) verdictValuesRef.current = values
+  const verdictValues = verdictValuesRef.current
 
   const errorCount = expansion
     ? expansion.global_errors.length +
@@ -338,8 +342,10 @@ export function TemplateParamsDialog({
   }
 
   const renderField = (name: string, grouped = false) => {
+    // Verdicts flip only on settle — mid-validation flips bounce the dialog.
+    const verdictValue = verdictValues[name] ?? ''
     const preview = resolvedPreview(name)
-    const missing = settled && isMissing(name)
+    const missing = isMissing(name) && (values[name] ?? '') === verdictValue
     const meta = examples?.example_glyphs[name]
     // Templates declare their own types; nothing is inferred elsewhere.
     const valueType = meta?.type_hint
@@ -433,9 +439,7 @@ export function TemplateParamsDialog({
             </p>
           ) : (
             preview !== null &&
-            preview !== (values[name] ?? '') && (
-              <ResolvedPreview preview={preview} />
-            )
+            preview !== verdictValue && <ResolvedPreview preview={preview} />
           )}
         </div>
       </div>

--- a/frontend/src/features/viewer/ol-layers.ts
+++ b/frontend/src/features/viewer/ol-layers.ts
@@ -21,16 +21,15 @@
  */
 
 import ImageLayer from 'ol/layer/Image'
-import VectorTileLayer from 'ol/layer/VectorTile'
 import ImageWMS from 'ol/source/ImageWMS'
 import { fromLonLat } from 'ol/proj'
-import { applyStyle as applyMapboxStyle } from 'ol-mapbox-style'
 import { toWmsEndpoint } from './wms-capabilities'
 import type { LoadFunction } from 'ol/Image'
-import type VectorTileSource from 'ol/source/VectorTile'
-import { createLogger } from '@/lib/logger'
-
-const log = createLogger('viewer')
+import type VectorTileLayer from 'ol/layer/VectorTile'
+import {
+  CARTO_POSITRON_STYLE_URL,
+  makeVectorBasemapLayer,
+} from '@/lib/map/ol-basemap'
 
 // External web basemap (Carto vector); the SkinnyWMS native basemap is separate.
 export interface ExternalBasemapOption {
@@ -61,7 +60,7 @@ export const BASEMAPS: ReadonlyArray<ExternalBasemapOption> = [
     type: 'vector',
     id: 'carto-positron-vector',
     labelKey: 'basemaps.cartoPositron',
-    styleUrl: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
+    styleUrl: CARTO_POSITRON_STYLE_URL,
   },
 ]
 
@@ -97,16 +96,7 @@ export type BasemapLayer = ExternalBasemapLayer | ImageLayer<ImageWMS>
 export function makeBasemapLayer(
   opt: ExternalBasemapOption,
 ): ExternalBasemapLayer {
-  // Vector tiles (Mapbox-style JSON). declutter: no label overlap; extent: one world so margins stay empty.
-  const layer = new VectorTileLayer<VectorTileSource>({
-    declutter: true,
-    extent: WEB_MERCATOR_EXTENT,
-  })
-  // Empty CSS suppresses ol-mapbox-style's broken jsdelivr fontsource fetch; labels fall back to stack fonts.
-  applyMapboxStyle(layer, opt.styleUrl, { webfonts: '/empty-font.css' }).catch(
-    (err) => log.error('Failed to apply vector basemap style', { error: err }),
-  )
-  return layer
+  return makeVectorBasemapLayer(opt.styleUrl)
 }
 
 /**

--- a/frontend/src/lib/map/ol-basemap.ts
+++ b/frontend/src/lib/map/ol-basemap.ts
@@ -9,18 +9,21 @@
  */
 
 /**
- * Shared OpenLayers basemap helper. Uses Carto Positron raster (XYZ) tiles — a single image
- * source, simpler/more reliable than the vector style for a small picker. The host is already
- * CSP-allowlisted (see `index.html` / `vite.config.ts`).
+ * Shared OpenLayers basemap helper: Carto Positron vector tiles — Carto
+ * watermarks keyless RASTER tiles ("API KEY REQUIRED", 2026-08); the
+ * vector service is not (yet) enforced. Hosts are CSP-allowlisted.
  */
 
-import TileLayer from 'ol/layer/Tile'
+import VectorTileLayer from 'ol/layer/VectorTile'
 import { fromLonLat } from 'ol/proj'
-import XYZ from 'ol/source/XYZ'
+import { applyStyle as applyMapboxStyle } from 'ol-mapbox-style'
+import type VectorTileSource from 'ol/source/VectorTile'
+import { createLogger } from '@/lib/logger'
 
-/** Carto Positron raster tiles (light basemap). Host matches CSP `*.basemaps.cartocdn.com`. */
-export const CARTO_RASTER_TILE_URL =
-  'https://{a-d}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png'
+const log = createLogger('map')
+
+export const CARTO_POSITRON_STYLE_URL =
+  'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json'
 
 /** Standard Web Mercator world extent (the projection asymptotes at ±85.0511°). */
 export const WEB_MERCATOR_EXTENT: [number, number, number, number] = [
@@ -28,13 +31,21 @@ export const WEB_MERCATOR_EXTENT: [number, number, number, number] = [
   ...fromLonLat([180, 85.0511]),
 ] as [number, number, number, number]
 
-/** Carto Positron as an OpenLayers raster (XYZ) tile layer. */
-export function makeCartoBasemapLayer(): TileLayer<XYZ> {
-  return new TileLayer({
-    source: new XYZ({
-      url: CARTO_RASTER_TILE_URL,
-      attributions: '© OpenStreetMap contributors, © CARTO',
-      maxZoom: 20,
-    }),
+/** Vector-tile layer from a Mapbox-style JSON URL (attribution rides in its TileJSON). */
+export function makeVectorBasemapLayer(styleUrl: string): VectorTileLayer {
+  // declutter: no label overlap; extent: one world so margins stay empty.
+  const layer = new VectorTileLayer<VectorTileSource>({
+    declutter: true,
+    extent: WEB_MERCATOR_EXTENT,
   })
+  // Empty CSS suppresses ol-mapbox-style's broken jsdelivr fontsource fetch; labels fall back to stack fonts.
+  applyMapboxStyle(layer, styleUrl, { webfonts: '/empty-font.css' }).catch(
+    (err) => log.error('Failed to apply vector basemap style', { error: err }),
+  )
+  return layer
+}
+
+/** Carto Positron as an OpenLayers vector-tile layer. */
+export function makeCartoBasemapLayer(): VectorTileLayer {
+  return makeVectorBasemapLayer(CARTO_POSITRON_STYLE_URL)
 }


### PR DESCRIPTION
### Description

Two small frontend fixes around the geodomain picker: 

1.  **`fix(map)`**  CARTO now requires an API key for its basemaps (https://carto.com/basemaps/apikey/) and serves keyless *raster* tiles with an "API KEY REQUIRED" watermark baked in, which hit the Map Area picker's XYZ source; the picker now uses the same vector Positron style as the visualise viewer (not yet key-enforced), via a shared `makeVectorBasemapLayer` in `lib/map/ol-basemap.ts` that both surfaces delegate to. 

3. **`fix(configure)`**  releasing a bbox drag (or any param change) made the Template parameters dialog visibly bounce: resolved previews and missing-value hints were compared against fresh input while the expansion still reflected the old one, so the popup/dialog flashed in/out during the ~600 ms debounce+fetch window and the centered dialog (plus the anchored map popover) shifted. Now compare against a snapshot of the inputs the expansion was computed for, frozen until validation settles.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
