### PR TITLE
Feat/fix wms

### DIFF
--- a/backend/src/forecastbox/domain/lens/exceptions.py
+++ b/backend/src/forecastbox/domain/lens/exceptions.py
@@ -18,4 +18,15 @@ class NoLensFound(Exception):
 
 
 class UnproxyableLens(Exception):
-    """Raised when trying to proxy a Lens which is unproxyable, eg, has more than one port or is not running."""
+    """Raised when trying to proxy a Lens which is unproxyable, eg, has more than one port."""
+
+
+class LensStarting(Exception):
+    """Raised when trying to proxy a Lens which is still starting (process alive, port not yet bound).
+
+    The caller should retry later -- this is a transient condition.
+    """
+
+
+class LensFailure(Exception):
+    """Raised when trying to proxy a Lens which has exited (terminated or failed), and thus cannot serve requests."""

--- a/backend/src/forecastbox/domain/lens/manager.py
+++ b/backend/src/forecastbox/domain/lens/manager.py
@@ -18,6 +18,7 @@ Pyrsistent immutable structures allow safe lock-free reads.
 
 import logging
 import os
+import socket
 import subprocess
 import threading
 import uuid
@@ -68,17 +69,34 @@ class LensInstanceManager:
     instances: PMap[LensInstanceId, LensInstance] = pmap()
 
 
+def check_server_ready(host: str = "127.0.0.1", port: int = 8000, timeout: float = 0.1) -> bool:
+    """Ultra-fast check to see if the lens process has successfully bound to the port.
+
+    Returns True if the port is open and accepting connections, False otherwise.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(timeout)
+        try:
+            # connect_ex returns 0 on success, or an error code on failure
+            return s.connect_ex((host, port)) == 0
+        except Exception:
+            return False
+
+
 def _compute_status(instance: LensInstance) -> LensInstanceDetail:
     status: LensStatus
     if instance.lens_name == "skinnyWMS":
         if instance.process is None:
+            # process not spawned yet at all
             status = "starting"
-        elif instance.process.poll() is None:
+        elif instance.process.poll() is not None:
+            status = "terminated" if instance.process.returncode == 0 else "failed"
+        elif all(check_server_ready(port=port) for port in instance.ports):
+            # process alive and its port(s) are bound -- guvicorn/gunicorn finished starting
             status = "running"
-        elif instance.process.returncode == 0:
-            status = "terminated"
         else:
-            status = "failed"
+            # process alive but not yet listening -- still starting up
+            status = "starting"
     else:
         assert_never(instance.lens_name)
 

--- a/backend/src/forecastbox/domain/lens/proxy.py
+++ b/backend/src/forecastbox/domain/lens/proxy.py
@@ -80,7 +80,7 @@ from fastapi.responses import StreamingResponse
 from starlette.datastructures import Headers
 
 from forecastbox.domain.lens.core import PREFIX as PREFIX_ROOT
-from forecastbox.domain.lens.exceptions import UnproxyableLens
+from forecastbox.domain.lens.exceptions import LensFailure, LensStarting, UnproxyableLens
 from forecastbox.domain.lens.manager import LensInstanceId, get_status
 
 logger = logging.getLogger(__name__)
@@ -129,13 +129,17 @@ async def aclose_client() -> None:
 def _resolve_port(lens_instance_id: LensInstanceId) -> int:
     """Resolve a lens_instance_id to its bound port.
 
-    Forwards NoLensFound if the instance is unknown, and raises UnproxyableRens if it
-    is known but not `running`, or if it has a number of ports other than exactly one
-    (an invariant violation for the currently supported lens types).
+    Forwards NoLensFound if the instance is unknown. Raises LensStarting if the
+    instance is still starting up (transient, caller should retry), LensFailure if
+    the instance has exited (terminated or failed, not transient), and
+    UnproxyableLens if the instance is running but exposes a number of ports other
+    than exactly one (an invariant violation for the currently supported lens types).
     """
     detail = get_status(lens_instance_id)
+    if detail.status == "starting":
+        raise LensStarting(f"Lens instance {lens_instance_id!r} is still starting")
     if detail.status != "running":
-        raise UnproxyableLens(f"Lens instance {lens_instance_id!r} is not running (status={detail.status!r})")
+        raise LensFailure(f"Lens instance {lens_instance_id!r} is not running (status={detail.status!r})")
     if len(detail.ports) != 1:
         logger.error(f"Lens instance {lens_instance_id!r} does not expose exactly one port: {detail.ports!r}")
         raise UnproxyableLens(f"Lens instance {lens_instance_id!r} does not expose exactly one port")
@@ -222,7 +226,7 @@ async def forward(lens_instance_id: LensInstanceId, upstream_path: str, request:
     """Forward `request` to the lens identified by `lens_instance_id`, streaming both
     the request body upstream and the response body back downstream.
 
-    Forwards exceptions such as NoLensFound or UnproxyableLens.
+    Forwards exceptions such as NoLensFound, LensStarting, LensFailure, or UnproxyableLens.
     Raises HTTP exceptions in case of upstream connection failure.
     """
     port = _resolve_port(lens_instance_id)

--- a/backend/src/forecastbox/routes/lens.py
+++ b/backend/src/forecastbox/routes/lens.py
@@ -35,7 +35,7 @@ from forecastbox.domain.auth.users import get_auth_context
 from forecastbox.domain.lens import metadata_db
 from forecastbox.domain.lens import proxy as lens_proxy
 from forecastbox.domain.lens.core import PREFIX
-from forecastbox.domain.lens.exceptions import NoLensFound, UnproxyableLens
+from forecastbox.domain.lens.exceptions import LensFailure, LensStarting, NoLensFound, UnproxyableLens
 from forecastbox.domain.lens.manager import (
     LensInstanceDetail,
     LensInstanceId,
@@ -171,7 +171,11 @@ async def proxy_lens(
     except NoLensFound:
         raise HTTPException(status_code=404, detail=f"Lens instance {lens_instance_id!r} not found")
     except UnproxyableLens as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e))
+    except LensStarting as e:
+        raise HTTPException(status_code=503, detail=str(e))
+    except LensFailure as e:
+        raise HTTPException(status_code=500, detail=str(e))
 
 
 @router.get("/supported")

--- a/backend/tests/unit/domain/lens/test_lens_manager.py
+++ b/backend/tests/unit/domain/lens/test_lens_manager.py
@@ -23,6 +23,7 @@ from forecastbox.domain.lens.manager import (
     LensInstanceId,
     LensInstanceManager,
     _compute_status,
+    check_server_ready,
     get_status,
     list_instances,
     shutdown_all_lens_instances,
@@ -39,6 +40,17 @@ def reset_lens_manager() -> Iterator[None]:
     yield
     LensInstanceManager.instances = original_instances
     FreePortsManager.free_ports = original_ports
+
+
+@pytest.fixture(autouse=True)
+def assume_ports_bound() -> Iterator[None]:
+    """By default, pretend every lens port is bound (server finished starting).
+
+    Individual tests exercising the "process alive but port not bound yet" path
+    override this via `patch("forecastbox.domain.lens.manager.check_server_ready", ...)`.
+    """
+    with patch("forecastbox.domain.lens.manager.check_server_ready", return_value=True):
+        yield
 
 
 def _make_instance(process: subprocess.Popen | None = None, returncode: int | None = None) -> LensInstance:
@@ -68,6 +80,13 @@ class TestComputeStatus:
         mock_proc.poll.return_value = None  # still alive
         instance = _make_instance(process=mock_proc)
         assert _compute_status(instance).status == "running"
+
+    def test_running_process_with_unbound_port_is_starting(self) -> None:
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.poll.return_value = None  # still alive
+        instance = _make_instance(process=mock_proc)
+        with patch("forecastbox.domain.lens.manager.check_server_ready", return_value=False):
+            assert _compute_status(instance).status == "starting"
 
     def test_process_exited_zero_is_terminated(self) -> None:
         instance = _make_instance(returncode=0)
@@ -211,6 +230,12 @@ class TestShutdownAllInstances:
 
         with patch("forecastbox.domain.lens.manager.stop_instance", side_effect=flaky_stop):
             shutdown_all_lens_instances()  # should not raise
+
+
+class TestCheckServerReady:
+    def test_returns_false_when_nothing_listening(self) -> None:
+        # port 1 is a privileged, virtually-never-bound port; connecting should fail fast.
+        assert check_server_ready(port=1, timeout=0.05) is False
 
 
 class TestFreePortsManager:

--- a/backend/tests/unit/domain/lens/test_proxy.py
+++ b/backend/tests/unit/domain/lens/test_proxy.py
@@ -19,7 +19,7 @@ from fastapi import HTTPException, Request
 from pyrsistent import pmap
 
 from forecastbox.domain.lens import proxy as lens_proxy
-from forecastbox.domain.lens.exceptions import NoLensFound, UnproxyableLens
+from forecastbox.domain.lens.exceptions import LensFailure, LensStarting, NoLensFound, UnproxyableLens
 from forecastbox.domain.lens.manager import LensInstance, LensInstanceId, LensInstanceManager
 
 
@@ -44,6 +44,13 @@ def reset_lens_manager() -> Iterator[None]:
 
 
 @pytest.fixture(autouse=True)
+def assume_ports_bound() -> Iterator[None]:
+    """By default, pretend every lens port is bound, so a mocked alive process is `running`."""
+    with patch("forecastbox.domain.lens.manager.check_server_ready", return_value=True):
+        yield
+
+
+@pytest.fixture(autouse=True)
 def reset_proxy_client() -> Iterator[None]:
     yield
     lens_proxy._client = None
@@ -55,10 +62,19 @@ class TestResolvePort:
         with pytest.raises(NoLensFound):
             lens_proxy._resolve_port(LensInstanceId("ghost"))
 
-    def test_not_running_instance_raises_unproxyable(self) -> None:
+    def test_not_running_instance_raises_lens_starting(self) -> None:
         iid = LensInstanceId("starting-id")
         LensInstanceManager.instances = pmap({iid: LensInstance(process=None, lens_params={}, lens_name="skinnyWMS", ports={19000})})
-        with pytest.raises(UnproxyableLens):
+        with pytest.raises(LensStarting):
+            lens_proxy._resolve_port(iid)
+
+    def test_failed_instance_raises_lens_failure(self) -> None:
+        iid = LensInstanceId("failed-id")
+        mock_proc = MagicMock(spec=subprocess.Popen)
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+        LensInstanceManager.instances = pmap({iid: LensInstance(process=mock_proc, lens_params={}, lens_name="skinnyWMS", ports={19000})})
+        with pytest.raises(LensFailure):
             lens_proxy._resolve_port(iid)
 
     def test_running_instance_returns_sole_port(self) -> None:
@@ -144,11 +160,11 @@ class TestForward:
             await lens_proxy.forward(LensInstanceId("ghost"), "wms", request)
 
     @pytest.mark.asyncio
-    async def test_not_running_instance_raises_unproxyable(self) -> None:
+    async def test_not_running_instance_raises_lens_starting(self) -> None:
         iid = LensInstanceId("starting-id")
         LensInstanceManager.instances = pmap({iid: LensInstance(process=None, lens_params={}, lens_name="skinnyWMS", ports={19000})})
         request = _make_request()
-        with pytest.raises(UnproxyableLens):
+        with pytest.raises(LensStarting):
             await lens_proxy.forward(iid, "wms", request)
 
     @pytest.mark.asyncio

--- a/deployment/v2/Dockerfile-base
+++ b/deployment/v2/Dockerfile-base
@@ -3,6 +3,7 @@
 # - packages (bash+curl) for basic executability + getting remote data at runtime
 # - packages (libgfortran & friends) for being able to load ecmwf atlas lib
 # - packages (gdal) for that fiona unbuildable wheel required by ek plots < 1.0
+# - packages (glib) for the skinnywms
 # - no fiab itself, thats in either Dockerfile-dev or Dockerfile-release
 
 FROM debian:stable-slim
@@ -12,6 +13,7 @@ RUN : \
     && apt-get install -y bash curl ca-certificates \
     && apt-get install -y libgfortran5 libquadmath0 libgomp1 \
     && apt-get install -y gdal-bin libgdal-dev g++ \
+    && apt-get install -y libglib2.0-0t64 \
     && rm -rf /var/lib/apt/lists/* \
     && useradd --system --user-group --create-home --shell /bin/false fiab \
     && : ;


### PR DESCRIPTION
1/ Fixes the docker image to support skinnyWMS

2/ Expands the status check for the lens with a socket probe. This affects proxying:
2.1/ if lens is not found, we return 404 (as before) -- and the caller should probably start a new lens
2.2/ if lens is starting, we return a 503, and the caller should try later
2.3/ if lens has stopped/failed, we return 500 and the caller is out of lack
2.4/ if lens has more than one port (this is not possible in the current code), it returns a 400