### PR TITLE
[frontend] Frontend follow-ups to the lens proxy (#680)

### DIFF
--- a/frontend/development_guidelines/DEPLOYMENT.md
+++ b/frontend/development_guidelines/DEPLOYMENT.md
@@ -42,7 +42,7 @@ Content-Security-Policy:
 
 ### Notes
 
-- If you serve the backend on a different origin (e.g. `https://api.example.com`), add it to `connect-src` — including `wss://api.example.com` for the notification WebSocket, since `'self'`'s scheme-upgrade leniency applies only to the page's own origin.
+- If you serve the backend on a different origin (e.g. `https://api.example.com`), add it to `connect-src` — including `wss://api.example.com` for the notification WebSocket, since `'self'`'s scheme-upgrade leniency applies only to the page's own origin. Note the geo viewer's lens sources do **not** support this: they are addressed by a relative path under `/api/v1/lens/proxy/`, so lens viewing requires the app and backend to share an origin.
 - Reverse proxies in front of the backend must forward WebSocket upgrades on `/api/v1/notification/ws` (nginx: `proxy_http_version 1.1` plus the `Upgrade`/`Connection` headers).
 - `'unsafe-inline'` in `style-src` is required because three.js and some UI libraries inject styles at runtime. If this is unacceptable, consider using a CSP nonce strategy.
 - `worker-src 'self'` can be removed in production if MSW is not used.
@@ -54,6 +54,7 @@ CSP must mirror the allowances the built `index.html` meta CSP carries, or
 those features silently fail:
 
 - **Basemap:** `https://basemaps.cartocdn.com` and `https://*.basemaps.cartocdn.com` in `img-src`, `connect-src`, `style-src`, and `font-src`.
-- **WMS lens servers** run on dynamic loopback ports next to the backend: `http://localhost:*` and `http://127.0.0.1:*` in `img-src` and `connect-src` (single-host deployments; a same-origin lens proxy needs only `'self'`).
+- **WMS lens servers** need no allowance of their own: the backend proxies them at `/api/v1/lens/proxy/<id>/`, so lens traffic is same-origin and covered by `'self'`.
+- **Loopback WMS servers** the user runs on their own machine and adds by URL: `http://localhost:*` and `http://127.0.0.1:*` in `img-src` and `connect-src`. A single production bundle is served both from a domain and from localhost, and the baked meta CSP cannot tell the two apart, so these stay allowed in both. A proxy-level CSP fronting a domain deployment may drop them.
 - **Curated WMS servers** (the built-in list in `src/features/visualise/curated-wms.ts`) are baked into production builds' `img-src`/`connect-src` automatically.
 - **Additional WMS hosts** users should be able to add by URL: set `FIAB_CSP_EXTRA_HOSTS` at build time (space-separated source expressions, e.g. `FIAB_CSP_EXTRA_HOSTS="https://my.wms.host https://other.example"`), and mirror them in the proxy CSP.

--- a/frontend/mocks/handlers/wms.handlers.ts
+++ b/frontend/mocks/handlers/wms.handlers.ts
@@ -31,7 +31,7 @@ import {
 import { API_ENDPOINTS } from '@/api/endpoints'
 
 // Translucent 1×1 PNGs (red / blue) — GetMap alternates the color by
-// port so two mock lenses are visually distinguishable and comparison
+// routing key so two mock lenses are visually distinguishable and comparison
 // partitions (swipe/spy) can be eyeballed in dev:mock: any red/blue
 // blending would mean a leaking clip.
 const PNG_RED = Uint8Array.from(
@@ -60,8 +60,11 @@ function wmsKeyFor(url: URL): string {
   return proxied ? decodeURIComponent(proxied[1]) : url.port
 }
 
+/** Keys may be non-numeric lens ids, so alternate on a char sum, not a port. */
 function pngResponse(key: string) {
-  const png = Number(key) % 2 === 0 ? PNG_RED : PNG_BLUE
+  let sum = 0
+  for (let i = 0; i < key.length; i++) sum += key.charCodeAt(i)
+  const png = sum % 2 === 0 ? PNG_RED : PNG_BLUE
   return new HttpResponse(png.slice().buffer, {
     headers: { ...CORS, 'Content-Type': 'image/png' },
   })

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -190,7 +190,7 @@ export const API_ENDPOINTS = {
     list: `${API_PREFIX}/lens/list`,
     /** GET - List supported lens types */
     supported: `${API_PREFIX}/lens/supported`,
-    /** GET/POST - Proxy base; the running lens is reached at
+    /** ANY - Proxy base; the running lens is reached at
      *  `${proxyBase}/<lens_instance_id>/<upstream path>` */
     proxyBase: `${API_PREFIX}/lens/proxy`,
   },

--- a/frontend/src/features/viewer/wms-capabilities.ts
+++ b/frontend/src/features/viewer/wms-capabilities.ts
@@ -774,10 +774,19 @@ export function uniquePressureLevels(
  */
 export function rebaseLensUrl(url: string, baseUrl: string): string {
   try {
-    const upstream = new URL(url)
     if (isLensProxyUrl(baseUrl)) {
-      return `${baseUrl.replace(/\/$/, '')}${upstream.pathname}${upstream.search}`
+      const lensBase = baseUrl.replace(/\/+$/, '')
+      // The lens may advertise an internal address, a host-less path, or one
+      // already under the proxy (X-Forwarded-Prefix). The fake host is never
+      // contacted — it only lets `new URL` parse a host-less path; we keep
+      // the path and query.
+      const upstream = new URL(url, 'http://lens.invalid')
+      const path = upstream.pathname.startsWith(`${lensBase}/`)
+        ? upstream.pathname
+        : `${lensBase}${upstream.pathname}`
+      return `${path}${upstream.search}`
     }
+    const upstream = new URL(url)
     // External endpoints carry a path and/or query in the base (e.g.
     // `…/wms/?token=…`) and advertise public URLs — grafting the base onto
     // those doubles the path/query, so use them verbatim.

--- a/frontend/src/features/viewer/wms-capabilities.ts
+++ b/frontend/src/features/viewer/wms-capabilities.ts
@@ -767,20 +767,21 @@ export function uniquePressureLevels(
 }
 
 /**
- * Rewrite an absolute URL emitted by the lens (which embeds its internal
- * bind address, e.g. `http://0.0.0.0:54321/wms?...`) so it is fetched via
- * `baseUrl` (the browser-reachable lens proxy path): the upstream path +
- * query are grafted onto it. Returns the input unchanged on parse failure.
+ * Rewrite a URL advertised by the lens so it is fetched via `baseUrl`, the
+ * browser-reachable lens proxy path. The advertised form may be an internal
+ * bind address (`http://0.0.0.0:54321/wms?...`), a relative reference, or
+ * already proxied (X-Forwarded-Prefix); each resolves onto the proxy path.
+ * External bases are used verbatim, as is anything that fails to parse.
  */
 export function rebaseLensUrl(url: string, baseUrl: string): string {
   try {
     if (isLensProxyUrl(baseUrl)) {
       const lensBase = baseUrl.replace(/\/+$/, '')
-      // The lens may advertise an internal address, a host-less path, or one
-      // already under the proxy (X-Forwarded-Prefix). The fake host is never
-      // contacted — it only lets `new URL` parse a host-less path; we keep
-      // the path and query.
-      const upstream = new URL(url, 'http://lens.invalid')
+      // Relative refs resolve against the document that carried them — the
+      // WMS endpoint — so a query-only href keeps `/wms`. The fake host is
+      // never contacted; it only lets `new URL` parse a host-less ref.
+      const docBase = `http://lens.invalid${toWmsEndpoint(lensBase)}`
+      const upstream = new URL(url, docBase)
       const path = upstream.pathname.startsWith(`${lensBase}/`)
         ? upstream.pathname
         : `${lensBase}${upstream.pathname}`

--- a/frontend/tests/unit/features/viewer/wms-capabilities.test.ts
+++ b/frontend/tests/unit/features/viewer/wms-capabilities.test.ts
@@ -477,6 +477,20 @@ describe('rebaseLensUrl', () => {
       rebaseLensUrl('/wms?request=GetMap', '/api/v1/lens/proxy/lens-1'),
     ).toBe('/api/v1/lens/proxy/lens-1/wms?request=GetMap')
   })
+
+  it('keeps the WMS endpoint on a query-only advertised URL', () => {
+    // A query-only href is relative to the capabilities document itself, so
+    // it must resolve against `/wms` rather than the proxy root.
+    expect(rebaseLensUrl('?request=GetMap', '/api/v1/lens/proxy/lens-1')).toBe(
+      '/api/v1/lens/proxy/lens-1/wms?request=GetMap',
+    )
+  })
+
+  it('resolves a path-relative advertised URL as a sibling of /wms', () => {
+    expect(rebaseLensUrl('legend?layer=2t', '/api/v1/lens/proxy/lens-1')).toBe(
+      '/api/v1/lens/proxy/lens-1/legend?layer=2t',
+    )
+  })
 })
 
 describe('groupLayers', () => {

--- a/frontend/tests/unit/features/viewer/wms-capabilities.test.ts
+++ b/frontend/tests/unit/features/viewer/wms-capabilities.test.ts
@@ -460,6 +460,23 @@ describe('rebaseLensUrl', () => {
       ),
     ).toBe('/api/v1/lens/proxy/lens-1/legend?layer=2t')
   })
+
+  it('does not double the prefix on an already-proxied advertised URL', () => {
+    // A lens honouring X-Forwarded-Prefix advertises already-proxied URLs.
+    expect(
+      rebaseLensUrl(
+        'https://fiab.example/api/v1/lens/proxy/lens-1/wms?request=GetMap',
+        '/api/v1/lens/proxy/lens-1',
+      ),
+    ).toBe('/api/v1/lens/proxy/lens-1/wms?request=GetMap')
+  })
+
+  it('grafts a relative advertised URL onto the lens proxy base', () => {
+    // The proxy contract asks lenses to prefer relative self-URLs.
+    expect(
+      rebaseLensUrl('/wms?request=GetMap', '/api/v1/lens/proxy/lens-1'),
+    ).toBe('/api/v1/lens/proxy/lens-1/wms?request=GetMap')
+  })
 })
 
 describe('groupLayers', () => {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -34,7 +34,8 @@ export default defineConfig(({ mode }) => {
       }),
       viteReact(),
       tailwindcss(),
-      // CSP: the WMS lens lives on dynamic loopback ports in every build.
+      // Loopback is not for the lens (same-origin via the proxy) but for a
+      // user's own WMS — one bundle serves both a domain and localhost.
       // External WMS hosts: dev allows all; prod bakes in the curated list
       // plus FIAB_CSP_EXTRA_HOSTS (space-separated source expressions).
       {


### PR DESCRIPTION
### Description

The proxy contract leaves URL adaptation to the client: a lens may advertise a relative URL, honour `X-Forwarded-Prefix`, or bake in its internal bind address. `rebaseLensUrl` handled only the last, so the other shapes missed the proxy or doubled its prefix. 

Below, `…` is `/api/v1/lens/proxy` and `lens-1` the instance id; each row was measured by running `rebaseLensUrl` on both branches.

| Advertised URL | Before (`dev`) | After |
| --- | --- | --- |
| `http://0.0.0.0:54321/wms?request=GetMap` | `…/lens-1/wms?request=GetMap` | `…/lens-1/wms?request=GetMap` |
| `/wms?request=GetMap` | `/wms?request=GetMap` — misses the proxy | `…/lens-1/wms?request=GetMap` |
| `legend?layer=2t` | `legend?layer=2t` — resolves against the page | `…/lens-1/legend?layer=2t` |
| `?request=GetMap` | `?request=GetMap` — resolves against the page | `…/lens-1/wms?request=GetMap` |
| `https://fiab.example/api/v1/lens/proxy/lens-1/wms?request=GetMap` | `…/lens-1/api/v1/lens/proxy/lens-1/wms?request=GetMap` — doubled | `…/lens-1/wms?request=GetMap` |
| `https://eccharts.ecmwf.int/wms/?token=public&request=GetLegend` | verbatim | verbatim |



Also fixed: mock lens tiles were coloured by `Number(id)`, which is `NaN` for a lens instance id, so both comparison slots served one colour in `dev:mock`. And `DEPLOYMENT.md` credited the loopback CSP entries to the lens — they actually cover a WMS the user runs locally; the lens is same-origin behind the proxy and covered by `'self'`.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
