### PR TITLE
[frontend] feat: guided tour for the Configure page

### DIFF
--- a/frontend/mocks/data/fable.data.ts
+++ b/frontend/mocks/data/fable.data.ts
@@ -146,6 +146,41 @@ export const mockCatalogue: BlockFactoryCatalogue = {
         },
         inputs: ['dataset'],
       },
+      mapPlotSink: {
+        kind: 'sink',
+        title: 'Map Plot',
+        description: 'Render a geographic map using earthkit-plots',
+        configuration_options: {
+          param: {
+            title: 'Parameters',
+            description: "Parameters to select and plot (e.g. '2t', 'msl')",
+            value_type: 'list[param]',
+          },
+          domain: {
+            title: 'Domain',
+            description: 'Area to display: auto, global, or a named region',
+            value_type: 'geodomain',
+          },
+          format: {
+            title: 'Format',
+            description: 'Output image format',
+            value_type: serializeValueType(closedEnum(['png', 'pdf', 'svg'])),
+          },
+          groupby: {
+            title: 'Group By',
+            description: 'Dimension to create subplots over',
+            value_type: serializeValueType(
+              closedEnum(['valid_datetime', 'step', 'number', 'none']),
+            ),
+          },
+          splitby: {
+            title: 'Split By',
+            description: 'Dimensions to separate plots by',
+            value_type: 'list[str]',
+          },
+        },
+        inputs: ['dataset'],
+      },
     },
   },
 }
@@ -354,6 +389,11 @@ export function calculateExpansion(fable: FableBuilderV1): {
       factory: 'zarrSink',
       restrictions: {},
     },
+    {
+      plugin: pluginId('ecmwf', 'ecmwf-base'),
+      factory: 'mapPlotSink',
+      restrictions: {},
+    },
   ]
 
   for (const [blockId, instance] of Object.entries(fable.blocks)) {
@@ -367,6 +407,16 @@ export function calculateExpansion(fable: FableBuilderV1): {
       )
       block_errors[blockId] = errors
       continue
+    }
+
+    // Empty closed enums fail like the backend; other fields stay lenient.
+    for (const [key, option] of Object.entries(factory.configuration_options)) {
+      const value = instance.configuration_values[key] ?? ''
+      if (value === '' && option.value_type.startsWith('enumClosed')) {
+        errors.push(
+          `Invalid value for configuration option '${key}': expected ${option.value_type}. '' is not a valid option`,
+        )
+      }
     }
 
     // Check for missing inputs

--- a/frontend/src/features/fable-builder/components/ConfigureHelpDialog.tsx
+++ b/frontend/src/features/fable-builder/components/ConfigureHelpDialog.tsx
@@ -1,0 +1,145 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Feature guide + shortcut reference for the configuration canvas (header
+ * help button); also the guided tour's second launch surface.
+ */
+
+import { GraduationCap } from 'lucide-react'
+import { Trans, useTranslation } from 'react-i18next'
+import { formatForDisplay } from '@tanstack/react-hotkeys'
+import { BLOCK_KIND_METADATA } from '@/api/types/fable.types'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { P } from '@/components/base/typography'
+import { useTutorialsStore } from '@/stores/tutorialsStore'
+
+const SECTIONS = [
+  'canvas',
+  'palette',
+  'configure',
+  'validation',
+  'run',
+] as const
+
+/** Kind tags in copy (`<sourceKind>` …) take the palette colours. */
+const KIND_MARKUP = {
+  sourceKind: (
+    <span className={`font-medium ${BLOCK_KIND_METADATA.source.color}`} />
+  ),
+  transformKind: (
+    <span className={`font-medium ${BLOCK_KIND_METADATA.transform.color}`} />
+  ),
+  productKind: (
+    <span className={`font-medium ${BLOCK_KIND_METADATA.product.color}`} />
+  ),
+  outputKind: (
+    <span className={`font-medium ${BLOCK_KIND_METADATA.sink.color}`} />
+  ),
+}
+
+const SHORTCUTS = [
+  { keys: formatForDisplay('Mod+Z'), id: 'undo' },
+  { keys: formatForDisplay('Mod+Shift+Z'), id: 'redo' },
+] as const
+
+export function ConfigureHelpDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const { t } = useTranslation('configure')
+  const { t: tTut } = useTranslation('tutorials')
+  const tourStatus = useTutorialsStore((s) => s.statuses['configure-first-run'])
+  const startTour = () => {
+    onOpenChange(false)
+    useTutorialsStore.getState().start('configure-first-run')
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>{t('help.title')}</DialogTitle>
+          <DialogDescription>{t('help.intro')}</DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-x-8 gap-y-5 sm:grid-cols-2">
+          {SECTIONS.map((id) => (
+            <section key={id}>
+              <P className="text-sm font-semibold">
+                {t(`help.sections.${id}.title`)}
+              </P>
+              <P className="mt-0.5 text-sm text-muted-foreground">
+                <Trans
+                  t={t}
+                  i18nKey={`help.sections.${id}.body`}
+                  components={KIND_MARKUP}
+                />
+              </P>
+            </section>
+          ))}
+
+          <section>
+            <P className="text-sm font-semibold">
+              {tTut('launch.sectionTitle')}
+            </P>
+            <P className="mt-0.5 text-sm text-muted-foreground">
+              {tTut('firstRun.title')} — {tTut('firstRun.description')}
+              {tourStatus === 'completed' && (
+                <span className="ml-1 text-xs">
+                  · {tTut('launch.completed')}
+                </span>
+              )}
+            </P>
+            <Button
+              size="sm"
+              variant="outline"
+              className="mt-2 gap-1.5"
+              onClick={startTour}
+            >
+              <GraduationCap className="h-3.5 w-3.5" />
+              {tTut('launch.take')}
+            </Button>
+          </section>
+
+          <section>
+            <P className="text-sm font-semibold">{t('help.shortcuts.title')}</P>
+            <table className="mt-1 w-full text-sm">
+              <tbody>
+                {SHORTCUTS.map(({ keys, id }) => (
+                  <tr key={id} className="border-b border-border/60">
+                    <td className="w-24 py-1 pr-3 whitespace-nowrap">
+                      <kbd className="rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-xs">
+                        {keys}
+                      </kbd>
+                    </td>
+                    <td className="py-1 text-muted-foreground">
+                      {t(`help.shortcuts.${id}`)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </section>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/features/fable-builder/components/FableBuilderHeader.tsx
+++ b/frontend/src/features/fable-builder/components/FableBuilderHeader.tsx
@@ -16,6 +16,7 @@ import {
   Check,
   ChevronDown,
   Download,
+  HelpCircle,
   MoreVertical,
   Play,
   Redo2,
@@ -30,6 +31,7 @@ import { ValidationStatusBadge } from './shared/ValidationStatus'
 import { DraftStatus } from './DraftStatus'
 import { GraphOptionsDropdown } from './graph-mode/GraphOptionsDropdown'
 import { SaveConfigPopover } from './SaveConfigPopover'
+import { ConfigureHelpDialog } from './ConfigureHelpDialog'
 import type {
   BlockFactoryCatalogue,
   FableBuilderV1,
@@ -50,6 +52,7 @@ import {
 import { H1 } from '@/components/base/typography'
 import { copyToClipboard } from '@/lib/utils'
 import { showToast } from '@/lib/toast'
+import { TOUR, tourAttr } from '@/features/tutorials/anchors'
 import {
   Tooltip,
   TooltipContent,
@@ -73,6 +76,7 @@ export function FableBuilderHeader({
     t('header.share'),
   )
   const [savePopoverOpen, setSavePopoverOpen] = useState(false)
+  const [helpOpen, setHelpOpen] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const shareTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined)
 
@@ -307,6 +311,7 @@ export function FableBuilderHeader({
                         className="h-8 w-8"
                         onClick={handleNewConfiguration}
                         aria-label={t('header.newConfiguration')}
+                        {...tourAttr(TOUR.configure.newConfig)}
                       >
                         <BrushCleaning className="h-4 w-4" />
                       </Button>
@@ -376,6 +381,7 @@ export function FableBuilderHeader({
                           onClick={handleRunOnce}
                           disabled={!canReview}
                           className="gap-2"
+                          {...tourAttr(TOUR.configure.runOnce)}
                         >
                           <Play className="h-4 w-4" />
                           {t('header.runOnce')}
@@ -521,6 +527,18 @@ export function FableBuilderHeader({
                   open={savePopoverOpen}
                   onOpenChange={setSavePopoverOpen}
                 />
+
+                {/* Help lives in the header so the tour entry never hides. */}
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={() => setHelpOpen(true)}
+                  title={t('help.open')}
+                  aria-label={t('help.open')}
+                >
+                  <HelpCircle className="h-3.5 w-3.5" />
+                </Button>
               </>
             ) : (
               <>
@@ -552,6 +570,7 @@ export function FableBuilderHeader({
           </div>
         </div>
       </header>
+      <ConfigureHelpDialog open={helpOpen} onOpenChange={setHelpOpen} />
     </>
   )
 }

--- a/frontend/src/features/fable-builder/components/FableBuilderPage.tsx
+++ b/frontend/src/features/fable-builder/components/FableBuilderPage.tsx
@@ -9,7 +9,7 @@
  */
 
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { Link } from '@tanstack/react-router'
+import { Link, useNavigate } from '@tanstack/react-router'
 import { useTranslation } from 'react-i18next'
 import { AlertCircle, Package } from 'lucide-react'
 import { FableBuilderHeader } from './FableBuilderHeader'
@@ -35,6 +35,7 @@ import {
 } from '@/features/fable-builder/hooks/useDraftPersistence'
 import { useViewportFill } from '@/hooks/useViewportFill'
 import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
+import { useTutorialsStore } from '@/stores/tutorialsStore'
 import { shelveBenchIfDirty } from '@/features/fable-builder/stores/workbenchShelfStore'
 import { hasUnterminatedGlyph } from '@/features/fable-builder/utils/glyph-display'
 import { decodeFableFromURL } from '@/features/fable-builder/utils/url-state'
@@ -102,6 +103,8 @@ interface FableBuilderPageProps {
   templateName?: string
   /** Explicit blank-canvas intent; unsaved bench work parks on the shelf. */
   fresh?: boolean
+  /** One-shot `?tour=` launch; the param is stripped on start. */
+  tour?: 'first-run'
 }
 
 export function FableBuilderPage({
@@ -111,8 +114,19 @@ export function FableBuilderPage({
   templatePlugin,
   templateName,
   fresh = false,
+  tour,
 }: FableBuilderPageProps) {
   const { t } = useTranslation(['configure', 'common'])
+  const navigate = useNavigate()
+  useEffect(() => {
+    if (tour === undefined) return
+    useTutorialsStore.getState().start('configure-first-run')
+    void navigate({
+      to: '/configure',
+      search: (prev) => ({ ...prev, tour: undefined }),
+      replace: true,
+    })
+  }, [tour, navigate])
   const canvasFill = useViewportFill(true, { insetPx: 0 })
   const fable = useFableBuilderStore((state) => state.fable)
   const setFable = useFableBuilderStore((state) => state.setFable)

--- a/frontend/src/features/fable-builder/components/graph-mode/AddNodeButton.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/AddNodeButton.tsx
@@ -32,6 +32,7 @@ import {
 } from '@/components/ui/popover'
 import { Input } from '@/components/ui/input'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { TOUR, tourActionAttr, tourAttr } from '@/features/tutorials/anchors'
 import { cn } from '@/lib/utils'
 
 interface AddNodeButtonProps {
@@ -226,6 +227,7 @@ export const AddNodeButton = memo(function ({
         align="center"
         sideOffset={8}
         onClick={(e) => e.stopPropagation()}
+        {...tourAttr(TOUR.configure.addMenu)}
       >
         {canOfferInsert && (
           <div className="border-b p-2">
@@ -291,6 +293,8 @@ export const AddNodeButton = memo(function ({
                     return (
                       <button
                         key={factoryIdToKey(id)}
+                        data-factory-key={factoryIdToKey(id)}
+                        {...tourActionAttr('add-block')}
                         className={cn(
                           'flex w-full items-start gap-2 rounded-md p-2',
                           'text-left hover:bg-accent',

--- a/frontend/src/features/fable-builder/components/graph-mode/FableGraphCanvas.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/FableGraphCanvas.tsx
@@ -39,6 +39,7 @@ import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuild
 import { useSidebarBlockDrop } from '@/features/fable-builder/hooks/useSidebarBlockDrop'
 import { useMedia } from '@/hooks/useMedia'
 import { useUiStore } from '@/stores/uiStore'
+import { TOUR, tourAttr } from '@/features/tutorials/anchors'
 import { cn } from '@/lib/utils'
 
 interface FableGraphCanvasProps {
@@ -390,7 +391,11 @@ function FableGraphCanvasInner({ catalogue }: FableGraphCanvasProps) {
   // deselect, use the X button in the ConfigPanel header.
 
   return (
-    <div ref={containerRef} className="h-full w-full">
+    <div
+      ref={containerRef}
+      className="h-full w-full"
+      {...tourAttr(TOUR.configure.canvas)}
+    >
       <ReactFlow
         nodes={nodes}
         edges={edges}

--- a/frontend/src/features/fable-builder/components/graph-mode/nodes/BlockNode.tsx
+++ b/frontend/src/features/fable-builder/components/graph-mode/nodes/BlockNode.tsx
@@ -38,6 +38,7 @@ import {
 import { BlockActionMenu } from '@/features/fable-builder/components/shared/BlockActionMenu'
 import { BlockErrorOverlay } from '@/features/fable-builder/components/graph-mode/nodes/BlockErrorOverlay'
 import { parseGlyphSegments } from '@/features/fable-builder/utils/glyph-display'
+import { TOUR, tourAttr } from '@/features/tutorials/anchors'
 import { cn } from '@/lib/utils'
 
 export type FableNode = Node<FableNodeData>
@@ -124,6 +125,8 @@ export const BlockNode = memo(function ({
       tabIndex={0}
       onClick={handleClick}
       onKeyDown={(e) => e.key === 'Enter' && handleClick()}
+      data-block-kind={factory.kind}
+      {...tourAttr(TOUR.configure.block)}
       className={cn(
         'relative w-70 rounded-2xl border bg-card shadow-sm',
         'cursor-pointer transition-all duration-200',
@@ -304,6 +307,8 @@ export const BlockNode = memo(function ({
             id="output"
             title={t('blockNode.outputHandle')}
             onClick={(e) => e.stopPropagation()}
+            data-block-kind={factory.kind}
+            {...tourAttr(TOUR.configure.addDownstream)}
             className={cn(
               'flex! h-5! w-5! cursor-pointer! items-center justify-center rounded-full! border-4! bg-card!',
               'border-foreground/30! hover:border-primary!',

--- a/frontend/src/features/fable-builder/components/layout/BlockPalette.tsx
+++ b/frontend/src/features/fable-builder/components/layout/BlockPalette.tsx
@@ -41,6 +41,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
+import { TOUR, tourActionAttr, tourAttr } from '@/features/tutorials/anchors'
 import { cn } from '@/lib/utils'
 
 // Transparent image used to suppress the browser's default drag ghost.
@@ -170,7 +171,7 @@ export function BlockPalette({ catalogue }: BlockPaletteProps) {
   }
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full flex-col" {...tourAttr(TOUR.configure.palette)}>
       <div className="border-b border-border p-4">
         <div className="mb-3 flex items-center justify-between gap-2">
           <H2 className="text-sm font-semibold">{t('palette.title')}</H2>
@@ -245,6 +246,8 @@ export function BlockPalette({ catalogue }: BlockPaletteProps) {
                     return (
                       <button
                         key={factoryIdToKey(id)}
+                        data-factory-key={factoryIdToKey(id)}
+                        {...tourActionAttr('add-block')}
                         draggable={canInteract}
                         onClick={() =>
                           canInteract && handleAddBlock(id, factory)

--- a/frontend/src/features/fable-builder/components/layout/ConfigPanel.tsx
+++ b/frontend/src/features/fable-builder/components/layout/ConfigPanel.tsx
@@ -49,6 +49,7 @@ import { Badge } from '@/components/ui/badge'
 import { GlyphReferencePanel } from '@/features/fable-builder/components/shared/GlyphReferencePanel'
 import { BlockValidationProvider } from '@/features/fable-builder/context/BlockValidationContext'
 import { mapBlockErrorsToFields } from '@/features/fable-builder/utils/map-block-errors-to-fields'
+import { TOUR, tourAttr } from '@/features/tutorials/anchors'
 import { cn } from '@/lib/utils'
 
 interface ConfigPanelProps {
@@ -180,7 +181,10 @@ export function ConfigPanel({ catalogue }: ConfigPanelProps): React.ReactNode {
 
   if (!selectedBlock || !factory) {
     return (
-      <div className="relative flex h-full flex-col items-center justify-center p-6 text-center">
+      <div
+        className="relative flex h-full flex-col items-center justify-center p-6 text-center"
+        {...tourAttr(TOUR.configure.configPanel)}
+      >
         <Button
           variant="ghost"
           size="icon"
@@ -235,7 +239,10 @@ export function ConfigPanel({ catalogue }: ConfigPanelProps): React.ReactNode {
   const inputs = factory.inputs
 
   return (
-    <div className="flex h-full flex-col">
+    <div
+      className="flex h-full flex-col"
+      {...tourAttr(TOUR.configure.configPanel)}
+    >
       <div className="border-b border-border p-4">
         <div className="flex items-start justify-between gap-2">
           <div className="flex min-w-0 items-center gap-2">

--- a/frontend/src/features/fable-builder/components/layout/ThreeColumnLayout.tsx
+++ b/frontend/src/features/fable-builder/components/layout/ThreeColumnLayout.tsx
@@ -15,6 +15,7 @@ import { CollapsedSidebarHandle } from '@/components/common/CollapsedSidebarHand
 import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
 import { useUiPreferencesStore } from '@/features/fable-builder/stores/uiPreferencesStore'
 import { SplitHandleChrome } from '@/components/common/SplitResizeHandle'
+import { TOUR, tourAttr } from '@/features/tutorials/anchors'
 import { cn } from '@/lib/utils'
 
 interface ThreeColumnLayoutProps {
@@ -101,6 +102,7 @@ export function ThreeColumnLayout({
           side="left"
           onExpand={togglePalette}
           label={t('layout.showBlockPalette')}
+          buttonAttrs={tourAttr(TOUR.configure.expandPalette)}
         />
       )}
 
@@ -190,6 +192,7 @@ export function ThreeColumnLayout({
           side="right"
           onExpand={toggleConfigPanel}
           label={t('layout.showConfigPanel')}
+          buttonAttrs={tourAttr(TOUR.configure.expandConfig)}
         />
       )}
     </div>

--- a/frontend/src/features/fable-builder/components/shared/ValidationStatus.tsx
+++ b/frontend/src/features/fable-builder/components/shared/ValidationStatus.tsx
@@ -25,7 +25,10 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover'
+import { TOUR, tourAttr } from '@/features/tutorials/anchors'
 import { cn } from '@/lib/utils'
+
+const anchor = tourAttr(TOUR.configure.validation)
 
 interface Issue {
   blockId: string | null
@@ -88,7 +91,7 @@ export function ValidationStatusBadge({
 
   if (isValidating) {
     return (
-      <Badge variant="secondary" className={cn('gap-1', className)}>
+      <Badge variant="secondary" className={cn('gap-1', className)} {...anchor}>
         <Loader2 className="h-3 w-3 animate-spin" />
         {t('validationStatus.validating')}
       </Badge>
@@ -104,6 +107,7 @@ export function ValidationStatusBadge({
       <Badge
         variant="outline"
         className={cn('gap-1 border-green-200 text-green-600', className)}
+        {...anchor}
       >
         <CheckCircle2 className="h-3 w-3" />
         {t('validationStatus.valid')}
@@ -119,6 +123,7 @@ export function ValidationStatusBadge({
             variant="destructive"
             render={<button type="button" />}
             className={cn('cursor-pointer gap-1', className)}
+            {...anchor}
           />
         }
       >

--- a/frontend/src/features/tutorials/TutorialRunner.tsx
+++ b/frontend/src/features/tutorials/TutorialRunner.tsx
@@ -16,19 +16,21 @@
 
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { CheckCircle2, X } from 'lucide-react'
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { useRouter, useRouterState } from '@tanstack/react-router'
 import { TUTORIALS } from './registry'
-import { findTourElement } from './anchors'
+import { findTourElement, tourSelector } from './anchors'
 import { isPreSatisfied, stepProgress } from './engine/stepMachine'
 import { useAdvanceCondition } from './engine/useAdvanceCondition'
 import { useDomPresence, useTourAnchor } from './engine/useTourAnchor'
 import { CoachmarkCard } from './components/CoachmarkCard'
 import { SpotlightShade } from './components/SpotlightShade'
+import type { ReactElement } from 'react'
 import type {
   AdvanceWhen,
   SearchRecord,
   ShowMeAction,
+  StepBlocker,
   TutorialId,
 } from './engine/types'
 import { useTutorialsStore } from '@/stores/tutorialsStore'
@@ -38,15 +40,28 @@ import { showToast } from '@/lib/toast'
 
 const NEXT_CLICK: AdvanceWhen = { kind: 'next-click' }
 
-type PressAction = Exclude<ShowMeAction, { search: unknown }>
+/** Step keys are dynamic; the typed-key overloads cannot express them. */
+const TransDyn = Trans as unknown as (props: {
+  t: (key: string, opts?: Record<string, unknown>) => string
+  i18nKey: string
+  values?: Record<string, unknown>
+  components?: Record<string, ReactElement>
+}) => ReactElement
+
+/** `<v>…</v>` in any tour copy: a setting value the user must enter. */
+const VALUE_MARKUP = { v: <strong className="font-semibold text-foreground" /> }
+
+type PressAction = Extract<ShowMeAction, { within: string }>
 
 /** Our own modal dialogs (shadcn slots); the coachmark itself is non-modal. */
 const MODAL_SELECTOR =
   '[data-slot="dialog-content"], [data-slot="alert-dialog-content"]'
+/** Matches nothing — for steps without a `yieldTo` menu. */
+const NEVER_SELECTOR = '[data-tour-never]'
 
 /** Presses the first matching control in the anchor; false = none found. */
 function pressShowMe(action: PressAction): boolean {
-  const scope = findTourElement(action.within)
+  const scope = findTourElement(action.within, action.withinMatch)
   if (scope === null) return false
   const selectors =
     action.selector === undefined
@@ -104,27 +119,29 @@ function ActiveTutorial({
   const step = stepIndex < def.steps.length ? def.steps[stepIndex] : null
   const stepKeyBase = `${id}:${stepIndex}`
 
-  // Leaving the tour's page ends the run; the stored status stays as-is.
-  useEffect(() => {
-    if (pathname === def.route) return
-    showToast.info(t('common.endedToast'))
-    finish(null)
-  }, [pathname, def.route, finish, t])
-
   useEffect(() => {
     if (step === null) finish('completed')
   }, [step, finish])
 
   // Variant marker (e.g. the static-timeline notice).
-  const { element: variantMarker } = useTourAnchor(step?.variant?.whenPresent)
+  const { element: variantMarker } = useTourAnchor(
+    step?.variant?.whenPresent,
+    step?.variant?.whenPresentMatch,
+  )
   const variant =
     step?.variant !== undefined && variantMarker !== null
       ? step.variant
       : undefined
 
   const anchorId = variant?.anchor ?? step?.anchor
-  const { element, rect } = useTourAnchor(anchorId)
+  const { element, rect } = useTourAnchor(
+    anchorId,
+    variant?.anchor === undefined ? step?.anchorMatch : undefined,
+  )
   const modalOpen = useDomPresence(MODAL_SELECTOR)
+  const yielding = useDomPresence(
+    step?.yieldTo === undefined ? NEVER_SELECTOR : tourSelector(step.yieldTo),
+  )
 
   // Per-step-entry snapshots; satisfied-at-entry = review mode.
   const baseAdvance = variant?.advance ?? step?.advance ?? NEXT_CLICK
@@ -144,6 +161,14 @@ function ActiveTutorial({
   const advance = reviewing ? NEXT_CLICK : baseAdvance
   const stepKey = `${stepKeyBase}:${variant?.key ?? 'base'}`
 
+  // Route-leave ends the run — unless the step expects it (then completes).
+  useEffect(() => {
+    if (pathname === def.route) return
+    if (advance.kind === 'route' && advance.match(pathname)) return
+    showToast.info(t('common.endedToast'))
+    finish(null)
+  }, [pathname, def.route, advance, finish, t])
+
   const goNext = () => {
     if (stepIndex + 1 >= def.steps.length) finish('completed')
     else setStep(stepIndex + 1)
@@ -151,11 +176,21 @@ function ActiveTutorial({
   const goNextRef = useRef(goNext)
   goNextRef.current = goNext
 
+  // Why a signal step is still open; cleared on every step change.
+  const [blocker, setBlocker] = useState<StepBlocker | null>(null)
+  useEffect(() => setBlocker(null), [stepKey])
+
   useAdvanceCondition({
     advance,
     stepKey,
     searchAtEntry: entrySnapRef.current.search,
-    onMet: () => goNextRef.current(),
+    onBlocker: setBlocker,
+    onMet: () => {
+      // A route step is terminal: the card is gone, so say it out loud.
+      if (advance.kind === 'route')
+        showToast.success(t('common.completedToast'))
+      goNextRef.current()
+    },
   })
 
   // Anchor hidden inside a collapsed panel: press the real expand handle.
@@ -210,14 +245,14 @@ function ActiveTutorial({
   const progress = stepProgress(def.steps.length, stepIndex)
   const keyPrefix = `${def.i18nKey}.steps.${step.id}`
   const copyValues = def.copyValues?.(launch) ?? {}
+  const markup = { ...VALUE_MARKUP, ...def.markup }
   const title = tDyn(
     variant ? `${keyPrefix}.${variant.key}Title` : `${keyPrefix}.title`,
     copyValues,
   )
-  const body = tDyn(
-    variant ? `${keyPrefix}.${variant.key}Body` : `${keyPrefix}.body`,
-    copyValues,
-  )
+  const bodyKey = variant
+    ? `${keyPrefix}.${variant.key}Body`
+    : `${keyPrefix}.body`
 
   const quit = () => finish('dismissed')
   const goBack = () => setStep(stepIndex - 1)
@@ -235,12 +270,16 @@ function ActiveTutorial({
       } as never)
       return
     }
+    if ('apply' in action) {
+      if (!action.apply()) showToast.info(t('common.showMeUnavailable'))
+      return
+    }
     if (!pressShowMe(action)) {
       showToast.info(t('common.showMeUnavailable'))
       return
     }
     const followUp = action.then
-    if (followUp === undefined || 'search' in followUp) return
+    if (followUp === undefined || !('within' in followUp)) return
     // Poll briefly for the follow-up target (e.g. a dialog just opened).
     cancelFollowUp()
     let tries = 0
@@ -266,6 +305,7 @@ function ActiveTutorial({
   // Review steps show immediately even anchorless (their UI may be gone).
   const showCard =
     !modalOpen &&
+    !yielding &&
     (element !== null || anchorId === undefined || seeking || reviewing)
 
   return (
@@ -313,7 +353,24 @@ function ActiveTutorial({
             >
               {title}
             </h2>
-            <p className="text-sm text-muted-foreground">{body}</p>
+            <p className="text-sm text-muted-foreground">
+              <TransDyn
+                t={tDyn}
+                i18nKey={bodyKey}
+                values={copyValues}
+                components={markup}
+              />
+            </p>
+            {blocker !== null && !reviewing && (
+              <p className="text-xs font-medium text-amber-600 dark:text-amber-400">
+                <TransDyn
+                  t={tDyn}
+                  i18nKey={`${def.i18nKey}.${blocker.key}`}
+                  values={{ ...copyValues, ...blocker.values }}
+                  components={markup}
+                />
+              </p>
+            )}
             {element === null && anchorId !== undefined && !reviewing && (
               <p className="text-xs text-muted-foreground italic">
                 {t('common.waitingFor')}

--- a/frontend/src/features/tutorials/anchors.ts
+++ b/frontend/src/features/tutorials/anchors.ts
@@ -49,9 +49,10 @@ export function tourActionSelector(action: string): string {
   return `[data-tour-action="${action}"]:not([disabled])`
 }
 
-/** First visible element carrying the anchor id (hidden matches skipped). */
-export function findTourElement(id: string): Element | null {
-  for (const el of document.querySelectorAll(tourSelector(id))) {
+/** First visible element carrying the anchor id (hidden matches skipped);
+ * `match` narrows ids stamped on several elements (e.g. per block kind). */
+export function findTourElement(id: string, match = ''): Element | null {
+  for (const el of document.querySelectorAll(tourSelector(id) + match)) {
     if (el.getClientRects().length > 0) return el
   }
   return null

--- a/frontend/src/features/tutorials/anchors.ts
+++ b/frontend/src/features/tutorials/anchors.ts
@@ -17,6 +17,19 @@
  */
 
 export const TOUR = {
+  configure: {
+    canvas: 'configure.canvas',
+    palette: 'configure.palette',
+    addMenu: 'configure.add-menu',
+    block: 'configure.block',
+    addDownstream: 'configure.add-downstream',
+    configPanel: 'configure.config-panel',
+    validation: 'configure.validation',
+    newConfig: 'configure.new-config',
+    runOnce: 'configure.run-once',
+    expandPalette: 'configure.expand-palette',
+    expandConfig: 'configure.expand-config',
+  },
   visualise: {
     addSource: 'visualise.add-source',
     hub: 'visualise.hub',

--- a/frontend/src/features/tutorials/engine/stepMachine.ts
+++ b/frontend/src/features/tutorials/engine/stepMachine.ts
@@ -28,6 +28,9 @@ export function isPreSatisfied(
       return advance.check(search, search)
     case 'signal':
       return advance.check()
+    case 'route':
+      // Entry happens on the tour route, which is never the destination.
+      return false
   }
 }
 

--- a/frontend/src/features/tutorials/engine/types.ts
+++ b/frontend/src/features/tutorials/engine/types.ts
@@ -14,11 +14,18 @@
  * engine knows no page domain — tours bring their own launch type/signals.
  */
 
+import type { ReactElement } from 'react'
 import type { TutorialId } from '@/stores/tutorialsStore'
 
 export type { TutorialId }
 
 export type SearchRecord = Record<string, unknown>
+
+/** Why a step is still open: i18n key under the tour's subtree + values. */
+export interface StepBlocker {
+  key: string
+  values?: Record<string, unknown>
+}
 
 export type AdvanceWhen =
   | { kind: 'next-click' }
@@ -28,33 +35,42 @@ export type AdvanceWhen =
       kind: 'search'
       check: (search: SearchRecord, atEntry: SearchRecord) => boolean
     }
-  /** Any external state; `check` runs at entry and on each notification. */
+  /** External state; `check` at entry + each change; `explain` = why not. */
   | {
       kind: 'signal'
       subscribe: (onChange: () => void) => () => void
       check: () => boolean
+      explain?: () => StepBlocker | null
     }
+  /** Expected navigation away from the tour route (e.g. a submit). */
+  | { kind: 'route'; match: (pathname: string) => boolean }
 
 /** Alternate presentation while a marker anchor is present (e.g. the
  * static-timeline notice). */
 export interface StepVariant {
   whenPresent: string
+  /** Attribute filter on the marker (see `anchorMatch`). */
+  whenPresentMatch?: string
   /** i18n prefix: steps.<id>.<key>Title / <key>Body. */
   key: string
   anchor?: string
   advance?: AdvanceWhen
 }
 
-/** "Show me": the step's real action — press the control or apply its URL. */
+/** "Show me": the step's real action — press the control, apply its URL,
+ * or run a tour-supplied effect (false = nothing to do). */
 export type ShowMeAction =
   | {
       within: string
+      /** Attribute filter on the `within` anchor (see `anchorMatch`). */
+      withinMatch?: string
       /** Selector(s) in the anchor, by preference; omitted = the anchor. */
       selector?: string | ReadonlyArray<string>
       /** Follow-up press once its target appears (modals inert the page). */
       then?: ShowMeAction
     }
   | { search: (prev: SearchRecord) => SearchRecord }
+  | { apply: () => boolean }
 
 export interface RuntimeSnapshot<TLaunch> {
   /** Null while the launch signals resolve. */
@@ -66,6 +82,8 @@ export interface TutorialStep<TLaunch = unknown> {
   id: string
   /** `data-tour` id; absent = centered card. */
   anchor?: string
+  /** Extra attribute selector for ids stamped on several elements. */
+  anchorMatch?: string
   side?: 'top' | 'bottom' | 'left' | 'right'
   align?: 'start' | 'center' | 'end'
   advance: AdvanceWhen
@@ -75,6 +93,8 @@ export interface TutorialStep<TLaunch = unknown> {
   expandVia?: string
   /** On entry, ask the page once to close open overlays. */
   closeDialog?: boolean
+  /** Anchor id of a menu the step opens; the card hides while it shows. */
+  yieldTo?: string
   variant?: StepVariant
   /** Function form resolves against the live snapshot (dynamic targets). */
   showMe?: ShowMeAction | ((ctx: RuntimeSnapshot<TLaunch>) => ShowMeAction)
@@ -88,5 +108,7 @@ export interface TutorialDefinition<TLaunch = unknown> {
   i18nKey: string
   /** Interpolation values for every step's copy (e.g. the server name). */
   copyValues?: (launch: TLaunch) => Record<string, unknown>
+  /** Elements for `<tag>…</tag>` markup in step bodies (Trans components). */
+  markup?: Record<string, ReactElement>
   steps: ReadonlyArray<TutorialStep<TLaunch>>
 }

--- a/frontend/src/features/tutorials/engine/types.ts
+++ b/frontend/src/features/tutorials/engine/types.ts
@@ -34,6 +34,7 @@ export type AdvanceWhen =
   | {
       kind: 'search'
       check: (search: SearchRecord, atEntry: SearchRecord) => boolean
+      explain?: (search: SearchRecord) => StepBlocker | null
     }
   /** External state; `check` at entry + each change; `explain` = why not. */
   | {

--- a/frontend/src/features/tutorials/engine/useAdvanceCondition.ts
+++ b/frontend/src/features/tutorials/engine/useAdvanceCondition.ts
@@ -16,22 +16,26 @@
 
 import { useEffect, useRef } from 'react'
 import { useRouter, useRouterState } from '@tanstack/react-router'
-import type { AdvanceWhen, SearchRecord } from './types'
+import type { AdvanceWhen, SearchRecord, StepBlocker } from './types'
 
 export function useAdvanceCondition({
   advance,
   stepKey,
   searchAtEntry,
   onMet,
+  onBlocker,
 }: {
   advance: AdvanceWhen
   stepKey: string
   searchAtEntry: SearchRecord
   onMet: () => void
+  /** Latest `explain` result for signal steps (null once met/unknown). */
+  onBlocker?: (blocker: StepBlocker | null) => void
 }): void {
   // Raw-string selector is structural-sharing-safe; parse off the router.
   const router = useRouter()
   const searchStr = useRouterState({ select: (s) => s.location.searchStr })
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
 
   const metForRef = useRef<string | null>(null)
   const onMetRef = useRef(onMet)
@@ -43,16 +47,21 @@ export function useAdvanceCondition({
   }
   const fireRef = useRef(fire)
   fireRef.current = fire
+  const onBlockerRef = useRef(onBlocker)
+  onBlockerRef.current = onBlocker
 
   useEffect(() => {
     if (advance.kind !== 'signal') return
-    if (advance.check()) {
-      fireRef.current()
-      return
+    const evaluate = () => {
+      if (advance.check()) {
+        onBlockerRef.current?.(null)
+        fireRef.current()
+        return
+      }
+      onBlockerRef.current?.(advance.explain?.() ?? null)
     }
-    return advance.subscribe(() => {
-      if (advance.check()) fireRef.current()
-    })
+    evaluate()
+    return advance.subscribe(evaluate)
   }, [advance, stepKey])
 
   useEffect(() => {
@@ -60,4 +69,9 @@ export function useAdvanceCondition({
     const search = router.state.location.search as SearchRecord
     if (advance.check(search, searchAtEntry)) fireRef.current()
   }, [advance, stepKey, router, searchStr, searchAtEntry])
+
+  useEffect(() => {
+    if (advance.kind !== 'route') return
+    if (advance.match(pathname)) fireRef.current()
+  }, [advance, stepKey, pathname])
 }

--- a/frontend/src/features/tutorials/engine/useAdvanceCondition.ts
+++ b/frontend/src/features/tutorials/engine/useAdvanceCondition.ts
@@ -29,7 +29,7 @@ export function useAdvanceCondition({
   stepKey: string
   searchAtEntry: SearchRecord
   onMet: () => void
-  /** Latest `explain` result for signal steps (null once met/unknown). */
+  /** Latest `explain` result for signal/search steps (null once met). */
   onBlocker?: (blocker: StepBlocker | null) => void
 }): void {
   // Raw-string selector is structural-sharing-safe; parse off the router.
@@ -67,7 +67,12 @@ export function useAdvanceCondition({
   useEffect(() => {
     if (advance.kind !== 'search') return
     const search = router.state.location.search as SearchRecord
-    if (advance.check(search, searchAtEntry)) fireRef.current()
+    if (advance.check(search, searchAtEntry)) {
+      onBlockerRef.current?.(null)
+      fireRef.current()
+      return
+    }
+    onBlockerRef.current?.(advance.explain?.(search) ?? null)
   }, [advance, stepKey, router, searchStr, searchAtEntry])
 
   useEffect(() => {

--- a/frontend/src/features/tutorials/engine/useTourAnchor.ts
+++ b/frontend/src/features/tutorials/engine/useTourAnchor.ts
@@ -95,7 +95,10 @@ function sameRect(a: AnchorRect | null, b: AnchorRect | null): boolean {
   )
 }
 
-export function useTourAnchor(anchorId: string | undefined): {
+export function useTourAnchor(
+  anchorId: string | undefined,
+  match = '',
+): {
   element: Element | null
   rect: AnchorRect | null
 } {
@@ -109,7 +112,8 @@ export function useTourAnchor(anchorId: string | undefined): {
       return
     }
 
-    let current: Element | null = null
+    // Starts undefined so a re-subscription publishes even a null result.
+    let current: Element | null | undefined
     // Defer a frame: a synchronous setState trips the RO "undelivered" guard.
     let raf = 0
     const resizeObserver = new ResizeObserver(() => {
@@ -121,7 +125,7 @@ export function useTourAnchor(anchorId: string | undefined): {
     })
 
     const sync = () => {
-      const el = findTourElement(anchorId)
+      const el = findTourElement(anchorId, match)
       if (el !== current) {
         if (current) resizeObserver.disconnect()
         current = el
@@ -144,7 +148,7 @@ export function useTourAnchor(anchorId: string | undefined): {
       window.removeEventListener('resize', sync)
       document.removeEventListener('scroll', sync, { capture: true })
     }
-  }, [anchorId])
+  }, [anchorId, match])
 
   return { element, rect }
 }

--- a/frontend/src/features/tutorials/registry.ts
+++ b/frontend/src/features/tutorials/registry.ts
@@ -17,6 +17,10 @@ import {
   firstMapDefinition,
   useFirstMapLaunchContext,
 } from './tutorials/visualise-first-map'
+import {
+  firstRunDefinition,
+  useFirstRunLaunchContext,
+} from './tutorials/configure-first-run'
 import type { TutorialDefinition, TutorialId } from './engine/types'
 
 export interface TutorialEntry<TLaunch = unknown> {
@@ -34,5 +38,9 @@ export const TUTORIALS: Record<TutorialId, TutorialEntry> = {
   'visualise-first-map': defineTutorial({
     definition: firstMapDefinition,
     useLaunchContext: useFirstMapLaunchContext,
+  }),
+  'configure-first-run': defineTutorial({
+    definition: firstRunDefinition,
+    useLaunchContext: useFirstRunLaunchContext,
   }),
 }

--- a/frontend/src/features/tutorials/tutorials/configure-first-run.tsx
+++ b/frontend/src/features/tutorials/tutorials/configure-first-run.tsx
@@ -1,0 +1,447 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * "Build and run your first forecast" — clean /configure canvas to a
+ * submitted run on one canonical pipeline (source → select → ensemble
+ * statistics → map plot). The only module that knows both engine and page.
+ */
+
+import { TOUR, findTourElement, tourActionSelector } from '../anchors'
+import type {
+  AdvanceWhen,
+  ShowMeAction,
+  StepBlocker,
+  TutorialDefinition,
+} from '../engine/types'
+import type {
+  BlockFactoryCatalogue,
+  BlockKind,
+  PluginBlockFactoryId,
+} from '@/api/types/fable.types'
+import {
+  BLOCK_KIND_METADATA,
+  factoryIdToKey,
+  getFactory,
+} from '@/api/types/fable.types'
+import { useBlockCatalogue } from '@/api/hooks/useFable'
+import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
+
+/** Canonical blocks: the ECMWF base plugin, one of each kind. */
+const PLUGIN = { store: 'ecmwf', local: 'ecmwf-base' }
+const CANON: Record<BlockKind, PluginBlockFactoryId> = {
+  source: { plugin: PLUGIN, factory: 'operationalForecastSource' },
+  transform: { plugin: PLUGIN, factory: 'select' },
+  product: { plugin: PLUGIN, factory: 'ensembleStatistics' },
+  sink: { plugin: PLUGIN, factory: 'mapPlotSink' },
+}
+const CANON_KEY = Object.fromEntries(
+  Object.entries(CANON).map(([kind, id]) => [kind, factoryIdToKey(id)]),
+) as Record<BlockKind, string>
+
+/** Titles as the catalogue spells them; fallbacks keep copy readable. */
+const FALLBACK_TITLE: Record<BlockKind, string> = {
+  source: 'Operational forecast source',
+  transform: 'Select',
+  product: 'Ensemble Statistics',
+  sink: 'Map Plot',
+}
+
+/** Values every configure step teaches (and Show me applies). */
+const CANON_VALUES: Record<BlockKind, Record<string, string>> = {
+  source: { source: 'ecmwf-open-data', forecast: 'ifs-ens' },
+  transform: { dimension: 'step', values: '72' },
+  product: { param: '2t', statistic: 'mean' },
+  sink: {
+    param: '2t',
+    domain: 'global',
+    format: 'png',
+    groupby: 'none',
+    splitby: 'none',
+  },
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000
+/** Open data keeps only a few days of base times. */
+const MAX_BASE_TIME_AGE_MS = 4 * DAY_MS
+
+/** Yesterday 00 UTC (wire form). */
+function recentBaseTime(): string {
+  const day = new Date(Date.now() - DAY_MS)
+  return `${day.toISOString().slice(0, 10)}T00:00:00`
+}
+
+/** Past, and still within open-data retention. */
+function isRecentBaseTime(value: string): boolean {
+  const age = Date.now() - Date.parse(`${value}Z`)
+  return age >= 0 && age <= MAX_BASE_TIME_AGE_MS
+}
+
+export interface FirstRunLaunch {
+  titles: Record<BlockKind, string>
+}
+
+/** Last catalogue seen by the launch hook — names stray blocks in hints. */
+let catalogueRef: BlockFactoryCatalogue | null = null
+
+export function useFirstRunLaunchContext(): FirstRunLaunch | null {
+  const { data: catalogue } = useBlockCatalogue()
+  if (catalogue === undefined) return null
+  catalogueRef = catalogue
+  return { titles: canonicalTitles(catalogue) }
+}
+
+function canonicalTitles(
+  catalogue: BlockFactoryCatalogue,
+): Record<BlockKind, string> {
+  const titles = { ...FALLBACK_TITLE }
+  for (const kind of Object.keys(CANON) as Array<BlockKind>) {
+    const factory = getFactory(catalogue, CANON[kind])
+    if (factory !== undefined) titles[kind] = factory.title
+  }
+  return titles
+}
+
+// -------- Builder-store signals --------
+
+const state = () => useFableBuilderStore.getState()
+
+/** Instance id of the canonical block of `kind`, if on the canvas. */
+function blockOf(kind: BlockKind): string | null {
+  for (const [id, block] of Object.entries(state().fable.blocks)) {
+    if (factoryIdToKey(block.factory_id) === CANON_KEY[kind]) return id
+  }
+  return null
+}
+
+/** Validation settled and clean; sinks without expansions have no entry. */
+function blockValid(kind: BlockKind): boolean {
+  const id = blockOf(kind)
+  const validation = state().validationState
+  if (id === null || validation === null) return false
+  return (
+    !(id in validation.blockStates) || !validation.blockStates[id].hasErrors
+  )
+}
+
+const CANON_KEYS = new Set(Object.values(CANON_KEY))
+
+/** Blocks outside the tour's pipeline: other factories, or duplicates. */
+function strayBlocks(): Array<string> {
+  const seen = new Set<string>()
+  const strays: Array<string> = []
+  for (const [id, block] of Object.entries(state().fable.blocks)) {
+    const key = factoryIdToKey(block.factory_id)
+    if (!CANON_KEYS.has(key) || seen.has(key)) strays.push(id)
+    else seen.add(key)
+  }
+  return strays
+}
+
+function blockTitle(id: string): string {
+  const { factory_id } = state().fable.blocks[id]
+  const factory =
+    catalogueRef === null ? undefined : getFactory(catalogueRef, factory_id)
+  return factory?.title ?? factory_id.factory
+}
+
+const UPSTREAM: Partial<Record<BlockKind, BlockKind>> = {
+  transform: 'source',
+  product: 'transform',
+  sink: 'product',
+}
+
+/** The block's (single) input feeds from the canonical upstream block. */
+function wired(kind: BlockKind): boolean {
+  const upstream = UPSTREAM[kind]
+  if (upstream === undefined) return true
+  const id = blockOf(kind)
+  const upstreamId = blockOf(upstream)
+  if (id === null || upstreamId === null) return false
+  const [inputName] = Object.keys(state().fable.blocks[id].input_ids)
+  return state().fable.blocks[id].input_ids[inputName] === upstreamId
+}
+
+/** Rails: first field off the tour's values (the run is the tested one). */
+function offScriptField(kind: BlockKind): string | null {
+  const id = blockOf(kind)
+  if (id === null) return null
+  const values = state().fable.blocks[id].configuration_values
+  for (const [key, value] of Object.entries(CANON_VALUES[kind])) {
+    if (values[key] !== value) return key
+  }
+  if (kind === 'source' && !isRecentBaseTime(values.base_time)) {
+    return 'base_time'
+  }
+  return null
+}
+
+const blockCanonical = (kind: BlockKind) =>
+  blockOf(kind) !== null && offScriptField(kind) === null
+
+/** Card hint, by priority: stray block, wiring, off-script field, issues. */
+function explainRails(kind: BlockKind): StepBlocker | null {
+  const stray = strayBlocks().at(0)
+  if (stray !== undefined) {
+    return { key: 'rails.stray', values: { block: blockTitle(stray) } }
+  }
+  if (blockOf(kind) === null) return null
+  if (!wired(kind)) {
+    const titles =
+      catalogueRef === null ? FALLBACK_TITLE : canonicalTitles(catalogueRef)
+    return {
+      key: 'rails.unwired',
+      values: { block: titles[kind], upstream: titles[UPSTREAM[kind] ?? kind] },
+    }
+  }
+  const field = offScriptField(kind)
+  if (field !== null) return { key: `rails.${kind}.${field}` }
+  const validation = state().validationState
+  return validation !== null && !blockValid(kind)
+    ? { key: 'rails.invalid' }
+    : null
+}
+
+/** Structure rails: on script so far, and the block sits in its place. */
+const onScript = (kind: BlockKind) =>
+  strayBlocks().length === 0 && blockOf(kind) !== null && wired(kind)
+
+const canonicalAndValid = (kind: BlockKind) =>
+  signal(
+    () => onScript(kind) && blockCanonical(kind) && blockValid(kind),
+    () => explainRails(kind),
+  )
+
+/** Show me fixes structure first: drop strays, then wire, then `action`. */
+const railed =
+  (kind: BlockKind, action: () => ShowMeAction) => (): ShowMeAction => {
+    const strays = strayBlocks()
+    if (strays.length > 0) {
+      return {
+        apply: () => {
+          for (const id of strays) state().removeBlock(id)
+          return true
+        },
+      }
+    }
+    const id = blockOf(kind)
+    const upstream = UPSTREAM[kind]
+    if (id !== null && upstream !== undefined && !wired(kind)) {
+      return {
+        apply: () => {
+          const upstreamId = blockOf(upstream)
+          if (upstreamId === null) return false
+          const [inputName] = Object.keys(state().fable.blocks[id].input_ids)
+          state().connectBlocks(id, inputName, upstreamId)
+          return true
+        },
+      }
+    }
+    return action()
+  }
+
+function signal(
+  check: () => boolean,
+  explain?: () => StepBlocker | null,
+): AdvanceWhen {
+  return {
+    kind: 'signal',
+    subscribe: (onChange) => useFableBuilderStore.subscribe(onChange),
+    check,
+    explain,
+  }
+}
+
+const CANVAS_EMPTY = signal(
+  () => Object.keys(state().fable.blocks).length === 0,
+)
+
+// -------- Show me actions --------
+
+const factoryRow = (kind: BlockKind) =>
+  `[data-factory-key=${JSON.stringify(CANON_KEY[kind])}]${tourActionSelector('add-block')}`
+
+const kindMatch = (kind: BlockKind) => `[data-block-kind="${kind}"]`
+
+/** Press the + handle on the canonical `from` block, then the menu row. */
+const chainFrom = (from: BlockKind, add: BlockKind) => ({
+  within: TOUR.configure.addDownstream,
+  withinMatch: kindMatch(from),
+  then: { within: TOUR.configure.addMenu, selector: factoryRow(add) },
+})
+
+/** Fill the canonical values into the block of `kind`. */
+const fill = (kind: BlockKind) => ({
+  apply: () => {
+    const id = blockOf(kind)
+    if (id === null) return false
+    const values =
+      kind === 'source'
+        ? { ...CANON_VALUES.source, base_time: recentBaseTime() }
+        : CANON_VALUES[kind]
+    state().updateBlockConfigBatch(id, values)
+    return true
+  },
+})
+
+/** Combined add-and-fill step: add first, fill once the block exists. */
+const addThenFill = (from: BlockKind, kind: BlockKind) => () =>
+  blockOf(kind) === null ? chainFrom(from, kind) : fill(kind)
+
+/** Its second phase re-anchors to the config panel with `fill` copy. */
+const fillVariant = (kind: BlockKind) => ({
+  whenPresent: TOUR.configure.block,
+  whenPresentMatch: kindMatch(kind),
+  key: 'fill',
+  anchor: TOUR.configure.configPanel,
+})
+
+/** Kind tags in copy (`<sourceKind>` …) take the palette colours. */
+const kindMarkup = (kind: BlockKind) => (
+  <span className={`font-medium ${BLOCK_KIND_METADATA[kind].color}`} />
+)
+
+export const firstRunDefinition: TutorialDefinition<FirstRunLaunch> = {
+  id: 'configure-first-run',
+  route: '/configure',
+  i18nKey: 'firstRun',
+  copyValues: (launch) => ({
+    sourceBlock: launch.titles.source,
+    transformBlock: launch.titles.transform,
+    productBlock: launch.titles.product,
+    outputBlock: launch.titles.sink,
+  }),
+  markup: {
+    sourceKind: kindMarkup('source'),
+    transformKind: kindMarkup('transform'),
+    productKind: kindMarkup('product'),
+    outputKind: kindMarkup('sink'),
+  },
+  steps: [
+    {
+      id: 'orient',
+      anchor: TOUR.configure.canvas,
+      side: 'top',
+      advance: { kind: 'next-click' },
+      variant: { whenPresent: TOUR.configure.block, key: 'midSession' },
+    },
+    {
+      // Repeatable by construction: the tour builds from nothing.
+      id: 'fresh',
+      anchor: TOUR.configure.newConfig,
+      side: 'bottom',
+      advance: CANVAS_EMPTY,
+      showMe: { within: TOUR.configure.newConfig },
+    },
+    {
+      id: 'palette',
+      anchor: TOUR.configure.palette,
+      side: 'right',
+      advance: { kind: 'next-click' },
+      expandVia: TOUR.configure.expandPalette,
+    },
+    {
+      id: 'plugins',
+      anchor: TOUR.configure.palette,
+      side: 'right',
+      advance: { kind: 'next-click' },
+      expandVia: TOUR.configure.expandPalette,
+    },
+    {
+      id: 'addSource',
+      anchor: TOUR.configure.palette,
+      side: 'right',
+      advance: signal(
+        () => onScript('source'),
+        () => explainRails('source'),
+      ),
+      expandVia: TOUR.configure.expandPalette,
+      showMe: railed('source', () => ({
+        within: TOUR.configure.palette,
+        selector: factoryRow('source'),
+      })),
+    },
+    {
+      id: 'validation',
+      anchor: TOUR.configure.validation,
+      side: 'bottom',
+      advance: { kind: 'next-click' },
+    },
+    {
+      id: 'configureSource',
+      anchor: TOUR.configure.configPanel,
+      side: 'left',
+      advance: canonicalAndValid('source'),
+      expandVia: TOUR.configure.expandConfig,
+      showMe: railed('source', () => fill('source')),
+    },
+    {
+      id: 'addTransform',
+      anchor: TOUR.configure.addDownstream,
+      anchorMatch: kindMatch('source'),
+      side: 'right',
+      advance: signal(
+        () => onScript('transform'),
+        () => explainRails('transform'),
+      ),
+      showMe: railed('transform', () => chainFrom('source', 'transform')),
+      yieldTo: TOUR.configure.addMenu,
+    },
+    {
+      id: 'configureTransform',
+      anchor: TOUR.configure.configPanel,
+      side: 'left',
+      advance: canonicalAndValid('transform'),
+      expandVia: TOUR.configure.expandConfig,
+      showMe: railed('transform', () => fill('transform')),
+    },
+    {
+      id: 'product',
+      anchor: TOUR.configure.addDownstream,
+      anchorMatch: kindMatch('transform'),
+      side: 'right',
+      advance: canonicalAndValid('product'),
+      showMe: railed('product', addThenFill('transform', 'product')),
+      yieldTo: TOUR.configure.addMenu,
+      variant: fillVariant('product'),
+    },
+    {
+      id: 'output',
+      anchor: TOUR.configure.addDownstream,
+      anchorMatch: kindMatch('product'),
+      side: 'right',
+      advance: signal(
+        () =>
+          onScript('sink') &&
+          blockCanonical('sink') &&
+          blockValid('sink') &&
+          state().validationState?.isValid === true,
+        () => explainRails('sink'),
+      ),
+      showMe: railed('sink', addThenFill('product', 'sink')),
+      yieldTo: TOUR.configure.addMenu,
+      variant: fillVariant('sink'),
+    },
+    {
+      // Terminal: the submit navigates to the run page and completes the tour.
+      id: 'run',
+      anchor: TOUR.configure.runOnce,
+      side: 'bottom',
+      advance: {
+        kind: 'route',
+        match: (pathname) => pathname.startsWith('/execute/'),
+      },
+      showMe: () =>
+        findTourElement(TOUR.configure.runOnce, ':not([disabled])') === null
+          ? { apply: () => false }
+          : { within: TOUR.configure.runOnce },
+    },
+  ],
+}

--- a/frontend/src/features/tutorials/tutorials/visualise-first-map.tsx
+++ b/frontend/src/features/tutorials/tutorials/visualise-first-map.tsx
@@ -16,8 +16,15 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { TOUR, findTourElement, tourActionSelector } from '../anchors'
-import type { AdvanceWhen, TutorialDefinition } from '../engine/types'
+import type {
+  AdvanceWhen,
+  SearchRecord,
+  ShowMeAction,
+  StepBlocker,
+  TutorialDefinition,
+} from '../engine/types'
 import type { CuratedWmsServer } from '@/features/visualise/curated-wms'
+import type { ComparisonEntry } from '@/features/visualise/entry-ref'
 import { SLOT_B_OFF, entryRef } from '@/features/visualise/entry-ref'
 import { useCuratedWmsServers } from '@/features/visualise/curated-wms'
 import { probeWmsEndpoint } from '@/features/visualise/wms-probe'
@@ -34,8 +41,79 @@ const PREFERRED_SERVER_NAME = 'ECMWF'
 
 const hasEntries = () => useComparisonStore.getState().entries.length > 0
 
+/** Last launch seen by the hook — the rails need the server names. */
+let launchRef: FirstMapLaunch | null = null
+
+/** The named curated server's basket entry, if collected. */
+function wmsEntry(name: string): ComparisonEntry | undefined {
+  return useComparisonStore
+    .getState()
+    .entries.find((e) => e.kind === 'wms' && e.label === name)
+}
+
+/** Slot `param` shows the named server. */
+function slotIs(search: SearchRecord, param: 'a' | 'b', name: string) {
+  const entry = wmsEntry(name)
+  return entry !== undefined && search[param] === entryRef(entry)
+}
+
+const tourServerName = () => launchRef?.server.name ?? PREFERRED_SERVER_NAME
+const tourCompareName = () =>
+  launchRef === null ? 'DWD' : compareServerName(launchRef)
+
+/** Rails: A is the tour server; nothing else counts. */
+const SLOT_A_CANONICAL: AdvanceWhen = {
+  kind: 'search',
+  check: (search) => slotIs(search, 'a', tourServerName()),
+  explain: (search): StepBlocker | null => {
+    if (!hasEntries()) return null
+    if (wmsEntry(tourServerName()) === undefined) return { key: 'rails.addA' }
+    return search.a === undefined ? null : { key: 'rails.pickA' }
+  },
+}
+
+/** Rails: B is the comparison server. */
+const SLOT_B_CANONICAL: AdvanceWhen = {
+  kind: 'search',
+  check: (search) => slotIs(search, 'b', tourCompareName()),
+  explain: (search): StepBlocker | null => {
+    const set = typeof search.b === 'string' && search.b !== SLOT_B_OFF
+    if (wmsEntry(tourCompareName()) === undefined) {
+      return set ? { key: 'rails.addB' } : null
+    }
+    return { key: 'rails.pickB' }
+  },
+}
+
+/** Show me for slot A: assign the collected server, else press its Add. */
+function showMeSlotA(): ShowMeAction {
+  const name = tourServerName()
+  const entry = wmsEntry(name)
+  if (entry !== undefined) {
+    const ref = entryRef(entry)
+    return {
+      search: (prev) => ({
+        ...prev,
+        a: ref,
+        b: prev.b === ref ? SLOT_B_OFF : prev.b,
+      }),
+    }
+  }
+  const row = { within: TOUR.visualise.knownWms, selector: addSelector(name) }
+  // Mid-session the list sits in the Manage-sources dialog: open it first.
+  return findTourElement(TOUR.visualise.knownWms) !== null
+    ? row
+    : { within: TOUR.visualise.addSource, then: row }
+}
+
 /** Preferred server now, first reachable as probes land; frozen once added. */
 export function useFirstMapLaunchContext(): FirstMapLaunch | null {
+  const launch = useFirstMapLaunch()
+  launchRef = launch
+  return launch
+}
+
+function useFirstMapLaunch(): FirstMapLaunch | null {
   const servers = useCuratedWmsServers()
   const ordered = useMemo(
     () => [
@@ -66,12 +144,6 @@ export function useFirstMapLaunchContext(): FirstMapLaunch | null {
   return server === undefined ? null : { server }
 }
 
-const BASKET_NON_EMPTY: AdvanceWhen = {
-  kind: 'signal',
-  subscribe: (onChange) => useComparisonStore.subscribe(onChange),
-  check: hasEntries,
-}
-
 /** The named server's Add row in the curated list. */
 const addSelector = (name: string) =>
   `[data-server=${JSON.stringify(name)}]${tourActionSelector('add')}`
@@ -86,6 +158,12 @@ const layerRowSelector = (slot: 'a' | 'b') => [
 const compareServerName = (launch: FirstMapLaunch) =>
   launch.server.name === 'DWD' ? 'ECMWF' : 'DWD'
 
+/** Slot colours as the viewer paints them. */
+const SLOT_MARKUP = {
+  slotA: <span className="font-medium text-blue-700 dark:text-blue-300" />,
+  slotB: <span className="font-medium text-orange-700 dark:text-orange-300" />,
+}
+
 export const firstMapDefinition: TutorialDefinition<FirstMapLaunch> = {
   id: 'visualise-first-map',
   route: '/visualise',
@@ -94,6 +172,7 @@ export const firstMapDefinition: TutorialDefinition<FirstMapLaunch> = {
     server: launch.server.name,
     compareServer: compareServerName(launch),
   }),
+  markup: SLOT_MARKUP,
   steps: [
     {
       // Always first — the midSession variant re-anchors to the open map.
@@ -111,11 +190,8 @@ export const firstMapDefinition: TutorialDefinition<FirstMapLaunch> = {
       id: 'addServer',
       anchor: TOUR.visualise.knownWms,
       side: 'left',
-      advance: BASKET_NON_EMPTY,
-      showMe: (ctx) => ({
-        within: TOUR.visualise.knownWms,
-        selector: addSelector(ctx.launch?.server.name ?? ''),
-      }),
+      advance: SLOT_A_CANONICAL,
+      showMe: showMeSlotA,
     },
     {
       id: 'map',
@@ -175,17 +251,11 @@ export const firstMapDefinition: TutorialDefinition<FirstMapLaunch> = {
       id: 'compare',
       anchor: TOUR.visualise.addSource,
       side: 'bottom',
-      advance: {
-        kind: 'search',
-        check: (search) =>
-          typeof search.b === 'string' && search.b !== SLOT_B_OFF,
-      },
-      showMe: (ctx) => {
-        const name = ctx.launch === null ? 'DWD' : compareServerName(ctx.launch)
+      advance: SLOT_B_CANONICAL,
+      showMe: () => {
+        const name = tourCompareName()
         // Already collected (earlier run): Add is disabled; assign B directly.
-        const collected = useComparisonStore
-          .getState()
-          .entries.find((e) => e.kind === 'wms' && e.label === name)
+        const collected = wmsEntry(name)
         if (collected !== undefined) {
           return { search: (prev) => ({ ...prev, b: entryRef(collected) }) }
         }

--- a/frontend/src/locales/en/configure.json
+++ b/frontend/src/locales/en/configure.json
@@ -312,5 +312,37 @@
     "hoursAgo_other": "{{count}} hours ago",
     "daysAgo_one": "{{count}} day ago",
     "daysAgo_other": "{{count}} days ago"
+  },
+  "help": {
+    "open": "Help & shortcuts",
+    "title": "Configuration canvas",
+    "intro": "A forecast configuration is a pipeline of blocks: data flows from a source through transforms and products into outputs. Build it on the canvas, configure each block on the right, and run it from the header.",
+    "sections": {
+      "canvas": {
+        "title": "Canvas",
+        "body": "Blocks are cards wired left to right. Drag to pan, scroll to zoom, and use the controls in the corner to fit the view. Click a card to select it; its + handle adds a connected block, or drag from the handle to wire by hand."
+      },
+      "palette": {
+        "title": "Block palette",
+        "body": "Every block you can use, grouped by kind: <sourceKind>Source</sourceKind> fetches data, <transformKind>Transform</transformKind> reshapes it, <productKind>Product</productKind> computes something new, <outputKind>Output</outputKind> stores or plots the result. Blocks come from installed plugins — the Plugins page adds more. Greyed rows cannot follow the currently selected block."
+      },
+      "configure": {
+        "title": "Configuring a block",
+        "body": "The panel on the right lists the selected block’s inputs and fields. Fields offer the values the upstream data actually has. Type ${…} to reference a variable — local variables and glyphs resolve at run time."
+      },
+      "validation": {
+        "title": "Validation",
+        "body": "Every edit is checked on the spot. A red ring marks a block with issues; the header badge counts them and lists them — each entry jumps to its block. The pipeline can be run once it reads “Valid”."
+      },
+      "run": {
+        "title": "Running and saving",
+        "body": "Run Once submits the pipeline and opens its run page; the caret next to it offers a review step and scheduling. Save Config keeps the pipeline as a preset; the more menu shares, exports, or loads a configuration file. Unsaved work is kept as a draft in this browser."
+      }
+    },
+    "shortcuts": {
+      "title": "Keyboard shortcuts",
+      "undo": "Undo",
+      "redo": "Redo"
+    }
   }
 }

--- a/frontend/src/locales/en/tutorials.json
+++ b/frontend/src/locales/en/tutorials.json
@@ -13,7 +13,8 @@
     "stepOf": "{{current}} of {{total}}",
     "stepDone": "Done — you can move on",
     "waitingFor": "Waiting for this part of the page…",
-    "endedToast": "Tour ended — restart it any time from the page's Help dialog"
+    "endedToast": "Tour ended — restart it any time from the page's Help dialog",
+    "completedToast": "Tour completed"
   },
   "launch": {
     "sectionTitle": "Guided tours",

--- a/frontend/src/locales/en/tutorials.json
+++ b/frontend/src/locales/en/tutorials.json
@@ -25,6 +25,12 @@
   "firstMap": {
     "title": "Visualise forecasts on a map",
     "description": "Connect a live weather server, put a layer on the map, step it through time, and compare two forecast providers. About 3 minutes.",
+    "rails": {
+      "addA": "Not yet — the tour uses <v>{{server}}</v> in slot <slotA>A</slotA>. Press \"Add\" on it, or press Show me.",
+      "pickA": "Not yet — pick <v>{{server}}</v> for slot <slotA>A</slotA> in the bar above, or press Show me.",
+      "addB": "Not yet — <slotB>B</slotB> must be <v>{{compareServer}}</v>: add it under \"Manage sources\", or press Show me.",
+      "pickB": "Not yet — pick <v>{{compareServer}}</v> for slot <slotB>B</slotB> in the bar above, or press Show me."
+    },
     "steps": {
       "orient": {
         "title": "Visualise forecasts on a map",
@@ -34,15 +40,15 @@
       },
       "addServer": {
         "title": "Connect a live weather server",
-        "body": "These are public weather map services. Press \"Add\" on {{server}} — the map workspace opens with its live data. Forecasts you've run yourself appear under \"Recent runs with stored outputs\" — they go on the map the same way."
+        "body": "These are public weather map services. Press \"Add\" on <v>{{server}}</v> — the map workspace opens with its live data in slot <slotA>A</slotA>. Forecasts you've run yourself appear under \"Recent runs with stored outputs\" — they go on the map the same way."
       },
       "map": {
         "title": "This is your map",
-        "body": "Drag to pan, scroll to zoom — try it. The toolbar above holds the view tools; press \"F\" any time to fit the whole globe."
+        "body": "Drag to pan, scroll to zoom — try it. The toolbar above holds the view tools; press <v>F</v> any time to fit the whole globe."
       },
       "layer": {
         "title": "Put data on the map",
-        "body": "The panel on the right lists every layer the active source offers. Search for something familiar — try \"temperature\" — and click a row: it draws on the map."
+        "body": "The panel on the right lists every layer the active source offers. Search for something familiar — try <v>temperature</v> — and click a row: it draws on the map."
       },
       "active": {
         "title": "Your active layers live here",
@@ -56,19 +62,19 @@
       },
       "compare": {
         "title": "Add a second forecast",
-        "body": "Press \"Manage sources\" and add {{compareServer}} from the known servers — if it is already in your collection, pick it for slot B in the bar above instead. Either way B fills, and the map shows both forecasts side by side."
+        "body": "Press \"Manage sources\" and add <v>{{compareServer}}</v> from the known servers — if it is already in your collection, pick it for slot <slotB>B</slotB> in the bar above instead. Either way <slotB>B</slotB> fills, and the map shows both forecasts side by side."
       },
       "layerB": {
         "title": "Give B a layer too",
-        "body": "B's side stays empty until it has a layer of its own. In the layer browser, switch to \"B\" and click one of {{compareServer}}'s layers — it draws on B's half."
+        "body": "<slotB>B</slotB>'s side stays empty until it has a layer of its own. In the layer browser, switch to <slotB>B</slotB> and click one of <v>{{compareServer}}</v>'s layers — it draws on <slotB>B</slotB>'s half."
       },
       "modes": {
         "title": "Compare the two forecasts",
-        "body": "A and B are side by side right now. Try another mode up here — swipe, flicker, or spy — each one is a different way to spot where the forecasts disagree."
+        "body": "<slotA>A</slotA> and <slotB>B</slotB> are side by side right now. Try another mode up here — <v>swipe</v>, <v>flicker</v>, or <v>spy</v> — each one is a different way to spot where the forecasts disagree."
       },
       "done": {
         "title": "That's a live forecast comparison",
-        "body": "One more thing about time: with two sources the timeline only offers the timesteps A and B share — and some layers carry no time info at all. Everything you see lives in the page URL, so copying the address shares this exact view. Press \"H\" for help whenever you need it."
+        "body": "One more thing about time: with two sources the timeline only offers the timesteps <slotA>A</slotA> and <slotB>B</slotB> share — and some layers carry no time info at all. Everything you see lives in the page URL, so copying the address shares this exact view. Press <v>H</v> for help whenever you need it."
       }
     }
   },

--- a/frontend/src/locales/en/tutorials.json
+++ b/frontend/src/locales/en/tutorials.json
@@ -71,5 +71,90 @@
         "body": "One more thing about time: with two sources the timeline only offers the timesteps A and B share — and some layers carry no time info at all. Everything you see lives in the page URL, so copying the address shares this exact view. Press \"H\" for help whenever you need it."
       }
     }
+  },
+  "firstRun": {
+    "title": "Build and run your first forecast",
+    "description": "Assemble a four-block pipeline from a clean canvas — source, transform, product, output — fix its validation issues, and submit it as a run. About 5 minutes.",
+    "rails": {
+      "stray": "Not yet — remove <v>{{block}}</v>; it is not part of this tour's pipeline. Show me removes it.",
+      "unwired": "Not yet — connect <v>{{block}}</v> to <v>{{upstream}}</v>: drag from the + handle to its input, or press Show me.",
+      "invalid": "Values are right — the block still reports issues; see the badge.",
+      "source": {
+        "source": "Not yet — set Source to <v>ecmwf-open-data</v>.",
+        "forecast": "Not yet — set Forecast model to <v>ifs-ens</v>.",
+        "base_time": "Not yet — pick a Base time from <v>the last four days</v>."
+      },
+      "transform": {
+        "dimension": "Not yet — set Dimension to <v>step</v>.",
+        "values": "Not yet — set Values to <v>72</v>."
+      },
+      "product": {
+        "param": "Not yet — set Parameter to <v>2t</v>.",
+        "statistic": "Not yet — set Statistic to <v>mean</v>."
+      },
+      "sink": {
+        "param": "Not yet — set Parameters to <v>2t</v>.",
+        "domain": "Not yet — set Domain to <v>global</v>.",
+        "format": "Not yet — set Format to <v>png</v>.",
+        "groupby": "Not yet — set Group by to <v>none</v>.",
+        "splitby": "Not yet — set Split by to <v>none</v>."
+      }
+    },
+    "steps": {
+      "orient": {
+        "title": "Build and run your first forecast",
+        "body": "This canvas holds a forecast configuration: a pipeline of blocks that data flows through from left to right. In the next five minutes you'll build one from scratch — fetch a forecast, narrow it, compute a statistic, plot it — and submit it as a run.",
+        "midSessionTitle": "Take the tour from the top",
+        "midSessionBody": "There is already work on the canvas. The tour builds its pipeline from a clean canvas, so the next step parks what's here on the workbench shelf — nothing is lost, and you can bring it back any time."
+      },
+      "fresh": {
+        "title": "Start from a clean canvas",
+        "body": "Press \"New configuration\". Anything unsaved is parked on the workbench shelf — a banner offers to restore it — and you get an empty canvas to build on."
+      },
+      "palette": {
+        "title": "Blocks come in four kinds",
+        "body": "The palette lists every block you can use. <sourceKind>Source</sourceKind> fetches data. <transformKind>Transform</transformKind> reshapes it — selecting, cropping, regridding. <productKind>Product</productKind> computes something new from it. <outputKind>Output</outputKind> stores or plots the result. A pipeline starts with a source and ends with at least one output."
+      },
+      "plugins": {
+        "title": "Where blocks come from",
+        "body": "Every block here is provided by an installed plugin — these come with the ECMWF base plugin. Administrators install more on the Plugins page, including custom blocks written for your own models, data, and products."
+      },
+      "addSource": {
+        "title": "Add a source",
+        "body": "Click \"{{sourceBlock}}\" in the palette — or drag it onto the canvas. It appears as a card with a red ring: the block exists, but it isn't configured yet."
+      },
+      "validation": {
+        "title": "Red means \"not yet\"",
+        "body": "Every edit is checked on the spot. This badge counts the open issues — click it to list them; each entry jumps to its block. It turns \"Valid\" as soon as the whole pipeline checks out, and only then can you run it."
+      },
+      "configureSource": {
+        "title": "Configure the source",
+        "body": "A selected block is configured in the panel on the right. Set Source to <v>ecmwf-open-data</v>, Forecast model to <v>ifs-ens</v>, and Base time to <v>a day within the last four days, 00:00</v>. The tour moves on with exactly these values — they are the ones known to run — and the ring and badge clear as the last field lands."
+      },
+      "addTransform": {
+        "title": "Chain the next block",
+        "body": "A block's output handle is also its \"Add\" button. Click the + on the source and pick \"{{transformBlock}}\" — it lands on the canvas already wired. Prefer wiring by hand? Drag from the handle to any block's input."
+      },
+      "configureTransform": {
+        "title": "Narrow the data",
+        "body": "Transforms keep runs small: set Dimension to <v>step</v> and Values to <v>72</v> — only the 72-hour lead time goes downstream. The panel offers the choices the upstream data actually has; the tour moves on with these two values."
+      },
+      "product": {
+        "title": "Compute a product",
+        "body": "Now do it yourself: click the + on the Select block and pick \"{{productBlock}}\". It lands wired, unconfigured, and selected — the next half of this step fills it in.",
+        "fillTitle": "Configure the statistics",
+        "fillBody": "Set Parameter to <v>2t</v> (2-metre temperature) and Statistic to <v>mean</v> — the average over all ensemble members. The tour moves on with these values once the block validates."
+      },
+      "output": {
+        "title": "Finish with an output",
+        "body": "Same again: click the + on the statistics block and pick \"{{outputBlock}}\". It renders the result as an image.",
+        "fillTitle": "Configure the plot",
+        "fillBody": "Set Parameters to <v>2t</v>, Domain to <v>global</v>, Format to <v>png</v>, and both Group by and Split by to <v>none</v>. Once the badge says \"Valid\" with these values, the pipeline is complete."
+      },
+      "run": {
+        "title": "Run it",
+        "body": "Press \"Run Once\", give the run a name, and submit. You land on the run's page, where every block reports its progress and outputs appear as they finish. The caret next to the button repeats the same configuration on a schedule."
+      }
+    }
   }
 }

--- a/frontend/src/routes/_authenticated/configure.tsx
+++ b/frontend/src/routes/_authenticated/configure.tsx
@@ -24,6 +24,8 @@ const searchSchema = z.object({
   templateName: z.string().optional(),
   /** Explicit blank-canvas intent; a bench holding unsaved work asks first. */
   fresh: z.boolean().optional(),
+  /** Plain-link tour launch (help surfaces); stripped on start. */
+  tour: z.enum(['first-run']).optional().catch(undefined),
 })
 
 export type ConfigureSearch = z.infer<typeof searchSchema>
@@ -34,8 +36,15 @@ export const Route = createFileRoute('/_authenticated/configure')({
 })
 
 function ConfigurePage() {
-  const { state, fableId, template, templatePlugin, templateName, fresh } =
-    Route.useSearch()
+  const {
+    state,
+    fableId,
+    template,
+    templatePlugin,
+    templateName,
+    fresh,
+    tour,
+  } = Route.useSearch()
   return (
     <FableBuilderPage
       key={builderSessionKey({ fableId, template })}
@@ -45,6 +54,7 @@ function ConfigurePage() {
       templatePlugin={templatePlugin}
       templateName={templateName}
       fresh={fresh}
+      tour={tour}
     />
   )
 }

--- a/frontend/src/stores/tutorialsStore.ts
+++ b/frontend/src/stores/tutorialsStore.ts
@@ -18,7 +18,7 @@ import { create } from 'zustand'
 import { devtools, persist } from 'zustand/middleware'
 import { STORAGE_KEYS, STORE_VERSIONS } from '@/lib/storage-keys'
 
-export type TutorialId = 'visualise-first-map'
+export type TutorialId = 'visualise-first-map' | 'configure-first-run'
 
 export type TutorialOutcome = 'completed' | 'dismissed'
 

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -30,7 +30,12 @@ export const test = base.extend({
       window.localStorage.setItem(
         'fiab.store.tutorials',
         JSON.stringify({
-          state: { statuses: { 'visualise-first-map': 'dismissed' } },
+          state: {
+            statuses: {
+              'visualise-first-map': 'dismissed',
+              'configure-first-run': 'dismissed',
+            },
+          },
           version: 1,
         }),
       )

--- a/frontend/tests/e2e/tutorial-configure.spec.ts
+++ b/frontend/tests/e2e/tutorial-configure.spec.ts
@@ -1,0 +1,79 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * Guided-tour launch sanity on /configure. Raw @playwright/test on purpose:
+ * the shared fixtures mark the tour taken, and this spec exercises exactly
+ * that surface. The full step path runs in browser-mode integration tests.
+ */
+
+import { expect, test } from '@playwright/test'
+import type { Page } from '@playwright/test'
+
+const TUTORIALS_KEY = 'fiab.store.tutorials'
+const TOUR_TITLE = 'Build and run your first forecast'
+
+test.beforeEach(async ({ page }) => {
+  // Only the welcome dialog is suppressed; the tour invite stays live.
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      'fiab.store.onboarding',
+      JSON.stringify({ state: { status: 'skipped' }, version: 2 }),
+    )
+  })
+})
+
+async function openConfigure(page: Page, search = '') {
+  await page.goto('/')
+  await page.waitForURL(/overview/, { timeout: 15000 })
+  await page.goto(`/configure${search}`)
+  await expect(page.getByText('Block Palette')).toBeVisible({ timeout: 10000 })
+}
+
+test.describe('Configure guided tour', () => {
+  test('Help starts the tour; Skip tour records dismissed', async ({
+    page,
+  }) => {
+    await openConfigure(page)
+
+    await page.getByRole('button', { name: 'Help & shortcuts' }).click()
+    await expect(
+      page.getByRole('dialog', { name: 'Configuration canvas' }),
+    ).toBeVisible()
+    await page
+      .getByRole('button', { name: 'Take the interactive tour' })
+      .click()
+
+    await expect(page.getByRole('dialog', { name: TOUR_TITLE })).toBeVisible()
+    await page.getByRole('button', { name: 'Skip tour', exact: true }).click()
+    await expect(page.getByRole('dialog', { name: TOUR_TITLE })).toBeHidden()
+
+    const stored = await page.evaluate(
+      (key) => window.localStorage.getItem(key),
+      TUTORIALS_KEY,
+    )
+    expect(JSON.parse(stored ?? '{}')).toMatchObject({
+      state: { statuses: { 'configure-first-run': 'dismissed' } },
+    })
+  })
+
+  test('?tour=first-run launches the tour and strips the param', async ({
+    page,
+  }) => {
+    await openConfigure(page, '?tour=first-run')
+
+    await expect(page.getByRole('dialog', { name: TOUR_TITLE })).toBeVisible({
+      timeout: 10000,
+    })
+    await page.waitForURL((url) => !url.search.includes('tour'), {
+      timeout: 10000,
+    })
+  })
+})

--- a/frontend/tests/integration/features/tutorials/configure-tutorial.test.tsx
+++ b/frontend/tests/integration/features/tutorials/configure-tutorial.test.tsx
@@ -1,0 +1,402 @@
+/*
+ * (C) Copyright 2026- ECMWF and individual contributors.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+/**
+ * "Build and run your first forecast" guided tour against the real
+ * FableBuilderPage with MSW catalogue/expand/job handlers:
+ * - the full run, every action via Show me: clean canvas (pre-satisfied) →
+ *   palette → plugins → add source → validation → configure → chain a
+ *   Select via the + handle → configure → product → output → Run Once →
+ *   submit navigates to the run page and records `completed`
+ * - rails: a valid but off-script source keeps the step; Show me fixes it;
+ *   a stray block keeps the step until Show me removes it
+ * - quitting records `dismissed`; Help still offers the tour
+ * - a busy canvas starts at step 1 and the
+ *   fresh step really empties it
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { I18nextProvider } from 'react-i18next'
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  useSearch,
+} from '@tanstack/react-router'
+import { resetJobsState } from '@tests/../mocks/data/job.data'
+import { mockCatalogue } from '@tests/../mocks/data/fable.data'
+import type { Locator } from '@vitest/browser/context'
+import type { FableBuilderV1 } from '@/api/types/fable.types'
+import { Route as ConfigureRoute } from '@/routes/_authenticated/configure'
+import { FableBuilderPage } from '@/features/fable-builder/components/FableBuilderPage'
+import { TutorialsController } from '@/features/tutorials/TutorialsController'
+import { useFableBuilderStore } from '@/features/fable-builder/stores/fableBuilderStore'
+import { useTutorialsStore } from '@/stores/tutorialsStore'
+import i18n from '@/lib/i18n'
+
+vi.mock('@/features/auth/AuthContext', () => ({
+  useAuth: () => ({ authType: 'anonymous', isAuthenticated: true }),
+}))
+vi.mock('@/hooks/useUser', () => ({
+  useUser: () => ({ data: { is_superuser: true } }),
+}))
+
+const TOUR_TITLE = 'Build and run your first forecast'
+
+function ConfigurePage() {
+  const search = useSearch({ strict: false })
+  return <FableBuilderPage fresh={search.fresh} />
+}
+
+async function renderConfigureWithTours() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+  const rootRoute = createRootRoute({ component: () => <Outlet /> })
+  const authenticatedRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    id: '_authenticated',
+    component: () => (
+      <>
+        <Outlet />
+        <TutorialsController />
+      </>
+    ),
+  })
+  const configureRoute = createRoute({
+    getParentRoute: () => authenticatedRoute,
+    path: '/configure',
+    validateSearch: ConfigureRoute.options.validateSearch,
+    component: ConfigurePage,
+  })
+  // The submit's destination; the tour only needs the pathname to change.
+  const executeRoute = createRoute({
+    getParentRoute: () => authenticatedRoute,
+    path: '/execute/$jobId',
+    component: () => <h1>Run page</h1>,
+  })
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([
+      authenticatedRoute.addChildren([configureRoute, executeRoute]),
+    ]),
+    history: createMemoryHistory({ initialEntries: ['/configure'] }),
+  })
+  const screen = await render(
+    <QueryClientProvider client={queryClient}>
+      <I18nextProvider i18n={i18n}>
+        <RouterProvider router={router} />
+      </I18nextProvider>
+    </QueryClientProvider>,
+  )
+  return { router, screen }
+}
+
+const SOURCE_ONLY: FableBuilderV1 = {
+  blocks: {
+    source1: {
+      factory_id: {
+        plugin: { store: 'ecmwf', local: 'ecmwf-base' },
+        factory: 'operationalForecastSource',
+      },
+      configuration_values: {
+        source: 'mars',
+        forecast: 'aifs-ens',
+        base_time: '2026-01-01T00:00',
+      },
+      input_ids: {},
+    },
+  },
+}
+
+beforeEach(() => {
+  resetJobsState()
+  window.localStorage.clear()
+  useFableBuilderStore.getState().reset()
+  // No Tailwind here: pin the shade; lift dialogs above the inline backdrop.
+  const style = document.createElement('style')
+  style.setAttribute('data-test-shim', 'tutorials')
+  style.textContent =
+    '[data-slot="spotlight-shade"]{position:fixed;inset:0;pointer-events:none}' +
+    '[data-slot="alert-dialog-content"],[data-slot="dialog-content"]{position:fixed;top:0;left:0;z-index:50;max-height:100vh;overflow:auto}'
+  document.head.appendChild(style)
+})
+
+/** The Help dialog is the tour's launch surface; it closes on start. */
+async function openTourFromHelp(
+  screen: { getByRole: (role: string, opts: { name: string }) => Locator },
+  title = TOUR_TITLE,
+) {
+  await screen.getByRole('button', { name: 'Help & shortcuts' }).click()
+  await screen
+    .getByRole('button', { name: 'Take the interactive tour' })
+    .click()
+  await expect
+    .element(screen.getByRole('dialog', { name: title }))
+    .toBeVisible()
+}
+
+function blockKinds(): Array<string> {
+  return Array.from(
+    document.querySelectorAll('[data-tour="configure.block"]'),
+    (el) => el.getAttribute('data-block-kind') ?? '',
+  )
+}
+
+describe('configure first-run tutorial', () => {
+  it('walks the full path to a submitted run', { timeout: 60000 }, async () => {
+    const { screen, router } = await renderConfigureWithTours()
+
+    await openTourFromHelp(screen)
+    await expect
+      .element(screen.getByText('1 of 12', { exact: true }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Start', exact: true }).click()
+
+    // Empty canvas: the fresh step is already satisfied → review mode.
+    await expect
+      .element(
+        screen.getByRole('heading', { name: 'Start from a clean canvas' }),
+      )
+      .toBeVisible()
+    await expect
+      .element(screen.getByText('Done — you can move on'))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Continue', exact: true }).click()
+
+    await expect
+      .element(
+        screen.getByRole('heading', { name: 'Blocks come in four kinds' }),
+      )
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Next', exact: true }).click()
+    await expect
+      .element(screen.getByRole('heading', { name: 'Where blocks come from' }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Next', exact: true }).click()
+
+    // Show me presses the canonical source row in the palette.
+    await expect
+      .element(screen.getByRole('heading', { name: 'Add a source' }))
+      .toBeVisible()
+    await expect
+      .element(screen.getByText(/Click "Operational forecast source"/))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Show me', exact: true }).click()
+    await expect
+      .element(screen.getByRole('heading', { name: 'Red means "not yet"' }))
+      .toBeVisible()
+    expect(blockKinds()).toEqual(['source'])
+    await screen.getByRole('button', { name: 'Next', exact: true }).click()
+
+    // Show me fills the source; validation settles → next step.
+    await expect
+      .element(screen.getByRole('heading', { name: 'Configure the source' }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Show me', exact: true }).click()
+    await expect
+      .element(screen.getByRole('heading', { name: 'Chain the next block' }), {
+        timeout: 10000,
+      })
+      .toBeVisible()
+
+    // By hand: the card yields while the add menu is open.
+    document
+      .querySelector<HTMLElement>(
+        '[data-tour="configure.add-downstream"][data-block-kind="source"]',
+      )
+      ?.click()
+    await expect
+      .element(screen.getByRole('dialog', { name: 'Chain the next block' }))
+      .not.toBeInTheDocument()
+    await screen
+      .getByRole('button', { name: /^Select/ })
+      .last()
+      .click()
+    await expect
+      .element(screen.getByRole('heading', { name: 'Narrow the data' }), {
+        timeout: 10000,
+      })
+      .toBeVisible()
+    expect(blockKinds()).toEqual(['source', 'transform'])
+    await screen.getByRole('button', { name: 'Show me', exact: true }).click()
+
+    // Combined steps: first press adds, second fills.
+    await expect
+      .element(screen.getByRole('heading', { name: 'Compute a product' }), {
+        timeout: 10000,
+      })
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Show me', exact: true }).click()
+    await expect.poll(() => blockKinds()).toContain('product')
+    // The block exists → the step re-anchors to the config panel.
+    await expect
+      .element(
+        screen.getByRole('heading', { name: 'Configure the statistics' }),
+      )
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Show me', exact: true }).click()
+
+    await expect
+      .element(screen.getByRole('heading', { name: 'Finish with an output' }), {
+        timeout: 10000,
+      })
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Show me', exact: true }).click()
+    await expect.poll(() => blockKinds()).toContain('sink')
+    await expect
+      .element(screen.getByRole('heading', { name: 'Configure the plot' }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Show me', exact: true }).click()
+
+    // Run step: Show me opens the submit dialog; the user submits.
+    await expect
+      .element(screen.getByRole('heading', { name: 'Run it' }), {
+        timeout: 10000,
+      })
+      .toBeVisible()
+    await expect
+      .element(screen.getByText('Valid', { exact: true }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Show me', exact: true }).click()
+    await expect
+      .element(screen.getByRole('heading', { name: 'Submit Forecast Job' }))
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Submit Job' }).click()
+
+    // The expected navigation completes the tour instead of ending it.
+    await expect
+      .poll(() => router.state.location.pathname, { timeout: 10000 })
+      .toMatch(/^\/execute\//)
+    await expect
+      .poll(() => useTutorialsStore.getState().statuses['configure-first-run'])
+      .toBe('completed')
+    expect(useTutorialsStore.getState().active).toBeNull()
+  })
+
+  it('rails: a valid but off-script source does not advance', async () => {
+    const { screen } = await renderConfigureWithTours()
+    useTutorialsStore.getState().start('configure-first-run')
+    useTutorialsStore.getState().setStep(4)
+    await screen.getByRole('button', { name: 'Show me', exact: true }).click()
+    await screen.getByRole('button', { name: 'Next', exact: true }).click()
+    await expect
+      .element(screen.getByRole('heading', { name: 'Configure the source' }))
+      .toBeVisible()
+
+    // MARS validates fine in the mock, but it is not the tour's pipeline.
+    const store = useFableBuilderStore.getState()
+    const [id] = Object.keys(store.fable.blocks)
+    store.updateBlockConfigBatch(id, {
+      source: 'mars',
+      forecast: 'ifs-ens',
+      base_time: '2026-01-01T00:00:00',
+    })
+    await expect
+      .poll(() => useFableBuilderStore.getState().validationState?.isValid, {
+        timeout: 10000,
+      })
+      .toBe(true)
+    await expect
+      .element(screen.getByRole('heading', { name: 'Configure the source' }))
+      .toBeVisible()
+    // The card says which field is off-script.
+    await expect
+      .element(screen.getByText('Not yet — set Source to ecmwf-open-data.'))
+      .toBeVisible()
+
+    await screen.getByRole('button', { name: 'Show me', exact: true }).click()
+    await expect
+      .element(screen.getByRole('heading', { name: 'Chain the next block' }), {
+        timeout: 10000,
+      })
+      .toBeVisible()
+  })
+
+  it('rails: a stray block blocks the step until Show me removes it', async () => {
+    const { screen } = await renderConfigureWithTours()
+    useTutorialsStore.getState().start('configure-first-run')
+    useTutorialsStore.getState().setStep(4)
+    await expect
+      .element(screen.getByRole('heading', { name: 'Add a source' }))
+      .toBeVisible()
+
+    // Off-script block dragged in from the palette.
+    const zarr = mockCatalogue['ecmwf/ecmwf-base'].factories.zarrSink
+    useFableBuilderStore.getState().addBlock(
+      {
+        plugin: { store: 'ecmwf', local: 'ecmwf-base' },
+        factory: 'zarrSink',
+      },
+      zarr,
+    )
+    await expect.element(screen.getByText(/remove Zarr Sink/)).toBeVisible()
+
+    // First press removes the stray; second adds the canonical source.
+    await screen.getByRole('button', { name: 'Show me', exact: true }).click()
+    await expect.poll(() => blockKinds()).toEqual([])
+    await screen.getByRole('button', { name: 'Show me', exact: true }).click()
+    await expect
+      .element(screen.getByRole('heading', { name: 'Red means "not yet"' }))
+      .toBeVisible()
+  })
+
+  it('quitting records dismissed; Help still offers the tour', async () => {
+    const { screen } = await renderConfigureWithTours()
+
+    await openTourFromHelp(screen)
+    await screen.getByRole('button', { name: 'Skip tour', exact: true }).click()
+
+    await expect
+      .poll(() => useTutorialsStore.getState().statuses['configure-first-run'])
+      .toBe('dismissed')
+    await expect
+      .element(screen.getByRole('dialog', { name: TOUR_TITLE }))
+      .not.toBeInTheDocument()
+    await openTourFromHelp(screen)
+  })
+
+  it('a busy canvas starts at step 1 and the fresh step empties it', async () => {
+    useFableBuilderStore.getState().setFable(SOURCE_ONLY, null)
+    const { screen } = await renderConfigureWithTours()
+    await expect.poll(() => blockKinds()).toEqual(['source'])
+
+    // Mid-session variant on the orient step — no fast-forward.
+    await openTourFromHelp(screen, 'Take the tour from the top')
+    await screen.getByRole('button', { name: 'Start', exact: true }).click()
+
+    // Not pre-satisfied: Show me presses New configuration → 0 blocks.
+    await expect
+      .element(
+        screen.getByRole('heading', { name: 'Start from a clean canvas' }),
+      )
+      .toBeVisible()
+    await expect
+      .element(screen.getByText('Done — you can move on'))
+      .not.toBeInTheDocument()
+    await screen.getByRole('button', { name: 'Show me', exact: true }).click()
+    await expect
+      .element(
+        screen.getByRole('heading', { name: 'Blocks come in four kinds' }),
+        {
+          timeout: 10000,
+        },
+      )
+      .toBeVisible()
+    expect(blockKinds()).toEqual([])
+  })
+})

--- a/frontend/tests/integration/features/tutorials/tutorial-runner.test.tsx
+++ b/frontend/tests/integration/features/tutorials/tutorial-runner.test.tsx
@@ -16,8 +16,10 @@
  *   picker dialog → give B a layer → switch comparison mode → done,
  *   recording `completed`
  * - "Show me" presses the canonical server's real Add button
+ * - rails: a different server in slot A keeps the step; Show me repairs it
  * - quitting records `dismissed`; the hub CTA stays as it was
- * - a mid-session launch still starts at step 1, reviewing satisfied steps
+ * - a mid-session launch still starts at step 1; a run in slot A is not
+ *   the tour server, so the add step asks for it instead of reviewing
  * - the compare step's Show me assigns an already-collected DWD to slot B
  *   (an earlier tour run left it in the basket; B was deliberately off)
  */
@@ -44,6 +46,7 @@ import { TutorialsController } from '@/features/tutorials/TutorialsController'
 import { useComparisonStore } from '@/features/visualise/stores/comparisonStore'
 import { entryRef } from '@/features/visualise/entry-ref'
 import { useTutorialsStore } from '@/stores/tutorialsStore'
+import { requestOverlayClose } from '@/lib/overlay-requests'
 import i18n from '@/lib/i18n'
 
 const TIMES = '2026-07-06T00:00:00Z,2026-07-06T06:00:00Z'
@@ -288,6 +291,55 @@ describe('visualise first-map tutorial', () => {
       .toBeVisible()
   })
 
+  it(
+    'rails: another server in slot A keeps the step; Show me fixes it',
+    { timeout: 40000 },
+    async () => {
+      const screen = await renderVisualiseWithTours()
+      await screen
+        .getByRole('button', {
+          name: 'Take the "Visualise forecasts on a map" tour',
+        })
+        .click()
+      await screen.getByRole('button', { name: 'Start', exact: true }).click()
+
+      // DWD first: it takes slot A, which the tour reserves for ECMWF.
+      document
+        .querySelector<HTMLElement>(
+          '[data-tour-action="add"][data-server="DWD"]',
+        )
+        ?.click()
+      await expect
+        .element(screen.getByText(/the tour uses ECMWF in slot A/), {
+          timeout: 15000,
+        })
+        .toBeVisible()
+
+      // Show me adds ECMWF via the Manage-sources dialog (it lands in B);
+      // closing the dialog reveals the next hint, and Show me assigns A.
+      await screen.getByRole('button', { name: 'Show me', exact: true }).click()
+      await expect
+        .poll(
+          () =>
+            useComparisonStore
+              .getState()
+              .entries.some((e) => e.kind === 'wms' && e.label === 'ECMWF'),
+          { timeout: 15000 },
+        )
+        .toBe(true)
+      requestOverlayClose()
+      await expect
+        .element(screen.getByText(/pick ECMWF for slot A/), { timeout: 15000 })
+        .toBeVisible()
+      await screen.getByRole('button', { name: 'Show me', exact: true }).click()
+      await expect
+        .element(screen.getByRole('heading', { name: 'This is your map' }), {
+          timeout: 15000,
+        })
+        .toBeVisible()
+    },
+  )
+
   it('quitting records dismissed and keeps the CTA', async () => {
     const screen = await renderVisualiseWithTours()
 
@@ -337,20 +389,19 @@ describe('visualise first-map tutorial', () => {
       .toBeVisible()
     await screen.getByRole('button', { name: 'Start', exact: true }).click()
 
-    // The satisfied add step surfaces as review (centered — the hub is gone).
+    // Rails: the run in slot A is not the tour server, so no review mode —
+    // the card says what to do instead (centered: the hub is gone).
     await expect
       .element(
         screen.getByRole('heading', { name: 'Connect a live weather server' }),
       )
       .toBeVisible()
     await expect
-      .element(screen.getByText('Done — you can move on'))
+      .element(screen.getByText(/the tour uses ECMWF in slot A/))
       .toBeVisible()
-    await screen.getByRole('button', { name: 'Continue', exact: true }).click()
-
     await expect
-      .element(screen.getByRole('heading', { name: 'This is your map' }))
-      .toBeVisible()
+      .element(screen.getByText('Done — you can move on'))
+      .not.toBeInTheDocument()
   })
 
   it('compare Show me assigns an already-collected DWD to an off slot B', async () => {

--- a/frontend/tests/unit/features/tutorials/stepMachine.test.ts
+++ b/frontend/tests/unit/features/tutorials/stepMachine.test.ts
@@ -52,6 +52,10 @@ describe('isPreSatisfied', () => {
     count = 1
     expect(isPreSatisfied(advance, {})).toBe(true)
   })
+
+  it('route steps never pre-satisfy (entry is on the tour route)', () => {
+    expect(isPreSatisfied({ kind: 'route', match: () => true }, {})).toBe(false)
+  })
 })
 
 describe('stepProgress', () => {


### PR DESCRIPTION
### Description
Second guided tour on the engine from #692: "Build and run your first forecast" walks a new user from a clean canvas to a submitted run in 12 steps — canvas, the four block kinds and where they come from (plugins), adding and configuring a source, validation, chaining blocks via the + handle, a product and an output, then Run Once. Every action step has Show me.

**Rails.** Frontend validation only guarantees a valid configuration, not a successful run, so the tour pins one canonical pipeline verified end to end on the real backend: Operational forecast source (ecmwf-open-data, ifs-ens, recent base time) → Select (step 72) → Ensemble Statistics (2t, mean) → Map Plot (2t, global, png). Steps advance only with those values, the canonical wiring, and no stray blocks; the card explains what is off ("Not yet — set Forecast model to **ifs-ens**") and Show me fixes it. 

The visualise tour gets the same treatment for its two source slots (A = tour server, B = comparison server).

**Engine additions (generic, page-agnostic).** Attribute filters for anchor ids stamped on several elements (block nodes by kind), a `route` advance kind so the submit's navigation completes the tour, Show me `apply` effects, `explain` hints on signal/search steps, `<v>` and definition-supplied markup in copy (bold values, coloured kind names and A/B slots), and `yieldTo` so the card steps aside while a menu the step opens is visible. 

The coupling rule from #692 still enforced: page components import only `anchors.ts`, and the definition alone knows both sides.

**Entry points.** Header Help `?` on /configure opens a new guide (canvas, palette, configuring, validation, running) with a Guided-tours section, mirroring the compare viewer; `/configure?tour=first-run` launches by link.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
