### PR TITLE
fiab-core: add TimeDeltaType for ISO 8601 durations

### DIFF
--- a/backend/packages/fiab-core/src/fiab_core/types/__init__.py
+++ b/backend/packages/fiab-core/src/fiab_core/types/__init__.py
@@ -11,15 +11,17 @@
 FableType: Type system for Forecast As BLock Expression (Fable) configuration values.
 
 Provides parsing, validation, and conversion for a small set of type expressions:
-- str, int, float, date, datetime (atomic types)
-- timedelta (ISO 8601 duration, converted to datetime.timedelta)
-- none (the type whose only value is an explicit null)
-- country (string subtype)
-- enumClosed[subtype](...), enumOpen[subtype](...) (enumeration types, e.g. enumClosed[int](1,2))
-- list[FableType] (container types)
-- bboxWSEN (bounding box: exactly four integers, west-south-east-north, obeying constraints)
-- geodomain (bounding box or region/country names; the frontend renders a map/region picker)
-- union[FableType, ...] (union types)
+- str, int, float (common primitive types)
+- date, datetime, timedelta (ISO 8601 duration, converted to datetime.timedelta)
+- generic types and helpers:
+  - enumClosed[subtype](...), enumOpen[subtype](...) (enumeration types, e.g. enumClosed[int](1,2))
+  - list[FableType] (container type)
+  - union[FableType, ...] (union types)
+  - none (the type whose only value is an explicit null, to express optionality via union[?, none])
+- domain specific types:
+  - country (string subtype)
+  - bboxWSEN (bounding box: exactly four integers, west-south-east-north, obeying constraints)
+  - geodomain (bounding box or region/country names; the frontend renders a map/region picker)
 """
 
 from fiab_core.types.definitions import *

--- a/backend/packages/fiab-core/src/fiab_core/types/__init__.py
+++ b/backend/packages/fiab-core/src/fiab_core/types/__init__.py
@@ -12,6 +12,7 @@ FableType: Type system for Forecast As BLock Expression (Fable) configuration va
 
 Provides parsing, validation, and conversion for a small set of type expressions:
 - str, int, float, date, datetime (atomic types)
+- timedelta (ISO 8601 duration, converted to datetime.timedelta)
 - none (the type whose only value is an explicit null)
 - country (string subtype)
 - enumClosed[subtype](...), enumOpen[subtype](...) (enumeration types, e.g. enumClosed[int](1,2))

--- a/backend/packages/fiab-core/src/fiab_core/types/definitions.py
+++ b/backend/packages/fiab-core/src/fiab_core/types/definitions.py
@@ -10,8 +10,9 @@
 """Definitions of all the types"""
 
 import logging
+import re
 from abc import ABC, abstractmethod
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from typing import Any, Iterable, Literal, get_args
 
 import fiab_core  # to satisfy the type checker for artifacts annotation
@@ -141,6 +142,63 @@ class DatetimeType(FableType):
 
     def serialize(self) -> str:
         return "datetime"
+
+
+# NOTE deliberately no support for calendar-dependent components (years, months) since
+# they do not correspond to a fixed duration and would make the conversion ambiguous.
+# The leading 'P' designator is checked for and stripped separately, so it is not part
+# of this pattern. All groups are optional; at least one must actually be present for a
+# match to be considered meaningful (checked by the caller, since an all-absent match
+# still satisfies this regex, e.g. for a bare 'T').
+_TIMEDELTA_PATTERN = re.compile(
+    r"^"
+    r"(?:(?P<weeks>\d+)W)?"
+    r"(?:(?P<days>\d+)D)?"
+    r"(?:T"
+    r"(?:(?P<hours>\d+)H)?"
+    r"(?:(?P<minutes>\d+)M)?"
+    r"(?:(?P<seconds>\d+(?:\.\d+)?)S)?"
+    r")?"
+    r"$"
+)
+
+
+class TimeDeltaType(FableType):
+    """The timedelta type. Converts an ISO 8601 duration string to datetime.timedelta.
+
+    Supports the fixed-length components weeks (W), days (D), hours (H), minutes (M) and
+    seconds (S, may be fractional), the latter three following a literal 'T' designator,
+    e.g. 'P3DT12H30M', 'PT30M', 'P1W'. Calendar-dependent components (years, months) are
+    not supported, since a fixed number of days cannot represent them unambiguously.
+
+    The leading 'P' designator is optional on input for convenience, so e.g. 'T12H' or
+    '3DT1M' are accepted too.
+    """
+
+    def validate_convert(self, value: Any) -> timedelta:
+        if not isinstance(value, str):
+            raise NotStringInput(f"Expected string, got {type(value).__name__}")
+
+        raw = value.strip()
+        body = raw[1:] if raw.startswith("P") else raw
+        if not body:
+            raise WrongType(f"Cannot parse {value!r} as timedelta (expected ISO 8601 duration format)")
+
+        match = _TIMEDELTA_PATTERN.match(body)
+        if match is None or not any(match.groupdict().values()):
+            raise WrongType(f"Cannot parse {value!r} as timedelta (expected ISO 8601 duration format)")
+
+        groups = match.groupdict()
+        return timedelta(
+            weeks=int(groups["weeks"] or 0),
+            days=int(groups["days"] or 0),
+            hours=int(groups["hours"] or 0),
+            minutes=int(groups["minutes"] or 0),
+            seconds=float(groups["seconds"] or 0),
+        )
+
+    def serialize(self) -> str:
+        return "timedelta"
 
 
 # GENERIC TYPES

--- a/backend/packages/fiab-core/src/fiab_core/types/parser.py
+++ b/backend/packages/fiab-core/src/fiab_core/types/parser.py
@@ -63,7 +63,7 @@ def _parse(type_expr: str) -> tuple[FableType, str]:
     was consumed.
 
     Supports:
-    - Atomic types: 'str', 'int', 'float', 'date', 'datetime', 'none', 'country', 'bboxWSEN'
+    - Atomic types: 'str', 'int', 'float', 'date', 'datetime', 'timedelta', 'none', 'country', 'bboxWSEN'
     - Enumerations: "enumClosed[str]('item1','item2')", "enumOpen[int](1,2)"
     - Lists: 'list[int]', 'list[enumClosed[...](...)]', etc.
     - Union: 'union[int,str]', "union[enumClosed[str]('a','b'),date]", etc.
@@ -77,6 +77,7 @@ def _parse(type_expr: str) -> tuple[FableType, str]:
     _ATOMIC = [
         ("datetime", DatetimeType),
         ("date", DateType),
+        ("timedelta", TimeDeltaType),
         ("float", FloatType),
         ("int", IntType),
         ("none", NoneType),
@@ -139,7 +140,7 @@ def _parse(type_expr: str) -> tuple[FableType, str]:
 
     raise NotFableType(
         f"Invalid type expression: {type_expr!r}. "
-        "Expected one of: str, int, float, date, datetime, none, country, bboxWSEN, geodomain, "
+        "Expected one of: str, int, float, date, datetime, timedelta, none, country, bboxWSEN, geodomain, "
         "enumClosed[subtype](...), enumOpen[subtype](...), list[...], union[...]"
     )
 

--- a/backend/packages/fiab-core/tests/test_types.py
+++ b/backend/packages/fiab-core/tests/test_types.py
@@ -9,7 +9,7 @@
 
 """Unit tests for FableType and its subclasses."""
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 import pytest
 
@@ -27,6 +27,7 @@ from fiab_core.types.definitions import (
     NoneType,
     OpenEnumType,
     StringType,
+    TimeDeltaType,
     UnionType,
 )
 from fiab_core.types.exceptions import (
@@ -203,6 +204,123 @@ class TestDatetimeType:
             t.validate_convert(datetime.now())
         with pytest.raises(NotStringInput):
             t.validate_convert(None)
+
+
+class TestTimeDeltaType:
+    """Tests for TimeDeltaType"""
+
+    def test_serialize(self) -> None:
+        assert TimeDeltaType().serialize() == "timedelta"
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("P1D", timedelta(days=1)),
+            ("P3D", timedelta(days=3)),
+            ("P1W", timedelta(weeks=1)),
+            ("P2W3D", timedelta(weeks=2, days=3)),
+            ("PT12H", timedelta(hours=12)),
+            ("PT30M", timedelta(minutes=30)),
+            ("PT45S", timedelta(seconds=45)),
+            ("PT1.5S", timedelta(seconds=1.5)),
+            ("P3DT12H", timedelta(days=3, hours=12)),
+            ("P3DT1M", timedelta(days=3, minutes=1)),
+            ("PT1H30M15S", timedelta(hours=1, minutes=30, seconds=15)),
+            ("P0D", timedelta(0)),
+        ],
+    )
+    def test_convert_valid_iso8601_with_p_prefix(self, value: str, expected: timedelta) -> None:
+        assert TimeDeltaType().validate_convert(value) == expected
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("T12H", timedelta(hours=12)),
+            ("3DT1M", timedelta(days=3, minutes=1)),
+            ("1W", timedelta(weeks=1)),
+            ("3D", timedelta(days=3)),
+            ("T30M15S", timedelta(minutes=30, seconds=15)),
+        ],
+    )
+    def test_convert_valid_iso8601_without_p_prefix(self, value: str, expected: timedelta) -> None:
+        assert TimeDeltaType().validate_convert(value) == expected
+
+    def test_convert_empty_string_raises(self) -> None:
+        with pytest.raises(WrongType):
+            TimeDeltaType().validate_convert("")
+        with pytest.raises(WrongType):
+            TimeDeltaType().validate_convert("P")
+
+    def test_convert_no_components_raises(self) -> None:
+        # a bare 'T' (with or without the 'P') carries no actual duration
+        with pytest.raises(WrongType):
+            TimeDeltaType().validate_convert("PT")
+        with pytest.raises(WrongType):
+            TimeDeltaType().validate_convert("T")
+
+    def test_convert_unsupported_calendar_components_raises(self) -> None:
+        # years and months are deliberately unsupported: not a fixed duration
+        with pytest.raises(WrongType):
+            TimeDeltaType().validate_convert("P1Y")
+        with pytest.raises(WrongType):
+            TimeDeltaType().validate_convert("P1M")
+
+    def test_convert_garbage_raises(self) -> None:
+        with pytest.raises(WrongType):
+            TimeDeltaType().validate_convert("not_a_duration")
+        with pytest.raises(WrongType):
+            TimeDeltaType().validate_convert("P3Dfoo")
+
+    def test_convert_non_string_raises_type_error(self) -> None:
+        t = TimeDeltaType()
+        with pytest.raises(NotStringInput):
+            t.validate_convert(timedelta(days=1))
+        with pytest.raises(NotStringInput):
+            t.validate_convert(None)
+
+    def test_parse_and_round_trip(self) -> None:
+        t = parse("timedelta")
+        assert isinstance(t, TimeDeltaType)
+        assert t.validate_convert("P3DT12H") == timedelta(days=3, hours=12)
+        assert t.serialize() == "timedelta"
+
+
+class TestTimeDeltaCombinations:
+    """Tests combining TimeDeltaType with other types (list, union)."""
+
+    def test_list_of_timedelta(self) -> None:
+        t = parse("list[timedelta]")
+        assert isinstance(t, ListType)
+        assert isinstance(t.item_type, TimeDeltaType)
+        assert t.validate_convert("P1D,PT12H,T30M") == [
+            timedelta(days=1),
+            timedelta(hours=12),
+            timedelta(minutes=30),
+        ]
+
+    def test_union_timedelta_and_string(self) -> None:
+        t = parse("union[timedelta,str]")
+        assert isinstance(t, UnionType)
+        assert t.validate_convert("P1D") == timedelta(days=1)
+        assert t.validate_convert("hello") == "hello"
+
+    def test_union_timedelta_and_datetime(self) -> None:
+        t = parse("union[timedelta,datetime]")
+        assert isinstance(t, UnionType)
+        assert t.validate_convert("P1DT12H") == timedelta(days=1, hours=12)
+        assert t.validate_convert("2026-05-08T10:30:45") == datetime(2026, 5, 8, 10, 30, 45)
+
+    def test_union_datetime_and_timedelta(self) -> None:
+        t = parse("union[datetime,timedelta]")
+        assert isinstance(t, UnionType)
+        assert t.validate_convert("2026-05-08T10:30:45") == datetime(2026, 5, 8, 10, 30, 45)
+        assert t.validate_convert("P1DT12H") == timedelta(days=1, hours=12)
+
+    def test_serialize_round_trip(self) -> None:
+        assert parse("list[timedelta]").serialize() == "list[timedelta]"
+        assert parse("union[timedelta,str]").serialize() == "union[timedelta,str]"
+        assert parse("union[timedelta,datetime]").serialize() == "union[timedelta,datetime]"
+        assert parse("union[datetime,timedelta]").serialize() == "union[datetime,timedelta]"
 
 
 class TestClosedEnumType:
@@ -393,6 +511,7 @@ class TestFableTypeParse:
         assert isinstance(parse("float"), FloatType)
         assert isinstance(parse("date"), DateType)
         assert isinstance(parse("datetime"), DatetimeType)
+        assert isinstance(parse("timedelta"), TimeDeltaType)
 
     def test_parse_whitespace_handling(self) -> None:
         assert isinstance(parse("  str  "), StringType)


### PR DESCRIPTION
Introduce a new FableType for datetime.timedelta values, serializing as 'timedelta'. Parsing follows ISO 8601 duration format (weeks, days, hours, minutes, seconds), with the leading 'P' designator optional on input (e.g. 'T12H' or '3DT1M' are accepted alongside 'PT12H'/'P3DT1M'). Calendar-dependent components (years, months) are not supported since they do not map to a fixed-length duration.

Registered the new atomic type in the parser and added unit tests, including combinations with list[timedelta] and union types (with string and datetime members, in both orderings).