### PR TITLE
Fix race condition between backend startup and plugin store init

### DIFF
--- a/backend/src/forecastbox/domain/plugin/status.py
+++ b/backend/src/forecastbox/domain/plugin/status.py
@@ -12,11 +12,17 @@
 from fiab_core.fable import BlockFactoryCatalogue, PluginCompositeId
 
 from forecastbox.domain.plugin.state import PluginManager
+from forecastbox.domain.plugin.store import stores_ready
 from forecastbox.utility.concurrency.synchronization import timed_acquire
 
 
 def status_brief() -> str:
-    if PluginManager.updater_error is not None:
+    if not stores_ready():
+        # NOTE the plugin stores are populated asynchronously in a background task submitted
+        # at startup -- until that completes, plugin operations relying on them (eg install) are
+        # not usable yet, so report the same status as an in-progress plugin operation would.
+        return "initializing"
+    elif PluginManager.updater_error is not None:
         return f"failure: {PluginManager.updater_error}"
     elif PluginManager.operation_in_progress:
         return "running"

--- a/backend/src/forecastbox/domain/plugin/store.py
+++ b/backend/src/forecastbox/domain/plugin/store.py
@@ -113,8 +113,19 @@ def populate_store(store: PluginStore, client: httpx.Client) -> None:
 
 
 class StoresManager:
-    stores: PMap[PluginStoreId, PluginStore] = pmap()
+    stores: PMap[PluginStoreId, PluginStore] | None = None
+    """None until `initialize_stores` has completed at least once. Distinguishes 'not initialized
+    yet' from 'initialized, but happens to have no stores configured' (an empty PMap)."""
     stores_lock: threading.Lock = threading.Lock()
+
+
+def stores_ready() -> bool:
+    """Whether the stores have finished their (asynchronous, submitted-at-startup) initialization.
+
+    Callers such as `register_plugin_from_store` rely on `StoresManager.stores` being populated;
+    right after process startup this may not be the case yet, so this helper lets HTTP callers
+    (see `forecastbox.routes.status`) report readiness instead of failing with a 500."""
+    return StoresManager.stores is not None
 
 
 def initialize_stores(plugin_stores_config: PluginStoresConfig) -> None:
@@ -137,7 +148,7 @@ def get_plugins_detail() -> dict[PluginCompositeId, tuple[PluginStoreEntry, Plug
             store.plugins[pluginId],
             store.remote[pluginId],
         )
-        for storeId, store in StoresManager.stores.items()
+        for storeId, store in (StoresManager.stores or pmap()).items()
         for pluginId in store.plugins.keys()
     }
 
@@ -166,7 +177,7 @@ def register_plugin_from_store(plugin_composite_key: PluginCompositeId) -> Plugi
     present into the config file, unless already there. Returns the settings the plugin is configured
     with. Synchronous and self-contained -- performs no pip operation, that is the caller's job"""
     # No lock needed for reads with pyrsistent immutable structures
-    if not StoresManager.stores:
+    if StoresManager is None:
         raise ValueError("stores not initialized")
     storeId, pluginId = plugin_composite_key.store, plugin_composite_key.local
     store = StoresManager.stores.get(storeId, None)

--- a/backend/src/forecastbox/entrypoint/bootstrap/checks.py
+++ b/backend/src/forecastbox/entrypoint/bootstrap/checks.py
@@ -31,6 +31,33 @@ def _call_succ(response: CallResult, url: str) -> bool:
         assert_never(response)
 
 
+def _plugins_ready(response: CallResult, url: str) -> bool:
+    """Condition for `_wait_for` -- succeeds once the `/status` endpoint reports the plugin
+    subsystem as `ok`. Retries on `initializing`/`running` (plugin stores are populated
+    asynchronously in a background task submitted at startup, and a plugin operation may also
+    be legitimately in progress). Unlike `_call_succ`, a `ConnectError` is treated as a hard
+    failure rather than something to retry on: this condition is only ever used after
+    `check_backend_ready` has already confirmed the backend accepts connections, so losing the
+    connection at this point means the backend went down, not that it hasn't started yet. A
+    `ReadTimeout` is still tolerated, as the backend may simply be busy while starting up."""
+    if isinstance(response, httpx.Response):
+        if response.status_code != 200:
+            raise ValueError(f"failure on {url}: {response}")
+        plugins_status = response.json().get("plugins")
+        if plugins_status == "ok":
+            return True
+        elif plugins_status in ("initializing", "running"):
+            return False
+        else:
+            raise ValueError(f"plugins failure on {url}: {plugins_status}")
+    elif isinstance(response, httpx.ReadTimeout):
+        return False
+    elif isinstance(response, httpx.HTTPError):
+        raise ValueError(f"failure on {url}: {repr(response)}")
+    else:
+        assert_never(response)
+
+
 class StartupError(ValueError):
     pass
 
@@ -69,10 +96,15 @@ def check_backend_ready(
         raise
 
 
-def install_default_plugins(config: FIABConfig) -> None:
-    """Installs default plugins as specified by configs. Log-swallows all exceptions"""
+def install_default_plugins(config: FIABConfig, attempts: int = 20) -> None:
+    """Installs default plugins as specified by configs. Log-swallows all exceptions.
+
+    Plugin installation relies on the plugin stores, which are populated asynchronously in a
+    background task submitted at backend startup and may not be ready yet by the time this is
+    called -- wait for the `/status` endpoint to report the plugin subsystem as ready first."""
     try:
         with httpx.Client(follow_redirects=True) as client:
+            _wait_for(client, config.backend.local_url() + f"{ROUTE_PREFIX}/status", attempts, _plugins_ready)
             for pluginId in _default_plugins().keys():
                 url = config.backend.local_url() + f"{ROUTE_PREFIX}/plugin/install"
                 try:

--- a/backend/tests/unit/domain/plugins/test_plugin_status.py
+++ b/backend/tests/unit/domain/plugins/test_plugin_status.py
@@ -29,6 +29,14 @@ def _reset_plugin_state() -> Generator[None, None, None]:
     PluginManager.plugins = pmap()
 
 
+@pytest.fixture(autouse=True)
+def _stores_ready() -> Generator[None, None, None]:
+    # NOTE status_brief() defers to stores_ready() first -- these tests exercise the
+    # PluginManager-driven branches, so pretend the stores are already initialized.
+    with patch("forecastbox.domain.plugin.status.stores_ready", return_value=True):
+        yield
+
+
 def test_status_brief_ok() -> None:
     with patch("forecastbox.domain.plugin.status.PluginManager") as mock_pm:
         mock_pm.updater_error = None
@@ -50,6 +58,11 @@ def test_status_brief_failure() -> None:
         result = status_brief()
         assert result.startswith("failure:")
         assert "some error" in result
+
+
+def test_status_brief_initializing_when_stores_not_ready() -> None:
+    with patch("forecastbox.domain.plugin.status.stores_ready", return_value=False):
+        assert status_brief() == "initializing"
 
 
 def test_plugins_ready_true_when_ok() -> None:

--- a/backend/tests/unit/plugins/test_stores.py
+++ b/backend/tests/unit/plugins/test_stores.py
@@ -75,7 +75,7 @@ def test_initialize_stores_publishes_only_after_successful_fetch(monkeypatch: py
     with pytest.raises(RuntimeError):
         store_module.initialize_stores({PluginStoreId("someStore"): MagicMock()})
 
-    assert dict(StoresManager.stores) == {}
+    assert StoresManager.stores is not None and dict(StoresManager.stores) == {}
 
 
 def test_get_plugins_detail_is_lock_free_over_published_map(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
The plugin store is initialized asynchronously in a background task submitted at backend startup. main.py's launch_all used to consider the backend ready as soon as /status responded 200 and the gateway was up, then immediately called install_default_plugins, which could hit register_plugin_from_store before the stores were populated, raising 'stores not initialized' and surfacing as a 500.

Fold store readiness into status_brief(), the single owner of the plugin subsystem's status: it now reports 'initializing' while StoresManager.stores is still None (as opposed to an empty, but initialized, map), the same way an in-progress plugin operation is reported. routes/status.py stays a thin passthrough and no longer needs to know about stores.

install_default_plugins (the only caller that actually depends on the stores) now polls /status and waits for the plugins field to reach 'ok' before attempting any installs, reusing the existing retry loop. check_backend_ready is unchanged, since backend/gateway liveness does not require the stores to be ready. Its retry condition treats a ConnectError as a hard failure rather than something to sleep and retry on, since by the time install_default_plugins runs, check_backend_ready has already confirmed the backend accepts connections -- losing the connection at that point means the backend went down, not that it hasn't started yet. A ReadTimeout is still tolerated, as the backend may simply be busy while starting up.
