### PR TITLE
[deployment] dev docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,7 +11,6 @@ backend/MANIFEST.in
 **/node_modules
 
 # Build artifacts
-**/dist
 **/build
 cli/target/
 

--- a/.github/workflows/cd-docker.yml
+++ b/.github/workflows/cd-docker.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.release_tag }}
         run: |
-          just build "$RELEASE_TAG"
+          just buildRelease "$RELEASE_TAG"
 
       - name: Publish image
         if: ${{ github.event_name == 'release' || inputs.push }}

--- a/deployment/v2/.gitignore
+++ b/deployment/v2/.gitignore
@@ -1,2 +1,2 @@
-# possible remnant of the build command
-fiab.sh
+# possible leftovers by just
+just-*

--- a/deployment/v2/Dockerfile-base
+++ b/deployment/v2/Dockerfile-base
@@ -1,10 +1,9 @@
-# dockerfile with a plain fiab installation
+# dockerfile base for a fiab runtime
 # - slim debian as a base
 # - packages (bash+curl) for basic executability + getting remote data at runtime
 # - packages (libgfortran & friends) for being able to load ecmwf atlas lib
-# - the most recent release, pulled in at the build time
-# - no config override, meaning all defaults
-# - not properly warmed up (a TODO in fiab.sh captures this -- we do *not* install the default plugin, and we do *not* cache any runtime deps)
+# - packages (gdal) for that fiona unbuildable wheel required by ek plots < 1.0
+# - no fiab itself, thats in either Dockerfile-dev or Dockerfile-release
 
 FROM debian:stable-slim
 
@@ -12,13 +11,9 @@ RUN : \
     && apt-get update \
     && apt-get install -y bash curl ca-certificates \
     && apt-get install -y libgfortran5 libquadmath0 libgomp1 \
+    && apt-get install -y gdal-bin libgdal-dev g++ \
     && rm -rf /var/lib/apt/lists/* \
     && useradd --system --user-group --create-home --shell /bin/false fiab \
-    && :
+    && : ;
 
 USER fiab
-ARG FIAB_RELEASE="v0.0.0"
-ENV FIAB_RELEASE=$FIAB_RELEASE
-COPY fiab.sh /home/fiab/fiab.sh
-RUN /home/fiab/fiab.sh warmup
-ENTRYPOINT ["/home/fiab/fiab.sh"]

--- a/deployment/v2/Dockerfile-dev
+++ b/deployment/v2/Dockerfile-dev
@@ -1,0 +1,41 @@
+# dockerfile with the current state of the repo as the target
+# - installs just, uv
+# - installs vim, less, sqlite3
+# - copies the justfile and the whole backend directory
+# - uv sync correctly
+# - `just dev` as entrypoint
+
+FROM fiab-base:latest 
+
+USER root
+RUN apt-get update \
+    && apt install -y just \
+    && apt install -y less vim sqlite3 \
+    && : ;
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
+WORKDIR /home/fiab
+COPY justfile justfile
+COPY backend backend
+RUN rm -rf backend/.venv backend/.fiab backend/src/forecastbox/static && mkdir backend/.fiab
+COPY frontend/dist backend/src/forecastbox/static
+COPY install/artifacts.json install/artifacts.json
+# NOTE maybe allow for buildarg override?
+COPY deployment/v2/config.toml-dev backend/.fiab/config.toml
+# NOTE we need to still be root by now, COPY does *not* create files owned by USER
+RUN chown -R fiab:fiab /home/fiab
+
+# TODO this is slow and uncacheable -- instead run freeze to pylock in the outer just action, copy and venv install that first, and only then copy the rest of the backend
+# TODO for some reason ecmwf-base is also installed as a plugin -- eradicate! Null the store config?
+
+USER fiab
+ARG PYTHON_VERSION="3.13"
+ENV UV_PYTHON=$PYTHON_VERSION
+RUN : \
+     && cd backend && uv sync --extra runtime --all-packages && cd - \
+     && cd backend && mkdir .fiab/data_dir && echo "1761908420:d0.0.1" > .fiab/pylock.toml.timestamp && cd - \
+     && cd backend && FIAB_ROOT=.fiab uv run python -m forecastbox.entrypoint.warmup -p "localPluginTest:single,localPluginECMWF:single" && cd - \
+     && : ;
+
+
+ENTRYPOINT ["just", "dev"]

--- a/deployment/v2/Dockerfile-release
+++ b/deployment/v2/Dockerfile-release
@@ -1,0 +1,16 @@
+# dockerfile with a released fiab
+# - on top of Dockerfile-base
+# - the specified release, pulled in at the build time
+# - no config override, meaning all defaults
+
+FROM fiab-base:latest 
+
+ARG FIAB_RELEASE="v0.0.0"
+ENV FIAB_RELEASE=$FIAB_RELEASE
+RUN : \
+    && curl https://raw.githubusercontent.com/ecmwf/forecast-in-a-box/refs/tags/$FIAB_RELEASE/scripts/fiab.sh > /home/fiab/fiab.sh \
+    && chmod u+x /home/fiab/fiab.sh \
+    && /home/fiab/fiab.sh warmup \
+    && : ;
+
+ENTRYPOINT ["/home/fiab/fiab.sh"]

--- a/deployment/v2/config.toml-dev
+++ b/deployment/v2/config.toml-dev
@@ -1,0 +1,11 @@
+[external.plugin_stores.localPluginTest]
+url = "-e file://./packages/fiab-plugin-test"
+method = "localSingle"
+
+[external.plugin_stores.localPluginECMWF]
+url = "-e file://./packages/fiab-plugin-ecmwf"
+method = "localSingle"
+
+[external.artifact_stores.ecmwf]
+url = "file://./../install/artifacts.json"
+method = "file"

--- a/deployment/v2/justfile
+++ b/deployment/v2/justfile
@@ -6,30 +6,35 @@
 # that is guaranteed to be exec-able instead (the repo checkout itself).
 set tempdir := "."
 
-build release_tag="":
+buildRelease release_tag="":
     #!/usr/bin/env bash
-    cp ../../scripts/fiab.sh . # NOTE we could have context the repo root -- but too bulky and not needed
+    docker build -t fiab-base:latest -f Dockerfile-base .
     release_tag="{{release_tag}}"
     if [ -z "$release_tag" ]; then
         # NOTE that the backend version is not just for the tag, but also for invalidating the docker cache
-        backend_tag=$(git tag -l 'v*' | sed 's/^.//' | sort -V | tail -n1)
-        release_tag="v$backend_tag"
+        tag=$(git tag -l 'v*' | sed 's/^.//' | sort -V | tail -n1)
+        release_tag="v$tag"
+    else
+        tag="${release_tag#v}"
     fi
-    tag="${release_tag#v}"
-    docker build --build-arg FIAB_RELEASE="$release_tag" -t "fiab-slim:${tag}" -f Dockerfile-slim .
-    docker tag "fiab-slim:${tag}" fiab-slim:latest
+    docker build --build-arg FIAB_RELEASE="$release_tag" -t "fiab-slim:${tag}" -f Dockerfile-release .
+    docker tag "fiab-slim:${tag}" fiab-slim:release
 
-run:
-    docker run --rm -it -p 8000:8000 --shm-size=6gb fiab-slim:latest
-
-publish release_tag="":
+buildDev:
     #!/usr/bin/env bash
-    release_tag="{{release_tag}}"
-    if [ -z "$release_tag" ]; then
-        backend_tag=$(git tag -l 'v*' | sed 's/^.//' | sort -V | tail -n1)
-        release_tag="v$backend_tag"
+    docker build -t fiab-base:latest -f Dockerfile-base .
+    PYTHON_VERSION=$(uv run python --version | sed 's/Python \([0-9]\+\).\([0-9]\+\).*/\1.\2/')
+    docker build --build-arg PYTHON_VERSION="$PYTHON_VERSION" -t "fiab-slim:dev" -f Dockerfile-dev ../..
+
+run tag="release":
+    docker run --rm -it -p 8000:8000 --shm-size=6gb fiab-slim:"{{tag}}"
+
+publish tag="":
+    #!/usr/bin/env bash
+    tag="{{tag}}"
+    if [ -z "$tag" ]; then
+        tag=$(git tag -l 'v*' | sed 's/^.//' | sort -V | tail -n1)
     fi
-    tag="${release_tag#v}"
     registry="eccr.ecmwf.int/forecast-in-a-box/fiab-slim"
     docker tag "fiab-slim:${tag}" "${registry}:${tag}"
     docker tag "fiab-slim:${tag}" "${registry}:latest"

--- a/justfile
+++ b/justfile
@@ -74,7 +74,10 @@ dev *args:
 
     frontend_build_marker=frontend/dist/.git-commit
     frontend_build_needed=false
-    if [[ ! -L backend/src/forecastbox/static ||
+    if [[ ! -e frontend ]] ; then
+        # exotic scenario during docker dev
+        frontend_build_needed=false
+    elif [[ ! -L backend/src/forecastbox/static ||
         ! -d backend/src/forecastbox/static ||
         ! -f "$frontend_build_marker" ]] ; then
         frontend_build_needed=true


### PR DESCRIPTION
splits the docker `just build` command into buildRelease and buildDev

factors out the common platform docker file, and the two release/dev specifics docker files

makes the fiab.sh in the buildRelease to be pulled at runtime instead of copied from the repo

creates the dockerfile-dev to be based on `just dev` and `uv sync`
