### PR TITLE
[core] introduce the NoneType

### DIFF
--- a/backend/packages/fiab-core/src/fiab_core/types/__init__.py
+++ b/backend/packages/fiab-core/src/fiab_core/types/__init__.py
@@ -12,6 +12,7 @@ FableType: Type system for Forecast As BLock Expression (Fable) configuration va
 
 Provides parsing, validation, and conversion for a small set of type expressions:
 - str, int, float, date, datetime (atomic types)
+- none (the type whose only value is an explicit null)
 - country (string subtype)
 - enumClosed[subtype](...), enumOpen[subtype](...) (enumeration types, e.g. enumClosed[int](1,2))
 - list[FableType] (container types)

--- a/backend/packages/fiab-core/src/fiab_core/types/definitions.py
+++ b/backend/packages/fiab-core/src/fiab_core/types/definitions.py
@@ -15,7 +15,7 @@ from datetime import date, datetime
 from typing import Any, Iterable, Literal, get_args
 
 import fiab_core  # to satisfy the type checker for artifacts annotation
-from fiab_core.types.exceptions import NotStringInput, WrongType
+from fiab_core.types.exceptions import NotNoneInput, NotStringInput, WrongType
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +53,22 @@ class StringType(FableType):
 
     def serialize(self) -> str:
         return "str"
+
+
+class NoneType(FableType):
+    """The none type. The only accepted value is ``None``, which is returned as-is.
+
+    Meant to be used as a member of a union, eg ``union[int,none]``, to declare that
+    an option accepts an explicit null. Note that an explicit null is a different thing
+    than a missing value -- the latter is never passed to validate_convert at all."""
+
+    def validate_convert(self, value: Any) -> None:
+        if value is not None:
+            raise NotNoneInput(f"Expected None, got {type(value).__name__}")
+        return None
+
+    def serialize(self) -> str:
+        return "none"
 
 
 class IntType(FableType):
@@ -166,8 +182,8 @@ class ClosedEnumType(FableType):
         self._item_set = set(self.items)
 
     def validate_convert(self, value: Any) -> Any:
-        if not isinstance(value, str):
-            raise NotStringInput(f"Expected string, got {type(value).__name__}")
+        # NOTE no isinstance check here -- the subtype is responsible for rejecting
+        # inputs of a wrong shape, and it may well accept a non-string one (eg NoneType)
         converted = self.subtype.validate_convert(value)
         if converted not in self._item_set:
             options = ", ".join(str(item) for item in self.items)
@@ -190,8 +206,7 @@ class OpenEnumType(FableType):
         self.items = [self.subtype.validate_convert(item) for item in items]
 
     def validate_convert(self, value: Any) -> Any:
-        if not isinstance(value, str):
-            raise NotStringInput(f"Expected string, got {type(value).__name__}")
+        # NOTE see the comment in ClosedEnumType.validate_convert
         return self.subtype.validate_convert(value)
 
     def serialize(self) -> str:
@@ -221,7 +236,7 @@ class ListType(FableType):
         for i, item in enumerate(items):
             try:
                 result.append(self.item_type.validate_convert(item))
-            except (NotStringInput, WrongType) as e:
+            except (NotStringInput, NotNoneInput, WrongType) as e:
                 raise WrongType(f"Error converting list item at index {i} ({item!r}): {e}")
 
         return result
@@ -237,13 +252,18 @@ class UnionType(FableType):
         self.types = types
 
     def validate_convert(self, value: Any) -> Any:
-        if not isinstance(value, str):
-            raise NotStringInput(f"Expected string, got {type(value).__name__}")
+        # NOTE we deliberately try the member types *before* checking that the input is a
+        # string, because some members (notably NoneType) legitimately accept a non-string
+        # input. Only if no member accepted the value do we report the non-string input.
+        # This makes an input like a list against `union[none]` report NotStringInput, which
+        # is a bit misleading, but we accept that in exchange for a simpler implementation.
         for t in self.types:
             try:
                 return t.validate_convert(value)
-            except WrongType:
+            except (WrongType, NotStringInput, NotNoneInput):
                 continue
+        if not isinstance(value, str):
+            raise NotStringInput(f"Expected string, got {type(value).__name__}")
         raise WrongType(f"Cannot convert {value!r} to any of: {', '.join(t.serialize() for t in self.types)}")
 
     def serialize(self) -> str:

--- a/backend/packages/fiab-core/src/fiab_core/types/exceptions.py
+++ b/backend/packages/fiab-core/src/fiab_core/types/exceptions.py
@@ -18,5 +18,9 @@ class NotStringInput(TypeError):
     """Raised when validate_convert receives a non-string input."""
 
 
+class NotNoneInput(TypeError):
+    """Raised when validate_convert of a none-typed value receives a non-None input."""
+
+
 class WrongType(Exception):
     """Raised when a value cannot be converted to the target type."""

--- a/backend/packages/fiab-core/src/fiab_core/types/parser.py
+++ b/backend/packages/fiab-core/src/fiab_core/types/parser.py
@@ -63,7 +63,7 @@ def _parse(type_expr: str) -> tuple[FableType, str]:
     was consumed.
 
     Supports:
-    - Atomic types: 'str', 'int', 'float', 'date', 'datetime', 'country', 'bboxWSEN'
+    - Atomic types: 'str', 'int', 'float', 'date', 'datetime', 'none', 'country', 'bboxWSEN'
     - Enumerations: "enumClosed[str]('item1','item2')", "enumOpen[int](1,2)"
     - Lists: 'list[int]', 'list[enumClosed[...](...)]', etc.
     - Union: 'union[int,str]', "union[enumClosed[str]('a','b'),date]", etc.
@@ -79,6 +79,7 @@ def _parse(type_expr: str) -> tuple[FableType, str]:
         ("date", DateType),
         ("float", FloatType),
         ("int", IntType),
+        ("none", NoneType),
         ("str", StringType),
         ("param", ParameterType),
         ("artifact", ArtifactType),
@@ -138,7 +139,7 @@ def _parse(type_expr: str) -> tuple[FableType, str]:
 
     raise NotFableType(
         f"Invalid type expression: {type_expr!r}. "
-        "Expected one of: str, int, float, date, datetime, country, bboxWSEN, geodomain, "
+        "Expected one of: str, int, float, date, datetime, none, country, bboxWSEN, geodomain, "
         "enumClosed[subtype](...), enumOpen[subtype](...), list[...], union[...]"
     )
 

--- a/backend/packages/fiab-core/tests/test_types.py
+++ b/backend/packages/fiab-core/tests/test_types.py
@@ -24,12 +24,14 @@ from fiab_core.types.definitions import (
     GeoDomainType,
     IntType,
     ListType,
+    NoneType,
     OpenEnumType,
     StringType,
     UnionType,
 )
 from fiab_core.types.exceptions import (
     NotFableType,
+    NotNoneInput,
     NotStringInput,
     WrongType,
 )
@@ -53,6 +55,47 @@ class TestStringType:
             t.validate_convert(None)
         with pytest.raises(NotStringInput):
             t.validate_convert(["hello"])
+
+
+class TestNoneType:
+    """Tests for NoneType"""
+
+    def test_convert_none(self) -> None:
+        assert NoneType().validate_convert(None) is None
+
+    def test_convert_non_none_raises_type_error(self) -> None:
+        t = NoneType()
+        with pytest.raises(NotNoneInput):
+            t.validate_convert("")
+        with pytest.raises(NotNoneInput):
+            t.validate_convert("None")
+        with pytest.raises(NotNoneInput):
+            t.validate_convert(123)
+
+    def test_serialize(self) -> None:
+        assert NoneType().serialize() == "none"
+
+    def test_parse_and_round_trip(self) -> None:
+        t = parse("none")
+        assert isinstance(t, NoneType)
+        assert t.serialize() == "none"
+
+
+class TestNullableUnion:
+    """Tests for unions containing NoneType"""
+
+    def test_convert_none_and_member(self) -> None:
+        t = parse("union[int,none]")
+        assert t.validate_convert("42") == 42
+        assert t.validate_convert(None) is None
+
+    def test_convert_invalid_string(self) -> None:
+        t = parse("union[int,none]")
+        with pytest.raises(WrongType):
+            t.validate_convert("not_an_int")
+
+    def test_serialize_round_trip(self) -> None:
+        assert parse("union[str,none]").serialize() == "union[str,none]"
 
 
 class TestIntType:

--- a/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
+++ b/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
@@ -1,4 +1,5 @@
 import importlib.metadata
+import json
 import pathlib
 
 from cascade.low.func import Either
@@ -23,7 +24,7 @@ from fiab_core.fable import (
     RawOutput,
 )
 from fiab_core.plugin import BlockValidation, Error, Plugin
-from fiab_core.types import ArtifactType, ClosedEnumType, FableType, FloatType, IntType, StringType, parse
+from fiab_core.types import ArtifactType, ClosedEnumType, FableType, FloatType, IntType, NoneType, StringType, UnionType, parse
 
 TEXT = ConfigurationOptionId("text")
 DURATION = ConfigurationOptionId("duration")
@@ -50,8 +51,10 @@ catalogue = lambda: BlockFactoryCatalogue(
         BlockFactoryId("source_text"): BlockFactory(
             kind="source",
             title="Source Text",
-            description="Returns the input text",
-            configuration_options={TEXT: BlockConfigurationOption(title="", description="", value_type=StringType())},
+            description="Returns the input text, or a default when the text is an explicit null",
+            configuration_options={
+                TEXT: BlockConfigurationOption(title="", description="", value_type=UnionType([StringType(), NoneType()]))
+            },
             inputs=[],
         ),
         BlockFactoryId("source_sleep"): BlockFactory(
@@ -142,20 +145,47 @@ def expander(output: BlockInstanceOutput) -> list[BlockExpansion]:
     return []
 
 
-def compiler(lookup: ActionLookup, factory_id: BlockFactoryId, instance: BlockInstance) -> Either[Action, Error]:  # ty:ignore[invalid-type-arguments] # semigroup
+def _environment_spec() -> list[str]:
+    """The worker environment specification for this plugin.
+
+    When the plugin is installed from its local source tree (an editable install, or an
+    unversioned dev checkout), workers must be given that very source tree -- otherwise
+    in-tree runtime changes would silently not be exercised, as the released wheel of the
+    very same version would get installed instead. Only a regular install falls back to
+    the pinned release.
+    """
+    local_root = pathlib.Path(__file__).parent.parent.parent
     self_version = importlib.metadata.version("fiab-plugin-test")
-    if self_version == "0.0.0":
-        spec = [f"-e {pathlib.Path(__file__).parent.parent.parent}"]
-    else:
-        spec = [f"fiab-plugin-test=={self_version}"]
+    if self_version == "0.0.0" or _is_editable_install():
+        return [f"-e {local_root}"]
+    return [f"fiab-plugin-test=={self_version}"]
+
+
+def _is_editable_install() -> bool:
+    """Whether this distribution was installed editable, as recorded by PEP 610 metadata."""
+    try:
+        direct_url = importlib.metadata.distribution("fiab-plugin-test").read_text("direct_url.json")
+    except Exception:
+        return False
+    if not direct_url:
+        return False
+    try:
+        return bool(json.loads(direct_url).get("dir_info", {}).get("editable", False))
+    except json.JSONDecodeError:
+        return False
+
+
+def compiler(lookup: ActionLookup, factory_id: BlockFactoryId, instance: BlockInstance) -> Either[Action, Error]:  # ty:ignore[invalid-type-arguments] # semigroup
+    spec = _environment_spec()
     with PayloadBuildingContext(environment=spec):
         # with PayloadBuildingContext(environment=["-e /home/dev/src/fiab-plugin-test"]): # TODO handle the ssh:// scenario intelligently
         if factory_id == "source_42":
             action = from_source(Payload("fiab_plugin_test.runtime.source_42"))
         elif factory_id == "source_text":
             text = instance.configuration_values[TEXT]
-            if not isinstance(text, str):
-                return Either.error(f"Invalid type for {TEXT!r}: expected str, got {type(text).__name__}")
+            # NOTE an explicit null is a valid value here -- the default is imputed at runtime
+            if text is not None and not isinstance(text, str):
+                return Either.error(f"Invalid type for {TEXT!r}: expected str or None, got {type(text).__name__}")
             action = from_source(Payload("fiab_plugin_test.runtime.source_text", kwargs={"text": text}))
         elif factory_id == "source_sleep":
             text = instance.configuration_values[TEXT]

--- a/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
+++ b/backend/packages/fiab-plugin-test/src/fiab_plugin_test/__init__.py
@@ -154,25 +154,25 @@ def _environment_spec() -> list[str]:
     very same version would get installed instead. Only a regular install falls back to
     the pinned release.
     """
-    local_root = pathlib.Path(__file__).parent.parent.parent
     self_version = importlib.metadata.version("fiab-plugin-test")
-    if self_version == "0.0.0" or _is_editable_install():
-        return [f"-e {local_root}"]
-    return [f"fiab-plugin-test=={self_version}"]
-
-
-def _is_editable_install() -> bool:
-    """Whether this distribution was installed editable, as recorded by PEP 610 metadata."""
+    regular = [f"fiab-plugin-test=={self_version}"]
+    local_root = pathlib.Path(__file__).parent.parent.parent
     try:
         direct_url = importlib.metadata.distribution("fiab-plugin-test").read_text("direct_url.json")
+        if not direct_url:
+            return regular
+        dist = json.loads(direct_url)
+        is_editable = dist["dir_info"]["editable"]
+        # NOTE git installs etc probably behave oddly here but they make no sense here anyway
+        is_local = dist["url"].startswith("file:")
+        if not is_local:
+            return regular
+        elif is_editable:
+            return [f"-e {local_root}"]
+        else:
+            return [f"{local_root}"]
     except Exception:
-        return False
-    if not direct_url:
-        return False
-    try:
-        return bool(json.loads(direct_url).get("dir_info", {}).get("editable", False))
-    except json.JSONDecodeError:
-        return False
+        return regular
 
 
 def compiler(lookup: ActionLookup, factory_id: BlockFactoryId, instance: BlockInstance) -> Either[Action, Error]:  # ty:ignore[invalid-type-arguments] # semigroup

--- a/backend/packages/fiab-plugin-test/src/fiab_plugin_test/runtime.py
+++ b/backend/packages/fiab-plugin-test/src/fiab_plugin_test/runtime.py
@@ -14,7 +14,13 @@ def source_sleep(text: str, duration: float) -> str:
     return text
 
 
-def source_text(text: str) -> str:
+DEFAULT_TEXT = "Hic Sunt Leones"
+
+
+def source_text(text: str | None) -> str:
+    """Return the given text, imputing the default when an explicit null was configured."""
+    if text is None:
+        return DEFAULT_TEXT
     return text
 
 

--- a/backend/packages/fiab-plugin-test/tests/test_base.py
+++ b/backend/packages/fiab-plugin-test/tests/test_base.py
@@ -21,7 +21,21 @@ from fiab_core.fable import (
 )
 
 from fiab_plugin_test import _get_checkpoint_enum_type, catalogue, compiler, validator
-from fiab_plugin_test.runtime import sink_file, sink_image, source_filesize
+from fiab_plugin_test.runtime import DEFAULT_TEXT, sink_file, sink_image, source_filesize, source_text
+
+# ---------------------------------------------------------------------------
+# runtime.source_text
+# ---------------------------------------------------------------------------
+
+
+def test_source_text_returns_input() -> None:
+    assert source_text("hello") == "hello"
+    assert source_text("") == ""
+
+
+def test_source_text_imputes_default_on_none() -> None:
+    assert source_text(None) == DEFAULT_TEXT
+
 
 # ---------------------------------------------------------------------------
 # runtime.source_filesize

--- a/backend/src/forecastbox/domain/blueprint/service.py
+++ b/backend/src/forecastbox/domain/blueprint/service.py
@@ -169,7 +169,7 @@ class BlueprintValidationExpansion(FiabBaseModel):
     possible_sources: list[PluginBlockFactoryId]
     possible_expansions: dict[BlockInstanceId, list[SerializedBlockExpansion]]
     configuration_restrictions: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = Field(default_factory=dict)
-    resolved_configuration_options: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = Field(default_factory=dict)
+    resolved_configuration_options: dict[BlockInstanceId, dict[ConfigurationOptionId, str | None]] = Field(default_factory=dict)
     missing_glyphs: dict[BlockInstanceId, dict[ConfigurationOptionId, list[str]]] = Field(default_factory=dict)
     block_output_qubes: dict[BlockInstanceId, dict[str, Any]] = Field(default_factory=dict)
     """Per-block output qube serialized via ``Qube.to_json()`` (qubed node
@@ -228,7 +228,7 @@ def _validate_expand_with_buckets(
     )
     possible_expansions: dict[BlockInstanceId, list[SerializedBlockExpansion]] = {}
     configuration_restrictions: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = {}
-    resolved_configuration_options: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = {}
+    resolved_configuration_options: dict[BlockInstanceId, dict[ConfigurationOptionId, str | None]] = {}
     block_errors: dict[BlockInstanceId, list[str]] = defaultdict(list)
     missing_glyphs_result: dict[BlockInstanceId, dict[ConfigurationOptionId, list[str]]] = {}
     block_output_qubes: dict[BlockInstanceId, dict[str, Any]] = {}
@@ -527,7 +527,8 @@ def remap_builder_glyphs(builder: BlueprintBuilder, mapping: dict[str, str]) -> 
     Applied in a single non-recursive pass to:
 
     * every configuration option value string in every block (``${name}``
-      references inside ``${...}`` expressions);
+      references inside ``${...}`` expressions); options with an explicit null
+      value are left untouched;
     * every local-glyph value string (same rename inside ``${...}``);
     * every local-glyph key: if the key itself is present in *mapping*, it is
       renamed to the mapped value.
@@ -539,7 +540,10 @@ def remap_builder_glyphs(builder: BlueprintBuilder, mapping: dict[str, str]) -> 
 
     new_blocks: list[RoutableBlock] = []
     for routable in builder.blocks:
-        new_config = {opt_id: remap_glyph_names(val, mapping) for opt_id, val in routable.instance.configuration_values.items()}
+        new_config = {
+            opt_id: (val if val is None else remap_glyph_names(val, mapping))
+            for opt_id, val in routable.instance.configuration_values.items()
+        }
         new_blocks.append(
             routable.model_copy(update={"instance": routable.instance.model_copy(update={"configuration_values": new_config})})
         )

--- a/backend/src/forecastbox/domain/glyphs/resolution.py
+++ b/backend/src/forecastbox/domain/glyphs/resolution.py
@@ -53,6 +53,9 @@ def extract_glyphs(blockInstance: BlockInstance) -> Either[ExtractedGlyphs, list
     glyphed_options: set[ConfigurationOptionId] = set()
     errors: list[str] = []
     for key, value in blockInstance.configuration_values.items():
+        if value is None:
+            # An explicit null carries no glyphs and needs no interpolation.
+            continue
         result = extract_glyph_names(value)
         if result.e is not None:
             errors.append(f"{key!r}: {result.e}")
@@ -73,10 +76,13 @@ def extract_glyphs_per_option(blockInstance: BlockInstance) -> dict[Configuratio
     """Return a mapping from each option id to the set of glyph names it references.
 
     Only includes options that contain at least one glyph reference.
+    Options with an explicit null value are skipped, as they carry no glyphs.
     Malformed expressions are silently skipped; use ``extract_glyphs`` for error detection.
     """
     result: dict[ConfigurationOptionId, set[str]] = {}
     for key, value in blockInstance.configuration_values.items():
+        if value is None:
+            continue
         if not isinstance(value, str):
             raise TypeError(f"expected {key=}'s value to be a string, gotten {type(value)}")
         r = extract_glyph_names(value)
@@ -93,8 +99,11 @@ def resolve_configurations(blockInstance: BlockInstance, glyph_values: dict[str,
     Supports the full Jinja2 expression language with custom date/string filters.
     All glyphs referenced must be present in glyph_values. Call extract_glyphs
     and validate the set against available glyphs before invoking this function.
+    Options with an explicit null value are left untouched.
     """
     for key, value in blockInstance.configuration_values.items():
+        if value is None:
+            continue
         blockInstance.configuration_values[key] = render_expression(value, glyph_values)
 
 

--- a/backend/src/forecastbox/domain/run/compile.py
+++ b/backend/src/forecastbox/domain/run/compile.py
@@ -115,13 +115,14 @@ class CompilationResult:
     ``resolved_configuration_options`` maps each block instance id to the subset of its
     configuration options that referenced at least one glyph, together with their final
     (post-resolution) string values. This is used to persist the resolution actually used
-    at execution time, for later inspection/reproducibility.
+    at execution time, for later inspection/reproducibility. Options with an explicit null
+    value carry no glyphs and are therefore not included.
     """
 
     execution_spec: ExecutionSpecification
     run_outputs: RunOutputs
     compilation_detail: CompilationDetail
-    resolved_configuration_options: dict[BlockInstanceId, dict[ConfigurationOptionId, str]]
+    resolved_configuration_options: dict[BlockInstanceId, dict[ConfigurationOptionId, str | None]]
 
 
 def compile_builder(blueprint: BlueprintBuilder, glyph_values: dict[str, str]) -> CompilationResult:
@@ -139,7 +140,7 @@ def compile_builder(blueprint: BlueprintBuilder, glyph_values: dict[str, str]) -
     # Maps sink block ids to mime type used in RunOutputs (only relevant for external outputs).
     block_to_mime: dict[BlockInstanceId, str] = {}
     sink_tasks: set[TaskId] = set()
-    resolved_configuration_options: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = {}
+    resolved_configuration_options: dict[BlockInstanceId, dict[ConfigurationOptionId, str | None]] = {}
 
     block_lookup = {b.instance_id: b for b in blueprint.blocks}
 

--- a/backend/src/forecastbox/domain/run/db.py
+++ b/backend/src/forecastbox/domain/run/db.py
@@ -49,9 +49,10 @@ class CompilerRuntimeContext(FiabBaseModel):
     """
 
     glyphs: dict[str, str] = Field(default_factory=dict)
-    resolution: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = Field(default_factory=dict)
+    resolution: dict[BlockInstanceId, dict[ConfigurationOptionId, str | None]] = Field(default_factory=dict)
     """Maps each block instance id to the configuration options that were resolved via
-    glyph substitution, together with their final (post-resolution) string values."""
+    glyph substitution, together with their final (post-resolution) values. A value is
+    ``None`` only for an option whose configured value is an explicit null."""
 
 
 @dataclass(frozen=True, eq=True, slots=True)

--- a/backend/src/forecastbox/domain/run/service.py
+++ b/backend/src/forecastbox/domain/run/service.py
@@ -92,7 +92,7 @@ class RunDetail(FiabBaseModel):
     outputs: dict | None = None
     completed_block_ids: set[BlockInstanceId] | None = None
     planned_block_ids: set[BlockInstanceId] | None = None
-    resolution: dict[BlockInstanceId, dict[str, str]] | None = None
+    resolution: dict[BlockInstanceId, dict[str, str | None]] | None = None
 
 
 class ExecuteResult(FiabBaseModel):

--- a/backend/src/forecastbox/routes/blueprint.py
+++ b/backend/src/forecastbox/routes/blueprint.py
@@ -179,7 +179,7 @@ class BlueprintValidationExpansionResponse(FiabBaseModel):
     possible_sources: list[PluginBlockFactoryId]
     possible_expansions: dict[BlockInstanceId, list[SerializedBlockExpansion]]
     configuration_restrictions: dict[BlockInstanceId, dict[ConfigurationOptionId, str]] = {}
-    resolved_configuration_options: dict[BlockInstanceId, dict[ConfigurationOptionId, str]]
+    resolved_configuration_options: dict[BlockInstanceId, dict[ConfigurationOptionId, str | None]]
     missing_glyphs: dict[BlockInstanceId, dict[ConfigurationOptionId, list[str]]] = {}
     block_output_qubes: dict[BlockInstanceId, dict[str, Any]] = {}
 

--- a/backend/src/forecastbox/routes/run.py
+++ b/backend/src/forecastbox/routes/run.py
@@ -115,7 +115,7 @@ class RunDetailResponse(FiabBaseModel):
     outputs: RunOutputsResponse | None = None
     completed_block_ids: list[BlockInstanceId] | None = None
     planned_block_ids: list[BlockInstanceId] | None = None
-    resolution: dict[BlockInstanceId, dict[str, str]] | None = None
+    resolution: dict[BlockInstanceId, dict[str, str | None]] | None = None
 
 
 class RunListResponse(FiabBaseModel):

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -1526,6 +1526,108 @@ def test_blueprint_composite_glyph_execute(tmpdir: Any, backend_client_user: htt
     assert del_resp.is_success, del_resp.text
 
 
+def test_blueprint_nullable_option(tmpdir: Any, backend_client_user: httpx.Client) -> None:
+    """An option declared as ``union[str,none]`` accepts an explicit null, but not a missing value.
+
+    The ``source_text`` block declares its ``text`` option as nullable, and its runtime imputes
+    a default when the value is null. This test covers that:
+    - a *missing* value passes validation but fails compilation,
+    - an *explicit null* passes both, and the runtime default is applied.
+    """
+    fname = f"{tmpdir}/nullable_output_${{runId}}.txt"
+
+    def plugin_status() -> dict:
+        response = backend_client_user.get("/status", timeout=10)
+        assert response.is_success
+        return response.json()
+
+    retry_until(
+        plugin_status,
+        lambda data: data if data.get("plugins") == "ok" else None,
+        attempts=30,
+        sleep=1.0,
+        error_msg="Plugin loader did not reach 'ok' status",
+    )
+
+    def make_builder(configuration_values: dict[ConfigurationOptionId, Any]) -> BlueprintBuilder:
+        source_text = RoutableBlock(
+            instance_id=BlockInstanceId("source_text"),
+            plugin=testPluginId,
+            factory=BlockFactoryId("source_text"),
+            instance=BlockInstance(
+                configuration_values=configuration_values,
+                input_ids={},
+            ),
+        )
+        sink_file = RoutableBlock(
+            instance_id=BlockInstanceId("sink_file"),
+            plugin=testPluginId,
+            factory=BlockFactoryId("sink_file"),
+            instance=BlockInstance(
+                configuration_values=_config({"fname": fname}),
+                input_ids={"data": BlockInstanceId("source_text")},
+            ),
+        )
+        return BlueprintBuilder(blocks=[source_text, sink_file])
+
+    def submit(builder: BlueprintBuilder) -> str:
+        save_resp = backend_client_user.post("/blueprint/create", json=BlueprintSaveCommand(builder=builder).model_dump())
+        assert save_resp.is_success, save_resp.text
+        exec_resp = backend_client_user.post("/run/create", json={"blueprint_id": save_resp.json()["blueprint_id"]})
+        assert exec_resp.is_success, exec_resp.text
+        return exec_resp.json()["run_id"]
+
+    def poll_run(run_id: str) -> Any:
+        resp = backend_client_user.get("/run/get", params={"run_id": run_id}, timeout=10)
+        assert resp.is_success, resp.text
+        return resp.json()
+
+    def verify_failed(data: Any) -> bool | None:
+        if data["status"] == "failed":
+            return True
+        if data["status"] == "completed":
+            raise RuntimeError(f"Unexpected successful run: {data}")
+        return None
+
+    # --- Step 1: no value at all -- validation passes, compilation fails on the missing option ---
+    builder_missing = make_builder({})
+    expand_resp = backend_client_user.request(url="/blueprint/expand", method="put", json=builder_missing.model_dump())
+    assert expand_resp.is_success, expand_resp.text
+    assert not expand_resp.json()["block_errors"], expand_resp.text
+
+    run_id_missing = submit(builder_missing)
+    retry_until(
+        lambda: poll_run(run_id_missing),
+        verify_failed,
+        attempts=60,
+        sleep=1.0,
+        error_msg=f"Run {run_id_missing} never failed",
+    )
+    error = poll_run(run_id_missing)["error"]
+    assert "missing configuration options" in error and "text" in error, error
+
+    # --- Step 2: explicit null -- validation and compilation both pass ---
+    builder_null = make_builder({ConfigurationOptionId("text"): None})
+    expand_resp = backend_client_user.request(url="/blueprint/expand", method="put", json=builder_null.model_dump())
+    assert expand_resp.is_success, expand_resp.text
+    assert not expand_resp.json()["block_errors"], expand_resp.text
+    # the null value carries no glyphs, hence it is not part of the glyph resolution
+    assert expand_resp.json()["resolved_configuration_options"].get("source_text", {}).get("text") is None
+
+    run_id_null = submit(builder_null)
+    ensure_completed_v2(backend_client_user, run_id_null, sleep=1, attempts=120)
+
+    output = pathlib.Path(f"{tmpdir}/nullable_output_{run_id_null}.txt")
+    assert output.read_text() == "Hic Sunt Leones", output.read_text()
+    output.unlink()
+
+    # --- Step 3: the run detail reports the resolution, with no value for the nulled option ---
+    detail = poll_run(run_id_null)
+    resolution = detail["resolution"]
+    assert resolution["sink_file"]["fname"] == f"{tmpdir}/nullable_output_{run_id_null}.txt"
+    assert resolution.get("source_text", {}).get("text") is None
+
+
 # ---------------------------------------------------------------------------
 # Run delete and output-content tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
introduce NoneType to allow explicit nulls as configuration values

Adds a `none` Fable type whose only valid value is an explicit null, so that a block author can declare an option as eg `union[str,none]` and impute a default at the runtime level rather than at compile time.

Core:
 * NoneType + NotNoneInput, parsed/serialized as `none`
 * UnionType tries its member types before rejecting a non-string input, so that a NoneType member can accept a null; the enum types drop their redundant up-front string check, delegating it to the subtype

Backend: wherever a configuration value is subject to string processing (glyph extraction, jinja interpolation, glyph remapping), an explicit null is skipped; the type checking itself is of course still performed, so a null against a non-nullable option remains an error. A missing option still fails compilation, ie, the null must be explicit. Resolution of configuration options, as stored in the compiler runtime context and returned by the run detail, keeps its glyph-substitution semantics, but its value type is now nullable.

Test plugin: `source_text` declares its option as `union[str,none]` and imputes a default at runtime. Its worker environment now points at the local source tree whenever the plugin is installed editable -- otherwise the released wheel of the same version would be installed instead and in-tree runtime changes would not be exercised by the integration tests at all.

Adds the `test_blueprint_nullable_option` integration test covering the whole flow: validation, compilation failure on a missing value, successful run with an explicit null, the imputed default in the output, and the run detail resolution.