### PR TITLE
Bug/lens proxy

### DIFF
--- a/backend/src/forecastbox/domain/lens/proxy.py
+++ b/backend/src/forecastbox/domain/lens/proxy.py
@@ -176,6 +176,22 @@ def _build_upstream_headers(request: Request, port: int, lens_instance_id: LensI
     return headers
 
 
+def _has_body(request: Request) -> bool:
+    """Does this request carry a body worth streaming upstream?
+
+    Passing a stream for a bodyless GET makes httpx frame it as
+    Transfer-Encoding: chunked. gunicorn's sync worker never drains that body,
+    so it closes the socket with request data unread, the kernel answers RST,
+    and our in-flight response body read dies mid-stream.
+    """
+    if request.headers.get("transfer-encoding"):
+        return True
+    try:
+        return int(request.headers.get("content-length", "0")) > 0
+    except ValueError:
+        return False
+
+
 def _build_upstream_url(port: int, upstream_path: str, query: str) -> str:
     url = f"http://127.0.0.1:{port}/{upstream_path}"
     if query:
@@ -200,7 +216,7 @@ async def forward(lens_instance_id: LensInstanceId, upstream_path: str, request:
         request.method,
         url,
         headers=headers,
-        content=request.stream(),
+        **({"content": request.stream()} if _has_body(request) else {}),
     )
 
     # NOTE here we raise HTTP exceptions directly, not domain exceptions -- because we are indeed

--- a/backend/src/forecastbox/domain/lens/proxy.py
+++ b/backend/src/forecastbox/domain/lens/proxy.py
@@ -216,7 +216,7 @@ async def forward(lens_instance_id: LensInstanceId, upstream_path: str, request:
         request.method,
         url,
         headers=headers,
-        **({"content": request.stream()} if _has_body(request) else {}),
+        **({"content": request.stream()} if _has_body(request) else {}),  # ty:ignore # NOTE ty is for some reason mishandling the kwarg expansion
     )
 
     # NOTE here we raise HTTP exceptions directly, not domain exceptions -- because we are indeed

--- a/backend/tests/unit/domain/lens/test_proxy.py
+++ b/backend/tests/unit/domain/lens/test_proxy.py
@@ -159,3 +159,51 @@ class TestForward:
         chunks: list[bytes] = [chunk async for chunk in response.body_iterator]  # type: ignore[misc]
         assert b"".join(chunks) == b"hello world"
         upstream_response.aclose.assert_awaited_once()
+
+
+class TestUpstreamRequestFraming:
+    """A bodyless GET must not be framed as chunked upstream.
+
+    gunicorn's sync worker never drains a request body on a GET: it answers and
+    closes the socket with that body unread, the kernel sends RST rather than a
+    clean FIN, and the response we are still streaming back is truncated.
+    """
+
+    @staticmethod
+    def _running(iid: LensInstanceId) -> None:
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.poll.return_value = None
+        LensInstanceManager.instances = pmap({iid: LensInstance(process=mock_proc, lens_params={}, lens_name="skinnyWMS", ports={19042})})
+
+    @staticmethod
+    def _upstream() -> AsyncMock:
+        async def fake_aiter_raw() -> AsyncIterator[bytes]:
+            yield b"ok"
+
+        response = AsyncMock()
+        response.status_code = 200
+        response.headers = httpx.Headers({"content-type": "image/png"})
+        response.aiter_raw = fake_aiter_raw
+        response.aclose = AsyncMock()
+        return response
+
+    @pytest.mark.asyncio
+    async def test_bodyless_get_is_not_chunked(self) -> None:
+        iid = LensInstanceId("running-id")
+        self._running(iid)
+        send = AsyncMock(return_value=self._upstream())
+        with patch.object(httpx.AsyncClient, "send", send):
+            await lens_proxy.forward(iid, "wms", _make_request())
+        sent = send.await_args.args[0]
+        assert "transfer-encoding" not in {name.lower() for name in sent.headers}
+
+    @pytest.mark.asyncio
+    async def test_request_with_a_body_is_still_streamed(self) -> None:
+        iid = LensInstanceId("running-id")
+        self._running(iid)
+        request = _make_request("POST", headers=[(b"host", b"example.com"), (b"content-length", b"12")])
+        send = AsyncMock(return_value=self._upstream())
+        with patch.object(httpx.AsyncClient, "send", send):
+            await lens_proxy.forward(iid, "wms", request)
+        sent = send.await_args.args[0]
+        assert sent.headers.get("transfer-encoding") == "chunked"


### PR DESCRIPTION
Follow-up to #677: the lens proxy silently truncates WMS responses.

## Issue

Repeated GetMap through `/api/v1/lens/proxy/<id>/...` returns short bodies as `200 OK`. 40 sequential requests over one connection, proxied vs. the lens's own port:

| layer | direct | proxied |
|---|---|---|
| 2t | 100% | 72.5% |
| msl | 100% | 60.0% |
| 2d | 100% | 55.0% |
| 10v | 100% | 57.5% |

Six of seven layers across two output directories, so not dataset-specific. In the geo viewer the partial PNG fails to decode and the tile renders as an error.

## Cause

`forward` passed `content=request.stream()` for every request. WMS requests are bodyless GETs, but the stream has no known length, so httpx framed them `Transfer-Encoding: chunked`. gunicorn's sync worker never drains a request body on a GET — it answers and closes the socket with that body unread, the kernel sends RST instead of FIN, and the response body still being streamed back is cut off. Server-side it appears as `httpx.ReadError` out of `body_iterator`.


## Fix

Only stream a body when the request has one. Requests that do carry a body are unaffected.

## Verification

All failing layers now 100%, bodies byte-exact, throughput unchanged (~2% proxy overhead). New unit test fails on current `main`, passes with the fix.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
