### PR TITLE
fix(lens): strip inbound forwarding headers to avoid gunicorn 'Contradictory scheme headers'

### DIFF
--- a/backend/src/forecastbox/domain/lens/proxy.py
+++ b/backend/src/forecastbox/domain/lens/proxy.py
@@ -147,8 +147,27 @@ def _filtered_headers(headers: httpx.Headers | Headers, *, drop: frozenset[str] 
     return [(name, value) for name, value in headers.items() if name.lower() not in drop_names]
 
 
+#: Forwarding headers we (re)generate ourselves. Any inbound copies (set by an
+#: outer reverse proxy such as nginx) MUST be dropped before we append fresh ones:
+#: appending would leave the upstream with duplicate X-Forwarded-Proto values that
+#: disagree (nginx's "https" vs our internal "http"), which gunicorn rejects with
+#: "Contradictory scheme headers" (InvalidSchemeHeaders). We fold the inbound chain
+#: into our regenerated headers instead (X-Forwarded-For is extended, not dropped).
+_FORWARDING_HEADERS = frozenset(
+    {
+        "x-forwarded-for",
+        "x-forwarded-proto",
+        "x-forwarded-protocol",
+        "x-forwarded-ssl",
+        "x-forwarded-host",
+        "x-forwarded-prefix",
+        "forwarded",
+    }
+)
+
+
 def _build_upstream_headers(request: Request, port: int, lens_instance_id: LensInstanceId) -> list[tuple[str, str]]:
-    headers = _filtered_headers(request.headers, drop=frozenset({"host"}))
+    headers = _filtered_headers(request.headers, drop=frozenset({"host"}) | _FORWARDING_HEADERS)
 
     client_host = request.client.host if request.client is not None else None
     existing_xff = request.headers.get("x-forwarded-for")

--- a/backend/tests/unit/domain/lens/test_proxy.py
+++ b/backend/tests/unit/domain/lens/test_proxy.py
@@ -105,6 +105,35 @@ class TestBuildUpstreamHeaders:
         names = {name.lower() for name, _ in headers}
         assert "connection" not in names
 
+    def test_inbound_forwarding_headers_are_not_duplicated(self) -> None:
+        # An outer reverse proxy (nginx) already set X-Forwarded-Proto: https etc.
+        # We must regenerate a single, self-consistent set -- duplicate, disagreeing
+        # X-Forwarded-Proto values make gunicorn raise "Contradictory scheme headers".
+        request = _make_request(
+            headers=[
+                (b"host", b"example.com"),
+                (b"x-forwarded-proto", b"https"),
+                (b"x-forwarded-host", b"public.example.com"),
+                (b"x-forwarded-prefix", b"/outer"),
+                (b"forwarded", b"proto=https;host=public.example.com"),
+                (b"x-forwarded-for", b"203.0.113.9"),
+            ]
+        )
+        pairs = lens_proxy._build_upstream_headers(request, 19042, LensInstanceId("id-1"))
+        counts: dict[str, int] = {}
+        for name, _ in pairs:
+            counts[name.lower()] = counts.get(name.lower(), 0) + 1
+        assert counts["x-forwarded-proto"] == 1
+        assert counts["x-forwarded-host"] == 1
+        assert counts["x-forwarded-prefix"] == 1
+        assert counts["forwarded"] == 1
+        headers = dict(pairs)
+        # Our own values win; the inbound X-Forwarded-For chain is extended, not dropped.
+        assert headers["X-Forwarded-Proto"] == "http"
+        assert headers["X-Forwarded-Host"] == "example.com"
+        assert headers["X-Forwarded-Prefix"] == "/api/v1/lens/proxy/id-1"
+        assert headers["X-Forwarded-For"] == "203.0.113.9, 10.0.0.5"
+
 
 class TestForward:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

When FIAB runs behind a reverse proxy (e.g. nginx terminating TLS), every request to a WMS lens fails with:

> Bad Request — Contradictory scheme headers

The outer proxy sets `X-Forwarded-Proto: https`. The lens reverse proxy (`_build_upstream_headers`) forwarded that inbound header **and** appended its own `X-Forwarded-Proto` (the backend's internal scheme, `http`). SkinnyWMS's gunicorn then saw two disagreeing `X-Forwarded-Proto` values and rejected the request with `InvalidSchemeHeaders` ("Contradictory scheme headers", HTTP 400).

## Fix

In `backend/src/forecastbox/domain/lens/proxy.py`, drop all inbound forwarding headers (`X-Forwarded-For/Proto/Protocol/Ssl/Host/Prefix`, `Forwarded`) before regenerating our own single, self-consistent set. The `X-Forwarded-For` chain is preserved/extended, not lost.

This makes the lens proxy robust behind any outer reverse proxy without per-deployment nginx tweaks.

## Testing

- New unit test `test_inbound_forwarding_headers_are_not_duplicated` asserts each forwarding header appears exactly once, our values win, and the `X-Forwarded-For` chain is extended.
- Full lens-proxy unit suite passes; `ty` type-check clean.
- Verified end-to-end in a container behind nginx-style headers: proxied WMS `GetCapabilities` with `X-Forwarded-Proto: https` now returns **200** (was **400**). Confirmed directly against the lens gunicorn that a single scheme header -> 200 and duplicate disagreeing headers -> 400.