### PR TITLE
[frontend] Fix React #310 crash on the run page after Run once

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -12,6 +12,7 @@
 import pluginQuery from '@tanstack/eslint-plugin-query'
 import { tanstackConfig } from '@tanstack/eslint-config'
 import licenseHeader from 'eslint-plugin-license-header'
+import reactHooks from 'eslint-plugin-react-hooks'
 
 export default [
   { ignores: ['dist', '*.config.js', 'public', 'development_guidelines'] },
@@ -66,6 +67,12 @@ export default [
         },
       ],
     },
+  },
+  {
+    // Hooks after an early return crash with React #310 once the branch flips.
+    files: ['src/**/*.{ts,tsx}'],
+    plugins: { 'react-hooks': reactHooks },
+    rules: { 'react-hooks/rules-of-hooks': 'error' },
   },
   {
     files: ['!src/components/ui/**'],

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -57,6 +57,7 @@
         "@vitest/ui": "^4.1.11",
         "axe-core": "^4.12.1",
         "eslint-plugin-license-header": "^0.9.0",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "i18next-cli": "^1.67.7",
         "msw": "^2.15.0",
         "prettier": "3.9.6",
@@ -6555,6 +6556,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
@@ -7491,6 +7512,23 @@
       "dependencies": {
         "@types/set-cookie-parser": "^2.4.10",
         "set-cookie-parser": "^3.0.1"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/hono": {
@@ -12785,6 +12823,19 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/zstddec": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -78,6 +78,7 @@
     "@vitest/ui": "^4.1.11",
     "axe-core": "^4.12.1",
     "eslint-plugin-license-header": "^0.9.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "i18next-cli": "^1.67.7",
     "msw": "^2.15.0",
     "prettier": "3.9.6",

--- a/frontend/src/features/executions/outputs/OutputsView.tsx
+++ b/frontend/src/features/executions/outputs/OutputsView.tsx
@@ -312,6 +312,12 @@ export function OutputsView({
   const ActiveViewer = activeViewer?.adapter.Viewer ?? null
 
   /** True empty: no outputs payload AND no planned blocks. */
+  /** Distinct lost-output reasons; hook stays above the early return. */
+  const lostReasons = useMemo(
+    () => Array.from(new Set(Object.values(lostTaskIds))),
+    [lostTaskIds],
+  )
+
   if (items.length === 0 && blockSkeletons.length === 0) {
     // GRIB-only run — the Stored outputs card covers it; render nothing.
     if (hasStoredOutputs) return null
@@ -342,12 +348,6 @@ export function OutputsView({
   const totalAvailable = availableCount + storedStats.available
   const shownPending = visiblePendingCount + storedStats.pending
   const shownLost = visibleLostCount + storedStats.lost
-  /** Distinct backend reasons behind the unretained outputs. */
-  const lostReasons = useMemo(
-    () => Array.from(new Set(Object.values(lostTaskIds))),
-    [lostTaskIds],
-  )
-
   const toolbar = (
     <div className="flex w-full flex-wrap items-center justify-between gap-3">
       <P className="text-muted-foreground">


### PR DESCRIPTION
### Description
Hotfix for v5.0.0: opening a run straight from "Run once" crashed the run page with minified React error #310 ("Rendered more hooks than during the previous render") once the first outputs arrived; a refresh made it work again.

### Cause
- The outputs view returned early while a fresh run had no outputs yet, and the memo collecting unretained-output reasons (added in #706) sat below that return. When outputs arrived, the same component instance rendered one hook more than before and React threw, taking the page into the error boundary.

### Fix
- The memo now sits above the empty-state return, so the hook order is stable across the run's whole lifecycle.

### Guard
- Adds `eslint-plugin-react-hooks` and enforces `react-hooks/rules-of-hooks` as an error for `src/**`. Run against the whole tree it reported exactly this one violation; the schedule-page crash fixed in #706 was the same class, so the rule now catches both statically.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
