### PR TITLE
[backend.run] fix the run delete

### DIFF
--- a/backend/src/forecastbox/domain/run/background.py
+++ b/backend/src/forecastbox/domain/run/background.py
@@ -33,10 +33,11 @@ from forecastbox.domain.glyphs.resolution import (
     merge_glyph_values,
 )
 from forecastbox.domain.run import db
-from forecastbox.domain.run.cascade import execute_cascade
+from forecastbox.domain.run.cascade import delete_cascade_job, execute_cascade
 from forecastbox.domain.run.compile import compile_builder, resolve_intrinsic_glyph_values
 from forecastbox.domain.run.db import CompilerRuntimeContext
 from forecastbox.domain.run.detail import store_compilation_detail
+from forecastbox.domain.run.exceptions import RunAccessDenied, RunNotFound
 from forecastbox.domain.run.types import RunId
 from forecastbox.utility.auth import AuthContext
 from forecastbox.utility.memcache import TooLargeEntry
@@ -124,6 +125,24 @@ def execute_background(
                 cascade_proc=get_current_cascade_proc(),
                 outputs=compilation_result.run_outputs.model_dump(),
             )
+            get_id = lambda: f"{run_id=}, {attempt_count=}, {auth_context=}, cascade_job_id={response.job_id}"
+
+            def delete_cascade() -> None:
+                try:
+                    delete_cascade_job(cast(str, response.job_id))  # NOTE cast due to ty being confused
+                except Exception as e:
+                    logger.warning(f"cascade deletion of {get_id()} failed with {e!r}. Ignoring.")
+
+            try:
+                run_record = db.get_run(run_id, attempt_count, auth_context=auth_context)
+                if run_record.is_deleted:
+                    logger.debug(f"deleting cascade entity right after submission due to run entity deleted: {get_id()}.")
+                    delete_cascade()
+            except RunNotFound:
+                logger.warning(f"RunNotFound of run submitted by itself: {get_id()}. Issuing CascadeDelete.")
+                delete_cascade()
+            except RunAccessDenied:
+                logger.warning(f"RunAccessDenied to run submitted by itself: {get_id()}. Ignoring.")
         else:
             error = (response.error or "no error provided by cascade")[:255]
             db.update_run_runtime(run_id, attempt_count, status="failed", error=error)

--- a/backend/src/forecastbox/domain/run/cascade.py
+++ b/backend/src/forecastbox/domain/run/cascade.py
@@ -13,7 +13,15 @@ import time
 from pathlib import Path
 from typing import Literal
 
-from cascade.gateway.api import JobSpec, LocalProcesses, SlurmCluster, SshCluster, SubmitJobRequest, SubmitJobResponse
+from cascade.gateway.api import (
+    JobSpec,
+    LocalProcesses,
+    ResultDeletionRequest,
+    SlurmCluster,
+    SshCluster,
+    SubmitJobRequest,
+    SubmitJobResponse,
+)
 from cascade.gateway.client import request_response
 from cascade.low.core import JobInstance, JobInstanceRich, TaskId
 from fiab_core.fable import BlockInstanceId
@@ -154,3 +162,9 @@ def execute_cascade(spec: ExecutionSpecification) -> SubmitJobResponse:
         return SubmitJobResponse(job_id=None, error=repr(e))
 
     return submit_job_response
+
+
+def delete_cascade_job(cascade_job_id: str) -> None:
+    # TODO we actually have no cascade job deletion request! Once there is one, implement and replace
+    request = ResultDeletionRequest(datasets={cascade_job_id: []})  # type: ignore[invalid-argument-type]
+    request_response(request, get_gateway_url())

--- a/backend/src/forecastbox/routes/run.py
+++ b/backend/src/forecastbox/routes/run.py
@@ -38,7 +38,7 @@ from forecastbox.domain.auth.users import get_auth_context
 from forecastbox.domain.blueprint.types import BlueprintId
 from forecastbox.domain.gateway.service import get_gateway_url, get_logs_directory
 from forecastbox.domain.run import db, service
-from forecastbox.domain.run.cascade import RunOutputs
+from forecastbox.domain.run.cascade import RunOutputs, delete_cascade_job
 from forecastbox.domain.run.detail import retrieve_compilation_detail
 from forecastbox.domain.run.exceptions import CompilationDetailCorrupted, CompilationDetailNotFound, RunAccessDenied, RunNotFound
 from forecastbox.domain.run.types import RunId
@@ -139,7 +139,7 @@ class RunRestartResponse(FiabBaseModel):
 
 
 class RunDeleteRequest(FiabBaseModel):
-    """Identifies the attempt to delete. ``attempt_count`` must match the current latest attempt."""
+    """Identifies the attempt to delete."""
 
     run_id: RunId
     attempt_count: int
@@ -201,14 +201,11 @@ def _to_run_detail(domain_detail: service.RunDetail) -> RunDetailResponse:
     )
 
 
-async def _resolve_run_with_cascade(
+async def _resolve_run_record(
     execution_spec: RunLookup,
     auth_context: AuthContext,
-) -> tuple[db.RunRecord, str]:
-    """Fetch a Run and validate it has a cascade_job_id.
-
-    Raises HTTP 404 if not found or access denied, HTTP 409 if not yet submitted.
-    """
+) -> db.RunRecord:
+    """Fetch a Run. Raises HTTP 404 if not found or access denied."""
     try:
         execution = cast(
             db.RunRecord,
@@ -220,10 +217,7 @@ async def _resolve_run_with_cascade(
         raise HTTPException(status_code=404, detail=f"Run {execution_spec.run_id!r} not found.")
     except RunAccessDenied:
         raise HTTPException(status_code=403, detail=f"Access denied to execution {execution_spec.run_id!r}.")
-    cascade_job_id = execution.cascade_job_id
-    if cascade_job_id is None:
-        raise HTTPException(status_code=409, detail=f"Run {execution_spec.run_id!r} has not been submitted to cascade yet.")
-    return execution, cascade_job_id
+    return execution
 
 
 async def _build_run_logs_response(cascade_job_id: str, db_entity_ser: bytes) -> Response:
@@ -375,41 +369,23 @@ async def delete_run(
     request: RunDeleteRequest,
     auth_context: AuthContext = Depends(get_auth_context),
 ) -> None:
-    """Delete an execution from the database and cascade.
-
-    ``attempt_count`` must match the current latest attempt to prevent races.
-    Returns 409 if it does not match.
-    """
-    try:
-        current = cast(
-            db.RunRecord, await execution_manager.await_jobs_db("run.get", partial(db.get_run, request.run_id, auth_context=auth_context))
-        )
-    except RunNotFound:
-        raise HTTPException(status_code=404, detail=f"Run {request.run_id!r} not found.")
-    except RunAccessDenied:
-        raise HTTPException(status_code=403, detail=f"Access denied to execution {request.run_id!r}.")
-    if current.attempt_count != request.attempt_count:
-        raise HTTPException(
-            status_code=409,
-            detail=(
-                f"Attempt count conflict for execution {request.run_id!r}: "
-                f"expected {request.attempt_count}, current is {current.attempt_count}."
-            ),
-        )
+    """Delete an execution from the database and cascade."""
     spec = RunLookup(run_id=request.run_id, attempt_count=request.attempt_count)
-    _, cascade_job_id = await _resolve_run_with_cascade(spec, auth_context)
-    try:
-        client.request_response(
-            api.ResultDeletionRequest(datasets={cascade_job_id: []}),  # type: ignore[invalid-argument-type]
-            get_gateway_url(),
-        )
-    except Exception as e:
-        raise HTTPException(500, f"Job deletion failed: {e}")
-    finally:
+    run_record = await _resolve_run_record(spec, auth_context)
+    if run_record.cascade_job_id is not None:
+        # NOTE the else branch of this effectively lives in the background submission, which checks for entity being deleted after upserting cascade_job_id, and issuing a delete on its own
         try:
-            await execution_manager.await_jobs_db("run.delete", partial(db.soft_delete_run, request.run_id, auth_context=auth_context))
-        except (RunNotFound, RunAccessDenied):
-            pass
+            delete_cascade_job(run_record.cascade_job_id)
+        except Exception as e:
+            # NOTE we don't delete the db entity to not increase inconsistency
+            raise HTTPException(500, f"Job deletion failed: {e}")
+    try:
+        await execution_manager.await_jobs_db("run.delete", partial(db.soft_delete_run, request.run_id, auth_context=auth_context))
+    except RunNotFound:
+        # NOTE could only happen in a double delete which is from caller's PoV ok
+        logger.warning(f"presumably double delete on {request=}, ignoring")
+    except RunAccessDenied:
+        raise HTTPException(status_code=403, detail=f"Access denied to execution {spec.run_id!r}.")
 
 
 @router.post("/restart")
@@ -461,7 +437,9 @@ async def get_run_output_content(
     auth_context: AuthContext = Depends(get_auth_context),
 ) -> Response:
     """Retrieve the result of a specific output task, encoded as bytes."""
-    execution, cascade_job_id = await _resolve_run_with_cascade(spec, auth_context)
+    execution = await _resolve_run_record(spec, auth_context)
+    if execution.cascade_job_id is None:
+        raise HTTPException(status_code=409, detail=f"Run {spec.run_id!r} has not been submitted to cascade yet.")
     dataset = DatasetId(task=TaskId(dataset_id), output="0")
 
     # Serve from locally cached value when available, without contacting cascade.
@@ -480,7 +458,7 @@ async def get_run_output_content(
     if mime_result.t is None:
         raise HTTPException(500, f"Result mime lookup failed: {mime_result.e}")
     response = client.request_response(
-        api.ResultRetrievalRequest(job_id=JobId(cascade_job_id), dataset_id=dataset),
+        api.ResultRetrievalRequest(job_id=JobId(execution.cascade_job_id), dataset_id=dataset),
         get_gateway_url(),
     )
     response = cast(api.ResultRetrievalResponse, response)
@@ -501,6 +479,8 @@ async def get_run_logs(
     auth_context: AuthContext = Depends(get_auth_context),
 ) -> Response:
     """Return a zip archive of logs for the given execution attempt."""
-    db_entity, cascade_job_id = await _resolve_run_with_cascade(spec, auth_context)
-    entity_dict = asdict(db_entity)
-    return await _build_run_logs_response(cascade_job_id, orjson.dumps(entity_dict))
+    run_record = await _resolve_run_record(spec, auth_context)
+    if run_record.cascade_job_id is None:
+        raise HTTPException(status_code=409, detail=f"Run {spec.run_id!r} has not been submitted to cascade yet.")
+    entity_dict = asdict(run_record)
+    return await _build_run_logs_response(run_record.cascade_job_id, orjson.dumps(entity_dict))

--- a/backend/tests/integration/test_blueprint.py
+++ b/backend/tests/integration/test_blueprint.py
@@ -49,9 +49,14 @@ def _config(values: dict[str, str]) -> dict[ConfigurationOptionId, str]:
     return {ConfigurationOptionId(key): value for key, value in values.items()}
 
 
-def ensure_completed_v2(backend_client: httpx.Client, job_id: str, sleep: float = 0.5, attempts: int = 20) -> None:
+def ensure_completed_v2(
+    backend_client: httpx.Client, job_id: str, sleep: float = 0.5, attempts: int = 20, attempt_count: int | None = None
+) -> None:
     def do_action() -> Any:
-        response = backend_client.get("/run/get", params={"run_id": job_id}, timeout=10)
+        params = {"run_id": job_id}
+        if attempt_count is not None:
+            params["attempt_count"] = attempt_count
+        response = backend_client.get("/run/get", params=params, timeout=10)
         assert response.is_success, response.text
         return response.json()
 
@@ -1707,22 +1712,6 @@ def test_run_delete_not_found(backend_client_user: httpx.Client) -> None:
     """POST /run/delete with a non-existent run_id returns 404."""
     resp = backend_client_user.post("/run/delete", json={"run_id": "nonexistent-run-id", "attempt_count": 1})
     assert resp.status_code == 404
-
-
-def test_run_delete_attempt_conflict(backend_client_user: httpx.Client) -> None:
-    """POST /run/delete with a mismatched attempt_count returns 409."""
-    builder = _make_builder_source_only()
-    save_resp = backend_client_user.post("/blueprint/create", json=BlueprintSaveCommand(builder=builder).model_dump())
-    assert save_resp.is_success, save_resp.text
-    blueprint_id = save_resp.json()["blueprint_id"]
-
-    run_resp = backend_client_user.post("/run/create", json={"blueprint_id": blueprint_id})
-    assert run_resp.is_success, run_resp.text
-    run_id = run_resp.json()["run_id"]
-    attempt_count = run_resp.json()["attempt_count"]
-
-    del_resp = backend_client_user.post("/run/delete", json={"run_id": run_id, "attempt_count": attempt_count + 1})
-    assert del_resp.status_code == 409
 
 
 def test_run_restart_attempt_conflict(backend_client_user: httpx.Client) -> None:


### PR DESCRIPTION
1/ do not mandate cascade_job_id to be not None -- that was a bug which caused unsubmitted jobs to linger forever

2/ when actually submitting a cascade job, check whether the underlying entity is soft deleted -- and if so, issue a (delayed) cascade deletion request right away

3/ do not mandate the delete's attempt count to match the latest, we do allow to delete previous runs from db/cascade as well
