### PR TITLE
[plugin/ecmwf] add missign dep to operational src

### DIFF
--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -160,9 +160,9 @@ class OperationalForecastSource(Source):
 
         source = block.config_as_str(SOURCE)
         if source == "ecmwf-opendata":
-            metadata = {"environment": ["earthkit-data[ecmwf-opendata]"]} 
+            metadata = {"environment": ["earthkit-data[ecmwf-opendata]"]}
         elif source == "mars":
-            metadata = {"environment": ["earthkit-data[mars]"]} 
+            metadata = {"environment": ["earthkit-data[mars]"]}
         else:
             metadata = {}
 

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -158,6 +158,9 @@ class OperationalForecastSource(Source):
         date = basetime.strftime("%Y%m%d")
         time = self._convert_time(basetime.time().hour)
 
+        source = block.config_as_str(SOURCE)
+        metadata = {"environment": ["ecmwf-opendata"]} if source == "ecmwf-opendata" else {}
+
         subqube = fc_qube.select({"time": time}).compress()
         actions = []
         for levtype in subqube.axes()[LEVTYPE]:
@@ -176,7 +179,7 @@ class OperationalForecastSource(Source):
                             [
                                 Payload(
                                     "fiab_plugin_ecmwf.runtime.source.earthkit_source",
-                                    [block.config_as_str(SOURCE)],
+                                    [source],
                                     {
                                         "requests": [
                                             dict(
@@ -186,6 +189,7 @@ class OperationalForecastSource(Source):
                                             )
                                         ],
                                     },
+                                    metadata=metadata,
                                 )
                                 for p in datacube[PARAM]
                             ]

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/blocks.py
@@ -159,7 +159,12 @@ class OperationalForecastSource(Source):
         time = self._convert_time(basetime.time().hour)
 
         source = block.config_as_str(SOURCE)
-        metadata = {"environment": ["ecmwf-opendata"]} if source == "ecmwf-opendata" else {}
+        if source == "ecmwf-opendata":
+            metadata = {"environment": ["earthkit-data[ecmwf-opendata]"]} 
+        elif source == "mars":
+            metadata = {"environment": ["earthkit-data[mars]"]} 
+        else:
+            metadata = {}
 
         subqube = fc_qube.select({"time": time}).compress()
         actions = []


### PR DESCRIPTION
the operational forecast source block requires ecmwf-opendata dependency when it is run with ecmwf-openadata source
