### PR TITLE
[frontend] Visualise: make the map projection findable

### DIFF
--- a/frontend/src/features/tutorials/anchors.ts
+++ b/frontend/src/features/tutorials/anchors.ts
@@ -43,6 +43,7 @@ export const TOUR = {
     expandRight: 'visualise.expand-right',
     timeline: 'visualise.timeline',
     timelineStatic: 'visualise.timeline-static',
+    projection: 'visualise.projection',
   },
 } as const
 

--- a/frontend/src/features/tutorials/tutorials/visualise-first-map.tsx
+++ b/frontend/src/features/tutorials/tutorials/visualise-first-map.tsx
@@ -227,6 +227,12 @@ export const firstMapDefinition: TutorialDefinition<FirstMapLaunch> = {
       expandVia: TOUR.visualise.expandLeft,
     },
     {
+      id: 'projection',
+      anchor: TOUR.visualise.projection,
+      side: 'bottom',
+      advance: { kind: 'next-click' },
+    },
+    {
       id: 'time',
       anchor: TOUR.visualise.timeline,
       side: 'top',

--- a/frontend/src/features/viewer/geo/GeoToolbar.tsx
+++ b/frontend/src/features/viewer/geo/GeoToolbar.tsx
@@ -311,14 +311,16 @@ export function GeoToolbar({
             <Globe2 className="h-4 w-4" />
           </Button>
           <Popover>
+            {/* Reads the current projection so the control is findable. */}
             <PopoverTrigger
               render={
                 <Button
                   variant="ghost"
-                  size="icon"
-                  className="relative h-7 w-7 pointer-coarse:h-11 pointer-coarse:w-11"
+                  size="sm"
+                  className="relative h-7 gap-1 px-2 pointer-coarse:h-11"
                   title={`${t('projections.popover')} (${keyLabel(COMPARE_KEYS.projection)})`}
                   aria-label={t('projections.popover')}
+                  {...tourAttr(TOUR.visualise.projection)}
                 />
               }
             >
@@ -327,6 +329,10 @@ export function GeoToolbar({
                 show={reveal}
               />
               <Layers className="h-4 w-4" />
+              <span className="text-xs">
+                {t(`projections.short.${projection.id}`)}
+              </span>
+              <ChevronDown className="h-3 w-3 opacity-60" />
             </PopoverTrigger>
             <PopoverContent side="bottom" align="end" className="w-72 p-1">
               <P className="px-2 pt-1 pb-2 text-xs font-medium tracking-wide text-muted-foreground uppercase">

--- a/frontend/src/locales/en/tutorials.json
+++ b/frontend/src/locales/en/tutorials.json
@@ -54,6 +54,10 @@
         "title": "Your active layers live here",
         "body": "Every layer on the map is listed here with its legend and an opacity slider — reorder them to change drawing order. This panel is mission control for what's on the map."
       },
+      "projection": {
+        "title": "Change the map projection",
+        "body": "This button names the projection the map is drawn in. Open it to switch to a polar or equal-area view for high latitudes, and to pick the basemap that goes with it. Only projections every source can serve are offered."
+      },
       "time": {
         "title": "Step through time",
         "body": "This timeline is the forecast's \"Valid time\" axis, one mark per timestep. Click one step further along — or use the arrow buttons — and the map redraws for that moment.",

--- a/frontend/src/locales/en/visualise.json
+++ b/frontend/src/locales/en/visualise.json
@@ -200,7 +200,7 @@
     "firstStartHint": "A first start reads the run's files — usually 10–30 s."
   },
   "projections": {
-    "title": "Projection",
+    "title": "Map projection",
     "popover": "Projection & basemap",
     "merc": "Web Mercator",
     "geo": "Equirectangular (whole globe)",
@@ -208,7 +208,14 @@
     "spole": "Antarctic — polar stereographic",
     "laea": "Europe — equal-area (LAEA)",
     "blockedBy": "{{source}} does not serve this projection",
-    "snappedBack": "{{source}} does not serve the {{projection}} projection — back to Web Mercator"
+    "snappedBack": "{{source}} does not serve the {{projection}} projection — back to Web Mercator",
+    "short": {
+      "merc": "Mercator",
+      "geo": "Equirectangular",
+      "npole": "Arctic",
+      "spole": "Antarctic",
+      "laea": "Europe LAEA"
+    }
   },
   "wmsParams": {
     "t": "Temperature",

--- a/frontend/tests/integration/features/tutorials/tutorial-runner.test.tsx
+++ b/frontend/tests/integration/features/tutorials/tutorial-runner.test.tsx
@@ -165,7 +165,7 @@ describe('visualise first-map tutorial', () => {
       )
       .toBeVisible()
     await expect
-      .element(screen.getByText('1 of 10', { exact: true }))
+      .element(screen.getByText('1 of 11', { exact: true }))
       .toBeVisible()
     await screen.getByRole('button', { name: 'Start', exact: true }).click()
 
@@ -202,6 +202,14 @@ describe('visualise first-map tutorial', () => {
         {
           timeout: 10000,
         },
+      )
+      .toBeVisible()
+    await screen.getByRole('button', { name: 'Next', exact: true }).click()
+
+    // Projection step: informational, anchored on the labelled trigger.
+    await expect
+      .element(
+        screen.getByRole('heading', { name: 'Change the map projection' }),
       )
       .toBeVisible()
     await screen.getByRole('button', { name: 'Next', exact: true }).click()
@@ -385,7 +393,7 @@ describe('visualise first-map tutorial', () => {
       )
       .toBeVisible()
     await expect
-      .element(screen.getByText('1 of 10', { exact: true }))
+      .element(screen.getByText('1 of 11', { exact: true }))
       .toBeVisible()
     await screen.getByRole('button', { name: 'Start', exact: true }).click()
 
@@ -426,7 +434,7 @@ describe('visualise first-map tutorial', () => {
       })
       .not.toBeNull()
     useTutorialsStore.getState().start('visualise-first-map')
-    useTutorialsStore.getState().setStep(6)
+    useTutorialsStore.getState().setStep(7)
 
     // DWD's Add button reads "Added" (disabled) — nothing to press, so the
     // step applies the slot-bar assignment itself.


### PR DESCRIPTION
### Description

Follow-up to #708 after feedback that the projection picker was hard to find: it lived behind an icon-only layers button that reads as "basemap". Projection and basemap stay together in one popover; what changes is how the control announces itself.

### Trigger
- The toolbar button now shows the active projection with a chevron, in the same style as the Export button: "Mercator", "Equirectangular", "Arctic", "Antarctic" or "Europe LAEA". 
- The popover's first section is titled "Map projection"; the accessible name, keyboard hint and behaviour are unchanged, so existing tests and shortcuts still apply.

### Guided tour
- The first-map tour gains a step on the trigger, after the active-layers step, explaining polar and equal-area views and that only projections every source can serve are offered. The tour is now eleven steps.
### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
