### PR TITLE
fix: Switch MARS keys to extra_output_keys 

### DIFF
--- a/backend/packages/fiab-core/src/fiab_core/artifacts.py
+++ b/backend/packages/fiab-core/src/fiab_core/artifacts.py
@@ -109,6 +109,10 @@ class AnemoiCheckpoint(FiabCoreBaseModel):
     input_qube: dict[str, Any] = Field(description="Json Dump of the input qube structure, including variables, levels")
     output_qube: dict[str, Any] = Field(description="Json Dump of the output qube structure, including variables, levels, but not step")
 
+    supplementary_metadata: dict[str, list[str]] = Field(
+        default_factory=dict, description="Additional metadata for the checkpoint, stored as key-value pairs"
+    )
+
     configuration: AnemoiCheckpointConfiguration = Field(
         default_factory=AnemoiCheckpointConfiguration,
         description="Additional configuration for the checkpoint such as pre and post processors and control options",

--- a/backend/packages/fiab-core/src/fiab_core/artifacts.py
+++ b/backend/packages/fiab-core/src/fiab_core/artifacts.py
@@ -109,7 +109,7 @@ class AnemoiCheckpoint(FiabCoreBaseModel):
     input_qube: dict[str, Any] = Field(description="Json Dump of the input qube structure, including variables, levels")
     output_qube: dict[str, Any] = Field(description="Json Dump of the output qube structure, including variables, levels, but not step")
 
-    supplementary_metadata: dict[str, list[str]] = Field(
+    supplementary_metadata: dict[str, str] = Field(
         default_factory=dict, description="Additional metadata for the checkpoint, stored as key-value pairs"
     )
 

--- a/backend/packages/fiab-core/src/fiab_core/artifacts.py
+++ b/backend/packages/fiab-core/src/fiab_core/artifacts.py
@@ -109,8 +109,8 @@ class AnemoiCheckpoint(FiabCoreBaseModel):
     input_qube: dict[str, Any] = Field(description="Json Dump of the input qube structure, including variables, levels")
     output_qube: dict[str, Any] = Field(description="Json Dump of the output qube structure, including variables, levels, but not step")
 
-    supplementary_metadata: dict[str, str] = Field(
-        default_factory=dict, description="Additional metadata for the checkpoint, stored as key-value pairs"
+    extra_output_keys: dict[str, str] = Field(
+        default_factory=dict, description="Additional keys for output of a model, stored as key-value pairs"
     )
 
     configuration: AnemoiCheckpointConfiguration = Field(

--- a/backend/packages/fiab-plugin-ecmwf/scripts/get_metadata_from_anemoi.py
+++ b/backend/packages/fiab-plugin-ecmwf/scripts/get_metadata_from_anemoi.py
@@ -21,6 +21,8 @@ from typing import Any
 
 from qubed import Qube
 
+SUPPLEMENTARY_METADATA = {"class": ["ai"], "type": ["fc"], "stream": ["oper"]}
+
 
 @lru_cache(maxsize=None)
 def open_checkpoint(checkpoint_path: str) -> "Checkpoint":  # type: ignore
@@ -116,6 +118,7 @@ def generate_artifact_entry(
             "input_characteristics": [c.strip() for c in input_characteristics.split(",") if c.strip()],
             "input_qube": qubes["input_qube"],
             "output_qube": qubes["output_qube"],
+            "supplementary_metadata": SUPPLEMENTARY_METADATA,
             "input_options": {},
             "timestep": get_timestep(checkpoint_path),
         },

--- a/backend/packages/fiab-plugin-ecmwf/scripts/get_metadata_from_anemoi.py
+++ b/backend/packages/fiab-plugin-ecmwf/scripts/get_metadata_from_anemoi.py
@@ -21,7 +21,7 @@ from typing import Any
 
 from qubed import Qube
 
-SUPPLEMENTARY_METADATA = {"class": ["ai"], "type": ["fc"], "stream": ["oper"]}
+extra_output_keys = {"class": ["ai"], "type": ["fc"], "stream": ["oper"]}
 
 
 @lru_cache(maxsize=None)
@@ -118,7 +118,7 @@ def generate_artifact_entry(
             "input_characteristics": [c.strip() for c in input_characteristics.split(",") if c.strip()],
             "input_qube": qubes["input_qube"],
             "output_qube": qubes["output_qube"],
-            "supplementary_metadata": SUPPLEMENTARY_METADATA,
+            "extra_output_keys": extra_output_keys,
             "input_options": {},
             "timestep": get_timestep(checkpoint_path),
         },

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
@@ -71,6 +71,15 @@ class AnemoiBuilder:
         "Get local path to the checkpoint artifact, assumes it is already locally available, does not trigger download"
         return self.checkpoint.get_local_path()
 
+    def _add_supplementary_metadata(self, action: Action) -> Action:
+        """Add supplementary metadata from the checkpoint to the action.
+
+        Must be added to the action to ensure at compilation time that the metadata is available.
+        """
+        for key, values in self.checkpoint.supplementary_metadata.items():
+            action.set_scalar_coords({key: values})
+        return action
+
     def inference(self, lead_time: int, *, extra_environment: list[str] | None = None) -> Inference:
         """Build an Inference action for this checkpoint and lead time, with the appropriate environment for the input source if specified"""
         env = self.checkpoint.get_environment()
@@ -86,7 +95,7 @@ class AnemoiBuilder:
 
     def from_input(self, input_source: str, date: datetime, lead_time: int, ensemble: int = 1, **k: Any) -> Action:
         input_configuration = self.checkpoint.get_input_configuration(input_source)
-        return self.inference(lead_time=lead_time, extra_environment=INPUT_SOURCE_EXTRAS.get(input_source)).from_input(
+        action = self.inference(lead_time=lead_time, extra_environment=INPUT_SOURCE_EXTRAS.get(input_source)).from_input(
             input=input_configuration,
             date=strip_timezone(date),
             lead_time=lead_time,
@@ -94,11 +103,13 @@ class AnemoiBuilder:
             **k,
             payload_metadata={"artifacts": [self.artifact_id]},
         )
+        return self._add_supplementary_metadata(action)
 
     def from_initial_conditions(self, initial_conditions: Any, lead_time: int, **k: Any) -> Action:
-        return self.inference(lead_time=lead_time).from_initial_conditions(
+        action = self.inference(lead_time=lead_time).from_initial_conditions(
             initial_conditions, **k, payload_metadata={"artifacts": [self.artifact_id]}
         )
+        return self._add_supplementary_metadata(action)
 
     def get_initial_conditions(self, input_source: str, date: datetime, ensemble: int = 1, **k: Any) -> Action:
         env = self.checkpoint.get_environment()
@@ -165,6 +176,10 @@ class AnemoiBaseBlock:
     ) -> QubedOutput:
         """Get the output qube for the given checkpoint, lead time, and ensemble members"""
         qubed_output = checkpoint.combine_if_nested_qube(checkpoint.get_model_output(lead_time))
+
+        # Ensure alignment in output qube and action metadata
+        qubed_output = expand(qubed_output, checkpoint.supplementary_metadata)
+
         if checkpoint.is_ensemble_model is False:
             return QubedOutput(dataqube=qubed_output)
 

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/blocks.py
@@ -71,12 +71,12 @@ class AnemoiBuilder:
         "Get local path to the checkpoint artifact, assumes it is already locally available, does not trigger download"
         return self.checkpoint.get_local_path()
 
-    def _add_supplementary_metadata(self, action: Action) -> Action:
+    def _add_extra_output_keys(self, action: Action) -> Action:
         """Add supplementary metadata from the checkpoint to the action.
 
         Must be added to the action to ensure at compilation time that the metadata is available.
         """
-        for key, values in self.checkpoint.supplementary_metadata.items():
+        for key, values in self.checkpoint.extra_output_keys.items():
             action.set_scalar_coords({key: values})
         return action
 
@@ -103,13 +103,13 @@ class AnemoiBuilder:
             **k,
             payload_metadata={"artifacts": [self.artifact_id]},
         )
-        return self._add_supplementary_metadata(action)
+        return self._add_extra_output_keys(action)
 
     def from_initial_conditions(self, initial_conditions: Any, lead_time: int, **k: Any) -> Action:
         action = self.inference(lead_time=lead_time).from_initial_conditions(
             initial_conditions, **k, payload_metadata={"artifacts": [self.artifact_id]}
         )
-        return self._add_supplementary_metadata(action)
+        return self._add_extra_output_keys(action)
 
     def get_initial_conditions(self, input_source: str, date: datetime, ensemble: int = 1, **k: Any) -> Action:
         env = self.checkpoint.get_environment()
@@ -178,7 +178,7 @@ class AnemoiBaseBlock:
         qubed_output = checkpoint.combine_if_nested_qube(checkpoint.get_model_output(lead_time))
 
         # Ensure alignment in output qube and action metadata
-        qubed_output = expand(qubed_output, checkpoint.supplementary_metadata)
+        qubed_output = expand(qubed_output, checkpoint.extra_output_keys)
 
         if checkpoint.is_ensemble_model is False:
             return QubedOutput(dataqube=qubed_output)

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/utils.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/utils.py
@@ -127,7 +127,7 @@ class CheckpointArtifact:
         return checkpoint.configuration.is_ensemble_model is True
 
     @property
-    def supplementary_metadata(self) -> dict[str, list[str]]:
+    def supplementary_metadata(self) -> dict[str, str]:
         """Additional metadata from the checkpoint artifact for use in actions and qubes.
 
         i.e. MARS metadata

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/utils.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/utils.py
@@ -126,6 +126,14 @@ class CheckpointArtifact:
             return None
         return checkpoint.configuration.is_ensemble_model is True
 
+    @property
+    def supplementary_metadata(self) -> dict[str, list[str]]:
+        """Additional metadata from the checkpoint artifact for use in actions and qubes.
+
+        i.e. MARS metadata
+        """
+        return self.checkpoint().supplementary_metadata
+
     def get_model_output(self, lead_time: int) -> Qube | dict[str, Qube]:
         """Get the model output qube from the checkpoint artifact"""
         checkpoint = self.checkpoint()

--- a/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/utils.py
+++ b/backend/packages/fiab-plugin-ecmwf/src/fiab_plugin_ecmwf/anemoi/utils.py
@@ -127,12 +127,12 @@ class CheckpointArtifact:
         return checkpoint.configuration.is_ensemble_model is True
 
     @property
-    def supplementary_metadata(self) -> dict[str, str]:
+    def extra_output_keys(self) -> dict[str, str]:
         """Additional metadata from the checkpoint artifact for use in actions and qubes.
 
         i.e. MARS metadata
         """
-        return self.checkpoint().supplementary_metadata
+        return self.checkpoint().extra_output_keys
 
     def get_model_output(self, lead_time: int) -> Qube | dict[str, Qube]:
         """Get the model output qube from the checkpoint artifact"""

--- a/install/artifacts.json
+++ b/install/artifacts.json
@@ -2307,7 +2307,7 @@
           },
           "input_options": [
             {
-              "source0": {
+              "lam_0": {
                 "grid": "N320",
                 "pre_processors": [
                   {
@@ -2323,7 +2323,7 @@
             }
           ],
           "nested_model": true,
-          "region_of_interest": "source0"
+          "region_of_interest": "lam_0"
         },
         "timestep": "6h"
       }
@@ -2962,7 +2962,7 @@
           },
           "input_options": [
             {
-              "source0": {
+              "lam_0": {
                 "grid": "N320",
                 "pre_processors": [
                   {
@@ -2978,7 +2978,7 @@
             }
           ],
           "nested_model": true,
-          "region_of_interest": "source0"
+          "region_of_interest": "lam_0"
         },
         "timestep": "6h"
       }
@@ -3613,7 +3613,7 @@
           },
           "input_options": [
             {
-              "source0": {
+              "lam_0": {
                 "grid": "n320",
                 "pre_processors": [
                   {
@@ -3632,7 +3632,7 @@
             }
           ],
           "nested_model": true,
-          "region_of_interest": "source0"
+          "region_of_interest": "lam_0"
         },
         "timestep": "6h"
       }

--- a/install/artifacts.json
+++ b/install/artifacts.json
@@ -14,7 +14,7 @@
           "macos"
         ],
         "tags": {
-            "status": "demo"
+          "status": "demo"
         }
       },
       "specific": {
@@ -169,44 +169,6 @@
           "metadata": {},
           "children": [
             {
-              "key": "class",
-              "values": {
-                "type": "enum",
-                "dtype": "str",
-                "values": [
-                  "ai"
-                ]
-              },
-              "metadata": {},
-              "children": [
-                {
-                  "key": "type",
-                  "values": {
-                    "type": "enum",
-                    "dtype": "str",
-                    "values": [
-                      "fc"
-                    ]
-                  },
-                  "metadata": {},
-                  "children": [
-                    {
-                      "key": "stream",
-                      "values": {
-                        "type": "enum",
-                        "dtype": "str",
-                        "values": [
-                          "oper"
-                        ]
-                      },
-                      "metadata": {},
-                      "children": []
-                    }
-                  ]
-                }
-              ]
-            },
-            {
               "key": "levtype",
               "values": {
                 "type": "enum",
@@ -321,6 +283,17 @@
             }
           ]
         },
+        "supplementary_metadata": {
+          "stream": [
+            "oper"
+          ],
+          "type": [
+            "fc"
+          ],
+          "class": [
+            "ai"
+          ]
+        },
         "timestep": "6h"
       }
     },
@@ -336,7 +309,7 @@
           "linux"
         ],
         "tags": {
-            "status": "operational"
+          "status": "operational"
         }
       },
       "specific": {
@@ -496,44 +469,6 @@
           "metadata": {},
           "children": [
             {
-              "key": "class",
-              "values": {
-                "type": "enum",
-                "dtype": "str",
-                "values": [
-                  "ai"
-                ]
-              },
-              "metadata": {},
-              "children": [
-                {
-                  "key": "type",
-                  "values": {
-                    "type": "enum",
-                    "dtype": "str",
-                    "values": [
-                      "fc"
-                    ]
-                  },
-                  "metadata": {},
-                  "children": [
-                    {
-                      "key": "stream",
-                      "values": {
-                        "type": "enum",
-                        "dtype": "str",
-                        "values": [
-                          "oper"
-                        ]
-                      },
-                      "metadata": {},
-                      "children": []
-                    }
-                  ]
-                }
-              ]
-            },
-            {
               "key": "levtype",
               "values": {
                 "type": "enum",
@@ -664,6 +599,17 @@
             }
           ]
         },
+        "supplementary_metadata": {
+          "stream": [
+            "oper"
+          ],
+          "type": [
+            "fc"
+          ],
+          "class": [
+            "ai"
+          ]
+        },
         "timestep": "6h",
         "configuration": {
           "control_options": {
@@ -685,7 +631,7 @@
           "macos"
         ],
         "tags": {
-            "status": "operational"
+          "status": "operational"
         }
       },
       "specific": {
@@ -844,44 +790,6 @@
           "metadata": {},
           "children": [
             {
-              "key": "class",
-              "values": {
-                "type": "enum",
-                "dtype": "str",
-                "values": [
-                  "ai"
-                ]
-              },
-              "metadata": {},
-              "children": [
-                {
-                  "key": "type",
-                  "values": {
-                    "type": "enum",
-                    "dtype": "str",
-                    "values": [
-                      "fc"
-                    ]
-                  },
-                  "metadata": {},
-                  "children": [
-                    {
-                      "key": "stream",
-                      "values": {
-                        "type": "enum",
-                        "dtype": "str",
-                        "values": [
-                          "oper"
-                        ]
-                      },
-                      "metadata": {},
-                      "children": []
-                    }
-                  ]
-                }
-              ]
-            },
-            {
               "key": "levtype",
               "values": {
                 "type": "enum",
@@ -1012,6 +920,17 @@
             }
           ]
         },
+        "supplementary_metadata": {
+          "stream": [
+            "oper"
+          ],
+          "type": [
+            "fc"
+          ],
+          "class": [
+            "ai"
+          ]
+        },
         "timestep": "6h",
         "configuration": {
           "control_options": {
@@ -1032,7 +951,7 @@
           "linux"
         ],
         "tags": {
-            "status": "operational"
+          "status": "operational"
         }
       },
       "specific": {
@@ -1190,44 +1109,6 @@
           "metadata": {},
           "children": [
             {
-              "key": "class",
-              "values": {
-                "type": "enum",
-                "dtype": "str",
-                "values": [
-                  "ai"
-                ]
-              },
-              "metadata": {},
-              "children": [
-                {
-                  "key": "type",
-                  "values": {
-                    "type": "enum",
-                    "dtype": "str",
-                    "values": [
-                      "fc"
-                    ]
-                  },
-                  "metadata": {},
-                  "children": [
-                    {
-                      "key": "stream",
-                      "values": {
-                        "type": "enum",
-                        "dtype": "str",
-                        "values": [
-                          "oper"
-                        ]
-                      },
-                      "metadata": {},
-                      "children": []
-                    }
-                  ]
-                }
-              ]
-            },
-            {
               "key": "levtype",
               "values": {
                 "type": "enum",
@@ -1356,6 +1237,17 @@
             }
           ]
         },
+        "supplementary_metadata": {
+          "stream": [
+            "oper"
+          ],
+          "type": [
+            "fc"
+          ],
+          "class": [
+            "ai"
+          ]
+        },
         "timestep": "6h",
         "configuration": {
           "control_options": {
@@ -1377,7 +1269,7 @@
           "macos"
         ],
         "tags": {
-            "status": "operational"
+          "status": "operational"
         }
       },
       "specific": {
@@ -1535,44 +1427,6 @@
           "metadata": {},
           "children": [
             {
-              "key": "class",
-              "values": {
-                "type": "enum",
-                "dtype": "str",
-                "values": [
-                  "ai"
-                ]
-              },
-              "metadata": {},
-              "children": [
-                {
-                  "key": "type",
-                  "values": {
-                    "type": "enum",
-                    "dtype": "str",
-                    "values": [
-                      "fc"
-                    ]
-                  },
-                  "metadata": {},
-                  "children": [
-                    {
-                      "key": "stream",
-                      "values": {
-                        "type": "enum",
-                        "dtype": "str",
-                        "values": [
-                          "oper"
-                        ]
-                      },
-                      "metadata": {},
-                      "children": []
-                    }
-                  ]
-                }
-              ]
-            },
-            {
               "key": "levtype",
               "values": {
                 "type": "enum",
@@ -1701,6 +1555,17 @@
             }
           ]
         },
+        "supplementary_metadata": {
+          "stream": [
+            "oper"
+          ],
+          "type": [
+            "fc"
+          ],
+          "class": [
+            "ai"
+          ]
+        },
         "timestep": "6h",
         "configuration": {
           "control_options": {
@@ -1721,7 +1586,7 @@
           "linux"
         ],
         "tags": {
-            "status": "operational"
+          "status": "operational"
         }
       },
       "specific": {
@@ -1929,44 +1794,6 @@
           "metadata": {},
           "children": [
             {
-              "key": "class",
-              "values": {
-                "type": "enum",
-                "dtype": "str",
-                "values": [
-                  "ai"
-                ]
-              },
-              "metadata": {},
-              "children": [
-                {
-                  "key": "type",
-                  "values": {
-                    "type": "enum",
-                    "dtype": "str",
-                    "values": [
-                      "fc"
-                    ]
-                  },
-                  "metadata": {},
-                  "children": [
-                    {
-                      "key": "stream",
-                      "values": {
-                        "type": "enum",
-                        "dtype": "str",
-                        "values": [
-                          "oper"
-                        ]
-                      },
-                      "metadata": {},
-                      "children": []
-                    }
-                  ]
-                }
-              ]
-            },
-            {
               "key": "levtype",
               "values": {
                 "type": "enum",
@@ -2145,6 +1972,17 @@
             }
           ]
         },
+        "supplementary_metadata": {
+          "stream": [
+            "oper"
+          ],
+          "type": [
+            "fc"
+          ],
+          "class": [
+            "ai"
+          ]
+        },
         "timestep": "6h",
         "configuration": {
           "pre_processors": [
@@ -2169,7 +2007,7 @@
         "display_description": "",
         "comment": "",
         "tags": {
-            "status": "operational"
+          "status": "operational"
         },
         "disk_size_bytes": 1330651150,
         "supported_platforms": [
@@ -2332,44 +2170,6 @@
           "metadata": {},
           "children": [
             {
-              "key": "class",
-              "values": {
-                "type": "enum",
-                "dtype": "str",
-                "values": [
-                  "ai"
-                ]
-              },
-              "metadata": {},
-              "children": [
-                {
-                  "key": "type",
-                  "values": {
-                    "type": "enum",
-                    "dtype": "str",
-                    "values": [
-                      "fc"
-                    ]
-                  },
-                  "metadata": {},
-                  "children": [
-                    {
-                      "key": "stream",
-                      "values": {
-                        "type": "enum",
-                        "dtype": "str",
-                        "values": [
-                          "oper"
-                        ]
-                      },
-                      "metadata": {},
-                      "children": []
-                    }
-                  ]
-                }
-              ]
-            },
-            {
               "key": "levtype",
               "values": {
                 "type": "enum",
@@ -2488,6 +2288,17 @@
             }
           ]
         },
+        "supplementary_metadata": {
+          "stream": [
+            "oper"
+          ],
+          "type": [
+            "fc"
+          ],
+          "class": [
+            "ai"
+          ]
+        },
         "configuration": {
           "pre_processors": [],
           "post_processors": [],
@@ -2526,7 +2337,7 @@
         "display_description": "",
         "comment": "",
         "tags": {
-            "status": "operational"
+          "status": "operational"
         },
         "disk_size_bytes": 993937386,
         "supported_platforms": [
@@ -2690,44 +2501,6 @@
           "metadata": {},
           "children": [
             {
-              "key": "class",
-              "values": {
-                "type": "enum",
-                "dtype": "str",
-                "values": [
-                  "ai"
-                ]
-              },
-              "metadata": {},
-              "children": [
-                {
-                  "key": "type",
-                  "values": {
-                    "type": "enum",
-                    "dtype": "str",
-                    "values": [
-                      "fc"
-                    ]
-                  },
-                  "metadata": {},
-                  "children": [
-                    {
-                      "key": "stream",
-                      "values": {
-                        "type": "enum",
-                        "dtype": "str",
-                        "values": [
-                          "oper"
-                        ]
-                      },
-                      "metadata": {},
-                      "children": []
-                    }
-                  ]
-                }
-              ]
-            },
-            {
               "key": "levtype",
               "values": {
                 "type": "enum",
@@ -2858,6 +2631,17 @@
             }
           ]
         },
+        "supplementary_metadata": {
+          "stream": [
+            "oper"
+          ],
+          "type": [
+            "fc"
+          ],
+          "class": [
+            "ai"
+          ]
+        },
         "configuration": {
           "pre_processors": [],
           "post_processors": [],
@@ -2878,7 +2662,7 @@
         "display_description": "",
         "comment": "",
         "tags": {
-            "status": "operational"
+          "status": "operational"
         },
         "disk_size_bytes": 1449403913,
         "supported_platforms": [
@@ -3041,44 +2825,6 @@
           "metadata": {},
           "children": [
             {
-              "key": "class",
-              "values": {
-                "type": "enum",
-                "dtype": "str",
-                "values": [
-                  "ai"
-                ]
-              },
-              "metadata": {},
-              "children": [
-                {
-                  "key": "type",
-                  "values": {
-                    "type": "enum",
-                    "dtype": "str",
-                    "values": [
-                      "fc"
-                    ]
-                  },
-                  "metadata": {},
-                  "children": [
-                    {
-                      "key": "stream",
-                      "values": {
-                        "type": "enum",
-                        "dtype": "str",
-                        "values": [
-                          "oper"
-                        ]
-                      },
-                      "metadata": {},
-                      "children": []
-                    }
-                  ]
-                }
-              ]
-            },
-            {
               "key": "levtype",
               "values": {
                 "type": "enum",
@@ -3197,6 +2943,17 @@
             }
           ]
         },
+        "supplementary_metadata": {
+          "stream": [
+            "oper"
+          ],
+          "type": [
+            "fc"
+          ],
+          "class": [
+            "ai"
+          ]
+        },
         "configuration": {
           "pre_processors": [],
           "post_processors": [],
@@ -3235,7 +2992,7 @@
         "display_description": "",
         "comment": "",
         "tags": {
-            "status": "operational"
+          "status": "operational"
         },
         "disk_size_bytes": 1891893167,
         "supported_platforms": [
@@ -3394,44 +3151,6 @@
           "metadata": {},
           "children": [
             {
-              "key": "class",
-              "values": {
-                "type": "enum",
-                "dtype": "str",
-                "values": [
-                  "ai"
-                ]
-              },
-              "metadata": {},
-              "children": [
-                {
-                  "key": "type",
-                  "values": {
-                    "type": "enum",
-                    "dtype": "str",
-                    "values": [
-                      "fc"
-                    ]
-                  },
-                  "metadata": {},
-                  "children": [
-                    {
-                      "key": "stream",
-                      "values": {
-                        "type": "enum",
-                        "dtype": "str",
-                        "values": [
-                          "oper"
-                        ]
-                      },
-                      "metadata": {},
-                      "children": []
-                    }
-                  ]
-                }
-              ]
-            },
-            {
               "key": "levtype",
               "values": {
                 "type": "enum",
@@ -3544,6 +3263,17 @@
             }
           ]
         },
+        "supplementary_metadata": {
+          "stream": [
+            "oper"
+          ],
+          "type": [
+            "fc"
+          ],
+          "class": [
+            "ai"
+          ]
+        },
         "configuration": {
           "pre_processors": [],
           "post_processors": [],
@@ -3582,7 +3312,7 @@
         "display_description": "",
         "comment": "",
         "tags": {
-            "status": "demo"
+          "status": "demo"
         },
         "disk_size_bytes": 1016336351,
         "supported_platforms": [
@@ -3746,44 +3476,6 @@
           "metadata": {},
           "children": [
             {
-              "key": "class",
-              "values": {
-                "type": "enum",
-                "dtype": "str",
-                "values": [
-                  "ai"
-                ]
-              },
-              "metadata": {},
-              "children": [
-                {
-                  "key": "type",
-                  "values": {
-                    "type": "enum",
-                    "dtype": "str",
-                    "values": [
-                      "fc"
-                    ]
-                  },
-                  "metadata": {},
-                  "children": [
-                    {
-                      "key": "stream",
-                      "values": {
-                        "type": "enum",
-                        "dtype": "str",
-                        "values": [
-                          "oper"
-                        ]
-                      },
-                      "metadata": {},
-                      "children": []
-                    }
-                  ]
-                }
-              ]
-            },
-            {
               "key": "levtype",
               "values": {
                 "type": "enum",
@@ -3900,6 +3592,17 @@
                 }
               ]
             }
+          ]
+        },
+        "supplementary_metadata": {
+          "stream": [
+            "oper"
+          ],
+          "type": [
+            "fc"
+          ],
+          "class": [
+            "ai"
           ]
         },
         "configuration": {

--- a/install/artifacts.json
+++ b/install/artifacts.json
@@ -284,15 +284,9 @@
           ]
         },
         "supplementary_metadata": {
-          "stream": [
-            "oper"
-          ],
-          "type": [
-            "fc"
-          ],
-          "class": [
-            "ai"
-          ]
+          "stream": "oper",
+          "type": "fc",
+          "class": "ai"
         },
         "timestep": "6h"
       }
@@ -600,15 +594,9 @@
           ]
         },
         "supplementary_metadata": {
-          "stream": [
-            "oper"
-          ],
-          "type": [
-            "fc"
-          ],
-          "class": [
-            "ai"
-          ]
+          "stream": "oper",
+          "type": "fc",
+          "class": "ai"
         },
         "timestep": "6h",
         "configuration": {
@@ -921,15 +909,9 @@
           ]
         },
         "supplementary_metadata": {
-          "stream": [
-            "oper"
-          ],
-          "type": [
-            "fc"
-          ],
-          "class": [
-            "ai"
-          ]
+          "stream": "oper",
+          "type": "fc",
+          "class": "ai"
         },
         "timestep": "6h",
         "configuration": {
@@ -1238,15 +1220,9 @@
           ]
         },
         "supplementary_metadata": {
-          "stream": [
-            "oper"
-          ],
-          "type": [
-            "fc"
-          ],
-          "class": [
-            "ai"
-          ]
+          "stream": "oper",
+          "type": "fc",
+          "class": "ai"
         },
         "timestep": "6h",
         "configuration": {
@@ -1556,15 +1532,9 @@
           ]
         },
         "supplementary_metadata": {
-          "stream": [
-            "oper"
-          ],
-          "type": [
-            "fc"
-          ],
-          "class": [
-            "ai"
-          ]
+          "stream": "oper",
+          "type": "fc",
+          "class": "ai"
         },
         "timestep": "6h",
         "configuration": {
@@ -1973,15 +1943,9 @@
           ]
         },
         "supplementary_metadata": {
-          "stream": [
-            "oper"
-          ],
-          "type": [
-            "fc"
-          ],
-          "class": [
-            "ai"
-          ]
+          "stream": "oper",
+          "type": "fc",
+          "class": "ai"
         },
         "timestep": "6h",
         "configuration": {
@@ -2289,15 +2253,9 @@
           ]
         },
         "supplementary_metadata": {
-          "stream": [
-            "oper"
-          ],
-          "type": [
-            "fc"
-          ],
-          "class": [
-            "ai"
-          ]
+          "stream": "oper",
+          "type": "fc",
+          "class": "ai"
         },
         "configuration": {
           "pre_processors": [],
@@ -2632,15 +2590,9 @@
           ]
         },
         "supplementary_metadata": {
-          "stream": [
-            "oper"
-          ],
-          "type": [
-            "fc"
-          ],
-          "class": [
-            "ai"
-          ]
+          "stream": "oper",
+          "type": "fc",
+          "class": "ai"
         },
         "configuration": {
           "pre_processors": [],
@@ -2944,15 +2896,9 @@
           ]
         },
         "supplementary_metadata": {
-          "stream": [
-            "oper"
-          ],
-          "type": [
-            "fc"
-          ],
-          "class": [
-            "ai"
-          ]
+          "stream": "oper",
+          "type": "fc",
+          "class": "ai"
         },
         "configuration": {
           "pre_processors": [],
@@ -3264,15 +3210,9 @@
           ]
         },
         "supplementary_metadata": {
-          "stream": [
-            "oper"
-          ],
-          "type": [
-            "fc"
-          ],
-          "class": [
-            "ai"
-          ]
+          "stream": "oper",
+          "type": "fc",
+          "class": "ai"
         },
         "configuration": {
           "pre_processors": [],
@@ -3595,15 +3535,9 @@
           ]
         },
         "supplementary_metadata": {
-          "stream": [
-            "oper"
-          ],
-          "type": [
-            "fc"
-          ],
-          "class": [
-            "ai"
-          ]
+          "stream": "oper",
+          "type": "fc",
+          "class": "ai"
         },
         "configuration": {
           "pre_processors": [],

--- a/install/artifacts.json
+++ b/install/artifacts.json
@@ -2307,7 +2307,7 @@
           },
           "input_options": [
             {
-              "lam_0": {
+              "source0": {
                 "grid": "N320",
                 "pre_processors": [
                   {
@@ -2323,7 +2323,7 @@
             }
           ],
           "nested_model": true,
-          "region_of_interest": "lam_0"
+          "region_of_interest": "source0"
         },
         "timestep": "6h"
       }
@@ -2962,7 +2962,7 @@
           },
           "input_options": [
             {
-              "lam_0": {
+              "source0": {
                 "grid": "N320",
                 "pre_processors": [
                   {
@@ -2978,7 +2978,7 @@
             }
           ],
           "nested_model": true,
-          "region_of_interest": "lam_0"
+          "region_of_interest": "source0"
         },
         "timestep": "6h"
       }
@@ -3282,7 +3282,7 @@
           },
           "input_options": [
             {
-              "lam_0": {
+              "source0": {
                 "grid": "N320",
                 "pre_processors": [
                   {
@@ -3298,7 +3298,7 @@
             }
           ],
           "nested_model": true,
-          "region_of_interest": "lam_0"
+          "region_of_interest": "source0"
         },
         "timestep": "6h"
       }
@@ -3613,7 +3613,7 @@
           },
           "input_options": [
             {
-              "lam_0": {
+              "source0": {
                 "grid": "n320",
                 "pre_processors": [
                   {
@@ -3632,7 +3632,7 @@
             }
           ],
           "nested_model": true,
-          "region_of_interest": "lam_0"
+          "region_of_interest": "source0"
         },
         "timestep": "6h"
       }

--- a/install/artifacts.json
+++ b/install/artifacts.json
@@ -283,7 +283,7 @@
             }
           ]
         },
-        "supplementary_metadata": {
+        "extra_output_keys": {
           "stream": "oper",
           "type": "fc",
           "class": "ai"
@@ -593,7 +593,7 @@
             }
           ]
         },
-        "supplementary_metadata": {
+        "extra_output_keys": {
           "stream": "oper",
           "type": "fc",
           "class": "ai"
@@ -908,7 +908,7 @@
             }
           ]
         },
-        "supplementary_metadata": {
+        "extra_output_keys": {
           "stream": "oper",
           "type": "fc",
           "class": "ai"
@@ -1219,7 +1219,7 @@
             }
           ]
         },
-        "supplementary_metadata": {
+        "extra_output_keys": {
           "stream": "oper",
           "type": "fc",
           "class": "ai"
@@ -1531,7 +1531,7 @@
             }
           ]
         },
-        "supplementary_metadata": {
+        "extra_output_keys": {
           "stream": "oper",
           "type": "fc",
           "class": "ai"
@@ -1942,7 +1942,7 @@
             }
           ]
         },
-        "supplementary_metadata": {
+        "extra_output_keys": {
           "stream": "oper",
           "type": "fc",
           "class": "ai"
@@ -2252,7 +2252,7 @@
             }
           ]
         },
-        "supplementary_metadata": {
+        "extra_output_keys": {
           "stream": "oper",
           "type": "fc",
           "class": "ai"
@@ -2589,7 +2589,7 @@
             }
           ]
         },
-        "supplementary_metadata": {
+        "extra_output_keys": {
           "stream": "oper",
           "type": "fc",
           "class": "ai"
@@ -2895,7 +2895,7 @@
             }
           ]
         },
-        "supplementary_metadata": {
+        "extra_output_keys": {
           "stream": "oper",
           "type": "fc",
           "class": "ai"
@@ -3209,7 +3209,7 @@
             }
           ]
         },
-        "supplementary_metadata": {
+        "extra_output_keys": {
           "stream": "oper",
           "type": "fc",
           "class": "ai"
@@ -3534,7 +3534,7 @@
             }
           ]
         },
-        "supplementary_metadata": {
+        "extra_output_keys": {
           "stream": "oper",
           "type": "fc",
           "class": "ai"


### PR DESCRIPTION
### Description
Switch MARS keys to supplementary_metadata, and set as scalar fields

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
