### PR TITLE
fix: allow no args when calling just dev

### DIFF
--- a/justfile
+++ b/justfile
@@ -60,7 +60,7 @@ dev *args:
 
     args=({{args}})
 
-    for arg in "${args[@]}" ; do
+    for arg in ${args[@]+"${args[@]}"} ; do
         if [ "$arg" == "full-reinstall" ] ; then
             echo "full reinstall! Will drop the db and sync the venv"
             pushd backend

--- a/justfile
+++ b/justfile
@@ -60,6 +60,8 @@ dev *args:
 
     args=({{args}})
 
+    # NOTE on MacOS, empty array fails to expand in a for-safe way, hence we need
+    # conditional expansion into itself (${var+"$var"} basically)
     for arg in ${args[@]+"${args[@]}"} ; do
         if [ "$arg" == "full-reinstall" ] ; then
             echo "full reinstall! Will drop the db and sync the venv"


### PR DESCRIPTION
### Description
This pull request makes a minor update to the argument handling in the `justfile` script. It fixes the `just dev` command to allow it to run without options.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
